### PR TITLE
mobile-e2e: scaffold receipt status / comments / cost-split specs (skipped)

### DIFF
--- a/mobile/integration_test/helpers/pump.dart
+++ b/mobile/integration_test/helpers/pump.dart
@@ -27,3 +27,28 @@ Future<void> pumpUntilFound(
     'Timed out after ${timeout.inSeconds}s waiting for $finder',
   );
 }
+
+/// Inverse of [pumpUntilFound]: pumps frames until [finder] no longer
+/// matches anything, or [timeout] elapses. Useful for asserting that a
+/// widget disappears after a user action (e.g. swipe-delete on a list
+/// row) where the disappearance is driven by an API round-trip rather
+/// than an immediate setState.
+Future<void> pumpUntilGone(
+  WidgetTester tester,
+  Finder finder, {
+  Duration timeout = const Duration(seconds: 10),
+  Duration step = const Duration(milliseconds: 100),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    await tester.pump(step);
+    try {
+      if (finder.evaluate().isEmpty) return;
+    } catch (_) {
+      return;
+    }
+  }
+  throw StateError(
+    'Timed out after ${timeout.inSeconds}s waiting for $finder to disappear',
+  );
+}

--- a/mobile/integration_test/helpers/users.dart
+++ b/mobile/integration_test/helpers/users.dart
@@ -20,6 +20,11 @@ import 'env.dart';
 String adminDisplayName(WidgetTester tester) =>
     _displayNameForUsername(tester, E2eEnv.adminUsername);
 
+/// Same shape as [adminDisplayName] but for the e2e-user, so multi-user
+/// flows (group share, cost split) don't have to hard-code a displayName.
+String userDisplayName(WidgetTester tester) =>
+    _displayNameForUsername(tester, E2eEnv.userUsername);
+
 String _displayNameForUsername(WidgetTester tester, String username) {
   final ctx = tester.element(find.byType(Scaffold).first);
   final userModel = Provider.of<UserModel>(ctx, listen: false);

--- a/mobile/integration_test/receipt_comments_test.dart
+++ b/mobile/integration_test/receipt_comments_test.dart
@@ -1,0 +1,144 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:flutter_slidable/flutter_slidable.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:receipt_wrangler_mobile/shared/widgets/slidable_widget.dart';
+
+import 'helpers/api.dart';
+import 'helpers/login.dart';
+import 'helpers/platform_mocks.dart';
+import 'helpers/pump.dart';
+import 'helpers/receipt_test_helpers.dart';
+
+/// Exercises the comments feature end-to-end on an edit-mode receipt:
+/// add two comments via the bottom-sheet input, then swipe-delete the
+/// first one. Asserts against `Receipt.comments` from the API after each
+/// mutation -- the API list is the source of truth. A UI-only assertion
+/// would miss the documented swallow in `_submitCommentToApi`'s catch
+/// (receipt_comment_screen.dart:166-168), which can keep stale state in
+/// the UI even when the POST failed.
+void main() {
+  final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    if (Platform.isLinux) {
+      installLinuxDesktopMocks();
+    }
+  });
+
+  // TODO(unblock-comments): shares the same /view -> popup -> Edit menu
+  // navigation as receipt_status_lifecycle_test, which is currently broken on
+  // a null-check in `receipt_bottom_sheet_builder.dart:389:56` (see that
+  // spec's TODO). The comment input path then adds its own complexity around
+  // the bottom-sheet send button + slidable-row delete. Skipping until the
+  // shared setup is debugged; once status_lifecycle passes, this should be
+  // re-enabled and verified.
+  testWidgets('admin can add, view, and delete receipt comments',
+      skip: true,
+      (tester) async {
+    await binding.setSurfaceSize(const Size(1280, 900));
+    addTearDown(() => binding.setSurfaceSize(null));
+
+    await loginAsAdmin(tester);
+
+    final receiptName =
+        'e2e-comments-${DateTime.now().millisecondsSinceEpoch}';
+    final receiptId = await addManualReceiptViaUI(tester, receiptName);
+    scheduleReceiptCleanup(receiptId);
+
+    final jwt = await apiLogin();
+
+    // Move from /view to /edit so the comment bottom sheet (and the
+    // swipe-to-delete slidable) become interactive -- both gate on
+    // `formState == edit`. Tap the popup menu's "Edit" item.
+    //
+    // The ReceiptEditPopupMenu is gated on canEditReceipt(), which reads
+    // GroupModel; on cold-boot post-navigation, that model may not yet
+    // know the user's role in the receipt's group, so the button isn't
+    // mounted immediately. Same pumpUntilFound pattern as
+    // receipt_edit_test.dart:50.
+    final menuButton = find.byType(PopupMenuButton<dynamic>);
+    await pumpUntilFound(tester, menuButton);
+    await tester.tap(menuButton);
+    await pumpUntilFound(tester, find.text('Edit'));
+    await tester.tap(find.text('Edit'));
+    await pumpUntilUrl(tester, RegExp(r'/receipts/\d+/edit'));
+
+    // The Comments screen is pushed via Navigator (separate from GoRouter)
+    // by tapping the "Comments" compact-action button on the edit form
+    // (receipts/widgets/receipt_form.dart:391). The button is wrapped in
+    // a Tooltip("View Comments") -- byTooltip is a single deterministic
+    // match.
+    final commentsButton = find.byTooltip('View Comments');
+    await pumpUntilFound(tester, commentsButton);
+    await tester.tap(commentsButton);
+    await pumpUntilFound(tester, find.text('Receipt Comments'));
+
+    const firstComment = 'e2e first comment';
+    const secondComment = 'e2e second comment';
+
+    await _submitComment(tester, firstComment);
+    await pumpUntilFound(tester, find.text(firstComment));
+
+    await _submitComment(tester, secondComment);
+    await pumpUntilFound(tester, find.text(secondComment));
+
+    // Both comments now present on screen -- and the API should agree.
+    final afterAdds = await getReceipt(receiptId, jwt: jwt);
+    final commentsAfterAdds =
+        (afterAdds['comments'] as List).cast<Map<String, dynamic>>();
+    expect(commentsAfterAdds.length, 2,
+        reason: 'server should have 2 comments after two send taps; '
+            "if the UI shows 2 but the API has fewer that's a real bug "
+            'in _submitCommentToApi swallowing the POST error');
+    expect(commentsAfterAdds.map((c) => c['comment']).toList(),
+        containsAll(<String>[firstComment, secondComment]));
+
+    // Swipe-delete the first comment. The slidable wraps a Column of the
+    // comment row + a SizedBox spacer (receipt_comments.dart:42-47), so
+    // we locate the slidable by walking up from the text we want to remove.
+    final firstSlidable = find.ancestor(
+      of: find.text(firstComment),
+      matching: find.byType(SlidableWidget),
+    );
+    expect(firstSlidable, findsOneWidget);
+    await tester.drag(firstSlidable, const Offset(-300, 0));
+    await tester.pumpAndSettle();
+
+    // After the drag, the end-action pane reveals exactly one
+    // SlidableAction (the delete button). Tap it.
+    final deleteAction = find.byType(SlidableAction);
+    await pumpUntilFound(tester, deleteAction);
+    await tester.tap(deleteAction);
+
+    // Delete goes through `deleteComment` (await of API DELETE);
+    // pump until the deleted text is gone from the visible tree.
+    await pumpUntilGone(tester, find.text(firstComment));
+
+    final afterDelete = await getReceipt(receiptId, jwt: jwt);
+    final commentsAfterDelete =
+        (afterDelete['comments'] as List).cast<Map<String, dynamic>>();
+    expect(commentsAfterDelete.length, 1,
+        reason: 'server should have 1 comment after swipe-delete');
+    expect(commentsAfterDelete.single['comment'], secondComment);
+  });
+}
+
+/// Types [comment] into the bottom-sheet comment field and taps send.
+Future<void> _submitComment(WidgetTester tester, String comment) async {
+  final commentField = find.byWidgetPredicate(
+    (w) => w is FormBuilderTextField && w.name == 'comment',
+  );
+  await pumpUntilFound(tester, commentField);
+  await tester.enterText(commentField, comment);
+  // The submit button is disabled-until-non-empty via a BehaviorSubject;
+  // a single pump won't propagate the onChanged -> setState -> rebuild
+  // chain that re-enables the IconButton on slow targets.
+  for (int i = 0; i < 5; i++) {
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+  await tester.tap(find.byIcon(Icons.send));
+}

--- a/mobile/integration_test/receipt_comments_test.dart
+++ b/mobile/integration_test/receipt_comments_test.dart
@@ -29,13 +29,18 @@ void main() {
     }
   });
 
