### PR TITLE
Add backend unit tests for auth + receipt/AI pipeline; fix 3 latent bugs

### DIFF
--- a/api/internal/ai/base_client_test.go
+++ b/api/internal/ai/base_client_test.go
@@ -1,0 +1,109 @@
+package ai
+
+import (
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/structs"
+	"receipt-wrangler/api/internal/utils"
+	"testing"
+)
+
+func newBaseClientWithKey(key string) BaseClient {
+	return BaseClient{
+		Options: structs.AiChatCompletionOptions{},
+		ReceiptProcessingSettings: models.ReceiptProcessingSettings{
+			Key: key,
+		},
+	}
+}
+
+func TestGetKey_NoDecrypt_ReturnsRawKey(t *testing.T) {
+	client := newBaseClientWithKey("raw-key-unchanged")
+
+	got, err := client.getKey(false)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if got != "raw-key-unchanged" {
+		utils.PrintTestError(t, got, "raw-key-unchanged")
+	}
+}
+
+func TestGetKey_DecryptWithEmptyKey_ReturnsEmpty(t *testing.T) {
+	client := newBaseClientWithKey("")
+
+	got, err := client.getKey(true)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if got != "" {
+		utils.PrintTestError(t, got, "")
+	}
+}
+
+func TestGetKey_DecryptRoundTrip(t *testing.T) {
+	encryptionKey := "test-encryption-key"
+	t.Setenv("ENCRYPTION_KEY", encryptionKey)
+
+	plaintext := "sk-proj-abc123"
+	encoded, err := utils.EncryptAndEncodeToBase64(encryptionKey, plaintext)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	client := newBaseClientWithKey(encoded)
+	got, err := client.getKey(true)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if got != plaintext {
+		utils.PrintTestError(t, got, plaintext)
+	}
+}
+
+func TestDecryptKey_InvalidBase64_ReturnsError(t *testing.T) {
+	t.Setenv("ENCRYPTION_KEY", "test-encryption-key")
+
+	// "@@@" is not valid base64.
+	client := newBaseClientWithKey("@@@")
+	_, err := client.decryptKey()
+	if err == nil {
+		utils.PrintTestError(t, err, "expected base64 decode error")
+	}
+}
+
+func TestDecryptKey_WrongEncryptionKey_ReturnsError(t *testing.T) {
+	goodKey := "the-good-key"
+	badKey := "the-bad-key"
+
+	encoded, err := utils.EncryptAndEncodeToBase64(goodKey, "payload")
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	t.Setenv("ENCRYPTION_KEY", badKey)
+	client := newBaseClientWithKey(encoded)
+
+	_, err = client.decryptKey()
+	if err == nil {
+		utils.PrintTestError(t, err, "expected decryption error")
+	}
+}
+
+func TestGetKey_Decrypt_DelegatesToDecryptKey(t *testing.T) {
+	encryptionKey := "consistent-key"
+	t.Setenv("ENCRYPTION_KEY", encryptionKey)
+
+	encoded, err := utils.EncryptAndEncodeToBase64(encryptionKey, "unwrapped")
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	client := newBaseClientWithKey(encoded)
+	got, err := client.getKey(true)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if got != "unwrapped" {
+		utils.PrintTestError(t, got, "unwrapped")
+	}
+}

--- a/api/internal/ai/main_test.go
+++ b/api/internal/ai/main_test.go
@@ -1,0 +1,26 @@
+package ai
+
+import (
+	"fmt"
+	"os"
+	"receipt-wrangler/api/internal/repositories"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	code, err := run(m)
+	if err != nil {
+		fmt.Println(err)
+	}
+	os.Exit(code)
+}
+
+func run(m *testing.M) (code int, err error) {
+	defer teardown()
+	repositories.SetUpTestEnv()
+	return m.Run(), nil
+}
+
+func teardown() {
+	os.RemoveAll("./logs")
+}

--- a/api/internal/ai/ollama_test.go
+++ b/api/internal/ai/ollama_test.go
@@ -1,0 +1,164 @@
+package ai
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/structs"
+	"receipt-wrangler/api/internal/utils"
+	"testing"
+)
+
+// capturedOllamaRequest is what a test inspects after the client POSTs.
+type capturedOllamaRequest struct {
+	Method      string
+	Path        string
+	ContentType string
+	Body        map[string]interface{}
+}
+
+// newMockOllamaServer stands up an httptest server that captures the request
+// the client sent and returns a caller-chosen status/body. Returns the
+// server, a pointer to the captured request (filled after Do), and a cleanup
+// func.
+func newMockOllamaServer(t *testing.T, statusCode int, responseBody string) (*httptest.Server, *capturedOllamaRequest) {
+	t.Helper()
+	captured := &capturedOllamaRequest{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.Method = r.Method
+		captured.Path = r.URL.Path
+		captured.ContentType = r.Header.Get("Content-Type")
+
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err == nil && len(bodyBytes) > 0 {
+			_ = json.Unmarshal(bodyBytes, &captured.Body)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_, _ = w.Write([]byte(responseBody))
+	}))
+
+	t.Cleanup(server.Close)
+	return server, captured
+}
+
+func newOllamaClient(url, model string, enforceJSON bool, messages []structs.AiClientMessage) *OllamaClient {
+	return NewOllamaClient(
+		structs.AiChatCompletionOptions{
+			Messages:   messages,
+			DecryptKey: false,
+		},
+		models.ReceiptProcessingSettings{
+			Url:                       url,
+			Model:                     model,
+			EnforceJsonResponseFormat: enforceJSON,
+		},
+	)
+}
+
+func ollamaSuccessBody(content string) string {
+	resp := structs.OllamaTextResponse{}
+	resp.Model = "test-model"
+	resp.Message.Role = "assistant"
+	resp.Message.Content = content
+	resp.Done = true
+	raw, _ := json.Marshal(resp)
+	return string(raw)
+}
+
+func TestOllamaGetChatCompletion_HappyPath(t *testing.T) {
+	server, captured := newMockOllamaServer(t, http.StatusOK, ollamaSuccessBody("hello from ollama"))
+
+	client := newOllamaClient(server.URL, "llama3", false, []structs.AiClientMessage{
+		{Role: "user", Content: "hi"},
+	})
+	result, err := client.GetChatCompletion()
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	if result.Response != "hello from ollama" {
+		utils.PrintTestError(t, result.Response, "hello from ollama")
+	}
+	if result.RawResponse == "" {
+		utils.PrintTestError(t, "empty RawResponse", "non-empty")
+	}
+
+	if captured.Method != http.MethodPost {
+		utils.PrintTestError(t, captured.Method, http.MethodPost)
+	}
+	if captured.ContentType != "application/json" {
+		utils.PrintTestError(t, captured.ContentType, "application/json")
+	}
+	if captured.Body["model"] != "llama3" {
+		utils.PrintTestError(t, captured.Body["model"], "llama3")
+	}
+	if _, ok := captured.Body["format"]; ok {
+		utils.PrintTestError(t, "format field set unexpectedly", "format field absent when EnforceJsonResponseFormat=false")
+	}
+	// JSON numbers decode as float64
+	if v, ok := captured.Body["temperature"]; !ok || v.(float64) != 0 {
+		utils.PrintTestError(t, captured.Body["temperature"], float64(0))
+	}
+	if captured.Body["stream"] != false {
+		utils.PrintTestError(t, captured.Body["stream"], false)
+	}
+}
+
+func TestOllamaGetChatCompletion_EnforceJsonFormat(t *testing.T) {
+	server, captured := newMockOllamaServer(t, http.StatusOK, ollamaSuccessBody("{}"))
+
+	client := newOllamaClient(server.URL, "llama3", true, []structs.AiClientMessage{
+		{Role: "user", Content: "hi"},
+	})
+	_, err := client.GetChatCompletion()
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	if captured.Body["format"] != "json" {
+		utils.PrintTestError(t, captured.Body["format"], "json")
+	}
+}
+
+func TestOllamaGetChatCompletion_MalformedResponseBody(t *testing.T) {
+	server, _ := newMockOllamaServer(t, http.StatusOK, "not json at all")
+
+	client := newOllamaClient(server.URL, "llama3", false, []structs.AiClientMessage{
+		{Role: "user", Content: "hi"},
+	})
+	_, err := client.GetChatCompletion()
+	if err == nil {
+		utils.PrintTestError(t, err, "expected unmarshal error")
+	}
+}
+
+func TestOllamaGetChatCompletion_InvalidUrl(t *testing.T) {
+	// Completely invalid URL (percent-encoding parse error) → http.NewRequest
+	// itself fails before the network is touched.
+	client := newOllamaClient("http://%zz-not-valid", "m", false, nil)
+
+	_, err := client.GetChatCompletion()
+	if err == nil {
+		utils.PrintTestError(t, err, "expected request construction error")
+	}
+}
+
+func TestOllamaGetChatCompletion_ConnectionError(t *testing.T) {
+	server, _ := newMockOllamaServer(t, http.StatusOK, ollamaSuccessBody(""))
+	// Close immediately so the next request fails at the transport layer.
+	url := server.URL
+	server.Close()
+
+	client := newOllamaClient(url, "m", false, []structs.AiClientMessage{
+		{Role: "user", Content: "hi"},
+	})
+	_, err := client.GetChatCompletion()
+	if err == nil {
+		utils.PrintTestError(t, err, "expected connection error")
+	}
+}

--- a/api/internal/ai/open_ai.go
+++ b/api/internal/ai/open_ai.go
@@ -2,6 +2,7 @@ package ai
 
 import (
 	"encoding/json"
+	"errors"
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/structs"
 	"strings"
@@ -119,6 +120,9 @@ func (openAi OpenAiClient) GetChatCompletion() (structs.ChatCompletionResult, er
 	}
 
 	result.RawResponse = string(responseBytes)
+	if len(resp.Choices) == 0 {
+		return result, errors.New("empty choices from provider")
+	}
 	result.Response = resp.Choices[0].Message.Content
 	return result, nil
 }

--- a/api/internal/ai/open_ai_test.go
+++ b/api/internal/ai/open_ai_test.go
@@ -1,0 +1,274 @@
+package ai
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/structs"
+	"receipt-wrangler/api/internal/utils"
+	"strings"
+	"testing"
+)
+
+type capturedOpenAiRequest struct {
+	Method      string
+	Path        string
+	ContentType string
+	Body        map[string]interface{}
+}
+
+func newMockOpenAiServer(t *testing.T, statusCode int, responseBody string) (*httptest.Server, *capturedOpenAiRequest) {
+	t.Helper()
+	captured := &capturedOpenAiRequest{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.Method = r.Method
+		captured.Path = r.URL.Path
+		captured.ContentType = r.Header.Get("Content-Type")
+
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err == nil && len(bodyBytes) > 0 {
+			_ = json.Unmarshal(bodyBytes, &captured.Body)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_, _ = w.Write([]byte(responseBody))
+	}))
+
+	t.Cleanup(server.Close)
+	return server, captured
+}
+
+func openAiSuccessBody(content string) string {
+	resp := map[string]interface{}{
+		"id":      "chatcmpl-test",
+		"object":  "chat.completion",
+		"created": 1234567890,
+		"model":   "gpt-3.5-turbo",
+		"choices": []map[string]interface{}{
+			{
+				"index": 0,
+				"message": map[string]interface{}{
+					"role":    "assistant",
+					"content": content,
+				},
+				"finish_reason": "stop",
+			},
+		},
+	}
+	raw, _ := json.Marshal(resp)
+	return string(raw)
+}
+
+func newOpenAiClient(url, model, apiKey string, enforceJSON bool, messages []structs.AiClientMessage) *OpenAiClient {
+	return NewOpenAiClient(
+		structs.AiChatCompletionOptions{
+			Messages:   messages,
+			DecryptKey: false,
+		},
+		models.ReceiptProcessingSettings{
+			Url:                       url,
+			Model:                     model,
+			Key:                       apiKey,
+			EnforceJsonResponseFormat: enforceJSON,
+		},
+	)
+}
+
+func TestOpenAiGetChatCompletion_HappyPath_TextOnly(t *testing.T) {
+	server, captured := newMockOpenAiServer(t, http.StatusOK, openAiSuccessBody("hello from openai"))
+
+	client := newOpenAiClient(server.URL, "gpt-4o-mini", "test-key", false, []structs.AiClientMessage{
+		{Role: "user", Content: "hi"},
+	})
+	result, err := client.GetChatCompletion()
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	if result.Response != "hello from openai" {
+		utils.PrintTestError(t, result.Response, "hello from openai")
+	}
+	if result.RawResponse == "" {
+		utils.PrintTestError(t, "empty RawResponse", "non-empty")
+	}
+
+	if captured.Method != http.MethodPost {
+		utils.PrintTestError(t, captured.Method, http.MethodPost)
+	}
+	if !strings.Contains(captured.Path, "chat/completions") {
+		utils.PrintTestError(t, captured.Path, "path containing chat/completions")
+	}
+	if captured.Body["model"] != "gpt-4o-mini" {
+		utils.PrintTestError(t, captured.Body["model"], "gpt-4o-mini")
+	}
+	if _, hasRespFmt := captured.Body["response_format"]; hasRespFmt {
+		utils.PrintTestError(t, "response_format present for non-JSON mode", "absent")
+	}
+}
+
+func TestOpenAiGetChatCompletion_EnforceJsonResponseFormat(t *testing.T) {
+	server, captured := newMockOpenAiServer(t, http.StatusOK, openAiSuccessBody("{}"))
+
+	client := newOpenAiClient(server.URL, "gpt-4o-mini", "test-key", true, []structs.AiClientMessage{
+		{Role: "user", Content: "hi"},
+	})
+	_, err := client.GetChatCompletion()
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	respFmt, ok := captured.Body["response_format"].(map[string]interface{})
+	if !ok {
+		utils.PrintTestError(t, captured.Body["response_format"], "json_object response_format object")
+		return
+	}
+	if respFmt["type"] != "json_object" {
+		utils.PrintTestError(t, respFmt["type"], "json_object")
+	}
+}
+
+func TestOpenAiGetChatCompletion_DefaultModelWhenEmpty(t *testing.T) {
+	server, captured := newMockOpenAiServer(t, http.StatusOK, openAiSuccessBody("ok"))
+
+	// Empty model → default gpt-3.5-turbo.
+	client := newOpenAiClient(server.URL, "", "test-key", false, []structs.AiClientMessage{
+		{Role: "user", Content: "hi"},
+	})
+	_, err := client.GetChatCompletion()
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	if captured.Body["model"] != "gpt-3.5-turbo" {
+		utils.PrintTestError(t, captured.Body["model"], "gpt-3.5-turbo")
+	}
+}
+
+func TestOpenAiGetChatCompletion_VisionMessageIncludesImagePart(t *testing.T) {
+	server, captured := newMockOpenAiServer(t, http.StatusOK, openAiSuccessBody("looks like a receipt"))
+
+	client := newOpenAiClient(server.URL, "gpt-4o-mini", "test-key", false, []structs.AiClientMessage{
+		{
+			Role:    "user",
+			Content: "What's in this image?",
+			Images:  []string{"data:image/png;base64,iVBORw0K"},
+		},
+	})
+	_, err := client.GetChatCompletion()
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	// Messages is an array; each element has a content array with text + image_url parts.
+	messages, ok := captured.Body["messages"].([]interface{})
+	if !ok || len(messages) == 0 {
+		utils.PrintTestError(t, captured.Body["messages"], "non-empty array")
+		return
+	}
+	first, _ := messages[0].(map[string]interface{})
+	parts, ok := first["content"].([]interface{})
+	if !ok || len(parts) != 2 {
+		utils.PrintTestError(t, first["content"], "two-part content array")
+		return
+	}
+
+	textPart, _ := parts[0].(map[string]interface{})
+	imagePart, _ := parts[1].(map[string]interface{})
+	if textPart["type"] != "text" {
+		utils.PrintTestError(t, textPart["type"], "text")
+	}
+	if imagePart["type"] != "image_url" {
+		utils.PrintTestError(t, imagePart["type"], "image_url")
+	}
+	imageUrl, _ := imagePart["image_url"].(map[string]interface{})
+	if imageUrl["url"] != "data:image/png;base64,iVBORw0K" {
+		utils.PrintTestError(t, imageUrl["url"], "data:image/png;base64,iVBORw0K")
+	}
+}
+
+func TestOpenAiGetChatCompletion_HttpError500(t *testing.T) {
+	server, _ := newMockOpenAiServer(t, http.StatusInternalServerError, `{"error":{"message":"server error"}}`)
+
+	client := newOpenAiClient(server.URL, "gpt-4o-mini", "test-key", false, []structs.AiClientMessage{
+		{Role: "user", Content: "hi"},
+	})
+	result, err := client.GetChatCompletion()
+	if err == nil {
+		utils.PrintTestError(t, err, "expected error from 500 response")
+	}
+	// RawResponse should carry a marshaled (possibly empty) response struct.
+	if result.RawResponse == "" {
+		utils.PrintTestError(t, "empty RawResponse on error", "non-empty marshaled response")
+	}
+}
+
+func TestOpenAiGetChatCompletion_DecryptError(t *testing.T) {
+	server, _ := newMockOpenAiServer(t, http.StatusOK, openAiSuccessBody("ok"))
+
+	// DecryptKey=true with an invalid base64 key → getKey returns an error
+	// BEFORE any HTTP is attempted.
+	t.Setenv("ENCRYPTION_KEY", "whatever")
+
+	client := NewOpenAiClient(
+		structs.AiChatCompletionOptions{
+			Messages:   []structs.AiClientMessage{{Role: "user", Content: "hi"}},
+			DecryptKey: true,
+		},
+		models.ReceiptProcessingSettings{
+			Url: server.URL,
+			Key: "@@@", // not valid base64
+		},
+	)
+	_, err := client.GetChatCompletion()
+	if err == nil {
+		utils.PrintTestError(t, err, "expected decrypt error")
+	}
+}
+
+// Empty choices[] response: the client must return a clean error and keep
+// RawResponse populated for debuggability, rather than panicking on the
+// pre-fix `resp.Choices[0]` read (BUG-4).
+func TestOpenAiGetChatCompletion_EmptyChoicesReturnsError(t *testing.T) {
+	server, _ := newMockOpenAiServer(t, http.StatusOK, `{"id":"x","object":"chat.completion","created":1,"model":"gpt-3.5-turbo","choices":[]}`)
+
+	client := newOpenAiClient(server.URL, "gpt-3.5-turbo", "test-key", false, []structs.AiClientMessage{
+		{Role: "user", Content: "hi"},
+	})
+	result, err := client.GetChatCompletion()
+	if err == nil {
+		utils.PrintTestError(t, err, "expected error for empty choices")
+	}
+	if result.RawResponse == "" {
+		utils.PrintTestError(t, "empty RawResponse", "raw server body preserved for logging")
+	}
+	if result.Response != "" {
+		utils.PrintTestError(t, result.Response, "")
+	}
+}
+
+// Azure branch (URL contains "azure"): verifies the conditional path compiles
+// and executes without panicking. Points at a server whose URL path contains
+// "azure" to trigger the DefaultAzureConfig branch; the mock happily responds
+// to whatever path the SDK actually uses.
+func TestOpenAiGetChatCompletion_AzureBranch(t *testing.T) {
+	server, _ := newMockOpenAiServer(t, http.StatusOK, openAiSuccessBody("azure-ok"))
+
+	// Embed "azure" in the path so the URL string contains "azure" but the
+	// httptest server still handles the request.
+	url := server.URL + "/azure-deployment"
+
+	client := newOpenAiClient(url, "gpt-4o-mini", "test-key", false, []structs.AiClientMessage{
+		{Role: "user", Content: "hi"},
+	})
+	result, _ := client.GetChatCompletion()
+	// We don't assert on err — Azure SDK may build a different URL structure
+	// the mock doesn't fully satisfy; coverage of the branch is the goal.
+	// But if it succeeded, the response content should round-trip.
+	if result.Response != "" && result.Response != "azure-ok" {
+		utils.PrintTestError(t, result.Response, "azure-ok")
+	}
+}

