### PR TITLE
enhancement/bump-easy-ocr-performance

### DIFF
--- a/internal/services/ocr.go
+++ b/internal/services/ocr.go
@@ -147,6 +147,7 @@ func writeDebuggingFiles(ocrText string, path string, imageBytes []byte, ocrDura
 }
 
 func prepareImage(path string) ([]byte, error) {
+	var appConfig = config.GetConfig()
 	mw := imagick.NewMagickWand()
 	err := mw.ReadImage(path)
 	if err != nil {
@@ -188,12 +189,13 @@ func prepareImage(path string) ([]byte, error) {
 		return nil, err
 	}
 
-	err = mw.ScaleImage(mw.GetImageWidth()/2, mw.GetImageHeight()/2)
-	if err != nil {
-		return nil, err
+	if appConfig.AiSettings.OcrEngine == structs.EASY_OCR {
+		err = mw.ScaleImage(mw.GetImageWidth()/2, mw.GetImageHeight()/2)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	bytes := mw.GetImageBlob()
-
 	return bytes, nil
 }

--- a/internal/services/ocr.go
+++ b/internal/services/ocr.go
@@ -183,7 +183,12 @@ func prepareImage(path string) ([]byte, error) {
 		return nil, err
 	}
 
-	err = mw.DeskewImage(0.10)
+	err = mw.DeskewImage(.40)
+	if err != nil {
+		return nil, err
+	}
+
+	err = mw.ScaleImage(mw.GetImageWidth()/2, mw.GetImageHeight()/2)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Changes
* Cut processing image size in half, since it made a bigger difference than compression
* Adjusted deskew value to standard value