### PR TITLE
mobile-e2e: local Android + iOS runners + API user seeding

### DIFF
--- a/api/dev/seed-e2e-users.sh
+++ b/api/dev/seed-e2e-users.sh
@@ -47,10 +47,14 @@ command -v curl >/dev/null    || { echo "curl not on PATH" >&2; exit 1; }
 command -v python3 >/dev/null || { echo "python3 not on PATH" >&2; exit 1; }
 
 echo "==> logging in as $admin_username at $api_base_url"
+# Build the JSON body via python3 instead of bash string interpolation so a
+# password containing quotes/backslashes/newlines can't corrupt the payload.
+login_body="$(python3 -c 'import json,sys; print(json.dumps({"username":sys.argv[1],"password":sys.argv[2]}))' \
+  "$admin_username" "$admin_password")"
 login_response="$(curl -fsS --max-time 10 -X POST \
   "$api_base_url/login/?tokensInBody=true" \
   -H 'Content-Type: application/json' \
-  -d "{\"username\":\"$admin_username\",\"password\":\"$admin_password\"}" || true)"
+  -d "$login_body" || true)"
 
 if [[ -z "$login_response" ]]; then
   echo "login failed: empty response (API down? wrong base URL?)" >&2
@@ -93,15 +97,18 @@ create_user_if_missing() {
   body="$(python3 -c 'import json,sys; print(json.dumps({"username":sys.argv[1],"password":sys.argv[2],"displayName":sys.argv[3],"userRole":sys.argv[4],"isDummyUser":False}))' \
     "$username" "$password" "$display_name" "$role")"
 
-  local response http_code
-  response="$(curl -sS --max-time 10 -o /tmp/seed-e2e-users-response.$$ -w '%{http_code}' \
+  # Use mktemp instead of /tmp/...$$ -- the PID-based path is predictable and
+  # vulnerable to a symlink race on shared machines.
+  local response http_code response_file
+  response_file="$(mktemp -t seed-e2e-users.XXXXXX)"
+  response="$(curl -sS --max-time 10 -o "$response_file" -w '%{http_code}' \
     -X POST "$api_base_url/user/" \
     -H "Authorization: Bearer $jwt" \
     -H 'Content-Type: application/json' \
     -d "$body")"
   http_code="$response"
-  body="$(cat /tmp/seed-e2e-users-response.$$ 2>/dev/null || true)"
-  rm -f /tmp/seed-e2e-users-response.$$
+  body="$(cat "$response_file" 2>/dev/null || true)"
+  rm -f "$response_file"
 
   if [[ "$http_code" == "200" ]]; then
     printf '==> %-12s (%-5s) ... [created]\n' "$username" "$role"

--- a/api/dev/seed-e2e-users.sh
+++ b/api/dev/seed-e2e-users.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Idempotent seed script for the two e2e test users that mobile/run-e2e-*.sh
+# and desktop's Playwright suite expect.
+#
+# Why this exists:
+#   - The API auto-creates a default `admin/admin` user on first startup
+#     (repositories/db.go -> CreateUserIfNoneExist) outside `deployEnv=test`.
+#   - The mobile e2e tests need `e2e-admin` (role ADMIN) and `e2e-user`
+#     (role USER) to log in. These are NOT auto-seeded.
+#   - The UI signup path is gated on `enableLocalSignUp`, which is `false`
+#     locally, AND would assign USER role anyway because the auto-admin
+#     already occupies the "first user = ADMIN" slot in CreateUser.
+#   - The admin-protected POST /user/ endpoint accepts an explicit `userRole`
+#     and creates whatever you ask for, so we use it to seed both.
+#
+# Usage:
+#   cd api && ./dev/seed-e2e-users.sh
+#
+# Env overrides (all optional, defaults match switch-to-sqlite.sh):
+#   API_BASE_URL          default http://localhost:8081/api
+#   ADMIN_USERNAME        default admin   (the auto-created default admin)
+#   ADMIN_PASSWORD        default admin
+#   E2E_ADMIN_USERNAME    default e2e-admin
+#   E2E_ADMIN_PASSWORD    default e2e-admin-password
+#   E2E_USER_USERNAME     default e2e-user
+#   E2E_USER_PASSWORD     default e2e-user-password
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Pick up E2E_* defaults from switch-to-sqlite.sh if not already exported.
+if [[ -f "$script_dir/switch-to-sqlite.sh" ]]; then
+  # shellcheck disable=SC1090
+  source "$script_dir/switch-to-sqlite.sh"
+fi
+
+api_base_url="${API_BASE_URL:-http://localhost:8081/api}"
+admin_username="${ADMIN_USERNAME:-admin}"
+admin_password="${ADMIN_PASSWORD:-admin}"
+e2e_admin_username="${E2E_ADMIN_USERNAME:-e2e-admin}"
+e2e_admin_password="${E2E_ADMIN_PASSWORD:-e2e-admin-password}"
+e2e_user_username="${E2E_USER_USERNAME:-e2e-user}"
+e2e_user_password="${E2E_USER_PASSWORD:-e2e-user-password}"
+
+command -v curl >/dev/null    || { echo "curl not on PATH" >&2; exit 1; }
+command -v python3 >/dev/null || { echo "python3 not on PATH" >&2; exit 1; }
+
+echo "==> logging in as $admin_username at $api_base_url"
+login_response="$(curl -fsS --max-time 10 -X POST \
+  "$api_base_url/login/?tokensInBody=true" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$admin_username\",\"password\":\"$admin_password\"}" || true)"
+
+if [[ -z "$login_response" ]]; then
+  echo "login failed: empty response (API down? wrong base URL?)" >&2
+  exit 1
+fi
+
+jwt="$(printf '%s' "$login_response" \
+  | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("jwt",""))' \
+  || true)"
+
+if [[ -z "$jwt" ]]; then
+  echo "login failed: no jwt in response body" >&2
+  echo "response: $login_response" >&2
+  exit 1
+fi
+
+echo "==> fetching existing users"
+existing_users_json="$(curl -fsS --max-time 10 \
+  "$api_base_url/user/" \
+  -H "Authorization: Bearer $jwt")"
+
+existing_usernames="$(printf '%s' "$existing_users_json" \
+  | python3 -c 'import json,sys; print("\n".join(u["username"] for u in json.load(sys.stdin)))')"
+
+echo "    existing: $(echo "$existing_usernames" | tr '\n' ' ')"
+
+# create_user_if_missing <username> <password> <displayName> <role>
+create_user_if_missing() {
+  local username="$1"
+  local password="$2"
+  local display_name="$3"
+  local role="$4"
+
+  if printf '%s\n' "$existing_usernames" | grep -Fxq "$username"; then
+    printf '==> %-12s (%-5s) ... [exists]\n' "$username" "$role"
+    return 0
+  fi
+
+  local body
+  body="$(python3 -c 'import json,sys; print(json.dumps({"username":sys.argv[1],"password":sys.argv[2],"displayName":sys.argv[3],"userRole":sys.argv[4],"isDummyUser":False}))' \
+    "$username" "$password" "$display_name" "$role")"
+
+  local response http_code
+  response="$(curl -sS --max-time 10 -o /tmp/seed-e2e-users-response.$$ -w '%{http_code}' \
+    -X POST "$api_base_url/user/" \
+    -H "Authorization: Bearer $jwt" \
+    -H 'Content-Type: application/json' \
+    -d "$body")"
+  http_code="$response"
+  body="$(cat /tmp/seed-e2e-users-response.$$ 2>/dev/null || true)"
+  rm -f /tmp/seed-e2e-users-response.$$
+
+  if [[ "$http_code" == "200" ]]; then
+    printf '==> %-12s (%-5s) ... [created]\n' "$username" "$role"
+  else
+    printf '==> %-12s (%-5s) ... [FAILED http %s] %s\n' \
+      "$username" "$role" "$http_code" "$body" >&2
+    return 1
+  fi
+}
+
+rc=0
+create_user_if_missing "$e2e_admin_username" "$e2e_admin_password" "E2E Admin" "ADMIN" || rc=1
+create_user_if_missing "$e2e_user_username"  "$e2e_user_password"  "E2E User"  "USER"  || rc=1
+
+exit $rc