--- a/api/internal/handlers/login_test.go
+++ b/api/internal/handlers/login_test.go
@@ -1,0 +1,297 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"receipt-wrangler/api/internal/commands"
+	"receipt-wrangler/api/internal/constants"
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/repositories"
+	"receipt-wrangler/api/internal/structs"
+	"receipt-wrangler/api/internal/utils"
+	"testing"
+)
+
+func teardownLoginTests() {
+	repositories.TruncateTestDb()
+}
+
+// loginRequest builds a request with the given login command in the context
+// and an optional query string appended to the URL. When userAgent is
+// non-empty it's set on the request (used to simulate mobile clients).
+func loginRequest(cmd commands.LoginCommand, query, userAgent string) *http.Request {
+	url := "/api/login"
+	if query != "" {
+		url += "?" + query
+	}
+	r := httptest.NewRequest(http.MethodPost, url, nil)
+	r = r.WithContext(context.WithValue(r.Context(), "user", cmd))
+	if userAgent != "" {
+		r.Header.Set("User-Agent", userAgent)
+	}
+	return r
+}
+
+func createAdminUser(t *testing.T, username, password string) models.User {
+	t.Helper()
+	userRepo := repositories.NewUserRepository(nil)
+	user, err := userRepo.CreateUser(commands.SignUpCommand{
+		Username:    username,
+		Password:    password,
+		DisplayName: username,
+	})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	// CreateUser auto-promotes the first user to ADMIN; subsequent users
+	// default to USER. Force ADMIN explicitly for non-first users so the
+	// caller gets a predictable role.
+	if user.UserRole != models.ADMIN {
+		repositories.GetDB().Model(&models.User{}).Where("id = ?", user.ID).Update("user_role", models.ADMIN)
+		user.UserRole = models.ADMIN
+	}
+	return user
+}
+
+func TestLogin_UserNotFound(t *testing.T) {
+	defer teardownLoginTests()
+
+	w := httptest.NewRecorder()
+	r := loginRequest(commands.LoginCommand{Username: "nobody", Password: "pw"}, "", "")
+
+	Login(w, r)
+
+	if w.Result().StatusCode != http.StatusInternalServerError {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusInternalServerError)
+	}
+}
+
+func TestLogin_WrongPassword(t *testing.T) {
+	defer teardownLoginTests()
+
+	createAdminUser(t, "wrongpw-user", "correctpassword")
+
+	w := httptest.NewRecorder()
+	r := loginRequest(commands.LoginCommand{Username: "wrongpw-user", Password: "not-the-password"}, "", "")
+
+	Login(w, r)
+
+	if w.Result().StatusCode != http.StatusInternalServerError {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusInternalServerError)
+	}
+}
+
+func TestLogin_DummyUserRejected(t *testing.T) {
+	defer teardownLoginTests()
+
+	userRepo := repositories.NewUserRepository(nil)
+	_, err := userRepo.CreateUser(commands.SignUpCommand{
+		Username:    "dummy-user",
+		Password:    "Password",
+		DisplayName: "Dummy",
+		IsDummyUser: true,
+	})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	w := httptest.NewRecorder()
+	r := loginRequest(commands.LoginCommand{Username: "dummy-user", Password: "Password"}, "", "")
+
+	Login(w, r)
+
+	if w.Result().StatusCode != http.StatusInternalServerError {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusInternalServerError)
+	}
+}
+
+func TestLogin_SuccessFirstAdminSetsCookies(t *testing.T) {
+	defer teardownLoginTests()
+
+	createAdminUser(t, "first-admin", "Password")
+
+	w := httptest.NewRecorder()
+	r := loginRequest(commands.LoginCommand{Username: "first-admin", Password: "Password"}, "", "")
+
+	Login(w, r)
+
+	if w.Result().StatusCode != http.StatusOK {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusOK)
+	}
+
+	jwtCookieSet, refreshCookieSet := false, false
+	for _, c := range w.Result().Cookies() {
+		if c.Name == constants.JwtKey && c.Value != "" {
+			jwtCookieSet = true
+		}
+		if c.Name == constants.RefreshTokenKey && c.Value != "" {
+			refreshCookieSet = true
+		}
+	}
+	if !jwtCookieSet {
+		utils.PrintTestError(t, "jwt cookie not set", "jwt cookie present")
+	}
+	if !refreshCookieSet {
+		utils.PrintTestError(t, "refresh_token cookie not set", "refresh_token cookie present")
+	}
+
+	// Body should parse as AppData. Since we're not in mobile/tokensInBody
+	// mode, Jwt/RefreshToken should be empty in the body.
+	var appData structs.AppData
+	if err := json.NewDecoder(w.Result().Body).Decode(&appData); err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if appData.Jwt != "" {
+		utils.PrintTestError(t, appData.Jwt, "")
+	}
+	if appData.RefreshToken != "" {
+		utils.PrintTestError(t, appData.RefreshToken, "")
+	}
+
+	// Verify the first-admin path also kicked off default-prompt creation.
+	var promptCount int64
+	repositories.GetDB().Model(&models.Prompt{}).Count(&promptCount)
+	if promptCount == 0 {
+		utils.PrintTestError(t, "no default prompt created", "at least 1 prompt")
+	}
+}
+
+func TestLogin_SuccessSubsequentAdmin(t *testing.T) {
+	defer teardownLoginTests()
+
+	createAdminUser(t, "admin-one", "Password")
+
+	// First login marks admin-one's LastLoginDate so the second login will
+	// take the firstAdminToLogin=false branch.
+	w := httptest.NewRecorder()
+	r := loginRequest(commands.LoginCommand{Username: "admin-one", Password: "Password"}, "", "")
+	Login(w, r)
+	if w.Result().StatusCode != http.StatusOK {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusOK)
+	}
+
+	// Second login — same admin, should return 200 without re-running the
+	// "first admin" branch.
+	w2 := httptest.NewRecorder()
+	r2 := loginRequest(commands.LoginCommand{Username: "admin-one", Password: "Password"}, "", "")
+	Login(w2, r2)
+	if w2.Result().StatusCode != http.StatusOK {
+		utils.PrintTestError(t, w2.Result().StatusCode, http.StatusOK)
+	}
+
+	// Only one default prompt should exist — the branch shouldn't have run twice.
+	var promptCount int64
+	repositories.GetDB().Model(&models.Prompt{}).Count(&promptCount)
+	if promptCount != 1 {
+		utils.PrintTestError(t, promptCount, int64(1))
+	}
+}
+
+func TestLogin_TokensInBodyQuery(t *testing.T) {
+	defer teardownLoginTests()
+
+	createAdminUser(t, "body-tokens-user", "Password")
+
+	w := httptest.NewRecorder()
+	r := loginRequest(commands.LoginCommand{Username: "body-tokens-user", Password: "Password"}, "tokensInBody=true", "")
+
+	Login(w, r)
+
+	if w.Result().StatusCode != http.StatusOK {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusOK)
+	}
+
+	// No cookies should be set when tokensInBody=true.
+	for _, c := range w.Result().Cookies() {
+		if c.Name == constants.JwtKey || c.Name == constants.RefreshTokenKey {
+			utils.PrintTestError(t, "cookie unexpectedly set: "+c.Name, "no auth cookies")
+		}
+	}
+
+	var appData structs.AppData
+	if err := json.NewDecoder(w.Result().Body).Decode(&appData); err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if appData.Jwt == "" {
+		utils.PrintTestError(t, "empty jwt in body", "jwt set")
+	}
+	if appData.RefreshToken == "" {
+		utils.PrintTestError(t, "empty refresh token in body", "refresh token set")
+	}
+}
+
+func TestLogin_MobileUserAgent(t *testing.T) {
+	defer teardownLoginTests()
+
+	createAdminUser(t, "mobile-user", "Password")
+
+	w := httptest.NewRecorder()
+	r := loginRequest(commands.LoginCommand{Username: "mobile-user", Password: "Password"}, "", "Dart/3.2 (dart:io)")
+
+	Login(w, r)
+
+	if w.Result().StatusCode != http.StatusOK {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusOK)
+	}
+
+	// Mobile path: body carries tokens AND cookies are still set (because
+	// tokensInBody query flag is false).
+	var appData structs.AppData
+	if err := json.NewDecoder(w.Result().Body).Decode(&appData); err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if appData.Jwt == "" {
+		utils.PrintTestError(t, "empty jwt for mobile", "jwt set")
+	}
+	if appData.RefreshToken == "" {
+		utils.PrintTestError(t, "empty refresh token for mobile", "refresh token set")
+	}
+
+	jwtCookieSet := false
+	for _, c := range w.Result().Cookies() {
+		if c.Name == constants.JwtKey {
+			jwtCookieSet = true
+		}
+	}
+	if !jwtCookieSet {
+		utils.PrintTestError(t, "jwt cookie missing for mobile", "jwt cookie present")
+	}
+}
+
+func TestLogin_NonAdminUserSkipsFirstAdminBranch(t *testing.T) {
+	defer teardownLoginTests()
+
+	// Seed an admin first so the next user defaults to USER.
+	createAdminUser(t, "seed-admin", "Password")
+
+	userRepo := repositories.NewUserRepository(nil)
+	_, err := userRepo.CreateUser(commands.SignUpCommand{
+		Username:    "regular-user",
+		Password:    "Password",
+		DisplayName: "Regular",
+	})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	// Baseline: no prompts exist yet.
+	var beforeCount int64
+	repositories.GetDB().Model(&models.Prompt{}).Count(&beforeCount)
+
+	w := httptest.NewRecorder()
+	r := loginRequest(commands.LoginCommand{Username: "regular-user", Password: "Password"}, "", "")
+	Login(w, r)
+
+	if w.Result().StatusCode != http.StatusOK {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusOK)
+	}
+
+	// Non-admin login must not create a default prompt.
+	var afterCount int64
+	repositories.GetDB().Model(&models.Prompt{}).Count(&afterCount)
+	if afterCount != beforeCount {
+		utils.PrintTestError(t, afterCount, beforeCount)
+	}
+}

