### PR TITLE
Add Manage Roles list page and reusable breadcrumb

### DIFF
--- a/desktop/src/app/app-routing.module.ts
+++ b/desktop/src/app/app-routing.module.ts
@@ -83,6 +83,15 @@ const routes: Routes = [
         },
       },
       {
+        path: "roles",
+        loadChildren: () =>
+          import("../roles/roles.module").then((m) => m.RolesModule),
+        canActivate: [AuthGuard],
+        data: {
+          role: UserRole.Admin,
+        },
+      },
+      {
         path: "",
         redirectTo: "/auth/login",
         pathMatch: "full",

--- a/desktop/src/layout/sidebar/sidebar.component.html
+++ b/desktop/src/layout/sidebar/sidebar.component.html
@@ -78,6 +78,9 @@
         <button *appRole="'ADMIN'" [routerLink]="['/users']" mat-menu-item>
           Manage Users
         </button>
+        <button *appRole="'ADMIN'" [routerLink]="['/roles']" mat-menu-item>
+          Manage Roles
+        </button>
         <button [routerLink]="['/categories']" mat-menu-item>
           Manage Categories
         </button>

--- a/desktop/src/roles/role-list/role-list-item.interface.ts
+++ b/desktop/src/roles/role-list/role-list-item.interface.ts
@@ -1,0 +1,28 @@
+/**
+ * View-model for a single row in the roles list.
+ *
+ * This is a temporary, frontend-only shape used to render the list page until
+ * the backend role-list endpoint and its generated client exist. Once that
+ * lands, this will be replaced by (or mapped from) the generated role model.
+ */
+export interface RoleListItem {
+  id: string;
+  name: string;
+  description: string;
+  scopes: RoleScope[];
+  appCount: number;
+  groupCount: number;
+  members: RoleMember[];
+  userCount: number;
+  isSystem: boolean;
+  icon: string;
+  iconColor: string;
+  iconTint: string;
+}
+
+export type RoleScope = "app" | "group";
+
+export interface RoleMember {
+  name: string;
+  color: string;
+}

--- a/desktop/src/roles/role-list/role-list.component.html
+++ b/desktop/src/roles/role-list/role-list.component.html
@@ -1,0 +1,142 @@
+<div class="roles-page">
+  <app-breadcrumb [items]="crumbs"></app-breadcrumb>
+
+  <div class="page-title">
+    <div class="titles">
+      <h1>Roles</h1>
+      <p class="subtitle">
+        {{ roleCount() }} roles control what people can do across the app and
+        within groups. Assign roles to people from
+        <a [routerLink]="['/users']">Manage Users</a>.
+      </p>
+    </div>
+    <div class="tools">
+      <app-button
+        matButtonType="basic"
+        icon="filter_alt"
+        buttonText="Filter"
+      ></app-button>
+      <app-button
+        icon="add"
+        buttonText="Add Role"
+        (clicked)="addRole()"
+      ></app-button>
+    </div>
+  </div>
+
+  @if (roles().length === 0) {
+    <div class="empty-state">
+      <span class="empty-icon"><mat-icon>admin_panel_settings</mat-icon></span>
+      <h2>No roles yet</h2>
+      <p>
+        Create your first role to control what people can do across the app and
+        within groups.
+      </p>
+      <app-button
+        icon="add"
+        buttonText="Add Role"
+        (clicked)="addRole()"
+      ></app-button>
+    </div>
+  } @else {
+    <div class="table-wrap">
+      <table class="roles-table">
+        <thead>
+          <tr>
+            <th>Role</th>
+            <th class="col-scope">Scope</th>
+            <th class="col-perms">Permissions</th>
+            <th class="col-members">Members</th>
+            <th class="col-actions"></th>
+          </tr>
+        </thead>
+        <tbody>
+          @for (role of roles(); track role.id) {
+            <tr>
+              <td>
+                <div class="role-name">
+                  <span
+                    class="role-icon"
+                    [style.background]="role.iconTint"
+                    [style.color]="role.iconColor"
+                  >
+                    <mat-icon>{{ role.icon }}</mat-icon>
+                  </span>
+                  <div>
+                    <div class="nm">
+                      {{ role.name }}
+                      @if (role.isSystem) {
+                        <span class="badge-lock"
+                          ><mat-icon>lock</mat-icon>System</span
+                        >
+                      }
+                    </div>
+                    <div class="ds">{{ role.description }}</div>
+                  </div>
+                </div>
+              </td>
+              <td>
+                <div class="scope-chips">
+                  @if (role.scopes.includes("app")) {
+                    <span class="chip scope-app"
+                      ><mat-icon>apps</mat-icon>Application</span
+                    >
+                  }
+                  @if (role.scopes.includes("group")) {
+                    <span class="chip scope-group"
+                      ><mat-icon>workspaces</mat-icon>Group</span
+                    >
+                  }
+                </div>
+              </td>
+              <td>
+                <div class="perm-count">
+                  {{ role.appCount + role.groupCount }} <span>granted</span>
+                </div>
+                <div class="perm-bar">
+                  @for (segment of meter(role); track $index) {
+                    <i [ngClass]="segment"></i>
+                  }
+                </div>
+              </td>
+              <td>
+                @if (role.userCount === 0) {
+                  <span class="no-users">No users</span>
+                } @else {
+                  <div class="user-stack">
+                    @for (member of role.members.slice(0, 3); track member.name) {
+                      <span class="avatar" [style.background]="member.color">{{
+                        initials(member.name)
+                      }}</span>
+                    }
+                    @if (role.userCount > 3) {
+                      <span class="more">+{{ role.userCount - 3 }}</span>
+                    }
+                  </div>
+                }
+              </td>
+              <td>
+                <div class="row-actions">
+                  <app-button
+                    matButtonType="iconButton"
+                    color="accent"
+                    [icon]="role.isSystem ? 'visibility' : 'edit'"
+                    [tooltip]="role.isSystem ? 'View' : 'Edit'"
+                    (clicked)="editRole(role)"
+                  ></app-button>
+                  <app-button
+                    matButtonType="iconButton"
+                    color="accent"
+                    icon="more_vert"
+                    tooltip="More actions"
+                    (clicked)="openRoleMenu(role)"
+                  ></app-button>
+                </div>
+              </td>
+            </tr>
+          }
+        </tbody>
+      </table>
+    </div>
+  }
+</div>

--- a/desktop/src/roles/role-list/role-list.component.scss
+++ b/desktop/src/roles/role-list/role-list.component.scss
@@ -5,6 +5,7 @@
 $fg-muted: map.get(variables.$accent-palette, 500);
 $fg-strong: map.get(variables.$accent-palette, 900);
 $border: rgba(0, 0, 0, 0.06);
+
 // Violet "Group" scope accent — intentionally outside the brand palette (the
 // design uses it to distinguish group scope from the primary/app scope).
 $group-accent-bg: #ede9fe;

--- a/desktop/src/roles/role-list/role-list.component.scss
+++ b/desktop/src/roles/role-list/role-list.component.scss
@@ -1,0 +1,308 @@
+@use "sass:map";
+@use "../../variables.scss" as variables;
+
+// Local aliases mapping the design tokens to the app palette.
+$fg-muted: map.get(variables.$accent-palette, 500);
+$fg-strong: map.get(variables.$accent-palette, 900);
+$border: rgba(0, 0, 0, 0.06);
+// Violet "Group" scope accent — intentionally outside the brand palette (the
+// design uses it to distinguish group scope from the primary/app scope).
+$group-accent-bg: #ede9fe;
+$group-accent-fg: #6d28d9;
+$group-accent-bar: #a78bfa;
+
+.roles-page {
+  display: flex;
+  flex-direction: column;
+}
+
+.page-title {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: variables.$spacing-md;
+  margin: variables.$spacing-sm 0 variables.$spacing-lg;
+
+  .titles h1 {
+    font-size: 28px;
+    line-height: 1.2;
+    margin: 0;
+  }
+
+  .subtitle {
+    color: $fg-muted;
+    font-size: 14px;
+    margin: variables.$spacing-xs 0 0;
+    max-width: 640px;
+  }
+
+  .tools {
+    display: flex;
+    gap: variables.$spacing-sm;
+    align-items: center;
+    flex: none;
+  }
+}
+
+/* ---------- Empty state ---------- */
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: variables.$spacing-sm;
+  padding: variables.$spacing-2xl;
+  background: #fff;
+  border: 1px solid $border;
+  border-radius: variables.$border-radius-lg;
+  box-shadow: variables.$shadow-md;
+
+  .empty-icon {
+    width: 56px;
+    height: 56px;
+    border-radius: variables.$border-radius-xl;
+    background: map.get(variables.$primary-palette, 50);
+    color: map.get(variables.$primary-palette, 600);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: variables.$spacing-xs;
+
+    mat-icon {
+      font-size: 28px;
+      width: 28px;
+      height: 28px;
+    }
+  }
+
+  h2 {
+    font-size: 18px;
+    margin: 0;
+    color: $fg-strong;
+  }
+
+  p {
+    color: $fg-muted;
+    font-size: 14px;
+    margin: 0 0 variables.$spacing-sm;
+    max-width: 420px;
+  }
+}
+
+/* ---------- Table ---------- */
+.table-wrap {
+  overflow: auto;
+}
+
+.roles-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  border: 1px solid $border;
+  border-radius: variables.$border-radius-lg;
+  overflow: hidden;
+  box-shadow: variables.$shadow-md;
+
+  th,
+  td {
+    padding: 15px 18px;
+    text-align: left;
+    font-size: 14px;
+    border-bottom: 1px solid map.get(variables.$accent-palette, 100);
+    vertical-align: middle;
+  }
+
+  th {
+    background: map.get(variables.$accent-palette, 50);
+    font-weight: 600;
+    color: $fg-muted;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  tr:last-child td {
+    border-bottom: 0;
+  }
+
+  tbody tr {
+    transition: background 0.15s ease;
+  }
+
+  tbody tr:hover {
+    background: map.get(variables.$accent-palette, 50);
+  }
+
+  .col-scope {
+    width: 200px;
+  }
+  .col-perms {
+    width: 140px;
+  }
+  .col-members {
+    width: 150px;
+  }
+  .col-actions {
+    width: 60px;
+  }
+}
+
+.role-name {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+
+  .role-icon {
+    width: 38px;
+    height: 38px;
+    border-radius: 9px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: none;
+
+    mat-icon {
+      font-size: 20px;
+      width: 20px;
+      height: 20px;
+    }
+  }
+
+  .nm {
+    font-weight: 600;
+    color: $fg-strong;
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    gap: variables.$spacing-sm;
+  }
+
+  .ds {
+    color: $fg-muted;
+    font-size: 12.5px;
+    margin-top: 1px;
+    max-width: 360px;
+  }
+}
+
+.badge-lock {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  font-weight: 600;
+  color: $fg-muted;
+
+  mat-icon {
+    font-size: 15px;
+    width: 15px;
+    height: 15px;
+  }
+}
+
+.scope-chips {
+  display: flex;
+  gap: 6px;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 24px;
+  padding: 0 10px;
+  border-radius: 9999px;
+  font-size: 12px;
+  font-weight: 600;
+
+  mat-icon {
+    font-size: 13px;
+    width: 13px;
+    height: 13px;
+  }
+
+  &.scope-app {
+    background: map.get(variables.$primary-palette, 50);
+    color: map.get(variables.$primary-palette, 800);
+  }
+
+  &.scope-group {
+    background: $group-accent-bg;
+    color: $group-accent-fg;
+  }
+}
+
+.perm-count {
+  font-weight: 600;
+  font-size: 14px;
+  color: $fg-strong;
+
+  span {
+    font-weight: 400;
+    color: $fg-muted;
+    font-size: 13px;
+  }
+}
+
+.perm-bar {
+  display: flex;
+  gap: 3px;
+  margin-top: 2px;
+  width: 96px;
+
+  i {
+    height: 6px;
+    flex: 1;
+    border-radius: 3px;
+    background: map.get(variables.$accent-palette, 200);
+
+    &.app {
+      background: map.get(variables.$primary-palette, 400);
+    }
+
+    &.group {
+      background: $group-accent-bar;
+    }
+  }
+}
+
+.no-users {
+  color: map.get(variables.$accent-palette, 400);
+  font-size: 13px;
+}
+
+.user-stack {
+  display: inline-flex;
+  align-items: center;
+
+  .avatar {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-weight: 600;
+    font-size: 11px;
+    border: 2px solid #fff;
+    margin-left: -8px;
+
+    &:first-child {
+      margin-left: 0;
+    }
+  }
+
+  .more {
+    margin-left: variables.$spacing-sm;
+    font-size: 13px;
+    color: $fg-muted;
+    font-weight: 500;
+  }
+}
+
+.row-actions {
+  display: flex;
+  gap: 2px;
+  justify-content: flex-end;
+}

