### PR TITLE
mobile-e2e CI: unblock Android, route through run-e2e-android.sh

### DIFF
--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -115,12 +115,33 @@ jobs:
         env:
           E2E_BASE_URL: ${{ secrets.E2E_BASE_URL }}
 
-      # The Flutter app hits the Go API directly, so the dart-define appends
-      # /api to the secret (which is the frontend root, like Playwright uses).
+      # Delegate to mobile/run-e2e-android.sh -- same script developers run
+      # locally. It auto-attaches to the emulator-runner-booted emulator-5554,
+      # builds a JSON-safe --dart-define-from-file payload via python3, and
+      # runs one `flutter drive` per spec wrapped in `timeout 600`. Between
+      # specs it force-stops + uninstalls io.receiptwrangler and pkills leaked
+      # dartvm processes (flutter drive's own uninstall targets the wrong
+      # applicationId and leaves the vmservice port owned, hanging the next
+      # spec's launch otherwise).
+      #
+      # The script gates its source of api/dev/switch-to-sqlite.sh on all four
+      # E2E_* creds being unset, so the secrets passed in env: here are NOT
+      # clobbered by the dev defaults.
+      #
+      # android-emulator-runner's `script:` is parsed by src/script-parser.ts,
+      # which splits on \n and runs each line as a separate `sh -c`. The
+      # folded scalar (`>-`) below collapses newlines to spaces, so the
+      # parser still sees one logical line. Inside that line we invoke the
+      # runner script, whose `#!/usr/bin/env bash` shebang gives the per-spec
+      # for-loop a real bash interpreter -- immune to whatever the
+      # script-parser does that killed the previous inline loop with
+      # `exit code null` on the first iteration.
+      #
+      # 12 specs below match the prior inline list -- no scope change.
       - name: Run Flutter integration tests on Android
         uses: reactivecircus/android-emulator-runner@v2
         env:
-          E2E_BASE_URL: ${{ secrets.E2E_BASE_URL }}
+          E2E_MOBILE_BASE_URL: ${{ secrets.E2E_BASE_URL }}/api
           E2E_ADMIN_USERNAME: ${{ secrets.E2E_ADMIN_USERNAME }}
           E2E_ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD }}
           E2E_USER_USERNAME: ${{ secrets.E2E_USER_USERNAME }}
@@ -137,47 +158,20 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-snapshot-save
           disable-animations: true
           working-directory: ./mobile