--- a/api/internal/handlers/logout_test.go
+++ b/api/internal/handlers/logout_test.go
@@ -1,0 +1,57 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"receipt-wrangler/api/internal/constants"
+	"receipt-wrangler/api/internal/utils"
+	"testing"
+)
+
+func TestLogout_MobileClearsCookies(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/api/logout", nil)
+	r.Header.Set("User-Agent", "Dart/3.2 (dart:io)")
+	w := httptest.NewRecorder()
+
+	Logout(w, r)
+
+	if w.Result().StatusCode != http.StatusOK {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusOK)
+	}
+
+	jwtClear, refreshClear := false, false
+	for _, c := range w.Result().Cookies() {
+		if c.Name == constants.JwtKey && c.MaxAge == -1 && c.Value == "" {
+			jwtClear = true
+		}
+		if c.Name == constants.RefreshTokenKey && c.MaxAge == -1 && c.Value == "" {
+			refreshClear = true
+		}
+	}
+	if !jwtClear {
+		utils.PrintTestError(t, "jwt clearing cookie missing", "jwt cookie with MaxAge=-1 and empty value")
+	}
+	if !refreshClear {
+		utils.PrintTestError(t, "refresh_token clearing cookie missing", "refresh_token cookie with MaxAge=-1 and empty value")
+	}
+}
+
+// Non-mobile requests: Logout itself does not clear cookies — that's the
+// RevokeRefreshToken middleware's job in the real route chain. So the
+// handler just writes a 200.
+func TestLogout_NonMobileReturnsOkWithoutClearingCookies(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/api/logout", nil)
+	w := httptest.NewRecorder()
+
+	Logout(w, r)
+
+	if w.Result().StatusCode != http.StatusOK {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusOK)
+	}
+
+	for _, c := range w.Result().Cookies() {
+		if c.Name == constants.JwtKey || c.Name == constants.RefreshTokenKey {
+			utils.PrintTestError(t, "unexpected auth cookie on non-mobile logout: "+c.Name, "no auth cookies")
+		}
+	}
+}

--- a/api/internal/middleware/login_test.go
+++ b/api/internal/middleware/login_test.go
@@ -1,0 +1,98 @@
+package middleware
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"receipt-wrangler/api/internal/commands"
+	"receipt-wrangler/api/internal/utils"
+	"testing"
+)
+
+func invokeValidateLoginData(t *testing.T, userData commands.LoginCommand) *httptest.ResponseRecorder {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost, "/api/login", nil)
+	r = r.WithContext(context.WithValue(r.Context(), "user", userData))
+	w := httptest.NewRecorder()
+	handler := ValidateLoginData(createFakeHandler())
+	handler.ServeHTTP(w, r)
+	return w
+}
+
+func TestValidateLoginData_Valid(t *testing.T) {
+	w := invokeValidateLoginData(t, commands.LoginCommand{
+		Username: "user",
+		Password: "password",
+	})
+
+	if w.Result().StatusCode != http.StatusOK {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusOK)
+	}
+}
+
+func TestValidateLoginData_EmptyUsername(t *testing.T) {
+	w := invokeValidateLoginData(t, commands.LoginCommand{
+		Username: "",
+		Password: "password",
+	})
+
+	if w.Result().StatusCode != http.StatusBadRequest {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusBadRequest)
+	}
+
+	errors := map[string]string{}
+	if err := json.NewDecoder(w.Result().Body).Decode(&errors); err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if _, ok := errors["username"]; !ok {
+		utils.PrintTestError(t, "missing username error", "username key present")
+	}
+	if _, ok := errors["password"]; ok {
+		utils.PrintTestError(t, "password error unexpectedly present", "no password key")
+	}
+}
+
+func TestValidateLoginData_EmptyPassword(t *testing.T) {
+	w := invokeValidateLoginData(t, commands.LoginCommand{
+		Username: "user",
+		Password: "",
+	})
+
+	if w.Result().StatusCode != http.StatusBadRequest {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusBadRequest)
+	}
+
+	errors := map[string]string{}
+	if err := json.NewDecoder(w.Result().Body).Decode(&errors); err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if _, ok := errors["password"]; !ok {
+		utils.PrintTestError(t, "missing password error", "password key present")
+	}
+	if _, ok := errors["username"]; ok {
+		utils.PrintTestError(t, "username error unexpectedly present", "no username key")
+	}
+}
+
+func TestValidateLoginData_BothEmpty(t *testing.T) {
+	w := invokeValidateLoginData(t, commands.LoginCommand{
+		Username: "",
+		Password: "",
+	})
+
+	if w.Result().StatusCode != http.StatusBadRequest {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusBadRequest)
+	}
+
+	errors := map[string]string{}
+	if err := json.NewDecoder(w.Result().Body).Decode(&errors); err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if _, ok := errors["username"]; !ok {
+		utils.PrintTestError(t, "missing username error", "username key present")
+	}
+	if _, ok := errors["password"]; !ok {
+		utils.PrintTestError(t, "missing password error", "password key present")
+	}
+}

--- a/api/internal/middleware/refresh_token.go
+++ b/api/internal/middleware/refresh_token.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"receipt-wrangler/api/internal/commands"
 	"receipt-wrangler/api/internal/logging"
@@ -9,6 +10,8 @@ import (
 	"receipt-wrangler/api/internal/repositories"
 	"receipt-wrangler/api/internal/services"
 	"receipt-wrangler/api/internal/utils"
+
+	"gorm.io/gorm"
 )
 
 func ValidateRefreshToken(next http.Handler) http.Handler {
@@ -59,8 +62,19 @@ func RevokeRefreshToken(next http.Handler) http.Handler {
 		}
 
 		hashTokenString := utils.Sha256Hash([]byte(refreshTokenString.(string)))
-		err = db.Model(&models.RefreshToken{}).Where("token = ?", hashTokenString).Find(&dbToken).Error
+		err = db.Model(&models.RefreshToken{}).Where("token = ?", hashTokenString).First(&dbToken).Error
 		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				emptyAccessTokenCookie := services.GetEmptyAccessTokenCookie()
+				emptyRefreshTokenCookie := services.GetEmptyRefreshTokenCookie()
+
+				http.SetCookie(w, &emptyAccessTokenCookie)
+				http.SetCookie(w, &emptyRefreshTokenCookie)
+
+				utils.WriteCustomErrorResponse(w, errMessage, http.StatusInternalServerError)
+				logging.LogStd(logging.LOG_LEVEL_ERROR, "Refresh token not found")
+				return
+			}
 			utils.WriteCustomErrorResponse(w, errMessage, http.StatusInternalServerError)
 			logging.LogStd(logging.LOG_LEVEL_ERROR, err.Error())
 			return

--- a/api/internal/middleware/refresh_token_test.go
+++ b/api/internal/middleware/refresh_token_test.go
@@ -1,0 +1,349 @@
+package middleware
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"receipt-wrangler/api/internal/commands"
+	"receipt-wrangler/api/internal/constants"
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/repositories"
+	"receipt-wrangler/api/internal/services"
+	"receipt-wrangler/api/internal/utils"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newRefreshUser(t *testing.T) models.User {
+	t.Helper()
+	user := models.User{
+		Username:           "refresh-user",
+		Password:           "hashedpassword",
+		DisplayName:        "Refresh User",
+		UserRole:           models.ADMIN,
+		DefaultAvatarColor: "#00FF00",
+	}
+	if err := repositories.GetDB().Create(&user).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	return user
+}
+
+// getRefreshTokenFromRequest --------------------------------------------------
+
+func TestGetRefreshTokenFromRequest_CookiePresent(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/api/refresh", nil)
+	r.AddCookie(&http.Cookie{Name: constants.RefreshTokenKey, Value: "cookie-refresh-token"})
+	w := httptest.NewRecorder()
+
+	token, err := getRefreshTokenFromRequest(r, w)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if token != "cookie-refresh-token" {
+		utils.PrintTestError(t, token, "cookie-refresh-token")
+	}
+}
+
+func TestGetRefreshTokenFromRequest_NoCookie(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/api/refresh", nil)
+	w := httptest.NewRecorder()
+
+	_, err := getRefreshTokenFromRequest(r, w)
+	if err == nil {
+		utils.PrintTestError(t, err, "expected cookie-missing error")
+	}
+}
+
+func TestGetRefreshTokenFromRequest_MobileBodyWithToken(t *testing.T) {
+	body, _ := json.Marshal(commands.LogoutCommand{RefreshToken: "body-refresh-token"})
+	r := httptest.NewRequest(http.MethodPost, "/api/refresh", bytes.NewReader(body))
+	r.Header.Set("User-Agent", "Dart/3.2 (dart:io)")
+	w := httptest.NewRecorder()
+
+	token, err := getRefreshTokenFromRequest(r, w)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if token != "body-refresh-token" {
+		utils.PrintTestError(t, token, "body-refresh-token")
+	}
+}
+
+func TestGetRefreshTokenFromRequest_MobileEmptyBody(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/api/refresh", strings.NewReader(""))
+	r.Header.Set("User-Agent", "Dart/3.2 (dart:io)")
+	w := httptest.NewRecorder()
+
+	// Empty body -> json.Unmarshal returns "unexpected end of JSON input".
+	_, err := getRefreshTokenFromRequest(r, w)
+	if err == nil {
+		utils.PrintTestError(t, err, "expected JSON decode error")
+	}
+}
+
+// ValidateRefreshToken --------------------------------------------------------
+
+func TestValidateRefreshToken_ValidToken(t *testing.T) {
+	defer teardownAuthTest()
+	setupAuthTest()
+
+	user := newRefreshUser(t)
+	_, refreshToken, _, err := services.GenerateJWT(user.ID)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	r := httptest.NewRequest(http.MethodPost, "/api/refresh", nil)
+	r.AddCookie(&http.Cookie{Name: constants.RefreshTokenKey, Value: refreshToken})
+	w := httptest.NewRecorder()
+
+	nextCalled := false
+	var seenRefreshTokenString interface{}
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		seenRefreshTokenString = r.Context().Value("refreshTokenString")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ValidateRefreshToken(nextHandler).ServeHTTP(w, r)
+
+	if !nextCalled {
+		utils.PrintTestError(t, "next not called", "next called")
+	}
+	if w.Result().StatusCode != http.StatusOK {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusOK)
+	}
+	if seenRefreshTokenString != refreshToken {
+		utils.PrintTestError(t, seenRefreshTokenString, refreshToken)
+	}
+}
+
+func TestValidateRefreshToken_MissingToken(t *testing.T) {
+	defer teardownAuthTest()
+	setupAuthTest()
+
+	r := httptest.NewRequest(http.MethodPost, "/api/refresh", nil)
+	w := httptest.NewRecorder()
+
+	ValidateRefreshToken(createFakeHandler()).ServeHTTP(w, r)
+
+	if w.Result().StatusCode != http.StatusInternalServerError {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusInternalServerError)
+	}
+}
+
+func TestValidateRefreshToken_InvalidToken(t *testing.T) {
+	defer teardownAuthTest()
+	setupAuthTest()
+
+	r := httptest.NewRequest(http.MethodPost, "/api/refresh", nil)
+	r.AddCookie(&http.Cookie{Name: constants.RefreshTokenKey, Value: "not-a-real-jwt"})
+	w := httptest.NewRecorder()
+
+	ValidateRefreshToken(createFakeHandler()).ServeHTTP(w, r)
+
+	if w.Result().StatusCode != http.StatusInternalServerError {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusInternalServerError)
+	}
+}
+
+// RevokeRefreshToken ----------------------------------------------------------
+
+func seedRefreshToken(t *testing.T, userId uint, used bool) string {
+	t.Helper()
+	raw := "raw-refresh-" + time.Now().Format(time.RFC3339Nano)
+	token := models.RefreshToken{
+		UserId:    userId,
+		Token:     utils.Sha256Hash([]byte(raw)),
+		IsUsed:    used,
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}
+	if err := repositories.GetDB().Create(&token).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	return raw
+}
+
+func TestRevokeRefreshToken_UnusedToken(t *testing.T) {
+	defer teardownAuthTest()
+	setupAuthTest()
+
+	user := newRefreshUser(t)
+	raw := seedRefreshToken(t, user.ID, false)
+
+	r := httptest.NewRequest(http.MethodPost, "/api/refresh", nil)
+	r.AddCookie(&http.Cookie{Name: constants.RefreshTokenKey, Value: raw})
+	w := httptest.NewRecorder()
+
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	RevokeRefreshToken(next).ServeHTTP(w, r)
+
+	if !nextCalled {
+		utils.PrintTestError(t, "next not called", "next called")
+	}
+	if w.Result().StatusCode != http.StatusOK {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusOK)
+	}
+
+	// IsUsed should now be true.
+	var dbToken models.RefreshToken
+	if err := repositories.GetDB().Where("token = ?", utils.Sha256Hash([]byte(raw))).First(&dbToken).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if !dbToken.IsUsed {
+		utils.PrintTestError(t, dbToken.IsUsed, true)
+	}
+}
+
+func TestRevokeRefreshToken_AlreadyUsedToken(t *testing.T) {
+	defer teardownAuthTest()
+	setupAuthTest()
+
+	user := newRefreshUser(t)
+	raw := seedRefreshToken(t, user.ID, true)
+
+	r := httptest.NewRequest(http.MethodPost, "/api/refresh", nil)
+	r.AddCookie(&http.Cookie{Name: constants.RefreshTokenKey, Value: raw})
+	w := httptest.NewRecorder()
+
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	RevokeRefreshToken(next).ServeHTTP(w, r)
+
+	if nextCalled {
+		utils.PrintTestError(t, "next called on already-used token", "next not called")
+	}
+	if w.Result().StatusCode != http.StatusInternalServerError {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusInternalServerError)
+	}
+
+	// Verify the handler set clearing cookies.
+	foundJwt, foundRefresh := false, false
+	for _, c := range w.Result().Cookies() {
+		if c.Name == constants.JwtKey && c.MaxAge == -1 {
+			foundJwt = true
+		}
+		if c.Name == constants.RefreshTokenKey && c.MaxAge == -1 {
+			foundRefresh = true
+		}
+	}
+	if !foundJwt {
+		utils.PrintTestError(t, "jwt clearing cookie missing", "jwt cookie with MaxAge=-1")
+	}
+	if !foundRefresh {
+		utils.PrintTestError(t, "refresh clearing cookie missing", "refresh cookie with MaxAge=-1")
+	}
+}
+
+// Covers the fallback path where the context does NOT carry
+// "refreshTokenString" AND the request has no cookie — we expect a 500.
+func TestRevokeRefreshToken_NoContextNoCookie(t *testing.T) {
+	defer teardownAuthTest()
+	setupAuthTest()
+
+	r := httptest.NewRequest(http.MethodPost, "/api/refresh", nil)
+	w := httptest.NewRecorder()
+
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	RevokeRefreshToken(next).ServeHTTP(w, r)
+
+	if nextCalled {
+		utils.PrintTestError(t, "next called with no refresh token", "next not called")
+	}
+	if w.Result().StatusCode != http.StatusInternalServerError {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusInternalServerError)
+	}
+}
+
+// Token not found: the middleware must treat an unknown token as an auth
+// failure, clear the auth cookies, and return 500 — the same shape as the
+// already-used branch.
+func TestRevokeRefreshToken_TokenNotFound(t *testing.T) {
+	defer teardownAuthTest()
+	setupAuthTest()
+
+	r := httptest.NewRequest(http.MethodPost, "/api/refresh", nil)
+	r.AddCookie(&http.Cookie{Name: constants.RefreshTokenKey, Value: "never-stored"})
+	w := httptest.NewRecorder()
+
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	RevokeRefreshToken(next).ServeHTTP(w, r)
+
+	if nextCalled {
+		utils.PrintTestError(t, "next called for unknown refresh token", "next not called")
+	}
+	if w.Result().StatusCode != http.StatusInternalServerError {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusInternalServerError)
+	}
+
+	foundJwt, foundRefresh := false, false
+	for _, c := range w.Result().Cookies() {
+		if c.Name == constants.JwtKey && c.MaxAge == -1 {
+			foundJwt = true
+		}
+		if c.Name == constants.RefreshTokenKey && c.MaxAge == -1 {
+			foundRefresh = true
+		}
+	}
+	if !foundJwt {
+		utils.PrintTestError(t, "jwt clearing cookie missing", "jwt cookie with MaxAge=-1")
+	}
+	if !foundRefresh {
+		utils.PrintTestError(t, "refresh clearing cookie missing", "refresh cookie with MaxAge=-1")
+	}
+}
+
+// Covers the branch where upstream middleware has already placed
+// "refreshTokenString" into the context — RevokeRefreshToken should consume
+// that value instead of re-reading the cookie.
+func TestRevokeRefreshToken_UsesContextValue(t *testing.T) {
+	defer teardownAuthTest()
+	setupAuthTest()
+
+	user := newRefreshUser(t)
+	raw := seedRefreshToken(t, user.ID, false)
+
+	// Note: no cookie on the request — the context value is the only source.
+	r := httptest.NewRequest(http.MethodPost, "/api/refresh", nil)
+	r = r.WithContext(context.WithValue(r.Context(), "refreshTokenString", raw))
+	w := httptest.NewRecorder()
+
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	RevokeRefreshToken(next).ServeHTTP(w, r)
+
+	if !nextCalled {
+		utils.PrintTestError(t, "next not called", "next called")
+	}
+	if w.Result().StatusCode != http.StatusOK {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusOK)
+	}
+}
+

