### PR TITLE
fix duplicate-receipt navigate button not updating page (issue #442)

### DIFF
--- a/desktop/setup-jest.ts
+++ b/desktop/setup-jest.ts
@@ -1,3 +1,9 @@
 import { setupZonelessTestEnv } from 'jest-preset-angular/setup-env/zoneless';
 
 setupZonelessTestEnv();
+
+// jsdom does not implement HTMLCanvasElement.getContext; ng2-charts calls it
+// during component initialization, which spams console.error in otherwise
+// passing test runs. Returning null matches the no-op behavior the charts
+// already tolerate under jsdom.
+HTMLCanvasElement.prototype.getContext = jest.fn(() => null) as any;

--- a/desktop/src/dashboard/dashboard/dashboard.component.spec.ts
+++ b/desktop/src/dashboard/dashboard/dashboard.component.spec.ts
@@ -62,6 +62,7 @@ describe("DashboardComponent", () => {
     store = TestBed.inject(Store);
 
     store.reset({
+      ...store.snapshot(),
       dashboards: {
         dashboards: {
           "1": dashboards,

--- a/desktop/src/dashboard/group-dashboards/group-dashboards.component.spec.ts
+++ b/desktop/src/dashboard/group-dashboards/group-dashboards.component.spec.ts
@@ -48,7 +48,9 @@ describe("GroupDashboardsComponent", () => {
     });
     store = TestBed.inject(Store);
     store.reset({
+      ...store.snapshot(),
       groups: {
+        ...store.snapshot().groups,
         selectedGroupId: "1",
         groups: [],
       },
@@ -72,7 +74,9 @@ describe("GroupDashboardsComponent", () => {
       },
     ];
     store.reset({
+      ...store.snapshot(),
       groups: {
+        ...store.snapshot().groups,
         selectedGroupId: "1",
       },
       dashboards: {
@@ -106,7 +110,9 @@ describe("GroupDashboardsComponent", () => {
     ];
     const activatedRoute = TestBed.inject(ActivatedRoute);
     store.reset({
+      ...store.snapshot(),
       groups: {
+        ...store.snapshot().groups,
         selectedGroupId: "1",
       },
       dashboards: {
@@ -120,7 +126,9 @@ describe("GroupDashboardsComponent", () => {
     expect(component.dashboards()).toEqual(dashboards);
 
     store.reset({
+      ...store.snapshot(),
       groups: {
+        ...store.snapshot().groups,
         selectedGroupId: "2",
       },
       dashboards: {
@@ -140,7 +148,9 @@ describe("GroupDashboardsComponent", () => {
   it("should not navigate to selected dashboard", () => {
     const routerSpy = jest.spyOn(TestBed.inject(Router), "navigateByUrl");
     store.reset({
+      ...store.snapshot(),
       groups: {
+        ...store.snapshot().groups,
         selectedDashboardId: undefined,
       },
     });

--- a/desktop/src/group/group-settings-email/group-settings-email.component.spec.ts
+++ b/desktop/src/group/group-settings-email/group-settings-email.component.spec.ts
@@ -63,8 +63,6 @@ describe("GroupSettingsEmailComponent", () => {
   it("should init form with empty values", () => {
     component.ngOnInit();
 
-    console.log(component.form.value);
-
     expect(component.form.value).toEqual({
       systemEmailId: undefined,
       emailIntegrationEnabled: undefined,

--- a/desktop/src/receipts/receipt-form/receipt-form.component.spec.ts
+++ b/desktop/src/receipts/receipt-form/receipt-form.component.spec.ts
@@ -7,7 +7,7 @@ import { MatDialogModule } from "@angular/material/dialog";
 import { MatSnackBarModule } from "@angular/material/snack-bar";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { ActivatedRoute } from "@angular/router";
-import { of } from "rxjs";
+import { BehaviorSubject, of } from "rxjs";
 import { FormMode } from "src/enums/form-mode.enum";
 import { PipesModule } from "src/pipes/pipes.module";
 import { SharedUiModule } from "src/shared-ui/shared-ui.module";
@@ -20,8 +20,10 @@ import { ReceiptFormComponent } from "./receipt-form.component";
 describe("ReceiptFormComponent", () => {
   let component: ReceiptFormComponent;
   let fixture: ComponentFixture<ReceiptFormComponent>;
+  let routeDataSubject: BehaviorSubject<any>;
 
   beforeEach(async () => {
+    routeDataSubject = new BehaviorSubject<any>({});
     await TestBed.configureTestingModule({
       declarations: [ReceiptFormComponent],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -41,7 +43,9 @@ describe("ReceiptFormComponent", () => {
           useValue: {
             snapshot: {
               data: {}, queryParams: {}
-            }, params: of({})
+            },
+            data: routeDataSubject,
+            params: of({})
           },
         },
         provideHttpClient(withInterceptorsFromDi()),
@@ -246,14 +250,31 @@ describe("ReceiptFormComponent", () => {
       ids: ["1", "2", "3"],
       queueMode: QueueMode.VIEW,
     };
-    TestBed.inject(ActivatedRoute).snapshot.data = {
+    routeDataSubject.next({
       receipt: { id: 2 } as any,
-    };
-    component.ngOnInit();
+    });
 
     expect(component.queueIndex).toEqual(1);
     expect(component.queueIds).toEqual(["1", "2", "3"]);
     expect(component.queueMode).toEqual(QueueMode.VIEW);
     expect(component.submitButtonText).toEqual("Save & Next");
+  });
+
+  it("rebuilds form state when route data emits a new receipt (duplicate navigation)", () => {
+    routeDataSubject.next({
+      receipt: { id: 1, name: "Original", amount: "10.00", customFields: [] } as any,
+    });
+
+    expect(component.originalReceipt?.id).toEqual(1);
+    expect(component.form.get("name")?.value).toEqual("Original");
+    expect(component.editLink).toEqual("/receipts/1/edit");
+
+    routeDataSubject.next({
+      receipt: { id: 2, name: "Duplicate", amount: "10.00", customFields: [] } as any,
+    });
+
+    expect(component.originalReceipt?.id).toEqual(2);
+    expect(component.form.get("name")?.value).toEqual("Duplicate");
+    expect(component.editLink).toEqual("/receipts/2/edit");
   });
 });

--- a/desktop/src/receipts/receipt-form/receipt-form.component.ts
+++ b/desktop/src/receipts/receipt-form/receipt-form.component.ts
@@ -181,29 +181,34 @@ export class ReceiptFormComponent implements OnInit {
   public form: FormGroup = new FormGroup({});
 
   public ngOnInit(): void {
-    this.categories = this.activatedRoute.snapshot.data["categories"] ?? [];
-    this.tags = this.activatedRoute.snapshot.data["tags"] ?? [];
-    this.customFields = this.activatedRoute.snapshot.data["customFields"] ?? [];
-    this.originalReceipt = this.activatedRoute.snapshot.data["receipt"];
-    this.editLink = `/receipts/${this.originalReceipt?.id}/edit`;
-    this.mode = this.activatedRoute.snapshot.data["mode"];
-    this.customFieldsStatefulMenuItems = this.customFields.map(c => {
-      const selected = this.originalReceipt?.customFields.some(customField => customField.customFieldId === c.id) ?? false;
+    this.activatedRoute.data
+      .pipe(untilDestroyed(this))
+      .subscribe((data) => {
+        this.duplicatedSnackbarRef?.dismiss();
+        this.categories = data["categories"] ?? [];
+        this.tags = data["tags"] ?? [];
+        this.customFields = data["customFields"] ?? [];
+        this.originalReceipt = data["receipt"];
+        this.editLink = `/receipts/${this.originalReceipt?.id}/edit`;
+        this.mode = data["mode"];
+        this.customFieldsStatefulMenuItems = this.customFields.map(c => {
+          const selected = this.originalReceipt?.customFields.some(customField => customField.customFieldId === c.id) ?? false;
 
-      return {
-        value: c.id.toString(),
-        subtitle: this.customFieldTypePipe.transform(c.type),
-        displayValue: c.name,
-        selected: selected
-      };
-    });
-    this.setCancelLink();
-    this.initForm();
-    this.getImageFiles();
-    this.setHeaderText();
-    this.setShowLargeImagePreview();
-    this.setQueueData();
-    document.scrollingElement?.scrollTo(0, 0);
+          return {
+            value: c.id.toString(),
+            subtitle: this.customFieldTypePipe.transform(c.type),
+            displayValue: c.name,
+            selected: selected
+          };
+        });
+        this.setCancelLink();
+        this.initForm();
+        this.getImageFiles();
+        this.setHeaderText();
+        this.setShowLargeImagePreview();
+        this.setQueueData();
+        document.scrollingElement?.scrollTo(0, 0);
+      });
   }
 
   private setQueueData(): void {

--- a/desktop/src/shared-ui/status-icon/status-icon.component.spec.ts
+++ b/desktop/src/shared-ui/status-icon/status-icon.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatIconModule } from '@angular/material/icon';
 
 import { StatusIconComponent } from './status-icon.component';
 
@@ -8,7 +9,8 @@ describe('StatusIconComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [StatusIconComponent]
+      declarations: [StatusIconComponent],
+      imports: [MatIconModule],
     })
     .compileComponents();
     


### PR DESCRIPTION
## Summary
- Fix #442: navigating via the duplicate-receipt snackbar changed the URL but left the page showing the original receipt. `ReceiptFormComponent` is reused across `/receipts/:id/view` URLs, so `ngOnInit` only ran once and the snapshot-only route data read left the form pointed at the old receipt. Init logic now re-runs on each `activatedRoute.data` emission, and the open duplicate snackbar is dismissed when the new receipt lands.
- Silence console noise in the Jest test runs: stub `HTMLCanvasElement.getContext` in `setup-jest.ts` (ng2-charts canvas warnings), preserve existing store state in dashboard / group-dashboards spec `store.reset` calls (NGXS selector errors), import `MatIconModule` in the status-icon spec, and remove a stray `console.log` in the group-settings-email spec.

## Test plan
- [x] `npm test` in `desktop/` — 194 suites / 769 tests pass with zero console output
- [x] New regression spec in `receipt-form.component.spec.ts` covers re-init when route data emits a new receipt
- [ ] Manual: on desktop, view a receipt → Duplicate → click Navigate → confirm URL changes **and** the form shows the duplicated receipt
- [ ] Manual regression: initial view load, `/view` ↔ `/edit` toggle, queue navigation (`?ids=...&queueMode=...`), and `/receipts/add` all still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)