-  // TODO(unblock-comments): shares the same /view -> popup -> Edit menu
-  // navigation as receipt_status_lifecycle_test, which is currently broken on
-  // a null-check in `receipt_bottom_sheet_builder.dart:389:56` (see that
-  // spec's TODO). The comment input path then adds its own complexity around
-  // the bottom-sheet send button + slidable-row delete. Skipping until the
-  // shared setup is debugged; once status_lifecycle passes, this should be
-  // re-enabled and verified.
+  // TODO(comments-second-submit): with the form-key fix in place, this test
+  // gets past navigation and submits the FIRST comment to the API
+  // successfully. The SECOND `_submitComment(secondComment)` call's send-icon
+  // tap reports a hit-test miss and the POST never fires (API returns 1
+  // comment, expected 2). Suspected layout: after the first comment renders
+  // in the list, the bottom-sheet send button gets nudged below the visible
+  // area on the 1280x900 test surface. The pumpUntilFound that gates on
+  // `IconButton.onPressed != null` still hits because the widget exists; the
+  // miss is on the gesture-pump location. Needs either `ensureVisible(sendButton)`
+  // before the second tap, or a different scroll/keyboard handling. Skipping
+  // until investigated -- the bug this PR is unblocking (the null-check at
+  // receipt_bottom_sheet_builder.dart:389) is no longer the issue here.
   testWidgets('admin can add, view, and delete receipt comments',
       skip: true,
       (tester) async {
@@ -134,11 +139,18 @@ Future<void> _submitComment(WidgetTester tester, String comment) async {
   );
   await pumpUntilFound(tester, commentField);
   await tester.enterText(commentField, comment);
-  // The submit button is disabled-until-non-empty via a BehaviorSubject;
-  // a single pump won't propagate the onChanged -> setState -> rebuild
-  // chain that re-enables the IconButton on slow targets.
-  for (int i = 0; i < 5; i++) {
-    await tester.pump(const Duration(milliseconds: 100));
-  }
-  await tester.tap(find.byIcon(Icons.send));
+  await tester.pumpAndSettle(const Duration(seconds: 1));
+
+  // The submit IconButton is gated on the textBehaviorSubject stream
+  // (receipt_comment_screen.dart:82-85). Until the stream emits the new
+  // value, IconButton.onPressed stays null and the tap is a no-op.
+  // pumpUntil the *enabled* button (onPressed != null) -- not just the
+  // widget's existence -- before tapping.
+  final sendButton = find.byWidgetPredicate((w) =>
+      w is IconButton &&
+      w.icon is Icon &&
+      (w.icon as Icon).icon == Icons.send &&
+      w.onPressed != null);
+  await pumpUntilFound(tester, sendButton);
+  await tester.tap(sendButton);
 }

--- a/mobile/integration_test/receipt_cost_split_test.dart
+++ b/mobile/integration_test/receipt_cost_split_test.dart
@@ -1,0 +1,229 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:receipt_wrangler_mobile/shared/widgets/bottom_submit_button.dart';
+
+import 'helpers/api.dart';
+import 'helpers/login.dart';
+import 'helpers/platform_mocks.dart';
+import 'helpers/pump.dart';
+import 'helpers/receipt_test_helpers.dart';
+import 'helpers/users.dart';
+
+/// Exercises `ReceiptQuickActions` from the edit form: open the Quick
+/// Actions bottom sheet, select two users, drive the "Split Evenly"
+/// mode, save the receipt, then verify the API has two items each
+/// charged to one of the users at half the receipt total. Same shape
+/// for the "By Percentage" mode in the second testWidgets case (75/25).
+///
+/// We use two separate `testWidgets` (and two separate receipts) so the
+/// modes don't share item state -- `splitEvenly` appends to existing
+/// items rather than replacing them (quick_actions_submit_button.dart:44),
+/// so reusing one receipt for both modes would conflate the two cases'
+/// outputs.
+///
+/// Both cases assert against `Receipt.receiptItems` returned by the API
+/// -- the form-local `FormItem` list is only the source of truth until
+/// save, after which the server takes over.
+void main() {
+  final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    if (Platform.isLinux) {
+      installLinuxDesktopMocks();
+    }
+  });
+
+  // TODO(unblock-cost-split): shares the same /view -> popup -> Edit menu
+  // navigation as receipt_status_lifecycle_test (currently failing -- see
+  // that spec's TODO referencing the receiptFormKey.currentState! null check
+  // at receipt_bottom_sheet_builder.dart:389:56). Cost-split's submit also
+  // funnels through that handler, so it can't go green until the upstream
+  // bug is fixed.
+  testWidgets('Split Evenly creates one item per selected user',
+      skip: true,
+      (tester) async {
+    await binding.setSurfaceSize(const Size(1280, 900));
+    addTearDown(() => binding.setSurfaceSize(null));
+
+    await loginAsAdmin(tester);
+
+    final receiptName = 'e2e-split-even-${DateTime.now().millisecondsSinceEpoch}';
+    final receiptId = await addManualReceiptViaUI(
+      tester,
+      receiptName,
+      amount: '100.00',
+    );
+    scheduleReceiptCleanup(receiptId);
+
+    await _navigateToEdit(tester);
+    await _openQuickActionsSheet(tester);
+
+    // "Split Evenly" is index 0 of the ToggleButtons and is preselected
+    // (quick_actions.dart:43 `quickActionsSelection = [true, false, false]`).
+    // No mode toggle needed -- just pick the users and submit.
+    await _selectUsers(tester, [
+      adminDisplayName(tester),
+      userDisplayName(tester),
+    ]);
+
+    // The total widget updates with "2 users × $50.00 each" once both
+    // users are in the form. Wait for it so a slow recompute can't make
+    // the Split tap fire against stale fields.
+    await pumpUntilFound(tester, find.textContaining('2 users'));
+
+    await _tapSplitAndSave(tester);
+
+    final jwt = await apiLogin();
+    final receipt = await getReceipt(receiptId, jwt: jwt);
+    final items =
+        ((receipt['receiptItems'] as List?) ?? const []).cast<Map>();
+    expect(items.length, 2,
+        reason: 'Split Evenly with 2 users should produce 2 receipt items; '
+            'fewer suggests buildEvenSplitFormItems ran with the wrong '
+            'getSelectedUsers() snapshot');
+    final amounts = items.map((i) => _toDouble(i['amount'])).toList();
+    for (final a in amounts) {
+      expect(a, closeTo(50.0, 0.01),
+          reason: 'Each Split Evenly item should be receiptTotal / 2 = 50.00. '
+              'Off-by-cents would indicate Money2 rounding regressed.');
+    }
+    expect(
+        items.map((i) => i['chargedToUserId']).toSet().length,
+        2,
+        reason: 'Each item should be charged to a distinct user');
+  });
+
+  testWidgets('By Percentage creates items proportional to picked %',
+      skip: true,
+      (tester) async {
+    await binding.setSurfaceSize(const Size(1280, 900));
+    addTearDown(() => binding.setSurfaceSize(null));
+
+    await loginAsAdmin(tester);
+
+    final receiptName = 'e2e-split-pct-${DateTime.now().millisecondsSinceEpoch}';
+    final receiptId = await addManualReceiptViaUI(
+      tester,
+      receiptName,
+      amount: '100.00',
+    );
+    scheduleReceiptCleanup(receiptId);
+
+    await _navigateToEdit(tester);
+    await _openQuickActionsSheet(tester);
+
+    // Switch to "By Percentage" (toggle index 2). The labels live in
+    // `quickActions` in quick_actions.dart:38-42.
+    await tester.tap(find.text('By Percentage'));
+    await tester.pumpAndSettle();
+
+    await _selectUsers(tester, [
+      adminDisplayName(tester),
+      userDisplayName(tester),
+    ]);
+
+    // Wait for the per-user FilterChip rows to appear -- buildPercentageFields()
+    // only renders them once `users` is non-empty.
+    await pumpUntilFound(tester, find.widgetWithText(FilterChip, '75%'));
+
+    // Pick 75% for admin, 25% for the e2e user. FilterChip labels for
+    // each user are rendered identically ("25%", "50%", "75%", "100%",
+    // "Custom"), so we tap the .first instance for admin and .last for
+    // the second user. The rows are rendered in users-array order which
+    // matches our selection order.
+    await tester.tap(find.widgetWithText(FilterChip, '75%').first);
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilterChip, '25%').last);
+    await tester.pumpAndSettle();
+
+    await _tapSplitAndSave(tester);
+
+    final jwt = await apiLogin();
+    final receipt = await getReceipt(receiptId, jwt: jwt);
+    final items =
+        ((receipt['receiptItems'] as List?) ?? const []).cast<Map>();
+    expect(items.length, 2,
+        reason: 'By Percentage with 2 users should produce 2 items');
+    final amounts = items.map((i) => _toDouble(i['amount'])).toList()
+      ..sort();
+    expect(amounts[0], closeTo(25.0, 0.01),
+        reason: r'Lower portion should be 25% of $100 = $25.00');
+    expect(amounts[1], closeTo(75.0, 0.01),
+        reason: r'Higher portion should be 75% of $100 = $75.00');
+  });
+}
+
+double _toDouble(dynamic v) {
+  if (v is num) return v.toDouble();
+  return double.parse(v.toString());
+}
+
+Future<void> _navigateToEdit(WidgetTester tester) async {
+  // The ReceiptEditPopupMenu is gated on canEditReceipt(); on cold-boot
+  // after the /view navigation, the GroupModel may not yet know the user's
+  // role in the receipt's group, so the button isn't mounted immediately
+  // (see receipt_edit_test.dart:50 for the same pattern).
+  final menuButton = find.byType(PopupMenuButton<dynamic>);
+  await pumpUntilFound(tester, menuButton);
+  await tester.tap(menuButton);
+  await pumpUntilFound(tester, find.text('Edit'));
+  await tester.tap(find.text('Edit'));
+  await pumpUntilUrl(tester, RegExp(r'/receipts/\d+/edit'));
+}
+
+/// Locates the split-action IconButton on the edit form. It's the
+/// IconButton whose `icon` is an `SvgPicture` for `assets/icons/split.svg`
+/// (receipt_form.dart:482-489). The neighboring "Add Share" IconButton
+/// uses a Material `Icon`, not `SvgPicture`, so the predicate is unique.
+Future<void> _openQuickActionsSheet(WidgetTester tester) async {
+  final splitButton = find.byWidgetPredicate(
+    (w) => w is IconButton && w.icon is SvgPicture,
+  );
+  await pumpUntilFound(tester, splitButton);
+  await tester.tap(splitButton);
+  // The fullscreen bottom sheet header is "Quick Actions"; wait for the
+  // ToggleButtons row to render before driving the form.
+  await pumpUntilFound(tester, find.text('Split Evenly'));
+}
+
+/// Opens the "Users" MultiSelectField, taps each ChoiceChip whose label
+/// matches a display name in [displayNames], then taps the "Select"
+/// confirm button. The MultiSelectField's outer FormBuilderField wraps a
+/// GestureDetector(onTap:) that fires `showUserMultiSelect`; tapping the
+/// labeled "Users" InputDecorator hits that gesture detector.
+Future<void> _selectUsers(
+  WidgetTester tester,
+  List<String> displayNames,
+) async {
+  await tester.tap(find.widgetWithText(InputDecorator, 'Users'));
+  await pumpUntilFound(tester, find.text('Select Users'));
+
+  for (final name in displayNames) {
+    await tester.tap(find.widgetWithText(ChoiceChip, name));
+    await tester.pump(const Duration(milliseconds: 200));
+  }
+
+  await tester.tap(find.widgetWithText(BottomSubmitButton, 'Select'));
+  await tester.pumpAndSettle();
+}
+
+/// Submits the "Split" form, returns to the receipt edit screen, then
+/// submits the receipt itself. Lands on `/view` so the caller can poll
+/// the API.
+Future<void> _tapSplitAndSave(WidgetTester tester) async {
+  await tester.tap(find.widgetWithText(BottomSubmitButton, 'Split'));
+  // The bottom sheet pops; wait for the edit URL to be the visible route
+  // again before saving.
+  await pumpUntilUrl(tester, RegExp(r'/receipts/\d+/edit'));
+
+  // Drain frames so the outer BottomSubmitButton has the new items list
+  // committed to the form before we tap save.
+  await tester.pumpAndSettle(const Duration(seconds: 2));
+
+  await tester.tap(find.byType(BottomSubmitButton));
+  await pumpUntilUrl(tester, RegExp(r'/receipts/\d+/view'));
+}

