### PR TITLE
Fix create-docker-manifest job being skipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,9 @@ jobs:
 
   create-docker-manifest:
     needs: [build-docker-arm64, build-docker-amd64]
+    if: |
+      needs.build-docker-arm64.result == 'success' &&
+      needs.build-docker-amd64.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Login to Docker Hub

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,9 @@ jobs:
 
   create-docker-manifest:
     needs: [build-docker-arm64, build-docker-amd64]
+    if: |
+      needs.build-docker-arm64.result == 'success' &&
+      needs.build-docker-amd64.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Login to Docker Hub


### PR DESCRIPTION
## Summary
- The `create-docker-manifest` job in both `ci.yml` and `release.yml` was missing an `if:` condition, so GitHub Actions skipped it by default whenever a `needs` job ended in `skipped` state. Result: no multi-arch `latest` manifest was ever published and releases silently produced nothing.
- Added `if: needs.build-docker-arm64.result == 'success' && needs.build-docker-amd64.result == 'success'` to both workflows so the manifest job runs exactly when both arch builds succeed.
- Preferred over `if: always()` — avoids publishing a manifest against missing/stale arch tags when builds fail or are skipped.

## Test plan
- [ ] Merge, then push a trivial `docker/**` change on a branch and confirm `create-docker-manifest` runs green and Docker Hub shows a fresh multi-arch `latest`.
- [ ] Confirm a non-docker change (e.g. workflow-only) cleanly skips the manifest job rather than failing.
- [ ] Next tag release publishes the versioned multi-arch manifest end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)