### PR TITLE
fix vision images not sent for OPEN_AI_CUSTOM_NEW ai type

### DIFF
--- a/api/internal/services/receipt_processing.go
+++ b/api/internal/services/receipt_processing.go
@@ -191,7 +191,7 @@ func (service ReceiptProcessingService) processImage(
 				base64Image = ollamaImage
 			}
 
-			if receiptProcessingSettings.AiType == models.OPEN_AI_NEW || receiptProcessingSettings.AiType == models.OPEN_AI_CUSTOM {
+			if receiptProcessingSettings.AiType == models.OPEN_AI_NEW || receiptProcessingSettings.AiType == models.OPEN_AI_CUSTOM || receiptProcessingSettings.AiType == models.OPEN_AI_CUSTOM_NEW {
 				openAiImage, err := service.getOpenAiBase64Image(imagePath)
 				if err != nil {
 					return result, err


### PR DESCRIPTION
## Summary
- Adds `OPEN_AI_CUSTOM_NEW` to the vision-image encoding condition in `processImage` so custom OpenAI-compatible endpoints (Groq, etc.) actually attach images when vision mode is enabled.
- Fixes #495.

The legacy `OPEN_AI_CUSTOM` constant has value `"openAiCustom"`, while `OPEN_AI_CUSTOM_NEW` has value `"OPEN_AI_CUSTOM"` — which is what the database stores. The previous condition only matched the legacy value, so current configs silently skipped image encoding.

## Test plan
- [ ] Configure a custom OpenAI endpoint (e.g., Groq with a vision model) and enable vision mode
- [ ] Quick-scan a receipt and verify real data is extracted rather than placeholder values
- [ ] Regression: confirm `OPEN_AI`, legacy `openAiCustom`, Ollama, and Gemini vision flows still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)