### PR TITLE
Add delete-role endpoint and UI

### DIFF
--- a/api/internal/handlers/roles.go
+++ b/api/internal/handlers/roles.go
@@ -6,6 +6,7 @@ import (
 	"receipt-wrangler/api/internal/commands"
 	"receipt-wrangler/api/internal/constants"
 	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/permissions"
 	"receipt-wrangler/api/internal/services"
 	"receipt-wrangler/api/internal/structs"
 	"receipt-wrangler/api/internal/utils"
@@ -140,6 +141,67 @@ func UpdateRole(w http.ResponseWriter, r *http.Request) {
 
 			w.WriteHeader(http.StatusOK)
 			w.Write(bytes)
+
+			return 0, nil
+		},
+	}
+
+	HandleRequest(handler)
+}
+
+func DeleteRole(w http.ResponseWriter, r *http.Request) {
+	handler := structs.Handler{
+		ErrorMessage: "Error deleting role",
+		Writer:       w,
+		Request:      r,
+		UserRole:     models.ADMIN,
+		ResponseType: constants.ApplicationJson,
+		HandlerFunction: func(w http.ResponseWriter, r *http.Request) (int, error) {
+			id, err := utils.StringToUint(chi.URLParam(r, "roleId"))
+			if err != nil {
+				structs.WriteValidatorErrorResponse(w, structs.ValidatorError{
+					Errors: map[string]string{"roleId": "Invalid role id"},
+				}, http.StatusBadRequest)
+				return 0, nil
+			}
+
+			scope := permissions.Scope(r.URL.Query().Get("scope"))
+			if scope != permissions.ScopeApp && scope != permissions.ScopeGroup {
+				structs.WriteValidatorErrorResponse(w, structs.ValidatorError{
+					Errors: map[string]string{"scope": "Scope must be either APP or GROUP"},
+				}, http.StatusBadRequest)
+				return 0, nil
+			}
+
+			roleService := services.NewRoleService(nil)
+			err = roleService.DeleteRole(id, scope)
+			if err != nil {
+				if errors.Is(err, services.ErrRoleTypeMismatch) {
+					structs.WriteValidatorErrorResponse(w, structs.ValidatorError{
+						Errors: map[string]string{"scope": "Role type cannot be changed"},
+					}, http.StatusBadRequest)
+					return 0, nil
+				}
+				if errors.Is(err, services.ErrSystemRoleUndeletable) {
+					structs.WriteValidatorErrorResponse(w, structs.ValidatorError{
+						Errors: map[string]string{"role": "System roles cannot be deleted"},
+					}, http.StatusBadRequest)
+					return 0, nil
+				}
+				if errors.Is(err, services.ErrRoleAssigned) {
+					structs.WriteValidatorErrorResponse(w, structs.ValidatorError{
+						Errors: map[string]string{"role": "Role is assigned and cannot be deleted"},
+					}, http.StatusBadRequest)
+					return 0, nil
+				}
+				if errors.Is(err, services.ErrRoleNotFound) {
+					utils.WriteCustomErrorResponse(w, "Role not found", http.StatusNotFound)
+					return 0, nil
+				}
+				return http.StatusInternalServerError, err
+			}
+
+			w.WriteHeader(http.StatusOK)
 
 			return 0, nil
 		},

--- a/api/internal/handlers/roles_test.go
+++ b/api/internal/handlers/roles_test.go
@@ -322,3 +322,215 @@ func TestShouldReturnNotFoundForMissingRole(t *testing.T) {
 		utils.PrintTestError(t, w.Result().StatusCode, 404)
 	}
 }
+
+func deleteRoleRequest(roleId string, scope string, claims *validator.ValidatedClaims) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("DELETE", "/api?scope="+scope, nil)
+
+	ctx := chi.NewRouteContext()
+	ctx.URLParams.Add("roleId", roleId)
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, ctx))
+	r = r.WithContext(context.WithValue(r.Context(), jwtmiddleware.ContextKey{}, claims))
+
+	DeleteRole(w, r)
+	return w
+}
+
+func TestShouldDeleteAppRole(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	repositories.CreateTestRoles()
+
+	w := deleteRoleRequest("1", "APP", adminContext())
+
+	if w.Result().StatusCode != 200 {
+		utils.PrintTestError(t, w.Result().StatusCode, 200)
+		return
+	}
+
+	roleRepository := repositories.NewRoleRepository(nil)
+	if _, err := roleRepository.GetAppRoleById(1); err == nil {
+		utils.PrintTestError(t, "app role still exists", "app role should be deleted")
+	}
+}
+
+func TestShouldDeleteGroupRole(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	repositories.CreateTestRoles()
+
+	w := deleteRoleRequest("1", "GROUP", adminContext())
+
+	if w.Result().StatusCode != 200 {
+		utils.PrintTestError(t, w.Result().StatusCode, 200)
+		return
+	}
+
+	roleRepository := repositories.NewRoleRepository(nil)
+	if _, err := roleRepository.GetGroupRoleById(1); err == nil {
+		utils.PrintTestError(t, "group role still exists", "group role should be deleted")
+	}
+}
+
+func TestShouldNotDeleteRoleDueToRole(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	repositories.CreateTestRoles()
+
+	w := deleteRoleRequest("1", "APP", userContext())
+
+	if w.Result().StatusCode != 403 {
+		utils.PrintTestError(t, w.Result().StatusCode, 403)
+	}
+}
+
+func TestShouldReturnBadRequestForInvalidDeleteRoleId(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	w := deleteRoleRequest("abc", "APP", adminContext())
+
+	if w.Result().StatusCode != 400 {
+		utils.PrintTestError(t, w.Result().StatusCode, 400)
+	}
+}
+
+func TestShouldReturnBadRequestForInvalidDeleteScope(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	repositories.CreateTestRoles()
+
+	for _, scope := range []string{"", "BOGUS"} {
+		w := deleteRoleRequest("1", scope, adminContext())
+		if w.Result().StatusCode != 400 {
+			utils.PrintTestError(t, w.Result().StatusCode, 400)
+		}
+	}
+}
+
+func TestShouldReturnNotFoundForMissingDeleteRole(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	w := deleteRoleRequest("999", "APP", adminContext())
+
+	if w.Result().StatusCode != 404 {
+		utils.PrintTestError(t, w.Result().StatusCode, 404)
+	}
+}
+
+func TestShouldNotDeleteRoleDueToScopeMismatch(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	roleRepository := repositories.NewRoleRepository(nil)
+	created, err := roleRepository.CreateAppRole("App Role", "desc", []string{permissions.AppUsersCreate})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	// Deleting an app role id under the GROUP scope is a type mismatch, not a delete.
+	w := deleteRoleRequest(strconv.FormatUint(uint64(created.ID), 10), "GROUP", adminContext())
+
+	if w.Result().StatusCode != 400 {
+		utils.PrintTestError(t, w.Result().StatusCode, 400)
+		return
+	}
+
+	if _, err := roleRepository.GetAppRoleById(created.ID); err != nil {
+		utils.PrintTestError(t, err, "app role should be untouched")
+	}
+}
+
+func TestShouldNotDeleteSystemRole(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	db := repositories.GetDB()
+	systemRole := models.AppRole{
+		Name:        "System Role",
+		Description: "system role",
+		IsSystem:    true,
+		Permissions: []models.AppRolePermission{
+			{Permission: permissions.AppUsersCreate},
+		},
+	}
+	if err := db.Create(&systemRole).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	w := deleteRoleRequest(strconv.FormatUint(uint64(systemRole.ID), 10), "APP", adminContext())
+
+	if w.Result().StatusCode != 400 {
+		utils.PrintTestError(t, w.Result().StatusCode, 400)
+		return
+	}
+
+	roleRepository := repositories.NewRoleRepository(nil)
+	if _, err := roleRepository.GetAppRoleById(systemRole.ID); err != nil {
+		utils.PrintTestError(t, err, "system role should be untouched")
+	}
+}
+
+func TestShouldNotDeleteAssignedAppRole(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	roleRepository := repositories.NewRoleRepository(nil)
+	created, err := roleRepository.CreateAppRole("App Role", "desc", []string{permissions.AppUsersCreate})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	db := repositories.GetDB()
+	user := models.User{Username: "assigned-user", Password: "password", AppRoleID: &created.ID}
+	if err := db.Create(&user).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	w := deleteRoleRequest(strconv.FormatUint(uint64(created.ID), 10), "APP", adminContext())
+
+	if w.Result().StatusCode != 400 {
+		utils.PrintTestError(t, w.Result().StatusCode, 400)
+		return
+	}
+
+	if _, err := roleRepository.GetAppRoleById(created.ID); err != nil {
+		utils.PrintTestError(t, err, "assigned app role should be untouched")
+	}
+}
+
+func TestShouldNotDeleteAssignedGroupRole(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	roleRepository := repositories.NewRoleRepository(nil)
+	created, err := roleRepository.CreateGroupRole("Group Role", "desc", []string{permissions.GroupReceiptsCreate})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	db := repositories.GetDB()
+	user := models.User{Username: "member-user", Password: "password"}
+	if err := db.Table("users").Create(&user).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	group := models.Group{Name: "Test Group"}
+	if err := db.Create(&group).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	member := models.GroupMember{
+		UserID:      user.ID,
+		GroupID:     group.ID,
+		GroupRole:   models.OWNER,
+		GroupRoleID: &created.ID,
+	}
+	if err := db.Create(&member).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	w := deleteRoleRequest(strconv.FormatUint(uint64(created.ID), 10), "GROUP", adminContext())
+
+	if w.Result().StatusCode != 400 {
+		utils.PrintTestError(t, w.Result().StatusCode, 400)
+		return
+	}
+
+	if _, err := roleRepository.GetGroupRoleById(created.ID); err != nil {
+		utils.PrintTestError(t, err, "assigned group role should be untouched")
+	}
+}