--- a/api/internal/repositories/files.go
+++ b/api/internal/repositories/files.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"receipt-wrangler/api/internal/constants"
@@ -235,7 +234,8 @@ func (repository FileRepository) ConvertPdfToJpg(bytes []byte) ([]byte, error) {
 
 		// Add the current image to the finalImage wand.
 		if err := finalImage.AddImage(currImage); err != nil {
-			log.Fatal(err) // Handle the error appropriately
+			currImage.Destroy()
+			return nil, err
 		}
 
 		// Destroy the current image object as it's no longer needed.

--- a/api/internal/repositories/files_test.go
+++ b/api/internal/repositories/files_test.go
@@ -4,9 +4,55 @@ import (
 	"archive/zip"
 	"bytes"
 	"io"
+	"os"
+	"path/filepath"
+	"receipt-wrangler/api/internal/constants"
+	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/utils"
+	"strings"
 	"testing"
+
+	"gopkg.in/gographics/imagick.v3/imagick"
 )
+
+// testBasePath returns the path that tests should use as BASE_PATH so
+// GetTempDirectoryPath() and GetTestJpgBytes() resolve correctly. The repo
+// layout has the jpg fixture at /app/api/testing/test.jpg.
+func testBasePath() string {
+	return "/app/api"
+}
+
+// readTestJpgBytes is a local helper so tests don't depend on basePath
+// being set at package init.
+func readTestJpgBytes(t *testing.T) []byte {
+	t.Helper()
+	path := filepath.Join(testBasePath(), "testing", "test.jpg")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("unable to read test fixture %s: %v", path, err)
+	}
+	return b
+}
+
+// makePdfFromJpg converts a JPG byte blob into a minimal PDF using
+// ImageMagick. Returns the PDF bytes for use as a ConvertPdfToJpg fixture.
+func makePdfFromJpg(t *testing.T, jpgBytes []byte) []byte {
+	t.Helper()
+	mw := imagick.NewMagickWand()
+	defer mw.Destroy()
+
+	if err := mw.ReadImageBlob(jpgBytes); err != nil {
+		t.Fatalf("ImageMagick ReadImageBlob failed: %v", err)
+	}
+	if err := mw.SetImageFormat("pdf"); err != nil {
+		t.Fatalf("ImageMagick SetImageFormat pdf failed: %v", err)
+	}
+	pdf, err := mw.GetImageBlob()
+	if err != nil {
+		t.Fatalf("ImageMagick GetImageBlob failed: %v", err)
+	}
+	return pdf
+}
 
 func TestShouldZipMultipleFilesSuccessfully(t *testing.T) {
 	repository := NewFileRepository(nil)
@@ -224,6 +270,485 @@ func TestShouldHandleSpecialCharactersInFilenames(t *testing.T) {
 		if !found {
 			utils.PrintTestError(t, "File not found", expectedName)
 		}
+	}
+}
+
+// ---------- Pure-function tests (no filesystem/DB) ----------
+
+func TestValidateFileType_AcceptsJpg(t *testing.T) {
+	repository := NewFileRepository(nil)
+	jpg := readTestJpgBytes(t)
+
+	got, err := repository.ValidateFileType(jpg)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if !strings.HasPrefix(got, "image/") {
+		utils.PrintTestError(t, got, "image/*")
+	}
+}
+
+func TestValidateFileType_RejectsText(t *testing.T) {
+	repository := NewFileRepository(nil)
+
+	_, err := repository.ValidateFileType([]byte("just plain text"))
+	if err == nil {
+		utils.PrintTestError(t, err, "expected invalid file type error")
+	}
+}
+
+func TestValidateJsonFileType_AcceptsJson(t *testing.T) {
+	repository := NewFileRepository(nil)
+
+	got, err := repository.ValidateJsonFileType([]byte(`{"a":1}`))
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if !strings.Contains(got, "json") {
+		utils.PrintTestError(t, got, "*json*")
+	}
+}
+
+func TestValidateJsonFileType_RejectsImage(t *testing.T) {
+	repository := NewFileRepository(nil)
+	_, err := repository.ValidateJsonFileType(readTestJpgBytes(t))
+	if err == nil {
+		utils.PrintTestError(t, err, "expected invalid file type error for image")
+	}
+}
+
+func TestIsImage_TrueForJpg(t *testing.T) {
+	repository := NewFileRepository(nil)
+
+	got, err := repository.IsImage(readTestJpgBytes(t))
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if !got {
+		utils.PrintTestError(t, got, true)
+	}
+}
+
+func TestIsImage_ErrorOnInvalidType(t *testing.T) {
+	repository := NewFileRepository(nil)
+	_, err := repository.IsImage([]byte("plain text"))
+	if err == nil {
+		utils.PrintTestError(t, err, "expected validate error")
+	}
+}
+
+func TestIsPdf_FalseForJpg(t *testing.T) {
+	repository := NewFileRepository(nil)
+	got, err := repository.IsPdf(readTestJpgBytes(t))
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if got {
+		utils.PrintTestError(t, got, false)
+	}
+}
+
+func TestIsPdf_TrueForPdf(t *testing.T) {
+	repository := NewFileRepository(nil)
+	pdf := makePdfFromJpg(t, readTestJpgBytes(t))
+
+	got, err := repository.IsPdf(pdf)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if !got {
+		utils.PrintTestError(t, got, true)
+	}
+}
+
+func TestIsPdf_ErrorOnInvalidType(t *testing.T) {
+	repository := NewFileRepository(nil)
+	_, err := repository.IsPdf([]byte("plain text"))
+	if err == nil {
+		utils.PrintTestError(t, err, "expected validate error")
+	}
+}
+
+func TestGetFileType_PdfMappedToImageJpeg(t *testing.T) {
+	repository := NewFileRepository(nil)
+	pdf := makePdfFromJpg(t, readTestJpgBytes(t))
+
+	got, err := repository.GetFileType(pdf)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if got != "image/jpeg" {
+		utils.PrintTestError(t, got, "image/jpeg")
+	}
+}
+
+func TestGetFileType_JpgPassThrough(t *testing.T) {
+	repository := NewFileRepository(nil)
+	got, err := repository.GetFileType(readTestJpgBytes(t))
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if !strings.HasPrefix(got, "image/") {
+		utils.PrintTestError(t, got, "image/*")
+	}
+}
+
+func TestGetFileType_ErrorOnInvalidType(t *testing.T) {
+	repository := NewFileRepository(nil)
+	_, err := repository.GetFileType([]byte("plain text"))
+	if err == nil {
+		utils.PrintTestError(t, err, "expected validate error")
+	}
+}
+
+func TestBuildEncodedImageString_ProducesDataUri(t *testing.T) {
+	repository := NewFileRepository(nil)
+	got, err := repository.BuildEncodedImageString(readTestJpgBytes(t))
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if !strings.HasPrefix(got, "data:image/") {
+		utils.PrintTestError(t, got[:25], "data:image/... prefix")
+	}
+	if !strings.Contains(got, "base64,") {
+		utils.PrintTestError(t, got, "contains base64,")
+	}
+}
+
+func TestBuildEncodedImageString_ErrorOnInvalidType(t *testing.T) {
+	repository := NewFileRepository(nil)
+	_, err := repository.BuildEncodedImageString([]byte("plain text"))
+	if err == nil {
+		utils.PrintTestError(t, err, "expected error")
+	}
+}
+
+// ---------- Temp-path/filesystem tests ----------
+
+func TestGetTempDirectoryPath_UsesBasePath(t *testing.T) {
+	t.Setenv("BASE_PATH", testBasePath())
+
+	repository := NewFileRepository(nil)
+	got := repository.GetTempDirectoryPath()
+	want := filepath.Join(testBasePath(), "temp")
+	if got != want {
+		utils.PrintTestError(t, got, want)
+	}
+}
+
+func TestBuildTempFilePath_FormatAndExtension(t *testing.T) {
+	t.Setenv("BASE_PATH", testBasePath())
+
+	repository := NewFileRepository(nil)
+	got, err := repository.BuildTempFilePath("jpg")
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if !strings.HasPrefix(got, filepath.Join(testBasePath(), "temp")+"/") {
+		utils.PrintTestError(t, got, "prefixed with temp dir")
+	}
+	if !strings.HasSuffix(got, ".jpg") {
+		utils.PrintTestError(t, got, "*.jpg")
+	}
+}
+
+func TestGetTestJpgBytes_ReadsFixture(t *testing.T) {
+	t.Setenv("BASE_PATH", testBasePath())
+
+	repository := NewFileRepository(nil)
+	got, err := repository.GetTestJpgBytes()
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if len(got) == 0 {
+		utils.PrintTestError(t, len(got), ">0")
+	}
+}
+
+func TestWriteTempFile_WritesJpgBytes(t *testing.T) {
+	t.Setenv("BASE_PATH", testBasePath())
+
+	repository := NewFileRepository(nil)
+	jpg := readTestJpgBytes(t)
+
+	path, err := repository.WriteTempFile(jpg)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	defer os.Remove(path)
+
+	if !strings.HasSuffix(path, ".jpeg") {
+		utils.PrintTestError(t, path, "*.jpeg suffix")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if info.Size() == 0 {
+		utils.PrintTestError(t, info.Size(), ">0")
+	}
+}
+
+func TestWriteTempFile_RejectsInvalidFileType(t *testing.T) {
+	t.Setenv("BASE_PATH", testBasePath())
+
+	repository := NewFileRepository(nil)
+	_, err := repository.WriteTempFile([]byte("not an image"))
+	if err == nil {
+		utils.PrintTestError(t, err, "expected invalid-file-type error")
+	}
+}
+
+// ---------- ImageMagick conversion tests ----------
+
+func TestConvertPdfToJpg_HappyPath(t *testing.T) {
+	t.Setenv("BASE_PATH", testBasePath())
+
+	repository := NewFileRepository(nil)
+	pdf := makePdfFromJpg(t, readTestJpgBytes(t))
+
+	out, err := repository.ConvertPdfToJpg(pdf)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if len(out) == 0 {
+		utils.PrintTestError(t, len(out), ">0")
+	}
+	isImage, err := repository.IsImage(out)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if !isImage {
+		utils.PrintTestError(t, isImage, true)
+	}
+}
+
+func TestConvertPdfToJpg_InvalidBytes(t *testing.T) {
+	t.Setenv("BASE_PATH", testBasePath())
+
+	repository := NewFileRepository(nil)
+	_, err := repository.ConvertPdfToJpg([]byte("not a pdf"))
+	if err == nil {
+		utils.PrintTestError(t, err, "expected ImageMagick error")
+	}
+}
+
+func TestConvertHeicToJpg_InvalidBytes(t *testing.T) {
+	repository := NewFileRepository(nil)
+	_, err := repository.ConvertHeicToJpg([]byte("not heic"))
+	if err == nil {
+		utils.PrintTestError(t, err, "expected ImageMagick error")
+	}
+}
+
+func TestGetBytesFromImageBytes_JpgPassThrough(t *testing.T) {
+	repository := NewFileRepository(nil)
+	jpg := readTestJpgBytes(t)
+
+	got, err := repository.GetBytesFromImageBytes(jpg)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if len(got) != len(jpg) {
+		utils.PrintTestError(t, len(got), len(jpg))
+	}
+}
+
+func TestGetBytesFromImageBytes_PdfRoutesThroughConversion(t *testing.T) {
+	t.Setenv("BASE_PATH", testBasePath())
+
+	repository := NewFileRepository(nil)
+	pdf := makePdfFromJpg(t, readTestJpgBytes(t))
+
+	got, err := repository.GetBytesFromImageBytes(pdf)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if len(got) == 0 {
+		utils.PrintTestError(t, len(got), ">0")
+	}
+	// Result should be an image, not a PDF any more.
+	isImage, _ := repository.IsImage(got)
+	if !isImage {
+		utils.PrintTestError(t, isImage, true)
+	}
+}
+
+func TestGetBytesFromImageBytes_InvalidTypeErrors(t *testing.T) {
+	repository := NewFileRepository(nil)
+	_, err := repository.GetBytesFromImageBytes([]byte("nope"))
+	if err == nil {
+		utils.PrintTestError(t, err, "expected invalid-file-type error")
+	}
+}
+
+// ---------- DB-backed path helpers ----------
+
+func TestBuildGroupPath_WithAlternateName(t *testing.T) {
+	defer TruncateTestDb()
+
+	repository := NewFileRepository(nil)
+	got, err := repository.BuildGroupPath(42, "alt-name")
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if !strings.Contains(got, "42") || !strings.Contains(got, "alt-name") {
+		utils.PrintTestError(t, got, "contains 42 and alt-name")
+	}
+}
+
+func TestBuildGroupPath_LooksUpGroupByName(t *testing.T) {
+	defer TruncateTestDb()
+
+	db := GetDB()
+	group := models.Group{Name: "lookup-group"}
+	if err := db.Create(&group).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	repository := NewFileRepository(nil)
+	got, err := repository.BuildGroupPath(group.ID, "")
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if !strings.Contains(got, "lookup-group") {
+		utils.PrintTestError(t, got, "contains lookup-group")
+	}
+}
+
+func TestBuildFilePath_ComposesGroupAndFileName(t *testing.T) {
+	defer TruncateTestDb()
+
+	db := GetDB()
+	user := models.User{Username: "file-path-user", Password: "p", DisplayName: "x"}
+	if err := db.Create(&user).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	group := models.Group{Name: "files-group"}
+	if err := db.Create(&group).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	receipt := models.Receipt{Name: "r", GroupId: group.ID, PaidByUserID: user.ID}
+	if err := db.Create(&receipt).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	repository := NewFileRepository(nil)
+	got, err := repository.BuildFilePath(utils.UintToString(receipt.ID), "99", "photo.jpg")
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if !strings.Contains(got, "files-group") {
+		utils.PrintTestError(t, got, "contains files-group")
+	}
+	if !strings.HasSuffix(got, ".jpg") {
+		utils.PrintTestError(t, got, "*.jpg")
+	}
+}
+
+// ---------- Zip from temp files ----------
+
+func TestCreateZipFromTempFiles_ArchivesSeededFiles(t *testing.T) {
+	t.Setenv("BASE_PATH", testBasePath())
+
+	repository := NewFileRepository(nil)
+	tempDir := repository.GetTempDirectoryPath()
+	_ = os.MkdirAll(tempDir, 0o755)
+
+	f1 := "zip-src-a.txt"
+	f2 := "zip-src-b.txt"
+	if err := os.WriteFile(filepath.Join(tempDir, f1), []byte("alpha"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, f2), []byte("beta"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	defer os.Remove(filepath.Join(tempDir, f1))
+	defer os.Remove(filepath.Join(tempDir, f2))
+
+	zipName := "zipped-output.zip"
+	zipPath, err := repository.CreateZipFromTempFiles(zipName, []string{f1, f2})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	defer os.Remove(zipPath)
+
+	info, err := os.Stat(zipPath)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if info.Size() == 0 {
+		utils.PrintTestError(t, info.Size(), ">0")
+	}
+
+	zipBytes, _ := os.ReadFile(zipPath)
+	reader, err := zip.NewReader(bytes.NewReader(zipBytes), int64(len(zipBytes)))
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if len(reader.File) != 2 {
+		utils.PrintTestError(t, len(reader.File), 2)
+	}
+}
+
+func TestGetBytesForFileData_ReadsAndReturnsBytes(t *testing.T) {
+	t.Setenv("BASE_PATH", testBasePath())
+	defer TruncateTestDb()
+
+	db := GetDB()
+	user := models.User{Username: "fd-user", Password: "p", DisplayName: "x"}
+	if err := db.Create(&user).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	group := models.Group{Name: "bytes-group"}
+	if err := db.Create(&group).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	receipt := models.Receipt{Name: "r", GroupId: group.ID, PaidByUserID: user.ID}
+	if err := db.Create(&receipt).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	fileData := models.FileData{Name: "img.jpg", ReceiptId: receipt.ID, FileType: "image/jpeg"}
+	if err := db.Create(&fileData).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	// Write the JPG fixture to the exact path BuildFilePath will construct.
+	repository := NewFileRepository(nil)
+	targetPath, err := repository.BuildFilePath(utils.UintToString(receipt.ID), utils.UintToString(fileData.ID), fileData.Name)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	_ = os.MkdirAll(filepath.Dir(targetPath), 0o755)
+	jpg := readTestJpgBytes(t)
+	if err := os.WriteFile(targetPath, jpg, 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	defer os.Remove(targetPath)
+
+	got, err := repository.GetBytesForFileData(fileData)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if len(got) == 0 {
+		utils.PrintTestError(t, len(got), ">0")
+	}
+}
+
+// Sanity: a PDF fixture really is recognised as ApplicationPdf.
+func TestValidateFileType_AcceptsPdf(t *testing.T) {
+	repository := NewFileRepository(nil)
+	pdf := makePdfFromJpg(t, readTestJpgBytes(t))
+
+	got, err := repository.ValidateFileType(pdf)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if got != constants.ApplicationPdf {
+		utils.PrintTestError(t, got, constants.ApplicationPdf)
 	}
 }
 

--- a/api/internal/services/ai_test.go
+++ b/api/internal/services/ai_test.go
@@ -1,0 +1,339 @@
+package services
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"receipt-wrangler/api/internal/commands"
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/repositories"
+	"receipt-wrangler/api/internal/structs"
+	"receipt-wrangler/api/internal/utils"
+	"testing"
+)
+
+func aiTestSignUp() commands.SignUpCommand {
+	return commands.SignUpCommand{
+		Username:    "ai-test-user",
+		Password:    "Password",
+		DisplayName: "AI Test User",
+	}
+}
+
+// Shared mock-server helpers used across ai_test, receipt_processing_test,
+// and receipt_image_test. Each returns an httptest.Server plus a pointer to
+// a captured request for assertions, and registers cleanup.
+
+type capturedAiRequest struct {
+	Method string
+	Path   string
+	Body   map[string]interface{}
+}
+
+func newMockOpenAiServerForService(t *testing.T, statusCode int, body string) (*httptest.Server, *capturedAiRequest) {
+	t.Helper()
+	captured := &capturedAiRequest{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.Method = r.Method
+		captured.Path = r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &captured.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+	return server, captured
+}
+
+func newMockOllamaServerForService(t *testing.T, statusCode int, body string) (*httptest.Server, *capturedAiRequest) {
+	return newMockOpenAiServerForService(t, statusCode, body)
+}
+
+func openAiBody(content string) string {
+	return `{"id":"x","object":"chat.completion","created":1,"model":"gpt-3.5-turbo","choices":[{"index":0,"message":{"role":"assistant","content":"` + content + `"},"finish_reason":"stop"}]}`
+}
+
+func ollamaBody(content string) string {
+	return `{"model":"llama3","created_at":"2024-01-01T00:00:00Z","message":{"role":"assistant","content":"` + content + `"},"done":true}`
+}
+
+// seedPromptForAi creates a minimal Prompt row and returns its ID. Required
+// because ReceiptProcessingSettings.PromptId has a FK constraint.
+func seedPromptForAi(t *testing.T) uint {
+	t.Helper()
+	prompt := models.Prompt{Name: "test-prompt", Prompt: "ping"}
+	if err := repositories.GetDB().Create(&prompt).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	return prompt.ID
+}
+
+// seedSettingsForAi inserts a ReceiptProcessingSettings row with the given
+// AiType and URL (pointing at a mock server). Skips encryption: `Key` is
+// stored verbatim; tests pass DecryptKey=false.
+func seedSettingsForAi(t *testing.T, aiType models.AiClientType, url string) models.ReceiptProcessingSettings {
+	t.Helper()
+	promptId := seedPromptForAi(t)
+	settings := models.ReceiptProcessingSettings{
+		Name:     "test-settings-" + string(aiType),
+		AiType:   aiType,
+		Url:      url,
+		Model:    "test-model",
+		Key:      "plain-key",
+		PromptId: promptId,
+	}
+	if err := repositories.GetDB().Create(&settings).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	return settings
+}
+
+// NewAiService -------------------------------------------------------------
+
+func TestNewAiService_MissingRowReturnsError(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	_, err := NewAiService("999999")
+	if err == nil {
+		utils.PrintTestError(t, err, "expected not-found error")
+	}
+}
+
+func TestNewAiService_HappyPathLoadsSettings(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	settings := seedSettingsForAi(t, models.OPEN_AI_NEW, "http://example.invalid")
+	service, err := NewAiService(utils.UintToString(settings.ID))
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if service.ReceiptProcessingSettings.ID != settings.ID {
+		utils.PrintTestError(t, service.ReceiptProcessingSettings.ID, settings.ID)
+	}
+	if service.ReceiptProcessingSettings.AiType != models.OPEN_AI_NEW {
+		utils.PrintTestError(t, service.ReceiptProcessingSettings.AiType, models.OPEN_AI_NEW)
+	}
+}
+
+// CreateChatCompletion -----------------------------------------------------
+
+func TestCreateChatCompletion_OpenAi_HappyPath(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	server, _ := newMockOpenAiServerForService(t, http.StatusOK, openAiBody("hi from openai"))
+
+	settings := seedSettingsForAi(t, models.OPEN_AI_NEW, server.URL)
+	service := &AiService{ReceiptProcessingSettings: settings}
+
+	resp, task, err := service.CreateChatCompletion(structs.AiChatCompletionOptions{
+		Messages:   []structs.AiClientMessage{{Role: "user", Content: "ping"}},
+		DecryptKey: false,
+	})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if resp != "hi from openai" {
+		utils.PrintTestError(t, resp, "hi from openai")
+	}
+	if task.Status != models.SYSTEM_TASK_SUCCEEDED {
+		utils.PrintTestError(t, task.Status, models.SYSTEM_TASK_SUCCEEDED)
+	}
+	if task.ResultDescription == "" {
+		utils.PrintTestError(t, "empty ResultDescription", "non-empty raw response")
+	}
+	if task.EndedAt == nil {
+		utils.PrintTestError(t, task.EndedAt, "non-nil EndedAt")
+	}
+}
+
+func TestCreateChatCompletion_OpenAiCustom_HappyPath(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	server, _ := newMockOpenAiServerForService(t, http.StatusOK, openAiBody("custom-ok"))
+
+	settings := seedSettingsForAi(t, models.OPEN_AI_CUSTOM_NEW, server.URL)
+	service := &AiService{ReceiptProcessingSettings: settings}
+
+	resp, task, err := service.CreateChatCompletion(structs.AiChatCompletionOptions{
+		Messages:   []structs.AiClientMessage{{Role: "user", Content: "ping"}},
+		DecryptKey: false,
+	})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if resp != "custom-ok" {
+		utils.PrintTestError(t, resp, "custom-ok")
+	}
+	if task.Status != models.SYSTEM_TASK_SUCCEEDED {
+		utils.PrintTestError(t, task.Status, models.SYSTEM_TASK_SUCCEEDED)
+	}
+}
+
+func TestCreateChatCompletion_Ollama_HappyPath(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	server, _ := newMockOllamaServerForService(t, http.StatusOK, ollamaBody("hi from ollama"))
+
+	settings := seedSettingsForAi(t, models.OLLAMA, server.URL)
+	service := &AiService{ReceiptProcessingSettings: settings}
+
+	resp, task, err := service.CreateChatCompletion(structs.AiChatCompletionOptions{
+		Messages:   []structs.AiClientMessage{{Role: "user", Content: "ping"}},
+		DecryptKey: false,
+	})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if resp != "hi from ollama" {
+		utils.PrintTestError(t, resp, "hi from ollama")
+	}
+	if task.Status != models.SYSTEM_TASK_SUCCEEDED {
+		utils.PrintTestError(t, task.Status, models.SYSTEM_TASK_SUCCEEDED)
+	}
+}
+
+func TestCreateChatCompletion_InvalidAiType(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	// AiType has a DB-level validator, so we don't persist — CreateChatCompletion
+	// operates directly on the in-memory settings and doesn't query DB on the
+	// default branch.
+	service := &AiService{
+		ReceiptProcessingSettings: models.ReceiptProcessingSettings{
+			Name:   "bogus",
+			AiType: "BOGUS",
+			Url:    "http://example.invalid",
+		},
+	}
+	_, task, err := service.CreateChatCompletion(structs.AiChatCompletionOptions{
+		Messages:   []structs.AiClientMessage{{Role: "user", Content: "ping"}},
+		DecryptKey: false,
+	})
+	if err == nil {
+		utils.PrintTestError(t, err, "expected invalid ai type error")
+	}
+	// The default branch returns the systemTask at its SUCCEEDED initial
+	// value, but still errors out — document observed behavior.
+	_ = task
+}
+
+func TestCreateChatCompletion_DownedServer_Failed(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	server, _ := newMockOllamaServerForService(t, http.StatusOK, ollamaBody(""))
+	url := server.URL
+	server.Close() // shut down so the next request fails at transport
+
+	settings := seedSettingsForAi(t, models.OLLAMA, url)
+	service := &AiService{ReceiptProcessingSettings: settings}
+
+	_, task, err := service.CreateChatCompletion(structs.AiChatCompletionOptions{
+		Messages:   []structs.AiClientMessage{{Role: "user", Content: "ping"}},
+		DecryptKey: false,
+	})
+	if err == nil {
+		utils.PrintTestError(t, err, "expected connection error")
+	}
+	if task.Status != models.SYSTEM_TASK_FAILED {
+		utils.PrintTestError(t, task.Status, models.SYSTEM_TASK_FAILED)
+	}
+	if task.EndedAt == nil {
+		utils.PrintTestError(t, task.EndedAt, "non-nil EndedAt")
+	}
+}
+
+// CheckConnectivity --------------------------------------------------------
+
+func TestCheckConnectivity_HappyPath_SavesSystemTask(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	userRepo := repositories.NewUserRepository(nil)
+	user, err := userRepo.CreateUser(aiTestSignUp())
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	server, _ := newMockOllamaServerForService(t, http.StatusOK, ollamaBody("hello"))
+	settings := seedSettingsForAi(t, models.OLLAMA, server.URL)
+	service := &AiService{ReceiptProcessingSettings: settings}
+
+	task, err := service.CheckConnectivity(user.ID, false)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if task.Status != models.SYSTEM_TASK_SUCCEEDED {
+		utils.PrintTestError(t, task.Status, models.SYSTEM_TASK_SUCCEEDED)
+	}
+	// With settings ID > 0, the task should be persisted.
+	var count int64
+	repositories.GetDB().Model(&models.SystemTask{}).Count(&count)
+	if count == 0 {
+		utils.PrintTestError(t, "no SystemTask rows", ">=1")
+	}
+}
+
+func TestCheckConnectivity_NoSettingsId_DoesNotPersist(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	userRepo := repositories.NewUserRepository(nil)
+	user, err := userRepo.CreateUser(aiTestSignUp())
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	server, _ := newMockOllamaServerForService(t, http.StatusOK, ollamaBody("hello"))
+	// Settings ID = 0 (not persisted) → CheckConnectivity should not save.
+	service := &AiService{
+		ReceiptProcessingSettings: models.ReceiptProcessingSettings{
+			AiType:   models.OLLAMA,
+			Url:      server.URL,
+			Model:    "test-model",
+			PromptId: seedPromptForAi(t),
+		},
+	}
+
+	task, err := service.CheckConnectivity(user.ID, false)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if task.Status != models.SYSTEM_TASK_SUCCEEDED {
+		utils.PrintTestError(t, task.Status, models.SYSTEM_TASK_SUCCEEDED)
+	}
+
+	var count int64
+	repositories.GetDB().Model(&models.SystemTask{}).Count(&count)
+	if count != 0 {
+		utils.PrintTestError(t, count, int64(0))
+	}
+}
+
+func TestCheckConnectivity_Failure_RecordsFailedStatus(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	userRepo := repositories.NewUserRepository(nil)
+	user, err := userRepo.CreateUser(aiTestSignUp())
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	// Start a server then close it → Do() errors.
+	server, _ := newMockOllamaServerForService(t, http.StatusOK, ollamaBody(""))
+	url := server.URL
+	server.Close()
+
+	settings := seedSettingsForAi(t, models.OLLAMA, url)
+	service := &AiService{ReceiptProcessingSettings: settings}
+
+	task, err := service.CheckConnectivity(user.ID, false)
+	if err != nil {
+		// CheckConnectivity itself does not propagate the chat error; it
+		// records FAILED status and returns the saved SystemTask. So no
+		// error here is the expected shape.
+		utils.PrintTestError(t, err, nil)
+	}
+	if task.Status != models.SYSTEM_TASK_FAILED {
+		utils.PrintTestError(t, task.Status, models.SYSTEM_TASK_FAILED)
+	}
+}

--- a/api/internal/services/auth_test.go
+++ b/api/internal/services/auth_test.go
@@ -3,13 +3,18 @@ package services
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"receipt-wrangler/api/internal/commands"
+	"receipt-wrangler/api/internal/constants"
+	config "receipt-wrangler/api/internal/env"
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/repositories"
 	"receipt-wrangler/api/internal/structs"
 	"receipt-wrangler/api/internal/utils"
 	"testing"
 
+	jwtmiddleware "github.com/auth0/go-jwt-middleware/v2"
 	"github.com/auth0/go-jwt-middleware/v2/validator"
 )
 
@@ -212,5 +217,246 @@ func TestShouldNotLogUserInWithWrongPassword(t *testing.T) {
 
 	if err == nil {
 		utils.PrintTestError(t, err, "login error")
+	}
+}
+
+// BuildTokenCookies — non-dev environment (test env is "test", so this
+// exercises the SameSite=Strict / Secure=false branch).
+func TestBuildTokenCookies_NonDevEnvironment(t *testing.T) {
+	jwt := "jwt-token-value"
+	refreshToken := "refresh-token-value"
+
+	access, refresh := BuildTokenCookies(jwt, refreshToken)
+
+	if access.Name != constants.JwtKey {
+		utils.PrintTestError(t, access.Name, constants.JwtKey)
+	}
+	if access.Value != jwt {
+		utils.PrintTestError(t, access.Value, jwt)
+	}
+	if !access.HttpOnly {
+		utils.PrintTestError(t, access.HttpOnly, true)
+	}
+	if access.Path != "/" {
+		utils.PrintTestError(t, access.Path, "/")
+	}
+	if access.SameSite != http.SameSiteStrictMode {
+		utils.PrintTestError(t, access.SameSite, http.SameSiteStrictMode)
+	}
+	if access.Secure {
+		utils.PrintTestError(t, access.Secure, false)
+	}
+	if access.Expires.IsZero() {
+		utils.PrintTestError(t, "Expires is zero", "non-zero time")
+	}
+
+	if refresh.Name != constants.RefreshTokenKey {
+		utils.PrintTestError(t, refresh.Name, constants.RefreshTokenKey)
+	}
+	if refresh.Value != refreshToken {
+		utils.PrintTestError(t, refresh.Value, refreshToken)
+	}
+	if !refresh.HttpOnly {
+		utils.PrintTestError(t, refresh.HttpOnly, true)
+	}
+	if refresh.Path != "/" {
+		utils.PrintTestError(t, refresh.Path, "/")
+	}
+	if refresh.SameSite != http.SameSiteStrictMode {
+		utils.PrintTestError(t, refresh.SameSite, http.SameSiteStrictMode)
+	}
+	if refresh.Secure {
+		utils.PrintTestError(t, refresh.Secure, false)
+	}
+	if refresh.Expires.IsZero() {
+		utils.PrintTestError(t, "Expires is zero", "non-zero time")
+	}
+}
+
+// BuildTokenCookies dev branch: env=="dev" -> SameSite=None, Secure=true.
+// Skipped because config.env is set once from `-env=test` in SetUpTestEnv and
+// there is no exported hook to override it for a single test.
+// See bug report BUG-2 (testability).
+func TestBuildTokenCookies_DevEnvironment(t *testing.T) {
+	t.Skip("see BUG-2: config.env is package-private and fixed to 'test' for the suite; no hook to override per-test")
+	if config.GetDeployEnv() != "dev" {
+		return
+	}
+	access, refresh := BuildTokenCookies("j", "r")
+	if access.SameSite != http.SameSiteNoneMode {
+		utils.PrintTestError(t, access.SameSite, http.SameSiteNoneMode)
+	}
+	if !access.Secure {
+		utils.PrintTestError(t, access.Secure, true)
+	}
+	if refresh.SameSite != http.SameSiteNoneMode {
+		utils.PrintTestError(t, refresh.SameSite, http.SameSiteNoneMode)
+	}
+	if !refresh.Secure {
+		utils.PrintTestError(t, refresh.Secure, true)
+	}
+}
+
+// PrepareAccessTokenClaims — the current implementation takes a value
+// receiver and therefore cannot mutate the caller's claims. We assert the
+// observed behavior (caller's claims unchanged) and flag the apparent intent
+// as a bug — see BUG-1 in the bug report.
+func TestPrepareAccessTokenClaims_DoesNotMutateCaller(t *testing.T) {
+	claims := structs.Claims{}
+	claims.Issuer = "https://receiptWrangler.io"
+	claims.Audience = []string{"https://receiptWrangler.io"}
+
+	PrepareAccessTokenClaims(claims)
+
+	// Documenting observed behavior: caller's Issuer/Audience are unchanged
+	// because the function receives claims by value.
+	if claims.Issuer != "https://receiptWrangler.io" {
+		utils.PrintTestError(t, claims.Issuer, "https://receiptWrangler.io")
+	}
+	if len(claims.Audience) != 1 || claims.Audience[0] != "https://receiptWrangler.io" {
+		utils.PrintTestError(t, claims.Audience, []string{"https://receiptWrangler.io"})
+	}
+}
+
+// PrepareAccessTokenClaims — skipped test capturing the *intended* behavior:
+// after the call, Issuer should be "" and Audience should be empty. This
+// currently fails because of BUG-1 (value receiver). Kept as a pinned test
+// so the bug is easy to discover.
+func TestPrepareAccessTokenClaims_ClearsIssuerAndAudience(t *testing.T) {
+	t.Skip("see BUG-1: PrepareAccessTokenClaims takes structs.Claims by value; caller mutations are lost")
+
+	claims := structs.Claims{}
+	claims.Issuer = "https://receiptWrangler.io"
+	claims.Audience = []string{"https://receiptWrangler.io"}
+
+	PrepareAccessTokenClaims(claims)
+
+	if claims.Issuer != "" {
+		utils.PrintTestError(t, claims.Issuer, "")
+	}
+	if len(claims.Audience) != 0 {
+		utils.PrintTestError(t, claims.Audience, []string{})
+	}
+}
+
+func TestGetEmptyAccessTokenCookie(t *testing.T) {
+	cookie := GetEmptyAccessTokenCookie()
+
+	if cookie.Name != constants.JwtKey {
+		utils.PrintTestError(t, cookie.Name, constants.JwtKey)
+	}
+	if cookie.Value != "" {
+		utils.PrintTestError(t, cookie.Value, "")
+	}
+	if cookie.Path != "/" {
+		utils.PrintTestError(t, cookie.Path, "/")
+	}
+	if cookie.MaxAge != -1 {
+		utils.PrintTestError(t, cookie.MaxAge, -1)
+	}
+	if cookie.HttpOnly {
+		utils.PrintTestError(t, cookie.HttpOnly, false)
+	}
+}
+
+func TestGetEmptyRefreshTokenCookie(t *testing.T) {
+	cookie := GetEmptyRefreshTokenCookie()
+
+	if cookie.Name != constants.RefreshTokenKey {
+		utils.PrintTestError(t, cookie.Name, constants.RefreshTokenKey)
+	}
+	if cookie.Value != "" {
+		utils.PrintTestError(t, cookie.Value, "")
+	}
+	if cookie.Path != "/" {
+		utils.PrintTestError(t, cookie.Path, "/")
+	}
+	if cookie.MaxAge != -1 {
+		utils.PrintTestError(t, cookie.MaxAge, -1)
+	}
+	if !cookie.HttpOnly {
+		utils.PrintTestError(t, cookie.HttpOnly, true)
+	}
+}
+
+// GetAppData with nil request — no claims to populate.
+func TestGetAppData_PopulatesFields(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	userRepository := repositories.NewUserRepository(nil)
+	user, err := userRepository.CreateUser(commands.SignUpCommand{
+		Username:    "appdata-user",
+		Password:    "Password",
+		DisplayName: "AppData User",
+	})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	appData, err := GetAppData(user.ID, nil)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	// CreateUser seeds a "My Receipts" group and an "All" group; both should
+	// appear for the user.
+	if len(appData.Groups) == 0 {
+		utils.PrintTestError(t, "Groups length 0", ">0")
+	}
+	// At least the created user is in the Users list.
+	found := false
+	for _, u := range appData.Users {
+		if u.ID == user.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		utils.PrintTestError(t, "user not in appData.Users", "present")
+	}
+	if appData.UserPreferences.UserId != user.ID {
+		utils.PrintTestError(t, appData.UserPreferences.UserId, user.ID)
+	}
+	if appData.Icons == nil {
+		utils.PrintTestError(t, appData.Icons, "non-nil Icons slice")
+	}
+}
+
+// GetAppData with non-nil request that carries ValidatedClaims — Claims
+// should be populated on the AppData.
+func TestGetAppData_WithRequestPopulatesClaims(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	userRepository := repositories.NewUserRepository(nil)
+	user, err := userRepository.CreateUser(commands.SignUpCommand{
+		Username:    "claims-user",
+		Password:    "Password",
+		DisplayName: "Claims User",
+	})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	customClaims := &structs.Claims{
+		UserId:      user.ID,
+		Username:    user.Username,
+		Displayname: user.DisplayName,
+		UserRole:    models.ADMIN,
+	}
+	validatedClaims := &validator.ValidatedClaims{CustomClaims: customClaims}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	ctx := context.WithValue(req.Context(), jwtmiddleware.ContextKey{}, validatedClaims)
+	req = req.WithContext(ctx)
+
+	appData, err := GetAppData(user.ID, req)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if appData.Claims.UserId != user.ID {
+		utils.PrintTestError(t, appData.Claims.UserId, user.ID)
+	}
+	if appData.Claims.Username != user.Username {
+		utils.PrintTestError(t, appData.Claims.Username, user.Username)
 	}
 }

--- a/api/internal/services/receipt_image_test.go
+++ b/api/internal/services/receipt_image_test.go
@@ -1,0 +1,380 @@
+package services
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"receipt-wrangler/api/internal/commands"
+	"receipt-wrangler/api/internal/constants"
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/repositories"
+	"receipt-wrangler/api/internal/utils"
+	"testing"
+
+	"gopkg.in/gographics/imagick.v3/imagick"
+)
+
+// jpgToPdf converts a JPG blob to a one-page PDF using ImageMagick. Used by
+// the PDF-branch receipt-image test.
+func jpgToPdf(t *testing.T, jpgBytes []byte) []byte {
+	t.Helper()
+	mw := imagick.NewMagickWand()
+	defer mw.Destroy()
+	if err := mw.ReadImageBlob(jpgBytes); err != nil {
+		t.Fatalf("ImageMagick ReadImageBlob: %v", err)
+	}
+	if err := mw.SetImageFormat("pdf"); err != nil {
+		t.Fatalf("ImageMagick SetImageFormat pdf: %v", err)
+	}
+	out, err := mw.GetImageBlob()
+	if err != nil {
+		t.Fatalf("ImageMagick GetImageBlob: %v", err)
+	}
+	return out
+}
+
+// seedReceiptImagePipeline builds the full receipt-image pipeline graph:
+//
+//   - A User + a Group (non-All), with the user as a member.
+//   - A Prompt + ReceiptProcessingSettings (vision model) pointed at the
+//     given mock server URL.
+//   - A SystemSettings row linking to those processing settings.
+//   - A Receipt + FileData for that receipt, with the JPG fixture written
+//     to the path BuildFilePath will construct.
+//
+// Returns the user, the group, and the FileData (for
+// GetReceiptFromReceiptImageId / ReadReceiptImage invocations).
+func seedReceiptImagePipeline(t *testing.T, url string) (models.User, models.Group, models.FileData) {
+	t.Helper()
+	t.Setenv("BASE_PATH", "/app/api")
+	db := repositories.GetDB()
+
+	user := models.User{Username: "ri-user", Password: "p", DisplayName: "x"}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	group := models.Group{Name: "ri-group"}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("seed group: %v", err)
+	}
+	member := models.GroupMember{GroupID: group.ID, UserID: user.ID, GroupRole: models.OWNER}
+	if err := db.Create(&member).Error; err != nil {
+		t.Fatalf("seed group member: %v", err)
+	}
+	groupSettings := models.GroupSettings{GroupId: group.ID}
+	if err := db.Create(&groupSettings).Error; err != nil {
+		t.Fatalf("seed group settings: %v", err)
+	}
+
+	prompt := models.Prompt{Name: "ri-prompt", Prompt: "Extract: @ocrText"}
+	if err := db.Create(&prompt).Error; err != nil {
+		t.Fatalf("seed prompt: %v", err)
+	}
+
+	settings := models.ReceiptProcessingSettings{
+		Name:          "ri-rps",
+		AiType:        models.OLLAMA,
+		Url:           url,
+		Model:         "m",
+		IsVisionModel: true,
+		PromptId:      prompt.ID,
+	}
+	if err := db.Create(&settings).Error; err != nil {
+		t.Fatalf("seed settings: %v", err)
+	}
+
+	sysSettings := models.SystemSettings{
+		BaseModel:                   models.BaseModel{ID: 1},
+		ReceiptProcessingSettingsId: &settings.ID,
+	}
+	if err := db.Create(&sysSettings).Error; err != nil {
+		t.Fatalf("seed system settings: %v", err)
+	}
+
+	receipt := models.Receipt{Name: "r", GroupId: group.ID, PaidByUserID: user.ID}
+	if err := db.Create(&receipt).Error; err != nil {
+		t.Fatalf("seed receipt: %v", err)
+	}
+
+	fileData := models.FileData{Name: "img.jpg", ReceiptId: receipt.ID, FileType: "image/jpeg"}
+	if err := db.Create(&fileData).Error; err != nil {
+		t.Fatalf("seed file data: %v", err)
+	}
+
+	// Write the jpg to the path BuildFilePath will resolve.
+	fileRepo := repositories.NewFileRepository(nil)
+	path, err := fileRepo.BuildFilePath(utils.UintToString(receipt.ID), utils.UintToString(fileData.ID), fileData.Name)
+	if err != nil {
+		t.Fatalf("BuildFilePath: %v", err)
+	}
+	_ = os.MkdirAll(filepath.Dir(path), 0o755)
+	jpg, err := os.ReadFile(filepath.Join("/app/api/testing", "test.jpg"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	if err := os.WriteFile(path, jpg, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	t.Cleanup(func() { os.Remove(path) })
+
+	return user, group, fileData
+}
+
+// ---------- ReadReceiptImage ----------
+
+func TestReadReceiptImage_HappyPath(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	server, _ := newMockOllamaServerForService(t, http.StatusOK, ollamaReceiptJson("FromImage", "10"))
+	_, _, fileData := seedReceiptImagePipeline(t, server.URL)
+
+	receipt, _, err := ReadReceiptImage(utils.UintToString(fileData.ID))
+	if err != nil {
+		t.Fatalf("ReadReceiptImage: %v", err)
+	}
+	if receipt.Name != "FromImage" {
+		t.Errorf("expected 'FromImage', got %q", receipt.Name)
+	}
+}
+
+func TestReadReceiptImage_UnknownId(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	server, _ := newMockOllamaServerForService(t, http.StatusOK, ollamaReceiptJson("x", "1"))
+	seedReceiptImagePipeline(t, server.URL)
+
+	_, _, err := ReadReceiptImage("999999")
+	if err == nil {
+		t.Fatal("expected not-found error")
+	}
+}
+
+// PDF image path → ConvertPdfToJpg runs, temp file written + removed.
+func TestReadReceiptImage_PdfRoutesThroughConversion(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	t.Setenv("BASE_PATH", "/app/api")
+
+	server, _ := newMockOllamaServerForService(t, http.StatusOK, ollamaReceiptJson("PdfReceipt", "99"))
+	_, _, fileData := seedReceiptImagePipeline(t, server.URL)
+
+	// Replace the on-disk image with a PDF and update the FileData row to
+	// match.
+	db := repositories.GetDB()
+	fileRepo := repositories.NewFileRepository(nil)
+	path, err := fileRepo.BuildFilePath(utils.UintToString(fileData.ReceiptId), utils.UintToString(fileData.ID), fileData.Name)
+	if err != nil {
+		t.Fatalf("BuildFilePath: %v", err)
+	}
+
+	// Read original JPG, convert to PDF, overwrite target.
+	jpg, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read seeded jpg: %v", err)
+	}
+	// Reuse the files_test helper via a direct ImageMagick conversion.
+	fileRepoImpl := repositories.NewFileRepository(nil)
+	_ = fileRepoImpl // reserved for readability
+
+	pdfBytes := jpgToPdf(t, jpg)
+	if err := os.WriteFile(path, pdfBytes, 0o644); err != nil {
+		t.Fatalf("overwrite with pdf: %v", err)
+	}
+	// Update file type so ReadReceiptImage takes the PDF branch.
+	if err := db.Model(&models.FileData{}).Where("id = ?", fileData.ID).Update("file_type", constants.ApplicationPdf).Error; err != nil {
+		t.Fatalf("update file type: %v", err)
+	}
+
+	receipt, _, err := ReadReceiptImage(utils.UintToString(fileData.ID))
+	if err != nil {
+		t.Fatalf("ReadReceiptImage: %v", err)
+	}
+	if receipt.Name != "PdfReceipt" {
+		t.Errorf("expected 'PdfReceipt', got %q", receipt.Name)
+	}
+}
+
+// ---------- ReadReceiptImageFromFileOnly / WithEmailBody / ImagesWithEmailBody ----------
+
+func TestReadReceiptImageFromFileOnly(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	server, _ := newMockOllamaServerForService(t, http.StatusOK, ollamaReceiptJson("FileOnly", "3"))
+	_, group, _ := seedReceiptImagePipeline(t, server.URL)
+	imgPath := setupImagePathFixture(t)
+
+	receipt, _, err := ReadReceiptImageFromFileOnly(imgPath, utils.UintToString(group.ID))
+	if err != nil {
+		t.Fatalf("ReadReceiptImageFromFileOnly: %v", err)
+	}
+	if receipt.Name != "FileOnly" {
+		t.Errorf("expected 'FileOnly', got %q", receipt.Name)
+	}
+}
+
+func TestReadReceiptImageWithEmailBody(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	server, _ := newMockOllamaServerForService(t, http.StatusOK, ollamaReceiptJson("WithBody", "4"))
+	_, group, _ := seedReceiptImagePipeline(t, server.URL)
+	imgPath := setupImagePathFixture(t)
+
+	receipt, _, err := ReadReceiptImageWithEmailBody(imgPath, "email body", utils.UintToString(group.ID))
+	if err != nil {
+		t.Fatalf("ReadReceiptImageWithEmailBody: %v", err)
+	}
+	if receipt.Name != "WithBody" {
+		t.Errorf("expected 'WithBody', got %q", receipt.Name)
+	}
+}
+
+func TestReadReceiptImagesWithEmailBody_Multi(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	server, _ := newMockOllamaServerForService(t, http.StatusOK, ollamaReceiptJson("MultiBody", "5"))
+	_, group, _ := seedReceiptImagePipeline(t, server.URL)
+	imgPath := setupImagePathFixture(t)
+
+	receipt, _, err := ReadReceiptImagesWithEmailBody([]string{imgPath, imgPath}, "body", true, utils.UintToString(group.ID))
+	if err != nil {
+		t.Fatalf("ReadReceiptImagesWithEmailBody: %v", err)
+	}
+	if receipt.Name != "MultiBody" {
+		t.Errorf("expected 'MultiBody', got %q", receipt.Name)
+	}
+}
+
+func TestReadReceiptFromTextOnly(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	server, _ := newMockOllamaServerForService(t, http.StatusOK, ollamaReceiptJson("TextOnly", "6"))
+	_, group, _ := seedReceiptImagePipeline(t, server.URL)
+
+	receipt, _, err := ReadReceiptFromTextOnly("the full email body", utils.UintToString(group.ID))
+	if err != nil {
+		t.Fatalf("ReadReceiptFromTextOnly: %v", err)
+	}
+	if receipt.Name != "TextOnly" {
+		t.Errorf("expected 'TextOnly', got %q", receipt.Name)
+	}
+}
+
+func TestReadReceiptFromTextOnly_MissingSettings(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	// No seeds → NewSystemReceiptProcessingService returns an error.
+	_, _, err := ReadReceiptFromTextOnly("body", "")
+	if err == nil {
+		t.Fatal("expected error when system settings missing")
+	}
+}
+
+// ---------- MagicFillFromImage ----------
+
+func TestMagicFillFromImage_HappyPath(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	server, _ := newMockOllamaServerForService(t, http.StatusOK, ollamaReceiptJson("Magic", "7"))
+	_, group, _ := seedReceiptImagePipeline(t, server.URL)
+
+	jpg, err := os.ReadFile(filepath.Join("/app/api/testing", "test.jpg"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	cmd := commands.MagicFillCommand{ImageData: jpg}
+	receipt, _, err := MagicFillFromImage(cmd, utils.UintToString(group.ID))
+	if err != nil {
+		t.Fatalf("MagicFillFromImage: %v", err)
+	}
+	if receipt.Name != "Magic" {
+		t.Errorf("expected 'Magic', got %q", receipt.Name)
+	}
+}
+
+func TestMagicFillFromImage_InvalidImageData(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	server, _ := newMockOllamaServerForService(t, http.StatusOK, ollamaReceiptJson("x", "1"))
+	_, group, _ := seedReceiptImagePipeline(t, server.URL)
+
+	cmd := commands.MagicFillCommand{ImageData: []byte("not an image")}
+	_, _, err := MagicFillFromImage(cmd, utils.UintToString(group.ID))
+	if err == nil {
+		t.Fatal("expected invalid file type error")
+	}
+}
+
+// ---------- GetReceiptImagesForGroup / GetReceiptFromReceiptImageId ----------
+
+func TestGetReceiptImagesForGroup_FiltersByGroup(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	server, _ := newMockOllamaServerForService(t, http.StatusOK, ollamaReceiptJson("x", "1"))
+	user, group, _ := seedReceiptImagePipeline(t, server.URL)
+
+	// Add a second group + receipt + FileData that should NOT appear.
+	db := repositories.GetDB()
+	otherGroup := models.Group{Name: "other-group"}
+	if err := db.Create(&otherGroup).Error; err != nil {
+		t.Fatalf("seed other group: %v", err)
+	}
+	otherReceipt := models.Receipt{Name: "o", GroupId: otherGroup.ID, PaidByUserID: user.ID}
+	if err := db.Create(&otherReceipt).Error; err != nil {
+		t.Fatalf("seed other receipt: %v", err)
+	}
+	if err := db.Create(&models.FileData{Name: "other.jpg", ReceiptId: otherReceipt.ID, FileType: "image/jpeg"}).Error; err != nil {
+		t.Fatalf("seed other FileData: %v", err)
+	}
+
+	got, err := GetReceiptImagesForGroup(utils.UintToString(group.ID), utils.UintToString(user.ID))
+	if err != nil {
+		t.Fatalf("GetReceiptImagesForGroup: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("expected 1 FileData for the group, got %d", len(got))
+	}
+	if len(got) > 0 && got[0].Name != "img.jpg" {
+		t.Errorf("expected img.jpg, got %q", got[0].Name)
+	}
+}
+
+func TestGetReceiptImagesForGroup_UnknownGroup(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	_, err := GetReceiptImagesForGroup("999999", "1")
+	if err == nil {
+		t.Fatal("expected group-not-found error")
+	}
+}
+
+func TestGetReceiptFromReceiptImageId_Found(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	server, _ := newMockOllamaServerForService(t, http.StatusOK, ollamaReceiptJson("x", "1"))
+	_, _, fileData := seedReceiptImagePipeline(t, server.URL)
+
+	got, err := GetReceiptFromReceiptImageId(utils.UintToString(fileData.ID))
+	if err != nil {
+		t.Fatalf("GetReceiptFromReceiptImageId: %v", err)
+	}
+	if got.ID != fileData.ReceiptId {
+		t.Errorf("expected receipt id %d, got %d", fileData.ReceiptId, got.ID)
+	}
+}
+
+func TestGetReceiptFromReceiptImageId_MissingImage(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	_, err := GetReceiptFromReceiptImageId("999999")
+	if err == nil {
+		t.Fatal("expected FileData-not-found error")
+	}
+}
+
+// ReadAllReceiptImagesForGroup spins up multiple goroutines that each
+// instantiate an OcrService. That path needs tesseract + a proper OCR
+// engine configured. Skipped in favor of integration coverage.
+func TestReadAllReceiptImagesForGroup_SkippedByDefault(t *testing.T) {
+	t.Skip("Requires tesseract + OcrService wiring; covered by integration tests")
+}

--- a/api/internal/services/receipt_processing_test.go
+++ b/api/internal/services/receipt_processing_test.go
@@ -1,13 +1,20 @@
 package services
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"receipt-wrangler/api/internal/commands"
 	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/repositories"
+	"receipt-wrangler/api/internal/utils"
 )
 
 func TestFormatEmailContent_BothPresent(t *testing.T) {
@@ -239,5 +246,427 @@ func TestEncodeImageForAi_UnsupportedAiTypeReturnsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unsupported AI type") {
 		t.Errorf("expected error to mention 'unsupported AI type', got: %v", err)
+	}
+}
+
+// ---------- cleanResponse ----------
+
+func TestCleanResponse_StripsJsonMarkers(t *testing.T) {
+	service := ReceiptProcessingService{}
+	got := service.cleanResponse("```json\n{\"a\":1}\n```")
+	if strings.Contains(got, "```") {
+		t.Errorf("expected backticks stripped, got: %q", got)
+	}
+	if !strings.Contains(got, `{"a":1}`) {
+		t.Errorf("expected payload preserved, got: %q", got)
+	}
+}
+
+func TestCleanResponse_NoMarkersPassThrough(t *testing.T) {
+	service := ReceiptProcessingService{}
+	got := service.cleanResponse(`{"a":1}`)
+	if got != `{"a":1}` {
+		t.Errorf("expected %q, got %q", `{"a":1}`, got)
+	}
+}
+
+// ---------- Fixture helpers for the DB/orchestration tests ----------
+
+// seedReceiptProcessingFixtures creates the minimum viable graph to exercise
+// processing: a Prompt, a ReceiptProcessingSettings pointed at the given
+// mock-server URL with AiType=OLLAMA, and a matching
+// SystemReceiptProcessingSettings so NewSystemReceiptProcessingService works
+// when invoked with an empty groupId.
+func seedReceiptProcessingFixtures(t *testing.T, url string) models.ReceiptProcessingSettings {
+	t.Helper()
+	db := repositories.GetDB()
+
+	prompt := models.Prompt{Name: "p", Prompt: "Receipt: @ocrText"}
+	if err := db.Create(&prompt).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	settings := models.ReceiptProcessingSettings{
+		Name:          "test-rps",
+		AiType:        models.OLLAMA,
+		Url:           url,
+		Model:         "test-model",
+		IsVisionModel: false,
+		PromptId:      prompt.ID,
+	}
+	if err := db.Create(&settings).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	// Link as the active system settings so
+	// NewSystemReceiptProcessingService picks it up without a groupId.
+	sysSettings := models.SystemSettings{
+		BaseModel:                   models.BaseModel{ID: 1},
+		ReceiptProcessingSettingsId: &settings.ID,
+	}
+	if err := db.Create(&sysSettings).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	return settings
+}
+
+func ollamaReceiptJson(name, amount string) string {
+	content := fmt.Sprintf(`{"name":"%s","amount":"%s"}`, name, amount)
+	contentEscaped, _ := json.Marshal(content)
+	return `{"model":"test","created_at":"2024-01-01T00:00:00Z","message":{"role":"assistant","content":` + string(contentEscaped) + `},"done":true}`
+}
+
+func setupImagePathFixture(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "img.jpg")
+
+	jpg, err := os.ReadFile(filepath.Join("/app/api/testing", "test.jpg"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	if err := os.WriteFile(path, jpg, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+// ---------- Constructors ----------
+
+func TestNewReceiptProcessingService_InvalidId(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	_, err := NewReceiptProcessingService(nil, "999999", "")
+	if err == nil {
+		t.Fatal("expected not-found error for invalid settings id")
+	}
+}
+
+func TestNewReceiptProcessingService_HappyPath(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	settings := seedReceiptProcessingFixtures(t, "http://example.invalid")
+	service, err := NewReceiptProcessingService(nil, utils.UintToString(settings.ID), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if service.ReceiptProcessingSettings.ID != settings.ID {
+		t.Errorf("expected settings ID %d, got %d", settings.ID, service.ReceiptProcessingSettings.ID)
+	}
+}
+
+func TestNewReceiptProcessingService_WithFallback(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	primary := seedReceiptProcessingFixtures(t, "http://primary.invalid")
+	db := repositories.GetDB()
+	fallbackPrompt := models.Prompt{Name: "p-fallback", Prompt: "fallback"}
+	if err := db.Create(&fallbackPrompt).Error; err != nil {
+		t.Fatalf("seed fallback prompt: %v", err)
+	}
+	fallback := models.ReceiptProcessingSettings{
+		Name:     "fallback-rps",
+		AiType:   models.OLLAMA,
+		Url:      "http://fallback.invalid",
+		Model:    "m",
+		PromptId: fallbackPrompt.ID,
+	}
+	if err := db.Create(&fallback).Error; err != nil {
+		t.Fatalf("seed fallback: %v", err)
+	}
+
+	service, err := NewReceiptProcessingService(nil, utils.UintToString(primary.ID), utils.UintToString(fallback.ID))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if service.FallbackReceiptProcessingSettings.ID != fallback.ID {
+		t.Errorf("expected fallback ID %d, got %d", fallback.ID, service.FallbackReceiptProcessingSettings.ID)
+	}
+}
+
+func TestNewSystemReceiptProcessingService_NoGroupId(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	seedReceiptProcessingFixtures(t, "http://sys.invalid")
+	service, err := NewSystemReceiptProcessingService(nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if service.ReceiptProcessingSettings.ID == 0 {
+		t.Error("expected loaded ReceiptProcessingSettings to have nonzero ID")
+	}
+}
+
+// ---------- buildPrompt ----------
+
+func TestBuildPrompt_InterpolatesVariables(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	db := repositories.GetDB()
+	prompt := models.Prompt{
+		Name:   "bp",
+		Prompt: "categories=@categories tags=@tags ocr=@ocrText year=@currentYear",
+	}
+	if err := db.Create(&prompt).Error; err != nil {
+		t.Fatalf("seed prompt: %v", err)
+	}
+
+	service := ReceiptProcessingService{
+		ReceiptProcessingSettings: models.ReceiptProcessingSettings{PromptId: prompt.ID},
+	}
+	realPrompt, cmd, err := service.buildPrompt(service.ReceiptProcessingSettings, "some ocr")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(realPrompt, "ocr=some ocr") {
+		t.Errorf("expected ocr substituted, got: %q", realPrompt)
+	}
+	if !strings.Contains(realPrompt, "year=") {
+		t.Errorf("expected current-year substitution, got: %q", realPrompt)
+	}
+	if cmd.Status != models.SYSTEM_TASK_SUCCEEDED {
+		t.Errorf("expected SUCCEEDED, got: %s", cmd.Status)
+	}
+}
+
+func TestBuildPrompt_InvalidPromptId(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	service := ReceiptProcessingService{
+		ReceiptProcessingSettings: models.ReceiptProcessingSettings{PromptId: 999999},
+	}
+	_, cmd, err := service.buildPrompt(service.ReceiptProcessingSettings, "")
+	if err == nil {
+		t.Fatal("expected error for missing prompt")
+	}
+	if cmd.Status != models.SYSTEM_TASK_FAILED {
+		t.Errorf("expected FAILED, got: %s", cmd.Status)
+	}
+}
+
+// ---------- Image encoding helpers ----------
+
+func TestEncodeImageForAi_OpenAi(t *testing.T) {
+	path := setupImagePathFixture(t)
+	service := ReceiptProcessingService{}
+
+	got, err := service.encodeImageForAi(path, models.ReceiptProcessingSettings{AiType: models.OPEN_AI_NEW})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(got, "data:image/") {
+		t.Errorf("expected data URI prefix, got: %q", got[:min(25, len(got))])
+	}
+}
+
+func TestEncodeImageForAi_Ollama(t *testing.T) {
+	path := setupImagePathFixture(t)
+	service := ReceiptProcessingService{}
+
+	got, err := service.encodeImageForAi(path, models.ReceiptProcessingSettings{AiType: models.OLLAMA})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == "" {
+		t.Error("expected non-empty base64 string")
+	}
+	if strings.HasPrefix(got, "data:") {
+		t.Errorf("ollama path should return raw base64, got data URI: %q", got[:min(25, len(got))])
+	}
+}
+
+func TestEncodeImageForAi_Gemini(t *testing.T) {
+	path := setupImagePathFixture(t)
+	service := ReceiptProcessingService{}
+
+	got, err := service.encodeImageForAi(path, models.ReceiptProcessingSettings{AiType: models.GEMINI_NEW})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == "" {
+		t.Error("expected non-empty base64 string")
+	}
+}
+
+func TestGetOpenAiBase64Image_ReadFileError(t *testing.T) {
+	service := ReceiptProcessingService{}
+	_, err := service.getOpenAiBase64Image("/definitely/not/a/real/path/nope.jpg")
+	if err == nil {
+		t.Fatal("expected read-file error")
+	}
+}
+
+// ---------- Full orchestration: text-only happy path ----------
+
+func TestReadReceiptText_HappyPath(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	server, _ := newMockOllamaServerForService(t, http.StatusOK, ollamaReceiptJson("Coffee Shop", "5.25"))
+	settings := seedReceiptProcessingFixtures(t, server.URL)
+
+	service, err := NewReceiptProcessingService(nil, utils.UintToString(settings.ID), "")
+	if err != nil {
+		t.Fatalf("constructor: %v", err)
+	}
+
+	receipt, metadata, err := service.ReadReceiptText("email body goes here")
+	if err != nil {
+		t.Fatalf("ReadReceiptText: %v", err)
+	}
+	if receipt.Name != "Coffee Shop" {
+		t.Errorf("expected name 'Coffee Shop', got: %q", receipt.Name)
+	}
+	if !metadata.DidReceiptProcessingSettingsSucceed {
+		t.Error("expected DidReceiptProcessingSettingsSucceed=true")
+	}
+	if metadata.ReceiptProcessingSettingsIdRan != settings.ID {
+		t.Errorf("expected settings id %d, got %d", settings.ID, metadata.ReceiptProcessingSettingsIdRan)
+	}
+}
+
+func TestReadReceiptImagesWithEmailBody_HappyPath_Vision(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	server, _ := newMockOllamaServerForService(t, http.StatusOK, ollamaReceiptJson("Grocery", "42"))
+	settings := seedReceiptProcessingFixtures(t, server.URL)
+	// Switch to a vision model so we skip the OCR path and base64-encode images.
+	repositories.GetDB().Model(&models.ReceiptProcessingSettings{}).Where("id = ?", settings.ID).Update("is_vision_model", true)
+
+	service, err := NewReceiptProcessingService(nil, utils.UintToString(settings.ID), "")
+	if err != nil {
+		t.Fatalf("constructor: %v", err)
+	}
+	// Reload settings with the updated IsVisionModel flag so processImages sees it.
+	repositories.GetDB().Where("id = ?", settings.ID).First(&service.ReceiptProcessingSettings)
+
+	imgPath := setupImagePathFixture(t)
+	receipt, metadata, err := service.ReadReceiptImagesWithEmailBody([]string{imgPath}, "body", false)
+	if err != nil {
+		t.Fatalf("ReadReceiptImagesWithEmailBody: %v", err)
+	}
+	if receipt.Name != "Grocery" {
+		t.Errorf("expected name 'Grocery', got: %q", receipt.Name)
+	}
+	if !metadata.DidReceiptProcessingSettingsSucceed {
+		t.Error("expected DidReceiptProcessingSettingsSucceed=true")
+	}
+}
+
+func TestReadReceipt_FallbackUsedWhenPrimaryFails(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	primaryServer, _ := newMockOllamaServerForService(t, http.StatusOK, "")
+	primaryUrl := primaryServer.URL
+	primaryServer.Close()
+
+	fallbackServer, _ := newMockOllamaServerForService(t, http.StatusOK, ollamaReceiptJson("From Fallback", "7"))
+
+	primary := seedReceiptProcessingFixtures(t, primaryUrl)
+	db := repositories.GetDB()
+	fallbackPrompt := models.Prompt{Name: "fallback-p", Prompt: "fallback prompt"}
+	if err := db.Create(&fallbackPrompt).Error; err != nil {
+		t.Fatalf("seed fallback prompt: %v", err)
+	}
+	fallback := models.ReceiptProcessingSettings{
+		Name:     "fallback-rps",
+		AiType:   models.OLLAMA,
+		Url:      fallbackServer.URL,
+		Model:    "m",
+		PromptId: fallbackPrompt.ID,
+	}
+	if err := db.Create(&fallback).Error; err != nil {
+		t.Fatalf("seed fallback: %v", err)
+	}
+
+	service, err := NewReceiptProcessingService(nil, utils.UintToString(primary.ID), utils.UintToString(fallback.ID))
+	if err != nil {
+		t.Fatalf("constructor: %v", err)
+	}
+
+	receipt, metadata, err := service.ReadReceiptText("body")
+	if err != nil {
+		t.Fatalf("ReadReceiptText: %v", err)
+	}
+	if receipt.Name != "From Fallback" {
+		t.Errorf("expected 'From Fallback', got: %q", receipt.Name)
+	}
+	if metadata.DidReceiptProcessingSettingsSucceed {
+		t.Error("expected primary to NOT succeed")
+	}
+	if !metadata.DidFallbackReceiptProcessingSettingsSucceed {
+		t.Error("expected fallback to succeed")
+	}
+	if metadata.FallbackReceiptProcessingSettingsIdRan != fallback.ID {
+		t.Errorf("expected fallback id %d, got %d", fallback.ID, metadata.FallbackReceiptProcessingSettingsIdRan)
+	}
+}
+
+// ReadReceiptImage and ReadReceiptImageWithEmailBody are thin one-line
+// wrappers around readReceipt; cover them so the wrappers aren't 0%.
+func TestReadReceiptImage_SingleImageWrapper(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	server, _ := newMockOllamaServerForService(t, http.StatusOK, ollamaReceiptJson("Wrapper", "1"))
+	settings := seedReceiptProcessingFixtures(t, server.URL)
+	repositories.GetDB().Model(&models.ReceiptProcessingSettings{}).Where("id = ?", settings.ID).Update("is_vision_model", true)
+
+	service, err := NewReceiptProcessingService(nil, utils.UintToString(settings.ID), "")
+	if err != nil {
+		t.Fatalf("constructor: %v", err)
+	}
+	repositories.GetDB().Where("id = ?", settings.ID).First(&service.ReceiptProcessingSettings)
+
+	imgPath := setupImagePathFixture(t)
+	receipt, _, err := service.ReadReceiptImage(imgPath)
+	if err != nil {
+		t.Fatalf("ReadReceiptImage: %v", err)
+	}
+	if receipt.Name != "Wrapper" {
+		t.Errorf("expected 'Wrapper', got %q", receipt.Name)
+	}
+}
+
+func TestReadReceiptImageWithEmailBody_Wrapper(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	server, _ := newMockOllamaServerForService(t, http.StatusOK, ollamaReceiptJson("WrapperBody", "2"))
+	settings := seedReceiptProcessingFixtures(t, server.URL)
+	repositories.GetDB().Model(&models.ReceiptProcessingSettings{}).Where("id = ?", settings.ID).Update("is_vision_model", true)
+
+	service, err := NewReceiptProcessingService(nil, utils.UintToString(settings.ID), "")
+	if err != nil {
+		t.Fatalf("constructor: %v", err)
+	}
+	repositories.GetDB().Where("id = ?", settings.ID).First(&service.ReceiptProcessingSettings)
+
+	imgPath := setupImagePathFixture(t)
+	receipt, _, err := service.ReadReceiptImageWithEmailBody(imgPath, "email body")
+	if err != nil {
+		t.Fatalf("ReadReceiptImageWithEmailBody: %v", err)
+	}
+	if receipt.Name != "WrapperBody" {
+		t.Errorf("expected 'WrapperBody', got %q", receipt.Name)
+	}
+}
+
+func TestReadReceipt_AiReturnsInvalidJson(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	server, _ := newMockOllamaServerForService(t, http.StatusOK,
+		`{"model":"test","created_at":"2024-01-01T00:00:00Z","message":{"role":"assistant","content":"not json"},"done":true}`)
+	settings := seedReceiptProcessingFixtures(t, server.URL)
+
+	service, err := NewReceiptProcessingService(nil, utils.UintToString(settings.ID), "")
+	if err != nil {
+		t.Fatalf("constructor: %v", err)
+	}
+
+	_, metadata, err := service.ReadReceiptText("body")
+	if err == nil {
+		t.Fatal("expected JSON unmarshal error")
+	}
+	if metadata.DidReceiptProcessingSettingsSucceed {
+		t.Error("expected primary to NOT succeed on invalid JSON")
 	}
 }


### PR DESCRIPTION
## Summary

Covers the two biggest 0%-coverage areas of the Go backend and fixes three latent bugs surfaced while writing the tests.

### Coverage
**Total backend: 30.0% → 38.5%**

| Package | Before | After |
|---|---|---|
| `internal/services` | 30.8% | **52.0%** |
| `internal/middleware` | 26.6% | **49.5%** |
| `internal/repositories` | 33.5% | **41.5%** |
| `internal/handlers` | 34.5% | **36.3%** |
| `internal/ai` | 0.0% | **65.0%** (gemini intentionally skipped — hardcoded SDK URL) |

### New / extended tests
- **Authentication** — `handlers/login_test.go`, `handlers/logout_test.go`, `middleware/login_test.go`, `middleware/refresh_token_test.go`, extended `services/auth_test.go`.
- **AI clients** — `ai/main_test.go`, `ai/base_client_test.go`, `ai/open_ai_test.go`, `ai/ollama_test.go` (stdlib `httptest.NewServer` — no new deps).
- **AI service + receipt pipeline** — `services/ai_test.go`, `services/receipt_image_test.go`, extended `services/receipt_processing_test.go`.
- **Files repo** — extended `repositories/files_test.go` including `ConvertPdfToJpg` / `ConvertHeicToJpg` exercised through ImageMagick (installed in CI).

### Bugs fixed

- **BUG-3** — `middleware/refresh_token.go RevokeRefreshToken` used `.Find` instead of `.First`, so an unknown refresh token was silently treated as a successful revocation. Now explicitly clears auth cookies and returns 500 on `gorm.ErrRecordNotFound`.
- **BUG-4** — `ai/open_ai.go GetChatCompletion` read `resp.Choices[0]` without a length guard, panicking on empty-choices responses. Now returns a clean error; `RawResponse` is preserved for debuggability.
- **BUG-5** — `repositories/files.go ConvertPdfToJpg` called `log.Fatal(err)` on `AddImage` failure mid-loop, killing the entire API process. Now destroys the working image and returns the error to the caller.

## Test plan
- [ ] `cd api && go test ./...` passes locally
- [ ] CI job (`ci.yml`) passes on the branch — particularly the ImageMagick-backed `ConvertPdfToJpg` / `GetBytesFromImageBytes_PdfRoutesThroughConversion` tests
- [ ] `go tool cover -func=coverage.out | tail -1` shows ≥ 38.5%
- [ ] Auth regression check: log in (web + mobile), exercise `/api/token` refresh, confirm cookie-clearing on an unknown refresh token returns 500 with cleared cookies

🤖 Generated with [Claude Code](https://claude.com/claude-code)