### PR TITLE
Bug/fix duplicate refresh tokens

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -14,12 +14,12 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.23.2"
-      - name: Install tesseract dependencies
+      - name: Install app dependencies
         run: sudo sh set-up-dependencies.sh
       - name: Build
         run: go build -v ./...
       - name: Test
-        run: go test -coverprofile=coverage.out -covermode=atomic -p 1 -v ./...
+        run: go test -coverprofile=coverage.out -covermode=atomic -v ./...
       - name: Upload Coverage Report to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,12 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.23.2"
-      - name: Install tesseract dependencies
+      - name: Install app dependencies
         run: sudo sh set-up-dependencies.sh
       - name: Build
         run: go build -v ./...
       - name: Test
-        run: go test -coverprofile=coverage.out -covermode=atomic -p 1 -v ./...
+        run: go test -coverprofile=coverage.out -covermode=atomic -v ./...
       - name: Upload Coverage Report to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/internal/middleware/jwt.go
+++ b/internal/middleware/jwt.go
@@ -18,7 +18,7 @@ func MoveJWTCookieToHeader(next http.Handler) http.Handler {
 
 		accessTokenCookie, err := r.Cookie(constants.JwtKey)
 		if err != nil {
-			utils.WriteCustomErrorResponse(w, errMessage, http.StatusBadRequest)
+			utils.WriteCustomErrorResponse(w, errMessage, http.StatusForbidden)
 			logging.LogStd(logging.LOG_LEVEL_ERROR, errMessage)
 			return
 		}

--- a/internal/services/auth.go
+++ b/internal/services/auth.go
@@ -128,12 +128,18 @@ func GenerateJWT(userId uint) (string, string, structs.Claims, error) {
 		return "", "", structs.Claims{}, err
 	}
 
+	refreshTokenId, err := utils.GetRandomString(16)
+	if err != nil {
+		return "", "", structs.Claims{}, err
+	}
+
 	refreshTokenClaims := structs.Claims{
 		UserId: user.ID,
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    "https://receiptWrangler.io",
 			Audience:  []string{"https://receiptWrangler.io"},
 			ExpiresAt: utils.GetRefreshTokenExpiryDate(),
+			ID:        refreshTokenId,
 		},
 	}
 


### PR DESCRIPTION
# Changes
* Generate an ID for each token. Technically not guarenteed to be unique, but it is very unlikely to have ID collisions
* Update tests in workflows to run all at once 