### PR TITLE
Improve iOS privacy permission descriptions for clarity

### DIFF
--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -48,11 +48,11 @@
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
-	<string>Used for scanning images</string>
+	<string>Receipt Wrangler uses your camera to scan and photograph receipts. For example, you can take a photo of a paper receipt so the app can extract its details for tracking and splitting expenses.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Used for uploading images</string>
+	<string>Receipt Wrangler accesses your photo library so you can select existing photos of receipts to upload. For example, you can choose a receipt image you previously photographed to add it to a group for expense tracking.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>Used for downloading images</string>
+	<string>Receipt Wrangler saves receipt images to your photo library when you download them. For example, you can save a receipt image from the app to your photo library to share it outside the app or keep a local copy.</string>
 	<key>UIStatusBarHidden</key>
 	<false/>
 </dict>


### PR DESCRIPTION
## Summary
Updated the iOS app privacy permission descriptions in Info.plist to be more descriptive and user-friendly. The previous generic descriptions have been replaced with detailed explanations that clearly communicate to users why each permission is needed and how it will be used.

## Key Changes
- **Camera permission**: Enhanced description to explain that the camera is used for scanning and photographing receipts, with a concrete example of taking a photo of a paper receipt
- **Photo Library access permission**: Improved description to clarify that the app accesses the photo library to allow users to select existing receipt photos, with an example of choosing a previously photographed receipt
- **Photo Library save permission**: Updated description to explain that the app saves receipt images to the photo library, with examples of sharing or keeping local copies

## Details
These changes improve transparency and help users understand the purpose of each permission request. The new descriptions follow Apple's guidelines for privacy permission messaging by providing specific use cases and examples rather than generic statements.

https://claude.ai/code/session_01GzYtFx3ZUV3MV97SDtvGvk