--- a/mobile/integration_test/receipt_cost_split_test.dart
+++ b/mobile/integration_test/receipt_cost_split_test.dart
@@ -37,12 +37,17 @@ void main() {
     }
   });
 
-  // TODO(unblock-cost-split): shares the same /view -> popup -> Edit menu
-  // navigation as receipt_status_lifecycle_test (currently failing -- see
-  // that spec's TODO referencing the receiptFormKey.currentState! null check
-  // at receipt_bottom_sheet_builder.dart:389:56). Cost-split's submit also
-  // funnels through that handler, so it can't go green until the upstream
-  // bug is fixed.
+  // TODO(cost-split-shellContext): with the form-key fix in place, this test
+  // gets past navigation and the split-action IconButton tap fires
+  // `openQuickActionsBottomSheet` (receipt_form.dart:501), but
+  // `showFullscreenBottomSheet(shellContext as BuildContext, ...)` throws
+  // "Null check operator used on a null value" inside `Element.widget` ->
+  // `debugCheckHasMediaQuery` -> `showModalBottomSheet`. The cached
+  // `shellContext` (receipt_form.dart:53-54) appears to point at a
+  // deactivated Element by the time the user taps split. This is a separate
+  // production bug from the null-check this PR fixes; the bottom sheet never
+  // opens so the test then times out waiting for "Split Evenly". Skipping
+  // both modes until shellContext lifecycle is investigated.
   testWidgets('Split Evenly creates one item per selected user',
       skip: true,
       (tester) async {
@@ -184,6 +189,11 @@ Future<void> _openQuickActionsSheet(WidgetTester tester) async {
     (w) => w is IconButton && w.icon is SvgPicture,
   );
   await pumpUntilFound(tester, splitButton);
+  // The split-action button sits below the Shares row on the form,
+  // off-screen on the 1280x900 test surface. Scroll it into view so
+  // the tap lands -- otherwise the bottom sheet never opens.
+  await tester.ensureVisible(splitButton);
+  await tester.pumpAndSettle();
   await tester.tap(splitButton);
   // The fullscreen bottom sheet header is "Quick Actions"; wait for the
   // ToggleButtons row to render before driving the form.

--- a/mobile/integration_test/receipt_navigation_test.dart
+++ b/mobile/integration_test/receipt_navigation_test.dart
@@ -1,0 +1,122 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:receipt_wrangler_mobile/groups/widgets/receipt_list_item.dart';
+
+import 'helpers/login.dart';
+import 'helpers/platform_mocks.dart';
+import 'helpers/pump.dart';
+import 'helpers/receipt_test_helpers.dart';
+
+/// Switches between two receipts via the receipt list and verifies each
+/// /view screen shows the *current* receipt's data with no stale residue
+/// from the previous one.
+///
+/// Specifically pins down the post-fix behavior of
+/// `ReceiptModel.setReceipt()` (`receipt_model.dart:69`): when the receipt
+/// id actually changes the form key MUST regenerate so the FormBuilder
+/// remounts with the new initialValues, and `resetModel()` (called from
+/// the app-bar back arrow at `receipt_app_bar.dart:44-46`) MUST clear the
+/// previous receipt's data so it doesn't bleed into the list-flash or the
+/// next /view.
+///
+/// Catches:
+///   - A `setReceipt` regression that fails to swap form values when the id changes.
+///   - A `resetModel` regression that leaves stale name/amount in the model.
+///   - Any `late final`-captured field in the form tree that doesn't refresh.
+void main() {
+  final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    if (Platform.isLinux) {
+      installLinuxDesktopMocks();
+    }
+  });
+
+  testWidgets(
+      'admin can switch between two receipts via the list without stale data',
+      (tester) async {
+    await binding.setSurfaceSize(const Size(1280, 900));
+    addTearDown(() => binding.setSurfaceSize(null));
+
+    await loginAsAdmin(tester);
+
+    // Distinct names per receipt -- timestamped + A/B suffix so a fast
+    // double-create within the same millisecond can't accidentally produce
+    // identical strings.
+    final ts = DateTime.now().millisecondsSinceEpoch;
+    final nameA = 'e2e-nav-A-$ts';
+    final nameB = 'e2e-nav-B-$ts';
+
+    // Receipt A: created via UI, lands us on /receipts/<id1>/view.
+    // `addManualReceiptViaUI` returns as soon as the URL flips to /view,
+    // but the form's FutureBuilder still has to resolve the receipt
+    // before the name renders (ReceiptFormScreen shows a spinner in the
+    // interim). pumpUntilFound the name so the assertion doesn't race.
+    final id1 =
+        await addManualReceiptViaUI(tester, nameA, amount: '10.00');
+    scheduleReceiptCleanup(id1);
+    await pumpUntilFound(tester, find.text(nameA));
+
+    // Back to the list. The back arrow on /view is the TopAppBar's leading
+    // IconButton; it triggers `receiptModel.resetModel()` and pushes
+    // /groups/<groupId>/receipts (receipt_app_bar.dart:42-46).
+    await _tapBackArrow(tester);
+    await pumpUntilUrl(tester, RegExp(r'/groups/\d+/receipts'));
+
+    // Receipt B: created from the list. The bottom-nav "Add" entry is
+    // present on both /groups and /groups/<id>/receipts (group_select_bottom_nav.dart
+    // and group_bottom_nav.dart both declare it), so `addManualReceiptViaUI`'s
+    // pre-condition is satisfied from the list too.
+    final id2 =
+        await addManualReceiptViaUI(tester, nameB, amount: '99.99');
+    scheduleReceiptCleanup(id2);
+
+    // Positive find first to make pumpUntilFound wait for the new data,
+    // then the negative for receipt A. Doing them in this order avoids a
+    // false-clean from asserting absence before the screen has redrawn.
+    await pumpUntilFound(tester, find.text(nameB));
+    expect(find.text(nameA).evaluate(), isEmpty,
+        reason: 'receipt B\'s view must not still be rendering A\'s name '
+            '-- that\'d indicate setReceipt didn\'t propagate or some '
+            'late-final cached the prior receipt');
+
+    // Back to the list, then switch from B's view back to A.
+    await _tapBackArrow(tester);
+    await pumpUntilUrl(tester, RegExp(r'/groups/\d+/receipts'));
+    await pumpUntilFound(
+        tester, find.widgetWithText(ReceiptListItem, nameA));
+
+    await tester.tap(find.widgetWithText(ReceiptListItem, nameA));
+    await pumpUntilUrl(tester, RegExp(r'/receipts/\d+/view'));
+    await pumpUntilFound(tester, find.text(nameA));
+    expect(find.text(nameB).evaluate(), isEmpty,
+        reason: 'after navigating list -> A, B\'s name must not linger');
+
+    // Final hop: A -> list -> B.
+    await _tapBackArrow(tester);
+    await pumpUntilUrl(tester, RegExp(r'/groups/\d+/receipts'));
+    await pumpUntilFound(
+        tester, find.widgetWithText(ReceiptListItem, nameB));
+
+    await tester.tap(find.widgetWithText(ReceiptListItem, nameB));
+    await pumpUntilUrl(tester, RegExp(r'/receipts/\d+/view'));
+    await pumpUntilFound(tester, find.text(nameB));
+    expect(find.text(nameA).evaluate(), isEmpty,
+        reason: 'after the final list -> B switch, A\'s name must not linger');
+  });
+}
+
+/// Taps the AppBar's back arrow on the receipt /view screen. Scoped to a
+/// descendant of `AppBar` to dodge the (unlikely) case where another
+/// Icons.arrow_back lives elsewhere in the tree.
+Future<void> _tapBackArrow(WidgetTester tester) async {
+  final back = find.descendant(
+    of: find.byType(AppBar),
+    matching: find.byIcon(Icons.arrow_back),
+  );
+  await pumpUntilFound(tester, back);
+  await tester.tap(back);
+}

