### PR TITLE
Strip trailing commas from AI response before JSON parse

### DIFF
--- a/api/internal/services/receipt_processing.go
+++ b/api/internal/services/receipt_processing.go
@@ -11,6 +11,7 @@ import (
 	"receipt-wrangler/api/internal/repositories"
 	"receipt-wrangler/api/internal/structs"
 	"receipt-wrangler/api/internal/utils"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -278,7 +279,27 @@ func (service ReceiptProcessingService) processImages(
 func (service ReceiptProcessingService) cleanResponse(response string) string {
 	response = strings.ReplaceAll(response, "```json", "")
 	response = strings.ReplaceAll(response, "```", "")
+	response = stripTrailingCommas(response)
 	return response
+}
+
+// trailingCommaRegex matches a comma that is followed (ignoring whitespace)
+// by a closing brace or bracket, i.e. an illegal trailing comma in JSON.
+var trailingCommaRegex = regexp.MustCompile(`,(\s*[}\]])`)
+
+// stripTrailingCommas removes trailing commas before } or ] so that output
+// from LLMs that emit them (notably OpenAI gpt-4o) parses under Go's strict
+// encoding/json. Applied repeatedly to handle nested closings such as
+// "},\n  ],\n}". Commas inside string values are not matched because they
+// are not immediately followed by a closing brace/bracket.
+func stripTrailingCommas(s string) string {
+	for {
+		out := trailingCommaRegex.ReplaceAllString(s, "$1")
+		if out == s {
+			return out
+		}
+		s = out
+	}
 }
 
 // ocrImageResult is the per-image outcome from running OCR. Used by

--- a/api/internal/services/receipt_processing.go
+++ b/api/internal/services/receipt_processing.go
@@ -11,7 +11,6 @@ import (
 	"receipt-wrangler/api/internal/repositories"
 	"receipt-wrangler/api/internal/structs"
 	"receipt-wrangler/api/internal/utils"
-	"regexp"
 	"strings"
 	"time"
 )
@@ -283,23 +282,58 @@ func (service ReceiptProcessingService) cleanResponse(response string) string {
 	return response
 }
 
-// trailingCommaRegex matches a comma that is followed (ignoring whitespace)
-// by a closing brace or bracket, i.e. an illegal trailing comma in JSON.
-var trailingCommaRegex = regexp.MustCompile(`,(\s*[}\]])`)
-
 // stripTrailingCommas removes trailing commas before } or ] so that output
 // from LLMs that emit them (notably OpenAI gpt-4o) parses under Go's strict
-// encoding/json. Applied repeatedly to handle nested closings such as
-// "},\n  ],\n}". Commas inside string values are not matched because they
-// are not immediately followed by a closing brace/bracket.
+// encoding/json. It is string-aware: it tracks whether the scan position is
+// inside a JSON string (honoring backslash escapes) and only removes a comma
+// when the comma is outside any string and the next non-whitespace character
+// is a closing brace or bracket. This avoids corrupting values that legitimately
+// contain sequences like ",}" or ",]" inside a quoted string.
 func stripTrailingCommas(s string) string {
-	for {
-		out := trailingCommaRegex.ReplaceAllString(s, "$1")
-		if out == s {
-			return out
+	var b strings.Builder
+	b.Grow(len(s))
+
+	inString := false
+	escaped := false
+
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+
+		if inString {
+			b.WriteByte(c)
+			switch {
+			case escaped:
+				escaped = false
+			case c == '\\':
+				escaped = true
+			case c == '"':
+				inString = false
+			}
+			continue
 		}
-		s = out
+
+		if c == '"' {
+			inString = true
+			b.WriteByte(c)
+			continue
+		}
+
+		if c == ',' {
+			// Look ahead past whitespace for a closing brace/bracket.
+			j := i + 1
+			for j < len(s) && (s[j] == ' ' || s[j] == '\t' || s[j] == '\r' || s[j] == '\n') {
+				j++
+			}
+			if j < len(s) && (s[j] == '}' || s[j] == ']') {
+				// Trailing comma: drop it.
+				continue
+			}
+		}
+
+		b.WriteByte(c)
 	}
+
+	return b.String()
 }
 
 // ocrImageResult is the per-image outcome from running OCR. Used by

--- a/api/internal/services/receipt_processing_test.go
+++ b/api/internal/services/receipt_processing_test.go
@@ -270,6 +270,66 @@ func TestCleanResponse_NoMarkersPassThrough(t *testing.T) {
 	}
 }
 
+func TestCleanResponse_StripsTrailingCommas(t *testing.T) {
+	service := ReceiptProcessingService{}
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"object", `{"a":1,}`, `{"a":1}`},
+		{"array", `[1,2,3,]`, `[1,2,3]`},
+		{"nested", `{"x":[1,2,],"y":{"z":1,},}`, `{"x":[1,2],"y":{"z":1}}`},
+		{"whitespace before close", "{\"a\":1,\n}", "{\"a\":1\n}"},
+		{"valid json untouched", `{"a":1,"b":2}`, `{"a":1,"b":2}`},
+		{"comma inside string preserved", `{"name":"Beans, baked","amount":1,}`, `{"name":"Beans, baked","amount":1}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := service.cleanResponse(tt.in)
+			if got != tt.want {
+				t.Errorf("cleanResponse(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCleanResponse_TrailingCommaOutputIsParseable guards the actual purpose
+// of the fix: output from gpt-4o with trailing commas must unmarshal cleanly,
+// including a populated items array.
+func TestCleanResponse_TrailingCommaOutputIsParseable(t *testing.T) {
+	service := ReceiptProcessingService{}
+	raw := `{
+  "name": "BILLA",
+  "amount": 2306.86,
+  "items": [
+    { "name": "COTTAGE FIT", "amount": 197.4, },
+    { "name": "Beans, baked", "amount": 51.8, },
+  ],
+  "categories": [],
+  "tags": [],
+}`
+	cleaned := service.cleanResponse(raw)
+
+	var receipt struct {
+		Name   string  `json:"name"`
+		Amount float64 `json:"amount"`
+		Items  []struct {
+			Name   string  `json:"name"`
+			Amount float64 `json:"amount"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(cleaned), &receipt); err != nil {
+		t.Fatalf("expected cleaned response to parse, got error: %v\ncleaned: %s", err, cleaned)
+	}
+	if len(receipt.Items) != 2 {
+		t.Errorf("expected 2 items, got %d", len(receipt.Items))
+	}
+	if receipt.Items[1].Name != "Beans, baked" {
+		t.Errorf("expected comma-containing item name preserved, got %q", receipt.Items[1].Name)
+	}
+}
+
 // ---------- Fixture helpers for the DB/orchestration tests ----------
 
 // seedReceiptProcessingFixtures creates the minimum viable graph to exercise

--- a/api/internal/services/receipt_processing_test.go
+++ b/api/internal/services/receipt_processing_test.go
@@ -283,6 +283,14 @@ func TestCleanResponse_StripsTrailingCommas(t *testing.T) {
 		{"whitespace before close", "{\"a\":1,\n}", "{\"a\":1\n}"},
 		{"valid json untouched", `{"a":1,"b":2}`, `{"a":1,"b":2}`},
 		{"comma inside string preserved", `{"name":"Beans, baked","amount":1,}`, `{"name":"Beans, baked","amount":1}`},
+		// String-aware safety: a ",}" or ",]" sequence INSIDE a quoted value must
+		// not be touched; only the genuine trailing comma after the value is removed.
+		{"comma-brace inside string preserved", `{"note":"foo,}","amt":1,}`, `{"note":"foo,}","amt":1}`},
+		{"comma-bracket inside string preserved", `{"note":"foo,]","amt":1,}`, `{"note":"foo,]","amt":1}`},
+		{"escaped quote inside string", `{"note":"he said \"hi,\"","amt":1,}`, `{"note":"he said \"hi,\"","amt":1}`},
+		// cleanResponse chains fence-stripping then comma-stripping; cover the
+		// interaction directly so a regression in ordering is caught here.
+		{"fenced json with trailing comma", "```json\n{\"a\":1,}\n```", "\n{\"a\":1}\n"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -295,14 +303,18 @@ func TestCleanResponse_StripsTrailingCommas(t *testing.T) {
 }
 
 // TestCleanResponse_TrailingCommaOutputIsParseable guards the actual purpose
-// of the fix: output from gpt-4o with trailing commas must unmarshal cleanly,
-// including a populated items array.
+// of the fix: AI output with trailing commas must unmarshal cleanly into the
+// real production type used at the parse site (commands.UpsertReceiptCommand),
+// including a populated items array. Using the production type rather than a
+// hand-picked struct catches drift in the actual integration contract.
 func TestCleanResponse_TrailingCommaOutputIsParseable(t *testing.T) {
 	service := ReceiptProcessingService{}
+	// Note: UpsertReceiptCommand maps items via the "receiptItems" JSON key.
 	raw := `{
   "name": "BILLA",
   "amount": 2306.86,
-  "items": [
+  "date": "2026-06-03T00:00:00Z",
+  "receiptItems": [
     { "name": "COTTAGE FIT", "amount": 197.4, },
     { "name": "Beans, baked", "amount": 51.8, },
   ],
@@ -311,19 +323,15 @@ func TestCleanResponse_TrailingCommaOutputIsParseable(t *testing.T) {
 }`
 	cleaned := service.cleanResponse(raw)
 
-	var receipt struct {
-		Name   string  `json:"name"`
-		Amount float64 `json:"amount"`
-		Items  []struct {
-			Name   string  `json:"name"`
-			Amount float64 `json:"amount"`
-		} `json:"items"`
-	}
+	var receipt commands.UpsertReceiptCommand
 	if err := json.Unmarshal([]byte(cleaned), &receipt); err != nil {
 		t.Fatalf("expected cleaned response to parse, got error: %v\ncleaned: %s", err, cleaned)
 	}
+	if receipt.Name != "BILLA" {
+		t.Errorf("expected name BILLA, got %q", receipt.Name)
+	}
 	if len(receipt.Items) != 2 {
-		t.Errorf("expected 2 items, got %d", len(receipt.Items))
+		t.Fatalf("expected 2 items, got %d", len(receipt.Items))
 	}
 	if receipt.Items[1].Name != "Beans, baked" {
 		t.Errorf("expected comma-containing item name preserved, got %q", receipt.Items[1].Name)


### PR DESCRIPTION
## Problem

When using OpenAI for receipt processing, header fields (name, amount, date) populate but the `items` array is silently dropped — no items, no error in the UI.

Inspecting the Raw Chat Completion in the System Task shows the model returns a complete, correct `items` array. The only defect is trailing commas after the last property of each object and the last element of arrays. Reproduced consistently across `gpt-4o`, `gpt-4o-mini`, and `gpt-4o-2024-08-06`, and it persists with "Enforce JSON Response Format" enabled.

## Root cause

`cleanResponse` in `api/internal/services/receipt_processing.go` only strips markdown code fences before `json.Unmarshal`. Go's `encoding/json` rejects trailing commas, so the unmarshal fails and the extracted receipt (including items) is discarded.

## Fix

Add a `stripTrailingCommas` step to `cleanResponse`: a regex (`,(\s*[}\]])`) applied repeatedly to handle nested closings. Commas inside string values are not matched because they aren't immediately followed by a closing brace/bracket. This is provider-agnostic, so it also covers the Gemini/Ollama paths.

## Notes

A stricter alternative would be to send OpenAI structured outputs (`response_format: json_schema` with `strict: true`) for capable models — happy to follow up with that if preferred, but the `cleanResponse` fix stands on its own and helps all providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sanitization of AI-generated receipt JSON to remove illegal trailing commas and preserve commas inside quoted values, making receipt parsing more reliable and reducing failures.
* **Tests**
  * Added unit tests ensuring sanitized JSON parses correctly, covering nested structures and item names that contain commas to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->