--- a/api/internal/repositories/roles.go
+++ b/api/internal/repositories/roles.go
@@ -165,6 +165,16 @@ func (repository RoleRepository) GetAllRoles() ([]structs.RoleView, error) {
 		return nil, err
 	}
 
+	appRoleCounts, err := repository.countAppRoleAssignments()
+	if err != nil {
+		return nil, err
+	}
+
+	groupRoleCounts, err := repository.countGroupRoleAssignments()
+	if err != nil {
+		return nil, err
+	}
+
 	roles := make([]structs.RoleView, 0, len(appRoles)+len(groupRoles))
 
 	for _, role := range appRoles {
@@ -174,12 +184,13 @@ func (repository RoleRepository) GetAllRoles() ([]structs.RoleView, error) {
 		}
 
 		roles = append(roles, structs.RoleView{
-			Id:          role.ID,
-			Name:        role.Name,
-			Description: role.Description,
-			Scope:       permissions.ScopeApp,
-			IsSystem:    role.IsSystem,
-			Permissions: perms,
+			Id:            role.ID,
+			Name:          role.Name,
+			Description:   role.Description,
+			Scope:         permissions.ScopeApp,
+			IsSystem:      role.IsSystem,
+			Permissions:   perms,
+			AssignedCount: appRoleCounts[role.ID],
 		})
 	}
 
@@ -190,14 +201,106 @@ func (repository RoleRepository) GetAllRoles() ([]structs.RoleView, error) {
 		}
 
 		roles = append(roles, structs.RoleView{
-			Id:          role.ID,
-			Name:        role.Name,
-			Description: role.Description,
-			Scope:       permissions.ScopeGroup,
-			IsSystem:    role.IsSystem,
-			Permissions: perms,
+			Id:            role.ID,
+			Name:          role.Name,
+			Description:   role.Description,
+			Scope:         permissions.ScopeGroup,
+			IsSystem:      role.IsSystem,
+			Permissions:   perms,
+			AssignedCount: groupRoleCounts[role.ID],
 		})
 	}
 
 	return roles, nil
