### PR TITLE
mobile-e2e: iOS first-spec retry + gallery mock real-file fix

### DIFF
--- a/mobile/integration_test/helpers/file_selector_mock.dart
+++ b/mobile/integration_test/helpers/file_selector_mock.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
@@ -5,7 +6,7 @@ import 'package:flutter/services.dart' show rootBundle;
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 /// Replaces [FileSelectorPlatform.instance] with a stub that returns a
-/// fixed in-memory file from [openFiles]. Lets tests exercise the receipt
+/// fixed file on disk from [openFiles]. Lets tests exercise the receipt
 /// form's "Upload from Gallery" path without driving a native picker.
 ///
 /// The platform-interface swap works on every target Flutter supports, so
@@ -13,14 +14,26 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 /// iOS simulator. Unlike a per-platform method-channel mock, we don't
 /// have to discover three different channel names.
 ///
+/// We materialize a real temp file on disk and return `XFile(path, ...)`
+/// instead of `XFile.fromData(bytes, ...)`. Reason: on iOS Simulator,
+/// `XFile.fromData()` returns an XFile whose `.name` getter is empty,
+/// which then propagates through `MultipartFile(filename: ...)` as an
+/// empty filename. The Go API's multipart parser closes the connection
+/// on empty-filename uploads ("Connection closed before full header was
+/// received"), dio surfaces that as a generic `DioException [unknown]`,
+/// and the upload swallows it -- yielding a saved receipt with zero
+/// imageFiles. Backing the XFile with a real file path makes both
+/// `.name` and `.readAsBytes()` work identically on Android and iOS,
+/// matching the production picker shape.
+///
 /// `MockPlatformInterfaceMixin` is what lets a test class extend
 /// `FileSelectorPlatform` -- without it, `PlatformInterface.verify()`
 /// rejects the swap.
 class _FakeFileSelector extends FileSelectorPlatform
     with MockPlatformInterfaceMixin {
-  _FakeFileSelector(this._bytes, this._name);
+  _FakeFileSelector(this._path, this._name);
 
-  final Uint8List _bytes;
+  final String _path;
   final String _name;
 
   @override
@@ -30,15 +43,17 @@ class _FakeFileSelector extends FileSelectorPlatform
     String? confirmButtonText,
   }) async {
     return <XFile>[
-      XFile.fromData(_bytes, name: _name, mimeType: 'image/png'),
+      XFile(_path, name: _name, mimeType: 'image/png'),
     ];
   }
 }
 