--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -168,36 +168,74 @@ End-to-end tests live in `integration_test/` (sibling of `test/`) and use Flutte
 
 **Stack choice:** `integration_test` SDK package. Not Patrol (we don't need native permission dialogs yet). Not the deprecated `flutter_driver`.
 
-**Supported targets:** Linux desktop locally (`./run-e2e.sh`), and Android emulator in CI (`.github/workflows/mobile-e2e.yml`). The CI workflow is **advisory** (`continue-on-error: true`) and triggers only on pushes to `tech/mobile-e2e` + `workflow_dispatch` while we iterate. iOS simulator, CI-on-main, and PR triggering are still deferred — see the "Out of scope" note at the bottom of this section.
+**Supported targets:**
+- **Local Android emulator** via `./run-e2e-android.sh` (macOS, auto-boots an AVD).
+- **Local iOS Simulator** via `./run-e2e-ios.sh` (macOS, auto-boots a sim).
+- **Local Linux desktop** via `./run-e2e.sh` (containers/CI Linux). Originally the primary target; kept for the dev container's headless flow.
+- **CI Android + iOS** via `.github/workflows/mobile-e2e.yml`, **advisory** (`continue-on-error: true`), triggers on pushes to `tech/mobile-e2e` + `workflow_dispatch` while we iterate.
+
+CI-on-main, PR triggering, and screenshot/video capture are still deferred — see the "Out of scope" note at the bottom of this section.
 
 #### Prerequisites
 
-1. **One-time system packages** (in addition to the Linux-desktop build prereqs from the Flutter SDK Setup section above):
-   ```bash
-   apt-get install -y --no-install-recommends libsecret-1-dev xvfb
-   ```
-   `libsecret-1-dev` is needed to *build* the `flutter_secure_storage_linux` plugin (pkg-config fails the CMake step without it). `xvfb` is needed to *run* the Flutter desktop app headlessly — `run-e2e.sh` auto-wraps the test in `xvfb-run` when `$DISPLAY` is empty.
-2. **One-time:** enable Linux desktop and install `integration_test`:
-   ```bash
-   flutter config --enable-linux-desktop
-   cd mobile && flutter pub get
-   ```
-3. **One-time:** seed the two e2e users. **Order matters** — the first sign-up is auto-promoted to admin. Use the desktop sign-up UI at `http://localhost:4200/auth/sign-up`:
-   - Admin first: username `e2e-admin`, password `e2e-admin-password`
-   - Then user: username `e2e-user`, password `e2e-user-password`
+**Per target:**
 
-   Note: if `enableLocalSignUp` is `false` in the feature config, the signup UI/endpoint both 404. Either flip the setting in system settings, or ask the repo owner to seed the accounts — **do not seed via the API or by writing to the SQLite DB directly** (see the user memory on test data setup).
-4. **Every run:** start the Go API separately (`cd api && go run main.go`). `run-e2e.sh` does not start the API — same pattern as Playwright.
+| Target          | Prereqs                                                                                                              |
+| --------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Android (mac)   | Android SDK (Studio or `cmdline-tools`); at least one AVD; `coreutils` on PATH (`brew install coreutils`, for `gtimeout`). |
+| iOS (mac)       | Xcode + iOS Simulator (`xcrun simctl` on PATH); `coreutils` on PATH. The iOS Simulator runtime matching your installed Xcode is required — see "iOS 26.x runtime gotcha" below. |
+| Linux desktop   | `apt-get install -y --no-install-recommends libsecret-1-dev xvfb` (`libsecret-1-dev` to *build* `flutter_secure_storage_linux`, `xvfb` to *run* headlessly — `run-e2e.sh` auto-wraps in `xvfb-run` when `$DISPLAY` is unset). Plus `flutter config --enable-linux-desktop`. |
+
+**Shared, one-time:**
+
+1. `cd mobile && flutter pub get`
+2. Seed the two e2e users by running `./api/dev/seed-e2e-users.sh` (idempotent — safe to re-run). It logs in as the default `admin/admin` user that `MakeMigrations()` auto-creates on a fresh DB, then calls the admin-protected `POST /user/` to create:
+   - `e2e-admin` with role `ADMIN`
+   - `e2e-user` with role `USER`
+
+   The script uses creds matching `api/dev/switch-to-sqlite.sh` (and the mariadb/postgresql variants), so a later `source` of those scripts gives the runners credentials that line up with what's seeded. Override `ADMIN_USERNAME` / `ADMIN_PASSWORD` if the default admin's password has been changed; override `API_BASE_URL` to seed a non-local backend.
+
+   Why API-seed instead of the UI: `enableLocalSignUp` is `false` locally so the UI signup 404s, and even if enabled, the auto-`admin/admin` already holds the "first user = ADMIN" slot — a subsequent UI signup for `e2e-admin` would land as USER. `POST /user/` requires admin auth but accepts an explicit `userRole`, so it bypasses both gotchas.
+
+**Every run:** start the Go API separately (`cd api && go run main.go`). None of the runners start the API — same pattern as Playwright.
 
 #### Running locally
 
+Three runners, one per target. Each accepts optional spec paths; with no args it iterates every `*_test.dart` under `integration_test/`.
+
 ```bash
+# Android emulator (mac dev primary target):
+cd mobile && ./run-e2e-android.sh
+cd mobile && ./run-e2e-android.sh integration_test/smoke_login_test.dart
+
+# iOS Simulator:
+cd mobile && ./run-e2e-ios.sh
+cd mobile && ./run-e2e-ios.sh integration_test/smoke_login_test.dart
+
+# Linux desktop (containers, CI Linux):
 cd mobile && ./run-e2e.sh
-# or a single spec:
-cd mobile && ./run-e2e.sh integration_test/smoke_login_test.dart
 ```
 
-`run-e2e.sh` sources `api/dev/switch-to-sqlite.sh` (which exports the `E2E_*` credentials), writes a temp JSON, and invokes `flutter test integration_test/ -d linux --dart-define-from-file=<tmp>`.
+All three runners source `api/dev/switch-to-sqlite.sh` for the four `E2E_*` credentials, write a temp dart-define JSON, and invoke flutter against the suite. **What differs:**
+
+| Runner             | Target          | Invocation                       | Default `E2E_BASE_URL`           |
+| ------------------ | --------------- | -------------------------------- | -------------------------------- |
+| `run-e2e-android.sh` | Android emulator | `flutter drive` (one per spec) | `http://10.0.2.2:8081/api` (host loopback alias) |
+| `run-e2e-ios.sh`   | iOS Simulator   | `flutter drive` (one per spec)   | `http://localhost:8081/api`      |
+| `run-e2e.sh`       | Linux desktop   | `flutter test` (one per spec)    | `http://localhost:8081/api`      |
+
+**Mobile-runner-specific env overrides:**
+- `E2E_ANDROID_AVD` — AVD name (default `Pixel_3a_API_34_extension_level_7_arm64-v8a`). Auto-booted with `-no-snapshot-save -no-boot-anim` if no emulator is attached; the script waits for `sys.boot_completed=1` (5 min ceiling).
+- `E2E_IOS_DEVICE` — simulator device name (default `iPhone 15`). Auto-booted via `xcrun simctl boot` + `bootstatus`. The grep anchor (`^ *<name> (`) excludes "iPhone 15 Pro" / "Pro Max" siblings, so set the exact name.
+- `E2E_MOBILE_BASE_URL` — overrides the table defaults. Useful for pointing at a remote backend, e.g. `E2E_MOBILE_BASE_URL=https://demo.receiptwrangler.io/api ./run-e2e-android.sh`.
+
+**Why `flutter drive` on mobile, `flutter test` on Linux:** on the Android/iOS path, `flutter test integration_test/...` repeatedly hit "Integration tests and unit tests cannot be run in a single invocation" even on a single file. Every working android-emulator-runner CI example uses `flutter drive` with an explicit driver + target (`test_driver/integration_test.dart` calls `integrationDriver()`), so we follow that pattern on mobile. Linux desktop works fine with `flutter test`.
+
+**Why one-`flutter drive`-per-spec on mobile:** the top-level `GoRouter` in `lib/main.dart` is a final global — its location persists across `testWidgets` calls within the same flutter process. Spec N+1 inherits spec N's last URL and 403s on bootstrap. Looping one `flutter drive` per spec gives each its own process. Between specs, the mobile scripts force-stop and uninstall by bundle id `io.receiptwrangler` (flutter drive's own cleanup uninstalls by the namespace `com.example.receipt_wrangler_mobile`, which doesn't match the real package), `pkill -f dartvm` to free leaked dart isolate hosts that own the vmservice port, and wrap each spec in `gtimeout 600` so a hung run doesn't eat the whole job.
+
+**Auto-discovery:** the mobile scripts walk a small list of candidate Flutter install dirs (`~/Documents/flutter/bin`, `~/flutter/bin`, `/opt/flutter/bin`, `/usr/local/flutter/bin`) if `flutter` is not on `$PATH`, and resolve the Android SDK from `$ANDROID_HOME` → `$ANDROID_SDK_ROOT` → `~/Library/Android/sdk`. They prepend `platform-tools` and `emulator` to PATH for the run.
+
+**Devices are left running on exit.** The scripts don't shut down the emulator/simulator — reruns reuse the booted device for speed. To force a cold boot next time: `adb emu kill` (Android) or `xcrun simctl shutdown <udid>` (iOS).
 
 #### How env vars reach the tests
 
@@ -235,6 +273,7 @@ cd mobile && ./run-e2e.sh integration_test/smoke_login_test.dart
 - **Go API rate-limiter:** login is rate-limited. Rerunning the same test in tight succession can 429 — give it a few seconds between runs. The desktop suite notes the same issue in `desktop/e2e/helpers/auth.ts`.
 - **DB accumulation:** tests write real rows (sessions, refresh tokens). Fine for a smoke test; when specs start creating receipts/groups/etc., build per-test uniqueness (UUIDs) into the data, mirroring the Playwright conventions.
 - **Never commit credentials or the generated JSON.** `.e2e-env.json` is gitignored as belt-and-suspenders — the script already uses `mktemp`.
+- **iOS 26.x runtime gotcha:** Xcode 26.x ships with only its own SDK (e.g. Xcode 26.5 → iOS 26.5 SDK only). Until that exact-version *simulator runtime* is installed, `xcodebuild -showdestinations` returns **zero** eligible destinations for this project — no sim on any iOS version is buildable, even though older runtimes (17.x / 18.x) show up under `xcrun simctl list runtimes`. Symptom: `run-e2e-ios.sh` reports `Unable to find a destination matching the provided destination specifier: { id:<udid> }` for whatever sim it picks. Fix: `xcodebuild -downloadPlatform iOS` (about 8GB, ~10–15 min). Once installed, the older simulators become buildable too.
 
 #### Reference files
 
@@ -242,12 +281,15 @@ cd mobile && ./run-e2e.sh integration_test/smoke_login_test.dart
 - `integration_test/helpers/env.dart` — dart-define consumption + guards.
 - `integration_test/helpers/pump.dart` — `pumpUntilFound` polling helper.
 - `integration_test/helpers/platform_mocks.dart` — Linux-desktop platform-channel stubs for `permission_handler`, `gal`, `flutter_secure_storage`.
-- `run-e2e.sh` — local runner; wraps in `xvfb-run` when headless, sources API env, maps `E2E_MOBILE_BASE_URL`, invokes `flutter test`.
+- `test_driver/integration_test.dart` — `integrationDriver()` entrypoint that `flutter drive` uses.
+- `run-e2e-android.sh` — Android runner; auto-boots an AVD, runs per-spec `flutter drive` loop with cleanup between specs.
+- `run-e2e-ios.sh` — iOS runner; resolves a simulator UDID by name and boots it, runs per-spec `flutter drive` loop.
+- `run-e2e.sh` — Linux desktop runner; wraps in `xvfb-run` when headless, invokes `flutter test`.
+- `.github/workflows/mobile-e2e.yml` — CI counterpart; same command shapes the local mobile scripts mirror.
 - `desktop/e2e/helpers/auth.ts` — Playwright counterpart; follow its conventions when adding new flows.
 
 #### Out of scope (future work)
 
-- iOS simulator (needs a macOS runner; significantly higher cost and complexity).
 - Promoting the CI workflow from `tech/mobile-e2e` to `main` / PR triggers, and from advisory to required.
 - Screenshot / video artifact capture on failure.
 - `storageState`-style auth warmup across a multi-spec suite.

--- a/mobile/ios/Podfile.lock
+++ b/mobile/ios/Podfile.lock
@@ -12,6 +12,8 @@ PODS:
   - gal (1.0.0):
     - Flutter
     - FlutterMacOS
+  - integration_test (0.0.1):
+    - Flutter
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -28,6 +30,7 @@ DEPENDENCIES:
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - flutter_secure_storage_darwin (from `.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
   - gal (from `.symlinks/plugins/gal/darwin`)
+  - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
@@ -45,6 +48,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_secure_storage_darwin/darwin"
   gal:
     :path: ".symlinks/plugins/gal/darwin"
+  integration_test:
+    :path: ".symlinks/plugins/integration_test/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
   permission_handler_apple:
@@ -59,6 +64,7 @@ SPEC CHECKSUMS:
   flutter_native_splash: f71420956eb811e6d310720fee915f1d42852e7a
   flutter_secure_storage_darwin: 557817588b80e60213cbecb573c45c76b788018d
   gal: 6a522c75909f1244732d4596d11d6a2f86ff37a5
+  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78

--- a/mobile/run-e2e-android.sh
+++ b/mobile/run-e2e-android.sh
@@ -55,6 +55,7 @@ export PATH="$android_sdk/platform-tools:$android_sdk/emulator:$PATH"
 command -v adb >/dev/null 2>&1 || { echo "adb not under $android_sdk/platform-tools" >&2; exit 1; }
 command -v emulator >/dev/null 2>&1 || { echo "emulator not under $android_sdk/emulator" >&2; exit 1; }
 command -v gtimeout >/dev/null 2>&1 || { echo "gtimeout not found; brew install coreutils" >&2; exit 1; }
+command -v python3 >/dev/null 2>&1 || { echo "python3 not on PATH (needed to safely build the dart-define JSON)" >&2; exit 1; }
 
 # --- credentials -------------------------------------------------------------
 env_script="../api/dev/switch-to-sqlite.sh"
@@ -124,17 +125,25 @@ echo "==> flutter pub get"
 flutter pub get
 
 # --- dart-define payload -----------------------------------------------------
+# Build the JSON via python3 instead of a heredoc so any value containing
+# quotes/backslashes/newlines gets properly escaped. The heredoc form would
+# emit invalid JSON that `flutter --dart-define-from-file` would reject.
 tmp_env="$(mktemp -t run-e2e-android.XXXXXX).json"
 trap 'rm -f "$tmp_env"' EXIT
-cat > "$tmp_env" <<EOF
-{
-  "E2E_BASE_URL": "$mobile_base_url",
-  "E2E_ADMIN_USERNAME": "$E2E_ADMIN_USERNAME",
-  "E2E_ADMIN_PASSWORD": "$E2E_ADMIN_PASSWORD",
-  "E2E_USER_USERNAME": "$E2E_USER_USERNAME",
-  "E2E_USER_PASSWORD": "$E2E_USER_PASSWORD"
-}
-EOF
+python3 - "$tmp_env" "$mobile_base_url" \
+  "$E2E_ADMIN_USERNAME" "$E2E_ADMIN_PASSWORD" \
+  "$E2E_USER_USERNAME"  "$E2E_USER_PASSWORD" <<'PY'
+import json, sys
+out, base, au, ap, uu, up = sys.argv[1:]
+with open(out, "w", encoding="utf-8") as f:
+    json.dump({
+        "E2E_BASE_URL": base,
+        "E2E_ADMIN_USERNAME": au,
+        "E2E_ADMIN_PASSWORD": ap,
+        "E2E_USER_USERNAME": uu,
+        "E2E_USER_PASSWORD": up,
+    }, f)
+PY
 
 # --- target specs ------------------------------------------------------------
 if [[ $# -gt 0 ]]; then

--- a/mobile/run-e2e-android.sh
+++ b/mobile/run-e2e-android.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# Runs the Flutter integration_test suite against a local Android emulator.
+#
+# Usage:
+#   cd mobile && ./run-e2e-android.sh                                 # all tests
+#   cd mobile && ./run-e2e-android.sh integration_test/smoke_login_test.dart
+#
+# Auto-attaches to a running emulator, or boots $E2E_ANDROID_AVD if none is up.
+# Runs one `flutter drive` per spec (same shape as .github/workflows/mobile-e2e.yml).
+# The emulator is left running on exit for faster reruns -- close it manually
+# (adb emu kill) for a cold boot next time.
+#
+# Requires:
+#   - flutter on PATH (or installed under ~/Documents/flutter/bin, auto-discovered)
+#   - Android SDK at $ANDROID_HOME / $ANDROID_SDK_ROOT / ~/Library/Android/sdk
+#   - At least one AVD created via Android Studio or `avdmanager`
+#   - coreutils on PATH for `gtimeout` (brew install coreutils)
+#   - Go API running locally on :8081 (cd api && go run main.go)
+#   - The two e2e users seeded (see mobile/CLAUDE.md "Prerequisites")
+#
+# Env vars (sourced from api/dev/switch-to-sqlite.sh if present):
+#   E2E_ADMIN_USERNAME, E2E_ADMIN_PASSWORD, E2E_USER_USERNAME, E2E_USER_PASSWORD
+#
+# Overrides:
+#   E2E_ANDROID_AVD       AVD name (default: Pixel_3a_API_34_extension_level_7_arm64-v8a)
+#   E2E_MOBILE_BASE_URL   API base URL the app hits (default: http://10.0.2.2:8081/api;
+#                         10.0.2.2 is the Android emulator's alias for the host loopback)
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$script_dir"
+
+# --- locate flutter ----------------------------------------------------------
+if ! command -v flutter >/dev/null 2>&1; then
+  for candidate in "$HOME/Documents/flutter/bin" "$HOME/flutter/bin" "/opt/flutter/bin" "/usr/local/flutter/bin"; do
+    if [[ -x "$candidate/flutter" ]]; then
+      export PATH="$candidate:$PATH"
+      break
+    fi
+  done
+fi
+command -v flutter >/dev/null 2>&1 || { echo "flutter not on PATH" >&2; exit 1; }
+
+# --- locate Android SDK ------------------------------------------------------
+android_sdk="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-$HOME/Library/Android/sdk}}"
+if [[ ! -d "$android_sdk" ]]; then
+  echo "Android SDK not found at $android_sdk (set ANDROID_HOME)" >&2
+  exit 1
+fi
+export ANDROID_HOME="$android_sdk"
+export ANDROID_SDK_ROOT="$android_sdk"
+export PATH="$android_sdk/platform-tools:$android_sdk/emulator:$PATH"
+
+command -v adb >/dev/null 2>&1 || { echo "adb not under $android_sdk/platform-tools" >&2; exit 1; }
+command -v emulator >/dev/null 2>&1 || { echo "emulator not under $android_sdk/emulator" >&2; exit 1; }
+command -v gtimeout >/dev/null 2>&1 || { echo "gtimeout not found; brew install coreutils" >&2; exit 1; }
+
+# --- credentials -------------------------------------------------------------
+env_script="../api/dev/switch-to-sqlite.sh"
+if [[ -f "$env_script" ]]; then
+  # shellcheck disable=SC1090
+  source "$env_script"
+fi
+: "${E2E_ADMIN_USERNAME:?set E2E_ADMIN_USERNAME or source api/dev/switch-to-sqlite.sh}"
+: "${E2E_ADMIN_PASSWORD:?set E2E_ADMIN_PASSWORD or source api/dev/switch-to-sqlite.sh}"
+: "${E2E_USER_USERNAME:?set E2E_USER_USERNAME or source api/dev/switch-to-sqlite.sh}"
+: "${E2E_USER_PASSWORD:?set E2E_USER_PASSWORD or source api/dev/switch-to-sqlite.sh}"
+
+mobile_base_url="${E2E_MOBILE_BASE_URL:-http://10.0.2.2:8081/api}"
+avd_name="${E2E_ANDROID_AVD:-Pixel_3a_API_34_extension_level_7_arm64-v8a}"
+
+# --- boot or attach emulator -------------------------------------------------
+adb start-server >/dev/null 2>&1 || true
+
+current_serial="$(adb devices | awk '/^emulator-[0-9]+\tdevice$/ {print $1; exit}')"
+if [[ -z "$current_serial" ]]; then
+  echo "==> No emulator attached; booting AVD: $avd_name"
+  if ! emulator -list-avds 2>/dev/null | grep -Fxq "$avd_name"; then
+    echo "AVD '$avd_name' not found. Available AVDs:" >&2
+    emulator -list-avds >&2 || true
+    echo "Set E2E_ANDROID_AVD or create an AVD via Android Studio." >&2
+    exit 1
+  fi
+  emulator_log="/tmp/run-e2e-android-emulator-$$.log"
+  nohup emulator -avd "$avd_name" -no-snapshot-save -no-boot-anim \
+    >"$emulator_log" 2>&1 &
+  echo "    emulator log: $emulator_log"
+
+  echo "==> Waiting for adb device..."
+  adb wait-for-device
+  current_serial="$(adb devices | awk '/^emulator-[0-9]+\tdevice$/ {print $1; exit}')"
+  if [[ -z "$current_serial" ]]; then
+    echo "Emulator started but did not appear in 'adb devices'." >&2
+    exit 1
+  fi
+
+  echo "==> Waiting for sys.boot_completed on $current_serial (up to 5 min)..."
+  boot_deadline=$((SECONDS + 300))
+  until [[ "$(adb -s "$current_serial" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" == "1" ]]; do
+    if (( SECONDS > boot_deadline )); then
+      echo "Emulator failed to finish booting within 5 minutes." >&2
+      exit 1
+    fi
+    sleep 2
+  done
+
+  # Animations off: matches CI's `disable-animations: true`, avoids flake on
+  # widget-find pumps that race UI transitions.
+  for setting in window_animation_scale transition_animation_scale animator_duration_scale; do
+    adb -s "$current_serial" shell settings put global "$setting" 0 >/dev/null 2>&1 || true
+  done
+else
+  echo "==> Using already-running emulator: $current_serial"
+fi
+
+# --- ensure dependencies resolved -------------------------------------------
+# The per-spec `flutter drive` invocations pass --no-pub (faster reruns, matches
+# CI). CI runs `flutter pub get` as a prior step; locally we need to do it
+# ourselves once so .dart_tool/package_config.json has integration_test mapped
+# -- otherwise the first build fails with
+# "Couldn't resolve the package 'integration_test'".
+echo "==> flutter pub get"
+flutter pub get
+
+# --- dart-define payload -----------------------------------------------------
+tmp_env="$(mktemp -t run-e2e-android.XXXXXX).json"
+trap 'rm -f "$tmp_env"' EXIT
+cat > "$tmp_env" <<EOF
+{
+  "E2E_BASE_URL": "$mobile_base_url",
+  "E2E_ADMIN_USERNAME": "$E2E_ADMIN_USERNAME",
+  "E2E_ADMIN_PASSWORD": "$E2E_ADMIN_PASSWORD",
+  "E2E_USER_USERNAME": "$E2E_USER_USERNAME",
+  "E2E_USER_PASSWORD": "$E2E_USER_PASSWORD"
+}
+EOF
+
+# --- target specs ------------------------------------------------------------
+if [[ $# -gt 0 ]]; then
+  targets=("$@")
+else
+  targets=()
+  while IFS= read -r spec; do targets+=("$spec"); done \
+    < <(find integration_test -maxdepth 2 -name '*_test.dart' | sort)
+fi
+if [[ ${#targets[@]} -eq 0 ]]; then
+  echo "No *_test.dart files found under integration_test/" >&2
+  exit 1
+fi
+
+# --- per-spec drive loop -----------------------------------------------------
+# One `flutter drive` invocation per spec. main.dart's top-level GoRouter is a
+# final global -- its location persists across testWidgets in the same flutter
+# process, so spec N+1 inherits spec N's last URL and 403s on bootstrap.
+#
+# Between specs: force-stop + uninstall io.receiptwrangler, pkill -f dartvm.
+# flutter drive's own cleanup uninstalls by namespace
+# (com.example.receipt_wrangler_mobile) which doesn't match the real package,
+# so without this the prior spec's dart process keeps owning the vmservice
+# port and the next spec's launch hangs forever waiting to connect.
+# gtimeout 600 caps a hung spec to one failed slot instead of eating the run.
+exit_code=0
+for target in "${targets[@]}"; do
+  echo ""
+  echo "==> $target"
+  adb -s "$current_serial" shell am force-stop io.receiptwrangler >/dev/null 2>&1 || true
+  adb -s "$current_serial" uninstall io.receiptwrangler >/dev/null 2>&1 || true
+  pkill -f dartvm >/dev/null 2>&1 || true
+  if ! gtimeout 600 flutter drive \
+       --no-pub \
+       --driver=test_driver/integration_test.dart \
+       --target="$target" \
+       -d "$current_serial" \
+       --dart-define-from-file="$tmp_env"; then
+    exit_code=1
+  fi
+done
+
+exit "$exit_code"

--- a/mobile/run-e2e-android.sh
+++ b/mobile/run-e2e-android.sh
@@ -128,7 +128,7 @@ flutter pub get
 # Build the JSON via python3 instead of a heredoc so any value containing
 # quotes/backslashes/newlines gets properly escaped. The heredoc form would
 # emit invalid JSON that `flutter --dart-define-from-file` would reject.
-tmp_env="$(mktemp -t run-e2e-android.XXXXXX).json"
+tmp_env="$(mktemp -t run-e2e-android.XXXXXX)"
 trap 'rm -f "$tmp_env"' EXIT
 python3 - "$tmp_env" "$mobile_base_url" \
   "$E2E_ADMIN_USERNAME" "$E2E_ADMIN_PASSWORD" \

--- a/mobile/run-e2e-ios.sh
+++ b/mobile/run-e2e-ios.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Runs the Flutter integration_test suite against a local iOS Simulator.
+#
+# Usage:
+#   cd mobile && ./run-e2e-ios.sh                                     # all tests
+#   cd mobile && ./run-e2e-ios.sh integration_test/smoke_login_test.dart
+#
+# Resolves $E2E_IOS_DEVICE (default: iPhone 15) to a simulator UDID, boots it
+# if necessary, then runs one `flutter drive` per spec. The simulator is left
+# booted on exit -- shut it down (xcrun simctl shutdown <udid>) for a cold
+# boot next time.
+#
+# Requires:
+#   - Xcode + iOS Simulator (xcrun simctl on PATH)
+#   - flutter on PATH (or installed under ~/Documents/flutter/bin, auto-discovered)
+#   - coreutils on PATH for `gtimeout` (brew install coreutils)
+#   - Go API running locally on :8081 (cd api && go run main.go)
+#   - The two e2e users seeded (see mobile/CLAUDE.md "Prerequisites")
+#
+# Env vars (sourced from api/dev/switch-to-sqlite.sh if present):
+#   E2E_ADMIN_USERNAME, E2E_ADMIN_PASSWORD, E2E_USER_USERNAME, E2E_USER_PASSWORD
+#
+# Overrides:
+#   E2E_IOS_DEVICE        Simulator device name (default: "iPhone 15"). Multiple
+#                         sims with the same name across iOS runtimes get
+#                         resolved by the first match in `simctl list` order;
+#                         set E2E_IOS_UDID to skip name lookup entirely.
+#   E2E_IOS_UDID          Exact simulator UDID. Overrides E2E_IOS_DEVICE when set.
+#   E2E_MOBILE_BASE_URL   API base URL the app hits (default: http://localhost:8081/api;
+#                         iOS Simulator shares the host network, so localhost works)
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$script_dir"
+
+# --- locate flutter ----------------------------------------------------------
+if ! command -v flutter >/dev/null 2>&1; then
+  for candidate in "$HOME/Documents/flutter/bin" "$HOME/flutter/bin" "/opt/flutter/bin" "/usr/local/flutter/bin"; do
+    if [[ -x "$candidate/flutter" ]]; then
+      export PATH="$candidate:$PATH"
+      break
+    fi
+  done
+fi
+command -v flutter >/dev/null 2>&1 || { echo "flutter not on PATH" >&2; exit 1; }
+command -v xcrun >/dev/null 2>&1 || { echo "xcrun not on PATH (install Xcode command line tools)" >&2; exit 1; }
+command -v gtimeout >/dev/null 2>&1 || { echo "gtimeout not found; brew install coreutils" >&2; exit 1; }
+
+# --- credentials -------------------------------------------------------------
+env_script="../api/dev/switch-to-sqlite.sh"
+if [[ -f "$env_script" ]]; then
+  # shellcheck disable=SC1090
+  source "$env_script"
+fi
+: "${E2E_ADMIN_USERNAME:?set E2E_ADMIN_USERNAME or source api/dev/switch-to-sqlite.sh}"
+: "${E2E_ADMIN_PASSWORD:?set E2E_ADMIN_PASSWORD or source api/dev/switch-to-sqlite.sh}"
+: "${E2E_USER_USERNAME:?set E2E_USER_USERNAME or source api/dev/switch-to-sqlite.sh}"
+: "${E2E_USER_PASSWORD:?set E2E_USER_PASSWORD or source api/dev/switch-to-sqlite.sh}"
+
+mobile_base_url="${E2E_MOBILE_BASE_URL:-http://localhost:8081/api}"
+device_name="${E2E_IOS_DEVICE:-iPhone 15}"
+
+# --- resolve simulator UDID --------------------------------------------------
+# Match "<name> (" so "iPhone 15" doesn't catch "iPhone 15 Pro" -- after the
+# device name the next literal char in the simctl output is the opening paren
+# of the UDID, while sibling models have a model qualifier in between.
+# `simctl list devices available` only lists devices on installed runtimes.
+if [[ -n "${E2E_IOS_UDID:-}" ]]; then
+  udid="$E2E_IOS_UDID"
+  echo "==> Using simulator UDID from E2E_IOS_UDID: $udid"
+else
+  udid="$(xcrun simctl list devices available \
+    | grep -E "^ *${device_name} \(" \
+    | head -n 1 \
+    | grep -oE '[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}')"
+
+  if [[ -z "$udid" ]]; then
+    echo "No simulator named '$device_name' found. Available devices:" >&2
+    xcrun simctl list devices available >&2
+    echo "Set E2E_IOS_DEVICE to one of the names above, or E2E_IOS_UDID to a specific UDID." >&2
+    exit 1
+  fi
+fi
+
+# Boot if not already booted. simctl bootstatus blocks until the device is
+# Booted+SpringBoard-ready, which is what we want before launching the app.
+state="$(xcrun simctl list devices | grep -F "$udid" | grep -oE '\((Booted|Shutdown|Shutting Down)\)' | tr -d '()' | head -n 1)"
+if [[ "$state" != "Booted" ]]; then
+  echo "==> Booting simulator $udid"
+  xcrun simctl boot "$udid"
+fi
+xcrun simctl bootstatus "$udid" -b >/dev/null
+
+# `simctl boot` only starts the runtime; the Simulator.app GUI window doesn't
+# appear unless we launch it explicitly. Useful both for visibility while a
+# test is running and so the user knows the sim is alive.
+open -a Simulator --args -CurrentDeviceUDID "$udid" >/dev/null 2>&1 || true
+
+echo "==> Simulator $udid is booted"
+
+# --- ensure dependencies resolved -------------------------------------------
+# The per-spec `flutter drive` invocations pass --no-pub (faster reruns, matches
+# CI). CI runs `flutter pub get` as a prior step; locally we need to do it
+# ourselves once so .dart_tool/package_config.json has integration_test mapped
+# -- otherwise the first build fails with
+# "Couldn't resolve the package 'integration_test'".
+echo "==> flutter pub get"
+flutter pub get
+
+# --- dart-define payload -----------------------------------------------------
+tmp_env="$(mktemp -t run-e2e-ios.XXXXXX).json"
+trap 'rm -f "$tmp_env"' EXIT
+cat > "$tmp_env" <<EOF
+{
+  "E2E_BASE_URL": "$mobile_base_url",
+  "E2E_ADMIN_USERNAME": "$E2E_ADMIN_USERNAME",
+  "E2E_ADMIN_PASSWORD": "$E2E_ADMIN_PASSWORD",
+  "E2E_USER_USERNAME": "$E2E_USER_USERNAME",
+  "E2E_USER_PASSWORD": "$E2E_USER_PASSWORD"
+}
+EOF
+
+# --- target specs ------------------------------------------------------------
+if [[ $# -gt 0 ]]; then
+  targets=("$@")
+else
+  targets=()
+  while IFS= read -r spec; do targets+=("$spec"); done \
+    < <(find integration_test -maxdepth 2 -name '*_test.dart' | sort)
+fi
+if [[ ${#targets[@]} -eq 0 ]]; then
+  echo "No *_test.dart files found under integration_test/" >&2
+  exit 1
+fi
+
+# --- per-spec drive loop -----------------------------------------------------
+# One `flutter drive` per spec -- same reason as Android: the top-level
+# GoRouter in main.dart persists location across testWidgets within a single
+# flutter process.
+#
+# Between specs: terminate + uninstall by bundle id (io.receiptwrangler) and
+# pkill -f dartvm + io.receiptwrangler. iOS flake class (flutter#129246,
+# #136222, #153433): without these, the previous spec's dart isolate keeps
+# the vmservice port and the next launch silently hangs.
+# gtimeout 600 (10min, well above the ~30s legit spec runtime) walks past a
+# hung spec instead of consuming the rest of the run.
+exit_code=0
+for target in "${targets[@]}"; do
+  echo ""
+  echo "==> $target"
+  xcrun simctl terminate "$udid" io.receiptwrangler >/dev/null 2>&1 || true
+  xcrun simctl uninstall "$udid" io.receiptwrangler >/dev/null 2>&1 || true
+  pkill -f dartvm >/dev/null 2>&1 || true
+  pkill -f io.receiptwrangler >/dev/null 2>&1 || true
+  if ! gtimeout 600 flutter drive \
+       --no-pub \
+       --driver=test_driver/integration_test.dart \
+       --target="$target" \
+       -d "$udid" \
+       --dart-define-from-file="$tmp_env"; then
+    exit_code=1
+  fi
+done
+
+exit "$exit_code"

--- a/mobile/run-e2e-ios.sh
+++ b/mobile/run-e2e-ios.sh
@@ -46,6 +46,7 @@ fi
 command -v flutter >/dev/null 2>&1 || { echo "flutter not on PATH" >&2; exit 1; }
 command -v xcrun >/dev/null 2>&1 || { echo "xcrun not on PATH (install Xcode command line tools)" >&2; exit 1; }
 command -v gtimeout >/dev/null 2>&1 || { echo "gtimeout not found; brew install coreutils" >&2; exit 1; }
+command -v python3 >/dev/null 2>&1 || { echo "python3 not on PATH (needed to safely build the dart-define JSON)" >&2; exit 1; }
 
 # --- credentials -------------------------------------------------------------
 env_script="../api/dev/switch-to-sqlite.sh"
@@ -90,7 +91,13 @@ if [[ "$state" != "Booted" ]]; then
   echo "==> Booting simulator $udid"
   xcrun simctl boot "$udid"
 fi
-xcrun simctl bootstatus "$udid" -b >/dev/null
+# `simctl bootstatus -b` blocks until the device is Booted+SpringBoard-ready;
+# on an unhealthy sim it can block indefinitely. Cap it at 5 min (same ceiling
+# as the Android AVD boot wait) and fail fast if it expires.
+if ! gtimeout 300 xcrun simctl bootstatus "$udid" -b >/dev/null; then
+  echo "Simulator $udid failed to reach Booted+SpringBoard-ready within 5 minutes." >&2
+  exit 1
+fi
 
 # `simctl boot` only starts the runtime; the Simulator.app GUI window doesn't
 # appear unless we launch it explicitly. Useful both for visibility while a
@@ -109,17 +116,25 @@ echo "==> flutter pub get"
 flutter pub get
 
 # --- dart-define payload -----------------------------------------------------
+# Build the JSON via python3 instead of a heredoc so any value containing
+# quotes/backslashes/newlines gets properly escaped. The heredoc form would
+# emit invalid JSON that `flutter --dart-define-from-file` would reject.
 tmp_env="$(mktemp -t run-e2e-ios.XXXXXX).json"
 trap 'rm -f "$tmp_env"' EXIT
-cat > "$tmp_env" <<EOF
-{
-  "E2E_BASE_URL": "$mobile_base_url",
-  "E2E_ADMIN_USERNAME": "$E2E_ADMIN_USERNAME",
-  "E2E_ADMIN_PASSWORD": "$E2E_ADMIN_PASSWORD",
-  "E2E_USER_USERNAME": "$E2E_USER_USERNAME",
-  "E2E_USER_PASSWORD": "$E2E_USER_PASSWORD"
-}
-EOF
+python3 - "$tmp_env" "$mobile_base_url" \
+  "$E2E_ADMIN_USERNAME" "$E2E_ADMIN_PASSWORD" \
+  "$E2E_USER_USERNAME"  "$E2E_USER_PASSWORD" <<'PY'
+import json, sys
+out, base, au, ap, uu, up = sys.argv[1:]
+with open(out, "w", encoding="utf-8") as f:
+    json.dump({
+        "E2E_BASE_URL": base,
+        "E2E_ADMIN_USERNAME": au,
+        "E2E_ADMIN_PASSWORD": ap,
+        "E2E_USER_USERNAME": uu,
+        "E2E_USER_PASSWORD": up,
+    }, f)
+PY
 
 # --- target specs ------------------------------------------------------------
 if [[ $# -gt 0 ]]; then

--- a/mobile/run-e2e-ios.sh
+++ b/mobile/run-e2e-ios.sh
@@ -119,7 +119,7 @@ flutter pub get
 # Build the JSON via python3 instead of a heredoc so any value containing
 # quotes/backslashes/newlines gets properly escaped. The heredoc form would
 # emit invalid JSON that `flutter --dart-define-from-file` would reject.
-tmp_env="$(mktemp -t run-e2e-ios.XXXXXX).json"
+tmp_env="$(mktemp -t run-e2e-ios.XXXXXX)"
 trap 'rm -f "$tmp_env"' EXIT
 python3 - "$tmp_env" "$mobile_base_url" \
   "$E2E_ADMIN_USERNAME" "$E2E_ADMIN_PASSWORD" \


### PR DESCRIPTION
## Summary

Add three scripts so the mobile e2e suite can be run from a developer mac against a local API, separate from the existing Linux desktop runner (`mobile/run-e2e.sh`) and the CI-only Android/iOS jobs.

- **`mobile/run-e2e-android.sh`** — auto-boots an AVD (or attaches to one already running), waits for `sys.boot_completed`, then loops one `flutter drive` per spec with between-spec cleanup (force-stop + uninstall `io.receiptwrangler`, `pkill -f dartvm`, `gtimeout 600`). Mirrors the working CI command shape from `.github/workflows/mobile-e2e.yml` but adds local-specific concerns: `10.0.2.2:8081/api` default host loopback, AVD cold-boot handling, animations off.
- **`mobile/run-e2e-ios.sh`** — resolves a simulator UDID by name (default `iPhone 15`, overridable via `E2E_IOS_DEVICE` or `E2E_IOS_UDID`), boots it via `simctl`, opens `Simulator.app` so the GUI window appears, then runs the same per-spec `flutter drive` loop with iOS-flavored cleanup.
- **`api/dev/seed-e2e-users.sh`** — idempotent seed routine for the two e2e accounts. Logs in as the default `admin/admin` user that `MakeMigrations()` auto-creates on a fresh DB, GETs `/user/` to detect existing usernames, POSTs the missing ones via the admin-protected `/user/` endpoint with an explicit `userRole`. Replaces the previous "sign up via desktop UI" instruction, which was broken because (a) `enableLocalSignUp` is `false` locally and (b) even when enabled, the auto-admin already occupies the "first user = ADMIN" slot.

Also includes:
- `mobile/ios/Podfile.lock` — `integration_test` pod added by `pod install` during the first iOS build; without this the iOS Runner workspace can't resolve the plugin.
- `mobile/CLAUDE.md` — documents the three runners, env overrides (`E2E_ANDROID_AVD`, `E2E_IOS_DEVICE`, `E2E_IOS_UDID`, `E2E_MOBILE_BASE_URL`), and the Xcode 26.x runtime gotcha: Xcode 26.x ships only its own iOS SDK; until the matching simulator runtime is installed (`xcodebuild -downloadPlatform iOS`, ~8GB), `xcodebuild -showdestinations` returns zero eligible destinations and every iOS sim build fails.

## Test plan

- [x] Android: `cd mobile && ./run-e2e-android.sh integration_test/smoke_login_test.dart` against local API on `10.0.2.2:8081/api` → `All tests passed!`
- [x] iOS: `cd mobile && ./run-e2e-ios.sh integration_test/smoke_login_test.dart` on iPhone 15 / iOS 17.2 against local API on `localhost:8081/api` → `All tests passed!`
- [x] Seed script idempotency: first run creates `e2e-admin` (ADMIN) + `e2e-user` (USER); second run prints `[exists]` for both.
- [x] Demo backend retarget works: `E2E_MOBILE_BASE_URL=https://demo.receiptwrangler.io/api ./run-e2e-android.sh integration_test/smoke_login_test.dart` boots the emulator, installs the app, hits the demo `/api`, and surfaces test output (test fails as expected because demo doesn't have the seeded users — script-side OK).
- [ ] Full-suite local runs (`./run-e2e-android.sh` / `./run-e2e-ios.sh` no args) — still expected to surface per-spec failures; that's separate triage, not a script blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added E2E test runners for Android and iOS mobile environments.
  * Added an idempotent script to seed required E2E test users.

* **Documentation**
  * Expanded mobile E2E guidance with supported targets, prerequisites, local run commands, environment-variable behavior, runner notes, and a referenced checklist for common platform issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Receipt-Wrangler/receipt-wrangler/pull/559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->