### PR TITLE
fix hardcoded /app/api fixture paths breaking CI tests

### DIFF
--- a/api/internal/repositories/files_test.go
+++ b/api/internal/repositories/files_test.go
@@ -9,17 +9,20 @@ import (
 	"receipt-wrangler/api/internal/constants"
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/utils"
+	"runtime"
 	"strings"
 	"testing"
 
 	"gopkg.in/gographics/imagick.v3/imagick"
 )
 
-// testBasePath returns the path that tests should use as BASE_PATH so
-// GetTempDirectoryPath() and GetTestJpgBytes() resolve correctly. The repo
-// layout has the jpg fixture at /app/api/testing/test.jpg.
+// testBasePath returns the absolute path of the api/ directory so tests
+// can locate the shared testing/ fixtures regardless of CWD or where the
+// repo is checked out (dev container vs. CI vs. local clone).
 func testBasePath() string {
-	return "/app/api"
+	_, file, _, _ := runtime.Caller(0)
+	// file = .../api/internal/repositories/files_test.go
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
 }
 
 // readTestJpgBytes is a local helper so tests don't depend on basePath

--- a/api/internal/services/receipt_image_test.go
+++ b/api/internal/services/receipt_image_test.go
@@ -9,10 +9,19 @@ import (
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/repositories"
 	"receipt-wrangler/api/internal/utils"
+	"runtime"
 	"testing"
 
 	"gopkg.in/gographics/imagick.v3/imagick"
 )
+
+// testApiRoot returns the absolute path of the api/ directory. See the
+// identical helper in repositories/files_test.go for rationale.
+func testApiRoot() string {
+	_, file, _, _ := runtime.Caller(0)
+	// file = .../api/internal/services/receipt_image_test.go
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
 
 // jpgToPdf converts a JPG blob to a one-page PDF using ImageMagick. Used by
 // the PDF-branch receipt-image test.
@@ -46,7 +55,7 @@ func jpgToPdf(t *testing.T, jpgBytes []byte) []byte {
 // GetReceiptFromReceiptImageId / ReadReceiptImage invocations).
 func seedReceiptImagePipeline(t *testing.T, url string) (models.User, models.Group, models.FileData) {
 	t.Helper()
-	t.Setenv("BASE_PATH", "/app/api")
+	t.Setenv("BASE_PATH", testApiRoot())
 	db := repositories.GetDB()
 
 	user := models.User{Username: "ri-user", Password: "p", DisplayName: "x"}
@@ -109,7 +118,7 @@ func seedReceiptImagePipeline(t *testing.T, url string) (models.User, models.Gro
 		t.Fatalf("BuildFilePath: %v", err)
 	}
 	_ = os.MkdirAll(filepath.Dir(path), 0o755)
-	jpg, err := os.ReadFile(filepath.Join("/app/api/testing", "test.jpg"))
+	jpg, err := os.ReadFile(filepath.Join(testApiRoot(), "testing", "test.jpg"))
 	if err != nil {
 		t.Fatalf("read fixture: %v", err)
 	}
@@ -153,7 +162,7 @@ func TestReadReceiptImage_UnknownId(t *testing.T) {
 // PDF image path → ConvertPdfToJpg runs, temp file written + removed.
 func TestReadReceiptImage_PdfRoutesThroughConversion(t *testing.T) {
 	defer repositories.TruncateTestDb()
-	t.Setenv("BASE_PATH", "/app/api")
+	t.Setenv("BASE_PATH", testApiRoot())
 
 	server, _ := newMockOllamaServerForService(t, http.StatusOK, ollamaReceiptJson("PdfReceipt", "99"))
 	_, _, fileData := seedReceiptImagePipeline(t, server.URL)
@@ -277,7 +286,7 @@ func TestMagicFillFromImage_HappyPath(t *testing.T) {
 	server, _ := newMockOllamaServerForService(t, http.StatusOK, ollamaReceiptJson("Magic", "7"))
 	_, group, _ := seedReceiptImagePipeline(t, server.URL)
 
-	jpg, err := os.ReadFile(filepath.Join("/app/api/testing", "test.jpg"))
+	jpg, err := os.ReadFile(filepath.Join(testApiRoot(), "testing", "test.jpg"))
 	if err != nil {
 		t.Fatalf("read fixture: %v", err)
 	}

--- a/api/internal/services/receipt_processing_test.go
+++ b/api/internal/services/receipt_processing_test.go
@@ -322,7 +322,7 @@ func setupImagePathFixture(t *testing.T) string {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "img.jpg")
 
-	jpg, err := os.ReadFile(filepath.Join("/app/api/testing", "test.jpg"))
+	jpg, err := os.ReadFile(filepath.Join(testApiRoot(), "testing", "test.jpg"))
 	if err != nil {
 		t.Fatalf("read fixture: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Test helpers in `repositories/files_test.go` and `services/*_test.go` hardcoded `/app/api` as the fixture root. That path exists in the dev container but not in CI, where the checkout is at `/__w/receipt-wrangler/receipt-wrangler/api/` — so every test that needed `testing/test.jpg` failed with "no such file or directory".
- Replaced the hardcoded literal with a `runtime.Caller(0)`-based resolver that computes the `api/` directory from each test file's own source location. Works in any environment (dev container, CI, fresh clone, arbitrary CWD) with no env vars.
- Fixes the ~22 failing tests in the latest `test-api` run (the ones reporting `unable to read test fixture /app/api/testing/test.jpg`) plus `TestGetTestJpgBytes_ReadsFixture` that was returning 0 bytes.

Production code is not touched — this is a test-fixture-resolution fix only.

## Test plan

- [x] `go test ./internal/repositories/... ./internal/services/...` passes locally (21.1s + 74.9s)
- [x] All previously failing tests listed in the CI log now pass (verified the targeted `-run` subset)
- [ ] CI `test-api` job is green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)