### PR TITLE
Add persistent volumes to dev docker-compose configuration

### DIFF
--- a/api/dev/docker-compose.yaml
+++ b/api/dev/docker-compose.yaml
@@ -18,7 +18,26 @@ services:
       - "9000:22"
     networks:
       - app-net
+    volumes:
+      - app:/app
+      - docs:/docs
+      - go:/go
+      - root:/root
+      - etc:/etc
+      - usr:/usr
+      - var:/var
+      - opt:/opt
 
 networks:
   app-net:
+
+volumes:
+  app:
+  docs:
+  go:
+  root:
+  etc:
+  usr:
+  var:
+  opt:
 


### PR DESCRIPTION
## Summary
This change adds persistent volume mounts to the Docker Compose development environment to preserve data across container restarts and rebuilds.

## Key Changes
- Added volume mounts to the main service for critical directories:
  - Application code (`/app`)
  - Documentation (`/docs`)
  - Go installation (`/go`)
  - Root home directory (`/root`)
  - System directories (`/etc`, `/usr`, `/var`, `/opt`)
- Defined corresponding named volumes in the `volumes` section of the compose file

## Implementation Details
The volumes are mounted as named volumes rather than bind mounts, which provides better portability across different development environments while ensuring that important files and configurations persist between container lifecycle events.

https://claude.ai/code/session_01JkVubWmyS1tbqVtpmy5sjp