-          # Use `flutter drive`, NOT `flutter test`. On the Android emulator
-          # path, `flutter test integration_test/...` repeatedly hit
-          #   "Integration tests and unit tests cannot be run in a single
-          #    invocation."
-          # even targeting a single file, even though the same command works
-          # locally with `-d linux`. Every working Android-emulator-runner
-          # CI example (Flutter docs, etiennetheodore's guide, etc.) uses
-          # `flutter drive` with an explicit driver + target, so we follow
-          # that pattern. `mobile/test_driver/integration_test.dart` is the
-          # standard `integrationDriver()` entrypoint.
-          # Local Linux desktop runs (mobile/run-e2e.sh) keep using
-          # `flutter test integration_test/`, which works fine there.
-          #
-          # The receipt-add specs require their own process because the
-          # top-level GoRouter in main.dart is a final global -- its
-          # location persists across testWidgets in the same flutter
-          # invocation, so a previous test ending at /receipts/<id>/view
-          # triggers a 403 fetch on the next test's app.main(). Looping
-          # one `flutter drive` per spec gives each its own process.
-          #
-          # CRITICAL: android-emulator-runner's `script:` is parsed by
-          # src/script-parser.ts, which splits on \n and runs each line
-          # as a separate `sh -c`. Multi-line shell constructs (for, if,
-          # while, multi-statement blocks) silently break -- a `for ...; do`
-          # on one line and `done` on the next will fail with
-          # "Syntax error: end of file unexpected (expecting done)".
-          # The whole loop, including rc tracking and exit, MUST live on
-          # one logical line. The iOS job is regular `run:` and is not
-          # affected -- it gets one bash invocation for the whole block.
-          # Between specs: force-stop and uninstall by applicationId
-          # (io.receiptwrangler). flutter drive's own cleanup uninstalls
-          # by namespace (com.example.receipt_wrangler_mobile), which
-          # doesn't match the real package, so without this the prior
-          # spec's dart process keeps owning the vmservice port and the
-          # next spec's launch hangs forever waiting to connect.
-          # `pkill -f dartvm` cleans up host-side dart isolate processes
-          # that flutter drive can leak; `timeout 600` (10min, well above
-          # the longest legitimate spec runtime) converts a hung spec into
-          # a single failed slot the loop walks past instead of consuming
-          # the rest of the job's wall clock.
-          script: rc=0; for spec in integration_test/smoke_login_test.dart integration_test/receipt_add_test.dart integration_test/receipt_add_gallery_test.dart integration_test/receipt_add_share_test.dart integration_test/receipt_add_consecutive_test.dart integration_test/receipt_add_double_submit_test.dart integration_test/receipt_add_partial_image_test.dart integration_test/receipt_add_custom_field_test.dart integration_test/receipt_edit_test.dart integration_test/receipt_view_to_groups_navigation_test.dart integration_test/quick_scan_test.dart integration_test/quick_scan_disabled_test.dart; do echo "==> $spec"; adb -s emulator-5554 shell am force-stop io.receiptwrangler || true; adb -s emulator-5554 uninstall io.receiptwrangler || true; pkill -f dartvm || true; timeout 600 flutter drive --no-pub --driver=test_driver/integration_test.dart --target=$spec -d emulator-5554 --dart-define=E2E_BASE_URL="$E2E_BASE_URL/api" --dart-define=E2E_ADMIN_USERNAME="$E2E_ADMIN_USERNAME" --dart-define=E2E_ADMIN_PASSWORD="$E2E_ADMIN_PASSWORD" --dart-define=E2E_USER_USERNAME="$E2E_USER_USERNAME" --dart-define=E2E_USER_PASSWORD="$E2E_USER_PASSWORD" || rc=1; done; exit $rc
+          script: >-
+            ./run-e2e-android.sh
+            integration_test/smoke_login_test.dart
+            integration_test/receipt_add_test.dart
+            integration_test/receipt_add_gallery_test.dart
+            integration_test/receipt_add_share_test.dart
+            integration_test/receipt_add_consecutive_test.dart
+            integration_test/receipt_add_double_submit_test.dart
+            integration_test/receipt_add_partial_image_test.dart
+            integration_test/receipt_add_custom_field_test.dart
+            integration_test/receipt_edit_test.dart
+            integration_test/receipt_view_to_groups_navigation_test.dart
+            integration_test/quick_scan_test.dart
+            integration_test/quick_scan_disabled_test.dart
 
   ios-e2e:
     # macos-14 ships Xcode 15.4 + iOS 17.0/17.2/17.4/17.5/18.1/18.2

--- a/mobile/run-e2e-android.sh
+++ b/mobile/run-e2e-android.sh
@@ -14,7 +14,8 @@
 #   - flutter on PATH (or installed under ~/Documents/flutter/bin, auto-discovered)
 #   - Android SDK at $ANDROID_HOME / $ANDROID_SDK_ROOT / ~/Library/Android/sdk
 #   - At least one AVD created via Android Studio or `avdmanager`
-#   - coreutils on PATH for `gtimeout` (brew install coreutils)
+#   - GNU coreutils on PATH for `timeout`/`gtimeout` (Linux ships GNU `timeout`;
+#     macOS Homebrew coreutils ships the same binary as `gtimeout` to dodge BSD)
 #   - Go API running locally on :8081 (cd api && go run main.go)
 #   - The two e2e users seeded (see mobile/CLAUDE.md "Prerequisites")
 #
@@ -54,12 +55,27 @@ export PATH="$android_sdk/platform-tools:$android_sdk/emulator:$PATH"
 
 command -v adb >/dev/null 2>&1 || { echo "adb not under $android_sdk/platform-tools" >&2; exit 1; }
 command -v emulator >/dev/null 2>&1 || { echo "emulator not under $android_sdk/emulator" >&2; exit 1; }