+}
+
+// roleAssignmentCount is the row shape returned by the grouped assignment-count
+// queries: a role id and the number of users/members assigned to it.
+type roleAssignmentCount struct {
+	ID    uint
+	Count int
+}
+
+// countAppRoleAssignments returns a map of app role id -> number of users
+// currently assigned that role, in a single grouped query (avoids N+1).
+func (repository RoleRepository) countAppRoleAssignments() (map[uint]int, error) {
+	db := repository.GetDB()
+
+	var rows []roleAssignmentCount
+	err := db.Model(&models.User{}).
+		Select("app_role_id as id, count(*) as count").
+		Where("app_role_id IS NOT NULL").
+		Group("app_role_id").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	counts := make(map[uint]int, len(rows))
+	for _, row := range rows {
+		counts[row.ID] = row.Count
+	}
+
+	return counts, nil
+}
+
+// countGroupRoleAssignments returns a map of group role id -> number of group
+// members currently assigned that role, in a single grouped query.
+func (repository RoleRepository) countGroupRoleAssignments() (map[uint]int, error) {
+	db := repository.GetDB()
+
+	var rows []roleAssignmentCount
+	err := db.Model(&models.GroupMember{}).
+		Select("group_role_id as id, count(*) as count").
+		Where("group_role_id IS NOT NULL").
+		Group("group_role_id").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	counts := make(map[uint]int, len(rows))
+	for _, row := range rows {
+		counts[row.ID] = row.Count
+	}
+
+	return counts, nil
+}
+
+func (repository RoleRepository) CountUsersWithAppRole(id uint) (int64, error) {
+	db := repository.GetDB()
+
+	var count int64
+	err := db.Model(&models.User{}).Where("app_role_id = ?", id).Count(&count).Error
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+func (repository RoleRepository) CountGroupMembersWithGroupRole(id uint) (int64, error) {
+	db := repository.GetDB()
+
+	var count int64
+	err := db.Model(&models.GroupMember{}).Where("group_role_id = ?", id).Count(&count).Error
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+// DeleteAppRole deletes the app role and its permissions (children cascade via
+// the AppRolePermission OnDelete:CASCADE constraint).
+func (repository RoleRepository) DeleteAppRole(id uint) error {
+	db := repository.GetDB()
+	return db.Delete(&models.AppRole{}, id).Error
+}
+
+// DeleteGroupRole deletes the group role and its permissions and resource
+// grants (children cascade via their OnDelete:CASCADE constraints).
+func (repository RoleRepository) DeleteGroupRole(id uint) error {
+	db := repository.GetDB()
+	return db.Delete(&models.GroupRoleDefinition{}, id).Error
 }

--- a/api/internal/routers/role.go
+++ b/api/internal/routers/role.go
@@ -15,6 +15,7 @@ func BuildRoleRouter() *chi.Mux {
 	roleRouter.Get("/", handlers.GetRoles)
 	roleRouter.Post("/", handlers.CreateRole)
 	roleRouter.Put("/{roleId}", handlers.UpdateRole)
+	roleRouter.Delete("/{roleId}", handlers.DeleteRole)
 
 	return roleRouter
 }

--- a/api/internal/services/roles.go
+++ b/api/internal/services/roles.go
@@ -11,9 +11,11 @@ import (
 )
 
 var (
-	ErrRoleNotFound        = errors.New("role not found")
-	ErrRoleTypeMismatch    = errors.New("role type cannot be changed")
-	ErrSystemRoleImmutable = errors.New("system roles cannot be modified")
+	ErrRoleNotFound          = errors.New("role not found")
+	ErrRoleTypeMismatch      = errors.New("role type cannot be changed")
+	ErrSystemRoleImmutable   = errors.New("system roles cannot be modified")
+	ErrSystemRoleUndeletable = errors.New("system roles cannot be deleted")
+	ErrRoleAssigned          = errors.New("role is assigned and cannot be deleted")
 )
 
 type RoleService struct {
@@ -179,4 +181,57 @@ func resolveMissingRoleError(roleRepository repositories.RoleRepository, otherSc
 func (service RoleService) GetRoles() ([]structs.RoleView, error) {
 	roleRepository := repositories.NewRoleRepository(nil)
 	return roleRepository.GetAllRoles()
+}
+
+// DeleteRole deletes an app- or group-scoped role. The scope disambiguates the
+// id (app and group role ids overlap). System roles cannot be deleted, and a
+// role cannot be deleted while it is assigned to any user or group member.
+func (service RoleService) DeleteRole(id uint, scope permissions.Scope) error {
+	return repositories.GetDB().Transaction(func(tx *gorm.DB) error {
+		roleRepository := repositories.NewRoleRepository(tx)
+
+		if scope == permissions.ScopeApp {
+			existing, txErr := roleRepository.GetAppRoleById(id)
+			if errors.Is(txErr, gorm.ErrRecordNotFound) {
+				return resolveMissingRoleError(roleRepository, permissions.ScopeGroup, id)
+			}
+			if txErr != nil {
+				return txErr
+			}
+			if existing.IsSystem {
+				return ErrSystemRoleUndeletable
+			}
+
+			count, txErr := roleRepository.CountUsersWithAppRole(id)
+			if txErr != nil {
+				return txErr
+			}
+			if count > 0 {
+				return ErrRoleAssigned
+			}
+
+			return roleRepository.DeleteAppRole(id)
+		}
+
+		existing, txErr := roleRepository.GetGroupRoleById(id)
+		if errors.Is(txErr, gorm.ErrRecordNotFound) {
+			return resolveMissingRoleError(roleRepository, permissions.ScopeApp, id)
+		}
+		if txErr != nil {
+			return txErr
+		}
+		if existing.IsSystem {
+			return ErrSystemRoleUndeletable
+		}
+
+		count, txErr := roleRepository.CountGroupMembersWithGroupRole(id)
+		if txErr != nil {
+			return txErr
+		}
+		if count > 0 {
+			return ErrRoleAssigned
+		}
+
+		return roleRepository.DeleteGroupRole(id)
+	})
 }

--- a/api/internal/structs/role_view.go
+++ b/api/internal/structs/role_view.go
@@ -3,10 +3,11 @@ package structs
 import "receipt-wrangler/api/internal/permissions"
 
 type RoleView struct {
-	Id          uint              `json:"id"`
-	Name        string            `json:"name"`
-	Description string            `json:"description"`
-	Scope       permissions.Scope `json:"scope"`
-	IsSystem    bool              `json:"isSystem"`
-	Permissions []string          `json:"permissions"`
+	Id            uint              `json:"id"`
+	Name          string            `json:"name"`
+	Description   string            `json:"description"`
+	Scope         permissions.Scope `json:"scope"`
+	IsSystem      bool              `json:"isSystem"`
+	Permissions   []string          `json:"permissions"`
+	AssignedCount int               `json:"assignedCount"`
 }

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -2816,6 +2816,35 @@ paths:
       security:
         - bearerAuth: [ ]
         - apiKeyAuth: [ ]
+    delete:
+      tags:
+        - Role
+      summary: Delete role
+      description: >-
+        Deletes an app-scoped or group-scoped role. The scope query parameter
+        disambiguates the role id, since app and group role ids overlap. A role
+        cannot be deleted while it is assigned to any user or group member, and
+        system roles cannot be deleted.
+      operationId: deleteRole
+      parameters:
+        - in: query
+          name: scope
+          required: true
+          schema:
+            $ref: "#/components/schemas/PermissionScope"
+          description: Scope of the role to delete
+      responses:
+        200:
+          $ref: "#/components/responses/Ok"
+        400:
+          $ref: "#/components/responses/BadRequest"
+        404:
+          $ref: "#/components/responses/NotFound"
+        500:
+          $ref: "#/components/responses/Internal"
+      security:
+        - bearerAuth: [ ]
+        - apiKeyAuth: [ ]
 components:
   securitySchemes:
     bearerAuth:
@@ -3010,6 +3039,9 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Permission"
+        assignedCount:
+          type: integer
+          description: Number of users or group members currently assigned this role
     UpsertRoleCommand:
       type: object
       required:

--- a/desktop/e2e/roles.spec.ts
+++ b/desktop/e2e/roles.spec.ts
@@ -11,15 +11,18 @@ function uniqueName(tag: string) {
 
 type RoleType = 'app' | 'group';
 
-// NOTE: there is no delete-role flow yet (no endpoint/UI), so created roles can't
-// be cleaned up. Tests therefore use unique names and assert that the *specific*
-// role they created appears — never absolute row/count totals — so they stay
-// correct as roles accumulate on the shared DB. Add an afterEach cleanup here
-// once a delete flow exists.
+// Roles created during a test are tracked here and removed in afterEach so the
+// shared DB does not accumulate test data. The array is reset per test; under
+// Playwright's worker model each worker runs its tests sequentially, so this
+// module-level state is safe. Tests still use unique names and assert on the
+// *specific* role they created (never absolute totals) to stay parallel-safe.
+let createdRoles: string[] = [];
+
 async function createRole(
   page: Page,
   opts: { name: string; type: RoleType; template: string },
 ) {
+  createdRoles.push(opts.name);
   await page.goto('/roles');
   // Header "Add Role" button (the empty-state one, if present, is identical).
   await page.getByRole('button', { name: 'Add Role' }).first().click();
@@ -54,6 +57,46 @@ async function openRoleEditor(page: Page, name: string) {
   await expect(page.getByLabel('Role Name')).toHaveValue(name);
 }
 
+// Deletes a role from the list by name and asserts the row is gone. The delete
+// icon button has no accessible name, so it carries a data-testid. The
+// confirmation dialog's confirm button is the icon-only "done" submit button.
+async function deleteRole(page: Page, name: string) {
+  await page.goto('/roles');
+  const row = page.getByRole('row').filter({ hasText: name }).first();
+  await expect(row).toBeVisible();
+  await row.getByTestId('role-delete').click();
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  await dialog.locator('button:has(mat-icon:has-text("done"))').click();
+
+  await expect(page.getByRole('row').filter({ hasText: name })).toHaveCount(0);
+}
+
+// Best-effort cleanup: removes every list row whose name contains `name`
+// (catches renamed variants, e.g. "<name>-renamed"). Skips rows whose delete is
+// disabled (system/assigned) and stops once none remain.
+async function cleanupRole(page: Page, name: string) {
+  for (let i = 0; i < 20; i++) {
+    await page.goto('/roles');
+    // The table renders only after getRoles() resolves; wait for it before
+    // counting so a not-yet-loaded list isn't mistaken for "already gone".
+    await expect(page.locator('app-table')).toBeVisible();
+    const rows = page.getByRole('row').filter({ hasText: name });
+    if ((await rows.count()) === 0) {
+      return;
+    }
+    const del = rows.first().getByTestId('role-delete');
+    if (await del.isDisabled()) {
+      return;
+    }
+    await del.click();
+    const dialog = page.getByRole('dialog');
+    await dialog.locator('button:has(mat-icon:has-text("done"))').click();
+    await expect(dialog).toHaveCount(0);
+  }
+}
+
 // The summary panel's granted-permission count (driven by granted().size).
 async function grantedCount(page: Page): Promise<number> {
   return Number((await page.getByTestId('granted-permission-count').innerText()).trim());
@@ -71,7 +114,14 @@ async function saveRole(page: Page) {
 
 test.describe('roles', () => {
   test.beforeEach(async ({ page }) => {
+    createdRoles = [];
     await stubTokenRefresh(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    for (const name of createdRoles) {
+      await cleanupRole(page, name);
+    }
   });
 
   test('create an application role and see it in the table', async ({ page }) => {
@@ -186,6 +236,18 @@ test.describe('roles', () => {
     const row = page.getByRole('row').filter({ hasText: renamed }).first();
     await expect(row).toBeVisible();
     await expect(row).toContainText('Group');
+  });
+
+  test('create a role then delete it removes it from the table', async ({ page }) => {
+    const name = uniqueName('delete');
+    await createRole(page, { name, type: 'app', template: 'Read Only' });
+
+    // A freshly created, unassigned role is deletable.
+    await page.goto('/roles');
+    const row = page.getByRole('row').filter({ hasText: name }).first();
+    await expect(row.getByTestId('role-delete')).toBeEnabled();
+
+    await deleteRole(page, name);
   });
 
   test('cancelling an edit discards changes', async ({ page }) => {

--- a/desktop/e2e/roles.spec.ts
+++ b/desktop/e2e/roles.spec.ts
@@ -68,7 +68,7 @@ async function deleteRole(page: Page, name: string) {
 
   const dialog = page.getByRole('dialog');
   await expect(dialog).toBeVisible();
-  await dialog.locator('button:has(mat-icon:has-text("done"))').click();
+  await dialog.getByTestId('dialog-submit-button').click();
 
   await expect(page.getByRole('row').filter({ hasText: name })).toHaveCount(0);
 }
@@ -92,7 +92,7 @@ async function cleanupRole(page: Page, name: string) {
     }
     await del.click();
     const dialog = page.getByRole('dialog');
-    await dialog.locator('button:has(mat-icon:has-text("done"))').click();
+    await dialog.getByTestId('dialog-submit-button').click();
     await expect(dialog).toHaveCount(0);
   }
 }

--- a/desktop/src/open-api/api/role.service.ts
+++ b/desktop/src/open-api/api/role.service.ts
@@ -19,6 +19,8 @@ import { Observable }                                        from 'rxjs';
 // @ts-ignore
 import { InternalErrorResponse } from '../model/internalErrorResponse';
 // @ts-ignore
+import { PermissionScope } from '../model/permissionScope';
+// @ts-ignore
 import { Role } from '../model/role';
 // @ts-ignore
 import { UpsertRoleCommand } from '../model/upsertRoleCommand';
@@ -172,6 +174,95 @@ export class RoleService {
             {
                 context: localVarHttpContext,
                 body: upsertRoleCommand,
+                responseType: <any>responseType_,
+                withCredentials: this.configuration.withCredentials,
+                headers: localVarHeaders,
+                observe: observe,
+                transferCache: localVarTransferCache,
+                reportProgress: reportProgress
+            }
+        );
+    }
+
+    /**
+     * Delete role
+     * Deletes an app-scoped or group-scoped role. The scope query parameter disambiguates the role id, since app and group role ids overlap. A role cannot be deleted while it is assigned to any user or group member, and system roles cannot be deleted.
+     * @param scope Scope of the role to delete
+     * @param roleId Id of the role to update
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
+     */
+    public deleteRole(scope: PermissionScope, roleId: number, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any>;
+    public deleteRole(scope: PermissionScope, roleId: number, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<any>>;
+    public deleteRole(scope: PermissionScope, roleId: number, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<any>>;
+    public deleteRole(scope: PermissionScope, roleId: number, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
+        if (scope === null || scope === undefined) {
+            throw new Error('Required parameter scope was null or undefined when calling deleteRole.');
+        }
+        if (roleId === null || roleId === undefined) {
+            throw new Error('Required parameter roleId was null or undefined when calling deleteRole.');
+        }
+
+        let localVarQueryParameters = new HttpParams({encoder: this.encoder});
+        if (scope !== undefined && scope !== null) {
+          localVarQueryParameters = this.addToHttpParams(localVarQueryParameters,
+            <any>scope, 'scope');
+        }
+
+        let localVarHeaders = this.defaultHeaders;
+
+        let localVarCredential: string | undefined;
+        // authentication (apiKeyAuth) required
+        localVarCredential = this.configuration.lookupCredential('apiKeyAuth');
+        if (localVarCredential) {
+            localVarHeaders = localVarHeaders.set('Authorization', localVarCredential);
+        }
+
+        // authentication (bearerAuth) required
+        localVarCredential = this.configuration.lookupCredential('bearerAuth');
+        if (localVarCredential) {
+            localVarHeaders = localVarHeaders.set('Authorization', 'Bearer ' + localVarCredential);
+        }
+
+        let localVarHttpHeaderAcceptSelected: string | undefined = options && options.httpHeaderAccept;
+        if (localVarHttpHeaderAcceptSelected === undefined) {
+            // to determine the Accept header
+            const httpHeaderAccepts: string[] = [
+                'application/json'
+            ];
+            localVarHttpHeaderAcceptSelected = this.configuration.selectHeaderAccept(httpHeaderAccepts);
+        }
+        if (localVarHttpHeaderAcceptSelected !== undefined) {
+            localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
+        }
+
+        let localVarHttpContext: HttpContext | undefined = options && options.context;
+        if (localVarHttpContext === undefined) {
+            localVarHttpContext = new HttpContext();
+        }
+
+        let localVarTransferCache: boolean | undefined = options && options.transferCache;
+        if (localVarTransferCache === undefined) {
+            localVarTransferCache = true;
+        }
+
+
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
+            }
+        }
+
+        let localVarPath = `/role/${this.configuration.encodeParam({name: "roleId", value: roleId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: undefined})}`;
+        return this.httpClient.request<any>('delete', `${this.configuration.basePath}${localVarPath}`,
+            {
+                context: localVarHttpContext,
+                params: localVarQueryParameters,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/desktop/src/open-api/model/role.ts
+++ b/desktop/src/open-api/model/role.ts
@@ -18,6 +18,10 @@ export interface Role {
     scope: PermissionScope;
     isSystem: boolean;
     permissions: Array<Permission>;
+    /**
+     * Number of users or group members currently assigned this role
+     */
+    assignedCount?: number;
 }
 export namespace Role {
 }

--- a/desktop/src/roles/role-list/role-list-item.interface.ts
+++ b/desktop/src/roles/role-list/role-list-item.interface.ts
@@ -2,8 +2,9 @@
  * View-model for a single row in the roles list.
  *
  * Mapped from the generated `Role` model. A role belongs to exactly one scope
- * (application OR group). Member data is not populated yet — assigning roles to
- * users is a later slice — so `members`/`userCount` render as "No users".
+ * (application OR group). `userCount` is how many users/group members are
+ * currently assigned the role; it drives both the Members column and whether
+ * the role can be deleted (assigned roles cannot be deleted).
  */
 export interface RoleListItem {
   id: string;
@@ -11,7 +12,6 @@ export interface RoleListItem {
   description: string;
   scope: RoleScope;
   permissionCount: number;
-  members: RoleMember[];
   userCount: number;
   isSystem: boolean;
   icon: string;
@@ -23,8 +23,3 @@ export type RoleScope = "app" | "group";
 
 /** The type filter above the table, plus the implicit "all". */
 export type RoleListFilter = "all" | RoleScope;
-
-export interface RoleMember {
-  name: string;
-  color: string;
-}

--- a/desktop/src/roles/role-list/role-list.component.html
+++ b/desktop/src/roles/role-list/role-list.component.html
@@ -92,16 +92,9 @@
   @if (role.userCount === 0) {
     <span class="no-users">No users</span>
   } @else {
-    <div class="user-stack">
-      @for (member of role.members.slice(0, 3); track member.name) {
-        <span class="avatar" [style.background]="member.color">{{
-          initials(member.name)
-        }}</span>
-      }
-      @if (role.userCount > 3) {
-        <span class="more">+{{ role.userCount - 3 }}</span>
-      }
-    </div>
+    <span class="user-count"
+      >{{ role.userCount }} {{ role.userCount === 1 ? "user" : "users" }}</span
+    >
   }
 </ng-template>
 
@@ -115,12 +108,18 @@
       [tooltip]="role.isSystem ? 'View' : 'Edit'"
       (clicked)="editRole(role)"
     ></app-button>
-    <app-button
-      matButtonType="iconButton"
-      color="accent"
-      icon="more_vert"
-      tooltip="More actions"
-      (clicked)="openRoleMenu(role)"
-    ></app-button>
+    <app-delete-button
+      data-testid="role-delete"
+      [tooltip]="
+        role.isSystem
+          ? 'System roles cannot be deleted'
+          : role.userCount > 0
+            ? 'Role is assigned and cannot be deleted'
+            : 'Delete'
+      "
+      [disabled]="!canDelete(role)"
+      (clicked)="deleteRole(role)"
+      (click)="disabledDeleteClicked(role)"
+    ></app-delete-button>
   </div>
 </ng-template>

--- a/desktop/src/roles/role-list/role-list.component.scss
+++ b/desktop/src/roles/role-list/role-list.component.scss
@@ -221,34 +221,10 @@ app-filter-bar {
   font-size: 13px;
 }
 
-.user-stack {
-  display: inline-flex;
-  align-items: center;
-
-  .avatar {
-    width: 28px;
-    height: 28px;
-    border-radius: 50%;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    color: #fff;
-    font-weight: 600;
-    font-size: 11px;
-    border: 2px solid #fff;
-    margin-left: -8px;
-
-    &:first-child {
-      margin-left: 0;
-    }
-  }
-
-  .more {
-    margin-left: variables.$spacing-sm;
-    font-size: 13px;
-    color: $fg-muted;
-    font-weight: 500;
-  }
+.user-count {
+  font-size: 13px;
+  color: $fg-muted;
+  font-weight: 500;
 }
 
 .row-actions {

--- a/desktop/src/roles/role-list/role-list.component.spec.ts
+++ b/desktop/src/roles/role-list/role-list.component.spec.ts
@@ -3,16 +3,36 @@ import { provideHttpClient, withInterceptorsFromDi } from "@angular/common/http"
 import { provideHttpClientTesting } from "@angular/common/http/testing";
 import { CUSTOM_ELEMENTS_SCHEMA, provideZonelessChangeDetection } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { MatDialog } from "@angular/material/dialog";
 import { Router, RouterModule } from "@angular/router";
 import { of, throwError } from "rxjs";
 import {
   ApiModule,
   PermissionDescriptor,
+  PermissionScope,
   PermissionService,
   Role,
   RoleService,
 } from "../../open-api";
+import { SnackbarService } from "../../services";
 import { RoleListComponent } from "./role-list.component";
+import { RoleListItem, RoleScope } from "./role-list-item.interface";
+
+function listItem(overrides: Partial<RoleListItem> = {}): RoleListItem {
+  return {
+    id: "1",
+    name: "Some Role",
+    description: "",
+    scope: "app" as RoleScope,
+    permissionCount: 0,
+    userCount: 0,
+    isSystem: false,
+    icon: "apps",
+    iconColor: "",
+    iconTint: "",
+    ...overrides,
+  };
+}
 
 const DESCRIPTORS: PermissionDescriptor[] = [
   { key: "app.users.create", label: "", description: "", category: "Users", scope: "APP" },
@@ -44,11 +64,22 @@ const ROLES: Role[] = [
 async function setup(
   roles: Role[] = ROLES,
   permissions: PermissionDescriptor[] | "error" = DESCRIPTORS,
+  confirmResult = true,
 ): Promise<{
   component: RoleListComponent;
   fixture: ComponentFixture<RoleListComponent>;
   navigateSpy: jest.SpyInstance;
+  roleService: RoleService;
+  snackbar: SnackbarService;
+  dialogRef: { componentInstance: any; afterClosed: jest.Mock };
 }> {
+  const dialogRef = {
+    componentInstance: {} as any,
+    afterClosed: jest.fn().mockReturnValue(of(confirmResult)),
+  };
+  const matDialogMock = { open: jest.fn().mockReturnValue(dialogRef) };
+  const snackbarMock = { info: jest.fn(), success: jest.fn(), error: jest.fn() };
+
   TestBed.resetTestingModule();
   await TestBed.configureTestingModule({
     declarations: [RoleListComponent],
@@ -58,10 +89,14 @@ async function setup(
       provideZonelessChangeDetection(),
       provideHttpClient(withInterceptorsFromDi()),
       provideHttpClientTesting(),
+      { provide: MatDialog, useValue: matDialogMock },
+      { provide: SnackbarService, useValue: snackbarMock },
     ],
   }).compileComponents();
 
-  jest.spyOn(TestBed.inject(RoleService), "getRoles").mockReturnValue(of(roles) as any);
+  const roleService = TestBed.inject(RoleService);
+  jest.spyOn(roleService, "getRoles").mockReturnValue(of(roles) as any);
+  jest.spyOn(roleService, "deleteRole").mockReturnValue(of({}) as any);
   jest
     .spyOn(TestBed.inject(PermissionService), "getPermissions")
     .mockReturnValue(
@@ -76,7 +111,14 @@ async function setup(
   const fixture = TestBed.createComponent(RoleListComponent);
   const component = fixture.componentInstance;
   await fixture.whenStable();
-  return { component, fixture, navigateSpy };
+  return {
+    component,
+    fixture,
+    navigateSpy,
+    roleService,
+    snackbar: TestBed.inject(SnackbarService),
+    dialogRef,
+  };
 }
 
 describe("RoleListComponent", () => {
@@ -181,9 +223,50 @@ describe("RoleListComponent", () => {
     expect(component.roleCount()).toBe(2);
   });
 
-  it("returns up to two uppercased initials", async () => {
+  it("populates the member count from the role's assigned count", async () => {
+    const { component } = await setup([
+      { ...ROLES[1], id: 5, assignedCount: 3 },
+    ]);
+    expect(component.roles()[0].userCount).toBe(3);
+  });
+
+  it("allows deletion only for unassigned, non-system roles", async () => {
     const { component } = await setup();
-    expect(component.initials("Noah Hall")).toBe("NH");
-    expect(component.initials("dana")).toBe("D");
+    expect(component.canDelete(listItem())).toBe(true);
+    expect(component.canDelete(listItem({ isSystem: true }))).toBe(false);
+    expect(component.canDelete(listItem({ userCount: 2 }))).toBe(false);
+  });
+
+  it("deletes a role with its scope after confirmation, then reloads", async () => {
+    const { component, roleService } = await setup();
+    const reloadSpy = jest.spyOn(roleService, "getRoles");
+    const callsBefore = reloadSpy.mock.calls.length;
+
+    component.deleteRole(listItem({ id: "5", scope: "group" }));
+
+    expect(roleService.deleteRole).toHaveBeenCalledWith(PermissionScope.Group, 5);
+    expect(reloadSpy.mock.calls.length).toBe(callsBefore + 1);
+  });
+
+  it("does not delete when the confirmation is cancelled", async () => {
+    const { component, roleService } = await setup(ROLES, DESCRIPTORS, false);
+
+    component.deleteRole(listItem({ id: "5", scope: "app" }));
+
+    expect(roleService.deleteRole).not.toHaveBeenCalled();
+  });
+
+  it("explains why a disabled delete is blocked without revealing assignees", async () => {
+    const { component, snackbar } = await setup();
+
+    component.disabledDeleteClicked(listItem({ name: "Sys", isSystem: true }));
+    expect(snackbar.info).toHaveBeenCalledWith(
+      "Cannot delete Sys because it is a system role.",
+    );
+
+    component.disabledDeleteClicked(listItem({ name: "Busy", userCount: 4 }));
+    expect(snackbar.info).toHaveBeenCalledWith(
+      "Cannot delete Busy because it is currently assigned.",
+    );
   });
 });

--- a/desktop/src/roles/role-list/role-list.component.spec.ts
+++ b/desktop/src/roles/role-list/role-list.component.spec.ts
@@ -269,4 +269,18 @@ describe("RoleListComponent", () => {
       "Cannot delete Busy because it is currently assigned.",
     );
   });
+
+  it("shows an error and does not reload when delete fails", async () => {
+    const { component, roleService, snackbar } = await setup();
+    const reloadSpy = jest.spyOn(roleService, "getRoles");
+    const callsBefore = reloadSpy.mock.calls.length;
+    (roleService.deleteRole as jest.Mock).mockReturnValueOnce(
+      throwError(() => new Error("boom")) as any,
+    );
+
+    component.deleteRole(listItem({ id: "5", scope: "group" }));
+
+    expect(snackbar.error).toHaveBeenCalledWith("Failed to delete role");
+    expect(reloadSpy.mock.calls.length).toBe(callsBefore);
+  });
 });

--- a/desktop/src/roles/role-list/role-list.component.ts
+++ b/desktop/src/roles/role-list/role-list.component.ts
@@ -185,6 +185,13 @@ export class RoleListComponent implements AfterViewInit {
   }
 
   public deleteRole(role: RoleListItem): void {
+    // Defensive: the button gates this via [disabled], but guard programmatic
+    // calls so a non-deletable role never opens the confirmation or hits the API.
+    if (!this.canDelete(role)) {
+      this.disabledDeleteClicked(role);
+      return;
+    }
+
     const dialogRef = this.matDialog.open(ConfirmationDialogComponent);
     dialogRef.componentInstance.headerText = "Delete Role";
     dialogRef.componentInstance.dialogContent = `Are you sure you want to delete the role: ${role.name}?`;
@@ -224,6 +231,10 @@ export class RoleListComponent implements AfterViewInit {
         tap(() => {
           this.snackbarService.success("Role deleted successfully");
           this.loadRoles();
+        }),
+        catchError(() => {
+          this.snackbarService.error("Failed to delete role");
+          return EMPTY;
         }),
       )
       .subscribe();

--- a/desktop/src/roles/role-list/role-list.component.ts
+++ b/desktop/src/roles/role-list/role-list.component.ts
@@ -1,6 +1,7 @@
 import {
   AfterViewInit,
   Component,
+  DestroyRef,
   TemplateRef,
   computed,
   inject,
@@ -8,12 +9,20 @@ import {
   viewChild,
 } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { MatDialog } from "@angular/material/dialog";
 import { MatTableDataSource } from "@angular/material/table";
 import { Router } from "@angular/router";
 import { EMPTY, catchError, take, tap } from "rxjs";
-import { Role, RoleService, PermissionService } from "../../open-api";
+import {
+  PermissionScope,
+  Role,
+  RoleService,
+  PermissionService,
+} from "../../open-api";
+import { SnackbarService } from "../../services";
 import { TableColumn } from "../../table/table-column.interface";
 import { BreadcrumbItem } from "../../shared-ui/breadcrumb/breadcrumb-item.interface";
+import { ConfirmationDialogComponent } from "../../shared-ui/confirmation-dialog/confirmation-dialog.component";
 import { FilterTab } from "../../shared-ui/filter-bar/filter-tab.interface";
 import {
   RoleListFilter,
@@ -39,6 +48,9 @@ export class RoleListComponent implements AfterViewInit {
   private readonly permissionService = inject(PermissionService);
   private readonly roleService = inject(RoleService);
   private readonly router = inject(Router);
+  private readonly matDialog = inject(MatDialog);
+  private readonly snackbarService = inject(SnackbarService);
+  private readonly destroyRef = inject(DestroyRef);
 
   private readonly roleCellTemplate = viewChild.required<TemplateRef<any>>("roleCell");
   private readonly typeCellTemplate = viewChild.required<TemplateRef<any>>("typeCell");
@@ -154,16 +166,6 @@ export class RoleListComponent implements AfterViewInit {
     return this.scopeTotals()[role.scope];
   }
 
-  /** Up-to-two-letter initials for a member avatar. */
-  public initials(name: string): string {
-    return (name || "?")
-      .split(" ")
-      .map((part) => part[0])
-      .join("")
-      .slice(0, 2)
-      .toUpperCase();
-  }
-
   public addRole(): void {
     this.router.navigate(["/roles/new"]);
   }
@@ -176,8 +178,62 @@ export class RoleListComponent implements AfterViewInit {
     });
   }
 
-  // TODO: open the per-role actions menu once those actions exist.
-  public openRoleMenu(_role: RoleListItem): void {}
+  // A role can be deleted only when it is not a system role and nobody is
+  // assigned to it. Assigned roles must be unassigned before deletion.
+  public canDelete(role: RoleListItem): boolean {
+    return !role.isSystem && role.userCount === 0;
+  }
+
+  public deleteRole(role: RoleListItem): void {
+    const dialogRef = this.matDialog.open(ConfirmationDialogComponent);
+    dialogRef.componentInstance.headerText = "Delete Role";
+    dialogRef.componentInstance.dialogContent = `Are you sure you want to delete the role: ${role.name}?`;
+
+    dialogRef
+      .afterClosed()
+      .pipe(
+        take(1),
+        tap((result) => {
+          if (result) {
+            this.callDeleteApi(role);
+          }
+        }),
+      )
+      .subscribe();
+  }
+
+  // Explains why the delete button is disabled when a disabled button is
+  // clicked. We intentionally do not reveal who the role is assigned to.
+  public disabledDeleteClicked(role: RoleListItem): void {
+    if (role.isSystem) {
+      this.snackbarService.info(
+        `Cannot delete ${role.name} because it is a system role.`,
+      );
+    } else if (role.userCount > 0) {
+      this.snackbarService.info(
+        `Cannot delete ${role.name} because it is currently assigned.`,
+      );
+    }
+  }
+
+  private callDeleteApi(role: RoleListItem): void {
+    this.roleService
+      .deleteRole(this.toScopeEnum(role.scope), Number(role.id))
+      .pipe(
+        take(1),
+        tap(() => {
+          this.snackbarService.success("Role deleted successfully");
+          this.loadRoles();
+        }),
+      )
+      .subscribe();
+  }
+
+  // The view-model scope ('app'/'group') maps to the API's PermissionScope
+  // enum ('APP'/'GROUP') — the inverse of the mapping in toListItem.
+  private toScopeEnum(scope: RoleScope): PermissionScope {
+    return scope === "group" ? PermissionScope.Group : PermissionScope.App;
+  }
 
   private loadRoles(): void {
     this.roleService
@@ -186,7 +242,7 @@ export class RoleListComponent implements AfterViewInit {
         take(1),
         tap((roles) => this.roles.set(roles.map((role) => this.toListItem(role)))),
         catchError(() => EMPTY),
-        takeUntilDestroyed(),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
   }
@@ -200,8 +256,7 @@ export class RoleListComponent implements AfterViewInit {
       description: role.description ?? "",
       scope,
       permissionCount: role.permissions?.length ?? 0,
-      members: [],
-      userCount: 0,
+      userCount: role.assignedCount ?? 0,
       isSystem: role.isSystem,
       icon: visual.icon,
       iconColor: visual.color,

--- a/desktop/src/shared-ui/dialog-footer/dialog-footer.component.html
+++ b/desktop/src/shared-ui/dialog-footer/dialog-footer.component.html
@@ -1,5 +1,6 @@
 <div class="d-flex justify-content-end align-items-center">
   <app-submit-button
+    data-testid="dialog-submit-button"
     [tooltip]="submitButtonTooltip()"
     [disabled]="
       disableWhenProgressBarIsShown() ? showProgressBar() ?? false : false


### PR DESCRIPTION
## Summary
Adds the ability to delete a role from the Manage Roles page, following the app's existing "delete only when unassociated" pattern (prompts / receipt-processing settings).

- A role can be deleted only when it is **not assigned** to any user or group member and is **not a system role**. Otherwise the delete action is disabled with a tooltip explaining why (plus a snackbar on click). Deleting an assigned role requires unassigning everyone first — assignees are never shown.
- **API:** `DELETE /role/{roleId}?scope=APP|GROUP`. The scope disambiguates app vs group role ids (which overlap across the two tables). Returns 400 when the role is assigned or is a system role, 404 when missing. Roles now include an `assignedCount`.
- **Desktop:** inline delete button + confirmation dialog (replacing the previous no-op "more actions" button). The Members column now shows the real assigned-user count (a number only, never identities).

## Testing
- **Backend:** `go test ./...` green, including 15 new delete cases (success app/group, not-found, scope mismatch, system blocked, assigned blocked, auth 403, invalid id/scope).
- **Desktop unit:** 17 role-list tests green; production build green.
- **e2e:** `roles.spec.ts` — create-then-delete test plus an `afterEach` that deletes every created role; verified the suite leaves zero `e2e-role-*` rows behind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add role deletion endpoint with confirmation and contextual messages; prevents deleting system or currently assigned roles.
  * Role list shows assigned user/member counts and a dedicated delete button.
  * Client API and OpenAPI spec updated to support role deletion.

* **Tests**
  * Expanded unit and end-to-end tests covering deletion flows, validation, error handling, and cleanup of test-created roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->