--- a/mobile/integration_test/receipt_status_lifecycle_test.dart
+++ b/mobile/integration_test/receipt_status_lifecycle_test.dart
@@ -1,0 +1,139 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:receipt_wrangler_mobile/shared/widgets/bottom_submit_button.dart';
+
+import 'helpers/api.dart';
+import 'helpers/login.dart';
+import 'helpers/platform_mocks.dart';
+import 'helpers/pump.dart';
+import 'helpers/receipt_test_helpers.dart';
+
+/// Drives a receipt through the four ReceiptStatus values via the
+/// view-screen popup menu → Edit form, asserting after each transition that
+/// the server-side status matches. Catches regressions where:
+///   - the status dropdown ignores user selection in edit mode,
+///   - the form submits but doesn't actually persist the new status,
+///   - the API client serializes the enum differently than the server expects.
+///
+/// We compare against the JSON the API returns (`status` is the uppercase
+/// enum name) rather than re-driving the UI to read the value back -- the
+/// API is the source of truth and a UI round-trip could mask a save bug.
+void main() {
+  final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    if (Platform.isLinux) {
+      installLinuxDesktopMocks();
+    }
+  });
+
+  // TODO(unblock-status-lifecycle): after changing the receipt status via the
+  // FormBuilderDropdown and tapping BottomSubmitButton, the submit handler
+  // crashes with "Null check operator used on a null value" at
+  // `mobile/lib/receipts/nav/receipt_bottom_sheet_builder.dart:389:56`:
+  //     receiptModel.receiptFormKey.currentState!.saveAndValidate()
+  // The receiptFormKey is reset to a new GlobalKey inside ReceiptModel.setReceipt()
+  // (`receipt_model.dart:69`) every time the receipt is loaded -- including the
+  // /view -> /edit transition. The existing `receipt_edit_test` does the same
+  // flow but only modifies a FormBuilderTextField (Name) before submit and
+  // works fine; the failure here appears specific to the dropdown-then-submit
+  // ordering. Pumping `find.text('Name')` and pumpAndSettle(3s) did not unblock.
+  // Skipping the spec until the underlying timing/key bug is understood.
+  testWidgets('admin can move a receipt through all status transitions',
+      skip: true,
+      (tester) async {
+    await binding.setSurfaceSize(const Size(1280, 900));
+    addTearDown(() => binding.setSurfaceSize(null));
+
+    await loginAsAdmin(tester);
+
+    final receiptName =
+        'e2e-status-${DateTime.now().millisecondsSinceEpoch}';
+    final receiptId = await addManualReceiptViaUI(tester, receiptName);
+    scheduleReceiptCleanup(receiptId);
+
+    final jwt = await apiLogin();
+
+    // getDefaultReceipt() in lib/utils/receipts.dart sets the initial status
+    // to OPEN -- record-and-fail-fast if that ever changes so the rest of
+    // the lifecycle assertions stay meaningful.
+    final initial = await getReceipt(receiptId, jwt: jwt);
+    expect(initial['status'], 'OPEN',
+        reason: 'manual receipt should default to OPEN');
+
+    // OPEN is the starting point, so we drive only the three remaining
+    // transitions plus a round-trip back to OPEN to prove every value is
+    // reachable from any other.
+    for (final transition in const [
+      _StatusTransition('Needs Attention', 'NEEDS_ATTENTION'),
+      _StatusTransition('Resolved', 'RESOLVED'),
+      _StatusTransition('Draft', 'DRAFT'),
+      _StatusTransition('Open', 'OPEN'),
+    ]) {
+      await _changeStatusViaUI(tester, transition.label);
+
+      final updated = await getReceipt(receiptId, jwt: jwt);
+      expect(updated['status'], transition.apiValue,
+          reason: 'after submitting "${transition.label}" the server '
+              'should report status=${transition.apiValue}');
+    }
+  });
+}
+
+class _StatusTransition {
+  const _StatusTransition(this.label, this.apiValue);
+  final String label;
+  final String apiValue;
+}
+
+/// Pre-condition: caller is on `/receipts/<id>/view`. Opens the top-right
+/// popup menu, taps "Edit", changes the status dropdown to [optionLabel],
+/// taps the bottom submit button, and waits to land back on /view.
+Future<void> _changeStatusViaUI(WidgetTester tester, String optionLabel) async {
+  // Open the view-screen overflow menu and pick "Edit". The PopupMenuButton
+  // is gated on `canEditReceipt`, which reads from GroupModel -- on cold-boot
+  // after navigation, the model may not have populated the user's role in the
+  // receipt's group yet, so we pump until the menu button is actually mounted
+  // instead of tapping immediately.
+  final menuButton = find.byType(PopupMenuButton<dynamic>);
+  await pumpUntilFound(tester, menuButton);
+  await tester.tap(menuButton);
+  await pumpUntilFound(tester, find.text('Edit'));
+  await tester.tap(find.text('Edit'));
+
+  // Wait for the edit form to be fully mounted before any submit. The
+  // ReceiptModel.setReceipt() that fires on navigation rebuilds the
+  // receiptFormKey from scratch (receipt_model.dart:69), so the form's
+  // currentState is null for a few frames while the new widget attaches.
+  // saveAndValidate() in the submit handler dereferences currentState!
+  // with a null-check operator -- tapping Submit before that attachment
+  // completes throws "Null check operator used on a null value".
+  // Mirror receipt_edit_test.dart:59 -- wait for the Name field to render
+  // (a stable form element) before driving the form.
+  await pumpUntilFound(tester, find.text('Name'));
+
+  // Edit screen renders the same FormBuilder fields as add; the status
+  // dropdown is `FormBuilderDropdown<ReceiptStatus>(name: 'status')`.
+  final statusFinder = find.byWidgetPredicate(
+    (w) => w is FormBuilderDropdown && w.name == 'status',
+  );
+  await pumpUntilFound(tester, statusFinder);
+  await tester.tap(statusFinder);
+
+  // Same .last + frame-drain pattern as selectDropdown() in
+  // helpers/form_actions.dart -- the closed-state child stays in the tree
+  // behind the open menu and the option text appears twice.
+  await pumpUntilFound(tester, find.text(optionLabel));
+  await tester.tap(find.text(optionLabel).last);
+  for (int i = 0; i < 5; i++) {
+    await tester.pump(const Duration(milliseconds: 200));
+  }
+
+  await tester.pumpAndSettle(const Duration(seconds: 3));
+  await tester.tap(find.byType(BottomSubmitButton));
+  await pumpUntilUrl(tester, RegExp(r'/receipts/\d+/view'));
+}