-command -v gtimeout >/dev/null 2>&1 || { echo "gtimeout not found; brew install coreutils" >&2; exit 1; }
+# GNU coreutils ships the timeout binary as `timeout` on Linux and `gtimeout`
+# on macOS (brew dodges BSD's name conflict). Prefer gtimeout so a local macOS
+# `timeout` from a non-GNU coreutils install doesn't get picked accidentally.
+TIMEOUT_BIN="$(command -v gtimeout || command -v timeout || true)"
+[[ -n "$TIMEOUT_BIN" ]] || { echo "neither gtimeout nor timeout on PATH (install coreutils)" >&2; exit 1; }
 command -v python3 >/dev/null 2>&1 || { echo "python3 not on PATH (needed to safely build the dart-define JSON)" >&2; exit 1; }
 
 # --- credentials -------------------------------------------------------------
+# Source switch-to-sqlite.sh only when none of the four E2E_* creds are already
+# in the env. The script `export`s all four unconditionally, so sourcing it in
+# any context where a caller already populated even one of them (CI, or a
+# partial override locally) would silently clobber that value with the dev
+# default. The trailing `: "${VAR:?...}"` checks below catch the
+# partial-population case with a clear error rather than letting defaults paper
+# over a missing var.
 env_script="../api/dev/switch-to-sqlite.sh"
-if [[ -f "$env_script" ]]; then
+if [[ -z "${E2E_ADMIN_USERNAME:-}" \
+   && -z "${E2E_ADMIN_PASSWORD:-}" \
+   && -z "${E2E_USER_USERNAME:-}" \
+   && -z "${E2E_USER_PASSWORD:-}" \
+   && -f "$env_script" ]]; then
   # shellcheck disable=SC1090
   source "$env_script"
 fi
@@ -176,7 +192,7 @@ for target in "${targets[@]}"; do
   adb -s "$current_serial" shell am force-stop io.receiptwrangler >/dev/null 2>&1 || true
   adb -s "$current_serial" uninstall io.receiptwrangler >/dev/null 2>&1 || true
   pkill -f dartvm >/dev/null 2>&1 || true
-  if ! gtimeout 600 flutter drive \
+  if ! "$TIMEOUT_BIN" 600 flutter drive \
        --no-pub \
        --driver=test_driver/integration_test.dart \
        --target="$target" \


### PR DESCRIPTION
## Summary
- `android-e2e` was failing: the inline per-spec loop died with `##[error]The process '/usr/bin/sh' failed with exit code null` right after the first `adb uninstall` (whose expected non-zero exit was supposedly masked by `|| true`). `android-emulator-runner@v2`'s script-parser appears to abort the host shell on that adb exit. Moving the loop into \`mobile/run-e2e-android.sh\` puts it inside the script's own bash process, outside whatever the parser is doing.
- Same shape as the iOS-CI PR (#560). \`script:\` is a YAML folded scalar (\`>-\`) so the multi-line spec list collapses to one logical line at the script-parser — sidestepping its \`\\n\`-splits-each-line behavior.
- Two prereq edits in the runner script:
  - **TIMEOUT_BIN auto-detect**: \`command -v gtimeout || command -v timeout\`. Linux GNU coreutils ships \`timeout\`; macOS Homebrew ships \`gtimeout\`. Same binary, same flags. Without this the script refused to run on ubuntu CI.
  - **Source-guard broadened to all four E2E_* creds** (matches the merged iOS fix). Otherwise CI secrets would get clobbered by \`switch-to-sqlite.sh\` defaults.

iOS untouched — separate diagnosis pending (it also failed in the most recent run, but the failure mode is different and out of scope here).

## Test plan
- [x] \`bash -n mobile/run-e2e-android.sh\` clean
- [x] \`ruby -ryaml\` parses workflow; folded scalar collapses to single line — verified explicitly
- [x] Local empty-env smoke against local emulator + API: \`All tests passed!\`
- [x] Source-guard hole-plug: \`E2E_USER_USERNAME=foo ./run-e2e-android.sh integration_test/smoke_login_test.dart\` trips \`:?\` on \`E2E_ADMIN_USERNAME\` (proves it did NOT source defaults)
- [ ] CI: merge into \`tech/mobile-e2e\`, watch android-e2e: should log \`==> Using already-running emulator: emulator-5554\` then 12 \`==> integration_test/…\` headers with \`flutter drive\` actually executing each spec. Per-spec pass/fail is signal-only (\`continue-on-error: true\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined Android E2E testing workflow with improved script delegation and organization.
  * Enhanced system compatibility detection for test environment setup.
  * Improved credential handling to prevent unintended configuration conflicts.
  * Better error detection for missing dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Receipt-Wrangler/receipt-wrangler/pull/561?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->