-/// Loads `assets/test/sample.png` and installs a fake file-selector that
-/// returns it from `openFiles`. The bundled asset (16x16 RGBA PNG, ~300B)
-/// is shipped with the app so `rootBundle.load` works at runtime on every
-/// target. Pass `bytes` to override with a different fixture.
+/// Loads `assets/test/sample.png`, writes it to a fresh tempdir under
+/// `Directory.systemTemp`, and installs a fake file-selector that returns
+/// an XFile backed by that on-disk path. The bundled asset (16x16 RGBA
+/// PNG, ~300B) is shipped with the app so `rootBundle.load` works at
+/// runtime on every target. Pass `bytes` to override with a different
+/// fixture. The tempdir is process-scoped; the OS cleans it up.
 Future<void> installFileSelectorMock({
   Uint8List? bytes,
   String name = 'sample.png',
@@ -47,5 +62,8 @@ Future<void> installFileSelectorMock({
       (await rootBundle.load('assets/test/sample.png'))
           .buffer
           .asUint8List();
-  FileSelectorPlatform.instance = _FakeFileSelector(pngBytes, name);
+  final tempDir = await Directory.systemTemp.createTemp('file_selector_mock_');
+  final tempFile = File('${tempDir.path}/$name');
+  await tempFile.writeAsBytes(pngBytes, flush: true);
+  FileSelectorPlatform.instance = _FakeFileSelector(tempFile.path, name);
 }

--- a/mobile/run-e2e-ios.sh
+++ b/mobile/run-e2e-ios.sh
@@ -165,27 +165,47 @@ fi
 # GoRouter in main.dart persists location across testWidgets within a single
 # flutter process.
 #
-# Between specs: terminate + uninstall by bundle id (io.receiptwrangler) and
-# pkill -f dartvm + io.receiptwrangler. iOS flake class (flutter#129246,
-# #136222, #153433): without these, the previous spec's dart isolate keeps
-# the vmservice port and the next launch silently hangs.
+# Between specs (and between retry attempts): terminate + uninstall by bundle
+# id (io.receiptwrangler) and pkill -f dartvm + io.receiptwrangler. iOS flake
+# class (flutter#129246, #136222, #153433): without these, the previous spec's
+# dart isolate keeps the vmservice port and the next launch silently hangs.
 # gtimeout 600 (10min, well above the ~30s legit spec runtime) walks past a
 # hung spec instead of consuming the rest of the run.
-exit_code=0
-for target in "${targets[@]}"; do
-  echo ""
-  echo "==> $target"
+#
+# One retry on failure: the very first spec on a fresh CI runner pays a
+# cold pod install + ~150s Xcode build, after which flutter drive's log
+# reader can race the debug-server attach and abort with "The log reader
+# failed unexpectedly". Subsequent rebuilds are ~55s and don't hit it.
+# Retrying once catches that flake without slowing the happy path. The
+# first-attempt log stays visible so genuine breakage is still observable.
+prepare_sim() {
   xcrun simctl terminate "$udid" io.receiptwrangler >/dev/null 2>&1 || true
   xcrun simctl uninstall "$udid" io.receiptwrangler >/dev/null 2>&1 || true
   pkill -f dartvm >/dev/null 2>&1 || true
   pkill -f io.receiptwrangler >/dev/null 2>&1 || true
+}
+exit_code=0
+for target in "${targets[@]}"; do
+  echo ""
+  echo "==> $target"
+  prepare_sim
   if ! gtimeout 600 flutter drive \
        --no-pub \
        --driver=test_driver/integration_test.dart \
        --target="$target" \
        -d "$udid" \
        --dart-define-from-file="$tmp_env"; then
-    exit_code=1
+    echo "==> $target failed on attempt 1; retrying once after 5s..." >&2
+    sleep 5
+    prepare_sim
+    if ! gtimeout 600 flutter drive \
+         --no-pub \
+         --driver=test_driver/integration_test.dart \
+         --target="$target" \
+         -d "$udid" \
+         --dart-define-from-file="$tmp_env"; then
+      exit_code=1
+    fi
   fi
 done
 


### PR DESCRIPTION
## Summary
Two unrelated iOS-CI issues found in run \`26467304141\`:

### Issue A — smoke_login first-spec log-reader flake
The first iOS spec pays cold pod-install + ~150s Xcode build; \`flutter drive\`'s log reader can then race the debug-server attach and abort with \`The log reader failed unexpectedly\`. Specs 2-5 reuse the build cache and don't hit it.

Fix: wrap each \`flutter drive\` in a one-retry helper in \`mobile/run-e2e-ios.sh\`. On attempt-1 failure, re-run the inter-spec cleanup and try once more. Outer rc unchanged; attempt-1 log stays visible.

### Issue B — receipt_add_gallery_test failing on iOS (real bug)
Debug-print trace revealed: the integration mock returned \`XFile.fromData(bytes, name: 'sample.png')\`. **Bytes were intact (298 bytes) but \`.name\` came back empty on iOS Sim** — a cross_file iOS quirk. That empty name propagated as \`MultipartFile(filename: \"\")\`, the Go API's multipart parser closed the connection on the empty-filename upload (\`Connection closed before full header was received\`), dio surfaced \`DioException [unknown]\`, the swallowing catch in \`addReceipt\` let the test navigate to \`/view\` anyway with zero imageFiles attached.

Fix: \`installFileSelectorMock\` now writes the bytes to a real temp file under \`Directory.systemTemp\` and returns \`XFile(path, name: name, mimeType: ...)\`. Both \`.name\` and \`.readAsBytes()\` then behave identically to a production picker XFile on Android and iOS.

## Test plan
- [x] \`bash -n mobile/run-e2e-ios.sh\` clean
- [x] Local iOS Sim: \`./run-e2e-ios.sh integration_test/receipt_add_gallery_test.dart\` → \`All tests passed!\` (was failing before with Expected:1 Actual:0)
- [x] Local Android emu: same spec still passes (no regression from mock change)
- [x] Verified via debug prints: \`file.name=sample.png\`, \`path=/.../sample.png\`, \`filename=sample.png\`, upload completed without exception
- [ ] CI post-merge: ios-e2e job runs all 5 specs through with retry catching the cold-launch flake if it fires

## Out of scope
- Other receipt_add specs not currently in iOS CI list (could be added later)
- \`CustomFieldModel was used after being disposed\` log noise — non-fatal, separate ticket
- The swallowing catch in \`addReceipt\` (\`receipt_bottom_sheet_builder.dart:340\`) that hid this upload failure for so long — also separate concern; intentional UX choice today but worth re-litigating

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved test infrastructure for iOS end-to-end testing with enhanced setup and retry mechanisms to increase reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Receipt-Wrangler/receipt-wrangler/pull/562?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->