### PR TITLE
Clean up token generation

### DIFF
--- a/internal/handlers/token.go
+++ b/internal/handlers/token.go
@@ -2,30 +2,15 @@ package handlers
 
 import (
 	"net/http"
-	db "receipt-wrangler/api/internal/database"
-	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/utils"
 
 	"github.com/auth0/go-jwt-middleware/v2/validator"
 )
 
 func RefreshToken(w http.ResponseWriter, r *http.Request) {
-	// if we get here then we have teh jwt in token
-	// next we want to write a custom middle ware as  a wrapper for the jwt validator
-	// and validate the refresh token, and custom claims
-	// at this point we can generate a new set, and return them as cookies
-	// et voiala
 	oldRefreshToken := r.Context().Value("refreshToken").(*validator.ValidatedClaims)
-	db := db.GetDB()
-	var dbUser models.User
 
-	err := db.Model(models.User{}).Where("id = ?", oldRefreshToken.RegisteredClaims.Subject).First(&dbUser).Error
-	if err != nil {
-		utils.WriteCustomErrorResponse(w, "Error refreshing token", 500)
-		return
-	}
-
-	jwt, refreshToken, err := utils.GenerateJWT(dbUser.Username)
+	jwt, refreshToken, err := utils.GenerateJWT(oldRefreshToken.RegisteredClaims.Subject)
 	if err != nil {
 		utils.WriteErrorResponse(w, err, 500)
 		return

--- a/internal/utils/auth.go
+++ b/internal/utils/auth.go
@@ -36,21 +36,21 @@ func customClaims() validator.CustomClaims {
 	return &Claims{}
 }
 
-func GenerateJWT(username string) (string, string, error) {
+func GenerateJWT(userId string) (string, string, error) {
 	db := db.GetDB()
 	config := config.GetConfig()
 	var user models.User
 
-	err := db.Model(models.User{}).Where("username = ?", username).First(&user).Error
+	err := db.Model(models.User{}).Where("id = ?", userId).First(&user).Error
 	if err != nil {
 		return "", "", err
 	}
 
 	claims := &Claims{
-		UserID:      user.ID,
 		Displayname: user.DisplayName,
 		Username:    user.Username,
 		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   fmt.Sprint(user.ID),
 			Issuer:    "https://recieptWrangler.io",
 			Audience:  []string{"https://receiptWrangler.io"},
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),

--- a/internal/utils/claims.go
+++ b/internal/utils/claims.go
@@ -7,7 +7,6 @@ import (
 )
 
 type Claims struct {
-	UserID      uint
 	Username    string
 	Displayname string
 	jwt.RegisteredClaims


### PR DESCRIPTION
# Changes
* Clean up token generation to use the subject that contains the user id instead of querying multiple times and using the username.