### PR TITLE
fix tags field editable in receipt form view mode

### DIFF
--- a/desktop/src/receipts/receipt-form/receipt-form.component.html
+++ b/desktop/src/receipts/receipt-form/receipt-form.component.html
@@ -64,6 +64,7 @@
                 class="w-100"
                 [inputFormControl]="form | formGet : 'tags'"
                 [tags]="tags"
+                [readonly]="mode | inputReadonly"
               ></app-tag-autocomplete>
             }
             <app-datepicker


### PR DESCRIPTION
## Summary
- Adds the missing `[readonly]="mode | inputReadonly"` binding to `<app-tag-autocomplete>` on the receipt form so tags can't be added/removed in view mode.
- Audited every other field on the receipt form; tags was the only one missing the binding. Categories, item-list, and share-list autocompletes already forward readonly correctly.

Closes #484

## Test plan
- [ ] Open an existing receipt in view mode — tag chips have no remove button and the tag input is readonly
- [ ] Categories and all other fields remain non-editable in view mode (regression check)
- [ ] Switch to edit mode — tags can be added/removed normally
- [ ] Open in add mode — tags can be added/removed normally
- [ ] `npm run build` and `npm test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)