--- a/desktop/src/roles/role-list/role-list.component.spec.ts
+++ b/desktop/src/roles/role-list/role-list.component.spec.ts
@@ -1,0 +1,101 @@
+import { CUSTOM_ELEMENTS_SCHEMA, provideZonelessChangeDetection } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { RouterModule } from "@angular/router";
+import { of } from "rxjs";
+import { PermissionService } from "../../open-api";
+import { RoleListComponent } from "./role-list.component";
+import { RoleListItem } from "./role-list-item.interface";
+
+describe("RoleListComponent", () => {
+  let component: RoleListComponent;
+  let fixture: ComponentFixture<RoleListComponent>;
+  let permissionService: { getPermissions: jest.Mock };
+
+  const buildRole = (overrides: Partial<RoleListItem> = {}): RoleListItem => ({
+    id: "role-1",
+    name: "Administrator",
+    description: "Full access",
+    scopes: ["app", "group"],
+    appCount: 10,
+    groupCount: 5,
+    members: [],
+    userCount: 0,
+    isSystem: true,
+    icon: "shield_person",
+    iconColor: "#27b1ff",
+    iconTint: "#ccecff",
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    permissionService = { getPermissions: jest.fn().mockReturnValue(of([])) };
+
+    await TestBed.configureTestingModule({
+      declarations: [RoleListComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      imports: [RouterModule.forRoot([])],
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: PermissionService, useValue: permissionService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RoleListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("creates", () => {
+    expect(component).toBeTruthy();
+  });
+
+  it("renders the breadcrumb and the page title", () => {
+    expect(fixture.nativeElement.querySelector("app-breadcrumb")).toBeTruthy();
+    expect(fixture.nativeElement.querySelector("h1")?.textContent).toContain(
+      "Roles",
+    );
+  });
+
+  it("shows the empty state and no table when there are no roles", () => {
+    expect(component.roleCount()).toBe(0);
+    expect(fixture.nativeElement.querySelector(".empty-state")).toBeTruthy();
+    expect(fixture.nativeElement.querySelector(".roles-table")).toBeNull();
+  });
+
+  it("loads the permission total on init for the meter denominator", () => {
+    expect(permissionService.getPermissions).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the table with rows when roles are present", async () => {
+    component.roles.set([buildRole()]);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector(".empty-state")).toBeNull();
+    expect(fixture.nativeElement.querySelectorAll(".roles-table tbody tr").length).toBe(1);
+    expect(component.roleCount()).toBe(1);
+  });
+
+  describe("meter", () => {
+    it("returns ten segments with the filled ones flagged app/group", () => {
+      permissionService.getPermissions.mockReturnValue(of(new Array(20).fill({})));
+      // Re-create so the total is loaded from the new mock value.
+      fixture = TestBed.createComponent(RoleListComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+
+      const segments = component.meter(buildRole({ appCount: 10, groupCount: 0 }));
+      expect(segments.length).toBe(10);
+      // 10 of 20 permissions granted -> ~5 filled segments, app-dominant.
+      expect(segments.filter((s) => s === "app").length).toBe(5);
+      expect(segments.filter((s) => s === null).length).toBe(5);
+    });
+  });
+
+  describe("initials", () => {
+    it("returns up to two uppercased initials", () => {
+      expect(component.initials("Noah Hall")).toBe("NH");
+      expect(component.initials("dana")).toBe("D");
+    });
+  });
+});

--- a/desktop/src/roles/role-list/role-list.component.spec.ts
+++ b/desktop/src/roles/role-list/role-list.component.spec.ts
@@ -1,7 +1,8 @@
 import { CUSTOM_ELEMENTS_SCHEMA, provideZonelessChangeDetection } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterModule } from "@angular/router";
-import { of } from "rxjs";
+import { of, throwError } from "rxjs";
+import { ButtonModule } from "../../button";
 import { PermissionService } from "../../open-api";
 import { RoleListComponent } from "./role-list.component";
 import { RoleListItem } from "./role-list-item.interface";
@@ -33,7 +34,7 @@ describe("RoleListComponent", () => {
     await TestBed.configureTestingModule({
       declarations: [RoleListComponent],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
-      imports: [RouterModule.forRoot([])],
+      imports: [ButtonModule, RouterModule.forRoot([])],
       providers: [
         provideZonelessChangeDetection(),
         { provide: PermissionService, useValue: permissionService },
@@ -42,7 +43,7 @@ describe("RoleListComponent", () => {
 
     fixture = TestBed.createComponent(RoleListComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
   it("creates", () => {
@@ -66,23 +67,80 @@ describe("RoleListComponent", () => {
     expect(permissionService.getPermissions).toHaveBeenCalledTimes(1);
   });
 
+  it("does not throw and keeps the empty state when getPermissions fails", async () => {
+    permissionService.getPermissions.mockReturnValue(
+      throwError(() => new Error("boom")),
+    );
+
+    const errorFixture = TestBed.createComponent(RoleListComponent);
+    await errorFixture.whenStable();
+
+    expect(permissionService.getPermissions).toHaveBeenCalled();
+    expect(errorFixture.componentInstance).toBeTruthy();
+    expect(errorFixture.nativeElement.querySelector(".empty-state")).toBeTruthy();
+  });
+
   it("renders the table with rows when roles are present", async () => {
     component.roles.set([buildRole()]);
     await fixture.whenStable();
-    fixture.detectChanges();
 
     expect(fixture.nativeElement.querySelector(".empty-state")).toBeNull();
-    expect(fixture.nativeElement.querySelectorAll(".roles-table tbody tr").length).toBe(1);
+    expect(
+      fixture.nativeElement.querySelectorAll(".roles-table tbody tr").length,
+    ).toBe(1);
     expect(component.roleCount()).toBe(1);
   });
 
+  describe("interactions", () => {
+    let role: RoleListItem;
+
+    beforeEach(async () => {
+      role = buildRole();
+      component.roles.set([role]);
+      await fixture.whenStable();
+    });
+
+    it("invokes addRole when the Add Role button is clicked", () => {
+      const addRoleSpy = jest.spyOn(component, "addRole");
+      const addButton = Array.from(
+        fixture.nativeElement.querySelectorAll("button"),
+      ).find((button) =>
+        (button as HTMLElement).textContent?.includes("Add Role"),
+      ) as HTMLButtonElement;
+
+      addButton.click();
+
+      expect(addRoleSpy).toHaveBeenCalled();
+    });
+
+    it("invokes editRole with the role when the edit action is clicked", () => {
+      const editRoleSpy = jest.spyOn(component, "editRole");
+      const actionButtons =
+        fixture.nativeElement.querySelectorAll(".row-actions button");
+
+      (actionButtons[0] as HTMLButtonElement).click();
+
+      expect(editRoleSpy).toHaveBeenCalledWith(role);
+    });
+
+    it("invokes openRoleMenu with the role when the more action is clicked", () => {
+      const openRoleMenuSpy = jest.spyOn(component, "openRoleMenu");
+      const actionButtons =
+        fixture.nativeElement.querySelectorAll(".row-actions button");
+
+      (actionButtons[1] as HTMLButtonElement).click();
+
+      expect(openRoleMenuSpy).toHaveBeenCalledWith(role);
+    });
+  });
+
   describe("meter", () => {
-    it("returns ten segments with the filled ones flagged app/group", () => {
+    it("returns ten segments with the filled ones flagged app/group", async () => {
       permissionService.getPermissions.mockReturnValue(of(new Array(20).fill({})));
       // Re-create so the total is loaded from the new mock value.
       fixture = TestBed.createComponent(RoleListComponent);
       component = fixture.componentInstance;
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const segments = component.meter(buildRole({ appCount: 10, groupCount: 0 }));
       expect(segments.length).toBe(10);

--- a/desktop/src/roles/role-list/role-list.component.ts
+++ b/desktop/src/roles/role-list/role-list.component.ts
@@ -1,6 +1,6 @@
 import { Component, computed, inject, signal } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
-import { take, tap } from "rxjs";
+import { EMPTY, catchError, take, tap } from "rxjs";
 import { PermissionService } from "../../open-api";
 import { BreadcrumbItem } from "../../shared-ui/breadcrumb/breadcrumb-item.interface";
 import { RoleListItem } from "./role-list-item.interface";
@@ -66,8 +66,12 @@ export class RoleListComponent {
       .getPermissions()
       .pipe(
         take(1),
-        takeUntilDestroyed(),
         tap((permissions) => this.totalPermissions.set(permissions.length)),
+        catchError(() => {
+          this.totalPermissions.set(0);
+          return EMPTY;
+        }),
+        takeUntilDestroyed(),
       )
       .subscribe();
   }

--- a/desktop/src/roles/role-list/role-list.component.ts
+++ b/desktop/src/roles/role-list/role-list.component.ts
@@ -1,0 +1,74 @@
+import { Component, computed, inject, signal } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { take, tap } from "rxjs";
+import { PermissionService } from "../../open-api";
+import { BreadcrumbItem } from "../../shared-ui/breadcrumb/breadcrumb-item.interface";
+import { RoleListItem } from "./role-list-item.interface";
+
+@Component({
+  selector: "app-role-list",
+  templateUrl: "./role-list.component.html",
+  styleUrl: "./role-list.component.scss",
+  standalone: false,
+})
+export class RoleListComponent {
+  private readonly permissionService = inject(PermissionService);
+
+  public readonly crumbs: BreadcrumbItem[] = [
+    { label: "Admin" },
+    { label: "Roles" },
+  ];
+
+  // Empty until the backend role-list endpoint exists. The table below is built
+  // to render real rows the moment this signal is populated.
+  public readonly roles = signal<RoleListItem[]>([]);
+  public readonly roleCount = computed(() => this.roles().length);
+
+  // Total number of permissions in the registry — the denominator for each
+  // role's permission meter. Sourced from the one role/permission endpoint that
+  // exists today.
+  private readonly totalPermissions = signal(0);
+
+  constructor() {
+    this.loadPermissionTotal();
+  }
+
+  /** Number of filled segments (out of 10) for a role's permission meter. */
+  public meter(role: RoleListItem): (string | null)[] {
+    const total = this.totalPermissions() || 1;
+    const granted = role.appCount + role.groupCount;
+    const filled = Math.round((granted / total) * 10);
+    const fillClass = role.appCount >= role.groupCount ? "app" : "group";
+    return Array.from({ length: 10 }, (_, i) => (i < filled ? fillClass : null));
+  }
+
+  /** Up-to-two-letter initials for a member avatar. */
+  public initials(name: string): string {
+    return (name || "?")
+      .split(" ")
+      .map((part) => part[0])
+      .join("")
+      .slice(0, 2)
+      .toUpperCase();
+  }
+
+  // TODO: open the create-role flow once it exists (separate slice).
+  public addRole(): void {}
+
+  // TODO: open the edit/view-role flow once it exists (separate slice).
+  public editRole(_role: RoleListItem): void {}
+
+  // TODO: open the per-role actions menu once those actions exist.
+  public openRoleMenu(_role: RoleListItem): void {}
+
+  private loadPermissionTotal(): void {
+    this.permissionService
+      .getPermissions()
+      .pipe(
+        take(1),
+        takeUntilDestroyed(),
+        tap((permissions) => this.totalPermissions.set(permissions.length)),
+      )
+      .subscribe();
+  }
+}

--- a/desktop/src/roles/roles-routing.module.ts
+++ b/desktop/src/roles/roles-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from "@angular/core";
+import { RouterModule, Routes } from "@angular/router";
+import { RoleListComponent } from "./role-list/role-list.component";
+
+const routes: Routes = [
+  {
+    path: "",
+    component: RoleListComponent,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class RolesRoutingModule {}

--- a/desktop/src/roles/roles.module.ts
+++ b/desktop/src/roles/roles.module.ts
@@ -1,0 +1,23 @@
+import { CommonModule } from "@angular/common";
+import { NgModule } from "@angular/core";
+import { MatIconModule } from "@angular/material/icon";
+import { MatTooltipModule } from "@angular/material/tooltip";
+import { RouterModule } from "@angular/router";
+import { ButtonModule } from "../button";
+import { SharedUiModule } from "../shared-ui/shared-ui.module";
+import { RoleListComponent } from "./role-list/role-list.component";
+import { RolesRoutingModule } from "./roles-routing.module";
+
+@NgModule({
+  declarations: [RoleListComponent],
+  imports: [
+    ButtonModule,
+    CommonModule,
+    MatIconModule,
+    MatTooltipModule,
+    RouterModule,
+    SharedUiModule,
+    RolesRoutingModule,
+  ],
+})
+export class RolesModule {}

--- a/desktop/src/shared-ui/breadcrumb/breadcrumb-item.interface.ts
+++ b/desktop/src/shared-ui/breadcrumb/breadcrumb-item.interface.ts
@@ -1,0 +1,11 @@
+/**
+ * A single entry in a breadcrumb trail.
+ *
+ * Provide a `routerLink` for crumbs that should navigate; omit it for the
+ * current/terminal crumb. `icon` is an optional leading Material icon.
+ */
+export interface BreadcrumbItem {
+  label: string;
+  routerLink?: string | any[];
+  icon?: string;
+}

--- a/desktop/src/shared-ui/breadcrumb/breadcrumb.component.html
+++ b/desktop/src/shared-ui/breadcrumb/breadcrumb.component.html
@@ -1,0 +1,26 @@
+<nav class="breadcrumb" aria-label="Breadcrumb">
+  @for (item of items(); track $index; let last = $last) {
+    @if (item.routerLink && !last) {
+      <a class="crumb" [routerLink]="item.routerLink">
+        @if (item.icon) {
+          <mat-icon class="crumb-icon">{{ item.icon }}</mat-icon>
+        }
+        {{ item.label }}
+      </a>
+    } @else {
+      <span
+        class="crumb"
+        [class.current]="last"
+        [attr.aria-current]="last ? 'page' : null"
+      >
+        @if (item.icon) {
+          <mat-icon class="crumb-icon">{{ item.icon }}</mat-icon>
+        }
+        {{ item.label }}
+      </span>
+    }
+    @if (!last) {
+      <mat-icon class="separator">chevron_right</mat-icon>
+    }
+  }
+</nav>

--- a/desktop/src/shared-ui/breadcrumb/breadcrumb.component.html
+++ b/desktop/src/shared-ui/breadcrumb/breadcrumb.component.html
@@ -3,7 +3,7 @@
     @if (item.routerLink && !last) {
       <a class="crumb" [routerLink]="item.routerLink">
         @if (item.icon) {
-          <mat-icon class="crumb-icon">{{ item.icon }}</mat-icon>
+          <mat-icon class="crumb-icon" aria-hidden="true">{{ item.icon }}</mat-icon>
         }
         {{ item.label }}
       </a>
@@ -14,13 +14,13 @@
         [attr.aria-current]="last ? 'page' : null"
       >
         @if (item.icon) {
-          <mat-icon class="crumb-icon">{{ item.icon }}</mat-icon>
+          <mat-icon class="crumb-icon" aria-hidden="true">{{ item.icon }}</mat-icon>
         }
         {{ item.label }}
       </span>
     }
     @if (!last) {
-      <mat-icon class="separator">chevron_right</mat-icon>
+      <mat-icon class="separator" aria-hidden="true">chevron_right</mat-icon>
     }
   }
 </nav>

--- a/desktop/src/shared-ui/breadcrumb/breadcrumb.component.scss
+++ b/desktop/src/shared-ui/breadcrumb/breadcrumb.component.scss
@@ -1,0 +1,41 @@
+@use "sass:map";
+@use "../../variables.scss" as variables;
+
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: variables.$spacing-sm;
+  font-size: 13px;
+  color: map.get(variables.$accent-palette, 500);
+}
+
+.crumb {
+  display: inline-flex;
+  align-items: center;
+  gap: variables.$spacing-xs;
+  color: map.get(variables.$accent-palette, 500);
+  font-weight: 500;
+  text-decoration: none;
+
+  &.current {
+    color: map.get(variables.$accent-palette, 900);
+    font-weight: 600;
+  }
+}
+
+a.crumb:hover {
+  color: map.get(variables.$primary-palette, 600);
+  text-decoration: none;
+}
+
+.crumb-icon,
+.separator {
+  font-size: 16px;
+  width: 16px;
+  height: 16px;
+  line-height: 16px;
+}
+
+.separator {
+  opacity: 0.6;
+}

--- a/desktop/src/shared-ui/breadcrumb/breadcrumb.component.spec.ts
+++ b/desktop/src/shared-ui/breadcrumb/breadcrumb.component.spec.ts
@@ -19,9 +19,9 @@ describe("BreadcrumbComponent", () => {
     component = fixture.componentInstance;
   });
 
-  it("creates", () => {
+  it("creates", async () => {
     fixture.componentRef.setInput("items", [{ label: "Admin" }]);
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(component).toBeTruthy();
   });
 

--- a/desktop/src/shared-ui/breadcrumb/breadcrumb.component.spec.ts
+++ b/desktop/src/shared-ui/breadcrumb/breadcrumb.component.spec.ts
@@ -1,0 +1,66 @@
+import { provideZonelessChangeDetection } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { MatIconModule } from "@angular/material/icon";
+import { RouterModule } from "@angular/router";
+import { BreadcrumbComponent } from "./breadcrumb.component";
+
+describe("BreadcrumbComponent", () => {
+  let component: BreadcrumbComponent;
+  let fixture: ComponentFixture<BreadcrumbComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [BreadcrumbComponent],
+      imports: [MatIconModule, RouterModule.forRoot([])],
+      providers: [provideZonelessChangeDetection()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BreadcrumbComponent);
+    component = fixture.componentInstance;
+  });
+
+  it("creates", () => {
+    fixture.componentRef.setInput("items", [{ label: "Admin" }]);
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it("renders one crumb per item with a separator between them", async () => {
+    fixture.componentRef.setInput("items", [
+      { label: "Admin", routerLink: ["/admin"] },
+      { label: "Roles" },
+    ]);
+    await fixture.whenStable();
+
+    const crumbs = fixture.nativeElement.querySelectorAll(".crumb");
+    const separators = fixture.nativeElement.querySelectorAll(".separator");
+    expect(crumbs.length).toBe(2);
+    expect(separators.length).toBe(1);
+  });
+
+  it("links crumbs that have a routerLink and marks the last as the current page", async () => {
+    fixture.componentRef.setInput("items", [
+      { label: "Admin", routerLink: ["/admin"] },
+      { label: "Roles" },
+    ]);
+    await fixture.whenStable();
+
+    const link = fixture.nativeElement.querySelector("a.crumb");
+    const current = fixture.nativeElement.querySelector(".crumb.current");
+    expect(link?.textContent.trim()).toContain("Admin");
+    expect(current?.getAttribute("aria-current")).toBe("page");
+    expect(current?.textContent.trim()).toContain("Roles");
+  });
+
+  it("renders the last crumb as non-link even when it has a routerLink", async () => {
+    fixture.componentRef.setInput("items", [
+      { label: "Admin", routerLink: ["/admin"] },
+      { label: "Roles", routerLink: ["/roles"] },
+    ]);
+    await fixture.whenStable();
+
+    const links = fixture.nativeElement.querySelectorAll("a.crumb");
+    expect(links.length).toBe(1);
+    expect(links[0].textContent.trim()).toContain("Admin");
+  });
+});

--- a/desktop/src/shared-ui/breadcrumb/breadcrumb.component.ts
+++ b/desktop/src/shared-ui/breadcrumb/breadcrumb.component.ts
@@ -1,0 +1,23 @@
+import { Component, input } from "@angular/core";
+import { BreadcrumbItem } from "./breadcrumb-item.interface";
+
+/**
+ * Generic, reusable breadcrumb trail.
+ *
+ * Fully input-driven so it can be dropped into any page — the consumer passes
+ * an ordered list of {@link BreadcrumbItem}s. The final item is rendered as the
+ * current page (non-link, emphasised) regardless of whether it has a
+ * `routerLink`.
+ *
+ * @example
+ * <app-breadcrumb [items]="[{ label: 'Admin' }, { label: 'Roles' }]"></app-breadcrumb>
+ */
+@Component({
+  selector: "app-breadcrumb",
+  templateUrl: "./breadcrumb.component.html",
+  styleUrl: "./breadcrumb.component.scss",
+  standalone: false,
+})
+export class BreadcrumbComponent {
+  public readonly items = input.required<BreadcrumbItem[]>();
+}

--- a/desktop/src/shared-ui/shared-ui.module.ts
+++ b/desktop/src/shared-ui/shared-ui.module.ts
@@ -27,6 +27,7 @@ import { AddButtonComponent } from "./add-button/add-button.component";
 import { AuditDetailSectionComponent } from "./audit-detail-section/audit-detail-section.component";
 import { BackButtonComponent } from "./back-button/back-button.component";
 import { BaseTableComponent } from "./base-table/base-table.component";
+import { BreadcrumbComponent } from "./breadcrumb/breadcrumb.component";
 import { CancelButtonComponent } from "./cancel-button/cancel-button.component";
 import { CardComponent } from "./card/card.component";
 import { ConfirmationDialogComponent } from "./confirmation-dialog/confirmation-dialog.component";
@@ -68,6 +69,7 @@ import { PieChartUiComponent } from './pie-chart/pie-chart.component';
   declarations: [
     AddButtonComponent,
     BackButtonComponent,
+    BreadcrumbComponent,
     CancelButtonComponent,
     CardComponent,
     ConfirmationDialogComponent,
@@ -137,6 +139,7 @@ import { PieChartUiComponent } from './pie-chart/pie-chart.component';
   exports: [
     AddButtonComponent,
     BackButtonComponent,
+    BreadcrumbComponent,
     CancelButtonComponent,
     CardComponent,
     ConfirmationDialogComponent,


### PR DESCRIPTION
## Summary
- New admin **Manage Roles** list page (`/roles`, admin-gated) following the locked design: breadcrumb, page title + descriptive subtitle, Filter / Add Role actions, and a roles table (role, scope chips, permission meter, members, row actions). Renders a friendly empty state until role data exists.
- New generic, **input-driven breadcrumb** component (`app-breadcrumb`) in `shared-ui`, reusable on other pages. The terminal crumb renders as the current page; earlier crumbs with a `routerLink` navigate.
- Sidebar "Manage Roles" entry next to "Manage Users".

## Scope / deferred
The roles table uses a frontend-only view-model and renders empty for now. Role create/edit flow, NGXS role state + service, real role-list API wiring, and the Filter action are deferred to later slices (stubbed with TODOs). The page loads the permission registry count via `GET /permission` for the meter denominator.

## Testing
- `npx jest` — 197 suites / 797 tests pass (11 new).
- `ng build` — clean (pre-existing Bootstrap `@import` deprecation warnings only).

> Targets the `feature/role-rework` integration branch, not `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin-only "Manage Roles" added to the sidebar
  * New Roles page with table: name, description, scope chips, permissions meter, member avatars, and per-role actions
  * Empty-state UI with prominent "Add Role" call-to-action
  * Breadcrumb navigation component for improved page traversal
  * UI controls for filtering, adding, editing, and role action menus

* **Tests**
  * Unit tests covering breadcrumb and roles list behaviors, rendering, and interactions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Receipt-Wrangler/receipt-wrangler/pull/564?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->