--- a/mobile/integration_test/receipt_status_lifecycle_test.dart
+++ b/mobile/integration_test/receipt_status_lifecycle_test.dart
@@ -7,6 +7,7 @@ import 'package:integration_test/integration_test.dart';
 import 'package:receipt_wrangler_mobile/shared/widgets/bottom_submit_button.dart';
 
 import 'helpers/api.dart';
+import 'helpers/form_actions.dart';
 import 'helpers/login.dart';
 import 'helpers/platform_mocks.dart';
 import 'helpers/pump.dart';
@@ -31,20 +32,7 @@ void main() {
     }
   });
 
-  // TODO(unblock-status-lifecycle): after changing the receipt status via the
-  // FormBuilderDropdown and tapping BottomSubmitButton, the submit handler
-  // crashes with "Null check operator used on a null value" at
-  // `mobile/lib/receipts/nav/receipt_bottom_sheet_builder.dart:389:56`:
-  //     receiptModel.receiptFormKey.currentState!.saveAndValidate()
-  // The receiptFormKey is reset to a new GlobalKey inside ReceiptModel.setReceipt()
-  // (`receipt_model.dart:69`) every time the receipt is loaded -- including the
-  // /view -> /edit transition. The existing `receipt_edit_test` does the same
-  // flow but only modifies a FormBuilderTextField (Name) before submit and
-  // works fine; the failure here appears specific to the dropdown-then-submit
-  // ordering. Pumping `find.text('Name')` and pumpAndSettle(3s) did not unblock.
-  // Skipping the spec until the underlying timing/key bug is understood.
   testWidgets('admin can move a receipt through all status transitions',
-      skip: true,
       (tester) async {
     await binding.setSurfaceSize(const Size(1280, 900));
     addTearDown(() => binding.setSurfaceSize(null));
@@ -105,33 +93,25 @@ Future<void> _changeStatusViaUI(WidgetTester tester, String optionLabel) async {
   await pumpUntilFound(tester, find.text('Edit'));
   await tester.tap(find.text('Edit'));
 
-  // Wait for the edit form to be fully mounted before any submit. The
-  // ReceiptModel.setReceipt() that fires on navigation rebuilds the
-  // receiptFormKey from scratch (receipt_model.dart:69), so the form's
-  // currentState is null for a few frames while the new widget attaches.
-  // saveAndValidate() in the submit handler dereferences currentState!
-  // with a null-check operator -- tapping Submit before that attachment
-  // completes throws "Null check operator used on a null value".
-  // Mirror receipt_edit_test.dart:59 -- wait for the Name field to render
-  // (a stable form element) before driving the form.
+  // Wait for the edit form to mount before driving it. The same
+  // pumpUntilFound(Name) pattern used by receipt_edit_test.dart:59.
   await pumpUntilFound(tester, find.text('Name'));
 
-  // Edit screen renders the same FormBuilder fields as add; the status
-  // dropdown is `FormBuilderDropdown<ReceiptStatus>(name: 'status')`.
+  // The status field sits well below Name on the receipt form; on the
+  // 1280x900 test surface it's off-screen until we scroll it into view.
+  // Without ensureVisible the dropdown tap silently misses and the
+  // option text never renders, so pumpUntilFound inside selectDropdown
+  // times out.
   final statusFinder = find.byWidgetPredicate(
     (w) => w is FormBuilderDropdown && w.name == 'status',
   );
   await pumpUntilFound(tester, statusFinder);
-  await tester.tap(statusFinder);
+  await tester.ensureVisible(statusFinder);
+  await tester.pumpAndSettle();
 
-  // Same .last + frame-drain pattern as selectDropdown() in
-  // helpers/form_actions.dart -- the closed-state child stays in the tree
-  // behind the open menu and the option text appears twice.
-  await pumpUntilFound(tester, find.text(optionLabel));
-  await tester.tap(find.text(optionLabel).last);
-  for (int i = 0; i < 5; i++) {
-    await tester.pump(const Duration(milliseconds: 200));
-  }
+  // Use the proven dropdown helper -- it handles the .last/frame-drain
+  // pattern the closed-state child needs.
+  await selectDropdown(tester, 'status', optionLabel);
 
   await tester.pumpAndSettle(const Duration(seconds: 3));
   await tester.tap(find.byType(BottomSubmitButton));

--- a/mobile/lib/models/receipt_model.dart
+++ b/mobile/lib/models/receipt_model.dart
@@ -53,6 +53,20 @@ class ReceiptModel extends ChangeNotifier {
   GlobalKey<FormBuilderState> get quickActionsFormKey => _quickActionsFormKey;
 
   void setReceipt(Receipt receipt, bool notify) {
+    // Only regenerate the form key when we're loading a *different* receipt
+    // (or moving from the default-id-0 placeholder to a real one).
+    // `ReceiptFormScreen.build()` (receipt_form_screen.dart:88) calls
+    // setReceipt unconditionally on every screen rebuild after the
+    // FutureBuilder resolves. If we regen the GlobalKey every time, the
+    // FormBuilder gets a new key on each parent rebuild and Flutter tears
+    // down + remounts the entire form -- which makes the submit handler's
+    // `currentState` go null between taps ("Null check operator used on a
+    // null value" at receipt_bottom_sheet_builder.dart:389) and breaks
+    // dropdown interactions whose state is wiped mid-tap. Regenerating
+    // the key is only needed when the receipt identity actually changes,
+    // so the FormBuilderField initialValues get re-read for the new data.
+    final isNewReceipt = _receipt.id != receipt.id;
+
     _receipt = receipt;
 
     _modifiedReceipt = receipt;
@@ -66,7 +80,9 @@ class ReceiptModel extends ChangeNotifier {
     _imagesToUploadBehaviorSubject =
         BehaviorSubject<List<UploadMultipartFileData>>.seeded([]);
 
-    _receiptFormKey = GlobalKey<FormBuilderState>();
+    if (isNewReceipt) {
+      _receiptFormKey = GlobalKey<FormBuilderState>();
+    }
 
     if (notify) {
       notifyListeners();

--- a/mobile/lib/receipts/nav/receipt_bottom_nav.dart
+++ b/mobile/lib/receipts/nav/receipt_bottom_nav.dart
@@ -29,8 +29,19 @@ class _ReceiptBottomNav extends State<ReceiptBottomNav> {
 
   void updateModifiedReceipt() {
     var formState = getFormStateFromContext(context);
-    receiptModel.receiptFormKey.currentState!.save();
-    var form = {...receiptModel.receiptFormKey.currentState!.value};
+    // Defensive null check: the only current caller already guards on
+    // `currentState != null` (build()'s onDestinationSelected, line 138),
+    // but bare `!` here is the same inconsistency the receipt-submit
+    // handler had at receipt_bottom_sheet_builder.dart:389 -- a future
+    // refactor that calls this from a non-guarded path would crash with
+    // "Null check operator used on a null value". No-op when the form
+    // isn't currently attached to the model's key.
+    final state = receiptModel.receiptFormKey.currentState;
+    if (state == null) {
+      return;
+    }
+    state.save();
+    var form = {...state.value};
     var date = "";
 
     if (formState == WranglerFormState.view) {

--- a/mobile/lib/receipts/nav/receipt_bottom_sheet_builder.dart
+++ b/mobile/lib/receipts/nav/receipt_bottom_sheet_builder.dart
@@ -386,7 +386,16 @@ class ReceiptBottomSheetBuilder {
           if (loadingModel.isLoading) {
             return;
           }
-          if (!receiptModel.receiptFormKey.currentState!.saveAndValidate()) {
+          // Defensive null check: the form key reference is now stable
+          // (receipt_form.dart's `formKey` getter reads from the model
+          // every build), but a future regression that detaches the
+          // FormBuilder from the model's current key would surface here
+          // as a null currentState. Short-circuit to a no-op tap rather
+          // than crashing with "Null check operator used on a null value".
+          // Note: local name is `state` to avoid shadowing the outer
+          // `formState` field (WranglerFormState) used inside this closure.
+          final state = receiptModel.receiptFormKey.currentState;
+          if (state == null || !state.saveAndValidate()) {
             return;
           }
           // The Consumer rebuild + spinner is still useful UX -- it


### PR DESCRIPTION
## Summary
- Adds **four new integration specs** under `mobile/integration_test/` exercising receipt status lifecycle, comments add/view/delete, cost-split (Split Evenly + By Percentage), and **receipt-switching navigation** (view A → list → view B with no stale data).
- **Fixes the null-check crash** that originally forced the first three specs to `skip: true` — `Null check operator used on a null value` at `mobile/lib/receipts/nav/receipt_bottom_sheet_builder.dart:389:56`. See "Fix detail" below.
- Adds two small e2e helpers used by the new specs: `pumpUntilGone(finder)` in `helpers/pump.dart` and `userDisplayName(tester)` in `helpers/users.dart`.

## Fix detail
**Root cause**: `ReceiptModel.setReceipt()` (`receipt_model.dart:69`) regenerated `_receiptFormKey` to a fresh `GlobalKey` every time the screen rebuilt, including the per-build call from `ReceiptFormScreen.build()` inside the FutureBuilder `done` path (`receipt_form_screen.dart:88`). The `_ReceiptForm` widget captured the key with `late final formKey`, which froze on first access. After rebuild, the captured key and the model's current key diverged — the FormBuilder stayed attached to the old key, the submit handler at line 389 queried `receiptModel.receiptFormKey.currentState!` on the new (unattached) key → null → crash.

**Fix**: regenerate the form key only when `_receipt.id != receipt.id`. The FormBuilderField initialValues are only read at first mount, so a fresh key is needed for a *new* receipt; redundant `setReceipt` calls on the same receipt no longer tear the form down. With the key stable across rebuilds, the submit handler's `currentState` hits the still-attached state and validation proceeds normally.

**Belt-and-suspenders**: the two bare `!` dereferences in the receipt-submit code paths (`receipt_bottom_sheet_builder.dart:389`, `receipt_bottom_nav.dart:30-44`) are now defensive `?.` with early-return-on-null. The codebase's comment-form handling already used this pattern; the receipt-form was the inconsistency.

## What's enabled vs. still skipped

| Spec | Status |
|---|---|
| `receipt_status_lifecycle_test.dart` | **Enabled — passes** locally (`+2: All tests passed!`, ~1 min on local Android emu). |
| `receipt_navigation_test.dart` *(new)* | **Enabled — passes** locally (`+2: All tests passed!`, ~32s). Exercises A → list → B → list → A → list → B with name assertions on each /view. |
| `receipt_comments_test.dart` | Still `skip: true`. Original null-check is fixed, but the second `_submitComment` call's send-icon tap hit-test misses on the 1280x900 surface and the second POST never fires. New TODO above the spec. |
| `receipt_cost_split_test.dart` (both modes) | Still `skip: true`. Original null-check is fixed, but tapping the split-action button now throws "Null check operator used on a null value" inside `Element.widget` → `debugCheckHasMediaQuery` → `showModalBottomSheet` — the cached `shellContext` (`receipt_form.dart:53-54`) points at a deactivated Element by the time the user taps Split. **New product bug**; separate concern. New TODO above each `testWidgets`. |

## Findings (still applicable from prior round)
1. **No mobile UI to delete a receipt.** Receipt list `SlidableWidget` only reveals Edit; receipt view/edit popup's "Delete" entry is `Delete Image`. API supports `DELETE /receipt/<id>` (test cleanup uses it) but no UI exposes it.
2. **Attempted CI speedup via `flutter drive --use-application-binary`** broke the runner script (even the known-good `receipt_add_test` failed), so it was reverted before commit. Investigation deferred.

## Test plan
- [x] `flutter analyze` clean on every file I changed.
- [x] `cd mobile && ./run-e2e-android.sh integration_test/receipt_status_lifecycle_test.dart` → `+2: All tests passed!`.
- [x] `cd mobile && ./run-e2e-android.sh integration_test/receipt_navigation_test.dart` → `+2: All tests passed!`.
- [x] **Regression**: `cd mobile && ./run-e2e-android.sh integration_test/receipt_add_test.dart integration_test/receipt_edit_test.dart` → both `+2: All tests passed!`.
- [x] `cd mobile && ./run-e2e-android.sh integration_test/receipt_comments_test.dart integration_test/receipt_cost_split_test.dart` exits 0 (specs are skipped, not run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end integration tests covering receipt comments, cost-splitting, navigation, and full receipt status lifecycle
  * Added helpers for multi-user flows and a utility to wait until UI elements disappear

* **Bug Fixes**
  * Prevent crashes by guarding against detached/null form state when saving or submitting
  * Avoid unnecessary form remounts that could clear form values and interaction state

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Receipt-Wrangler/receipt-wrangler/pull/563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->