### PR TITLE
Update set-up-dependencies.sh

### DIFF
--- a/set-up-dependencies.sh
+++ b/set-up-dependencies.sh
@@ -3,7 +3,7 @@ apt-get install -y build-essential
 # Install pip
 apt-get update
 apt-get install python3-pip -y
-apt-get install python3.11-venv -y
+apt-get install python3.13-venv -y
 # Set up venv
 python3 -m venv wranglervenv
 source wranglervenv/bin/activate


### PR DESCRIPTION
easyocr wasn't installed after deploying 6.6.1 (unsure if this affects earlier versions).

Changing python venv version seems to resolve this since python version installed is 3.13 not 3.11. Running set-up-dependencies.sh in the container generated a bunch of errors that start w/ the wrong version of python3-venv, updating it resolved the errors and allowed it to build properly.