### PR TITLE
Assign legacy-equivalent roles to existing users on startup

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -214,13 +214,37 @@ It currently **coexists with** the legacy `models.UserRole` (`ADMIN`/`USER`) and
   EDITOR / OWNER tiers; Owner = every group permission). The sets live in
   `permissions/legacy.go` (`Legacy*Keys()` helpers) and were derived from the actual handler-level
   gating, not the desktop UI presets.
-- **Seeded only — not assigned and not enforced yet.** No user/member is given these roles here,
-  and group roles are seeded with `IsDefault = false`. Assignment + enforcement are later phases.
+- **Seeded only here — not enforced yet.** This step only creates the roles (group roles with
+  `IsDefault = false`); the one-time data migration below assigns them to existing users/members,
+  and enforcement is a later phase.
 - Idempotent: keyed on role `Name` (a `uniqueIndex`), safe on every boot; a pre-existing
-  same-named role is left untouched.
+  same-named role is left untouched. The five role names are shared constants
+  (`repositories/system_role_names.go`, `Legacy*RoleName`) used by both the seeder and the
+  migration.
 - **Known limitation:** because system roles are immutable and seeding skips existing names, a
   permission added to the registry later will **not** flow into an already-seeded Legacy Admin /
   Legacy Owner. Re-syncing system roles would need a dedicated reconciliation step (out of scope).
+
+### Legacy role assignment (one-time data migration)
+
+- A startup data migration back-fills the new role assignments from the legacy enums so existing
+  installs upgrade with **zero behavior change**: each `User.UserRole` maps onto the matching
+  `User.AppRoleID` (`ADMIN` → Legacy Admin, `USER` → Legacy User) and each `GroupMember.GroupRole`
+  onto `GroupMember.GroupRoleID` (`OWNER`/`EDITOR`/`VIEWER` → Legacy Owner/Editor/Viewer). Lives in
+  `repositories/data_migrations.go` (`assignLegacyEquivalentRoles`).
+- **Tracking:** one-time data migrations are recorded in a `data_migrations` ledger
+  (`models.DataMigration`, keyed by unique `name`) — distinct from GORM schema AutoMigrate. The
+  runner `RunDataMigrations` skips any migration already in the ledger and otherwise runs it **and**
+  writes the ledger row in a single `db.Transaction`, so a failure rolls back and retries next boot.
+  Append new one-time migrations to the `dataMigrations` registry slice.
+- Wired into `InitDB` **after** the bootstrap-admin step (roles must be seeded first, and this order
+  also assigns a fresh install's first admin). `InitDB` is only called from `main.go`, never the
+  test harness, so the migration does not auto-run in tests.
+- Updates are guarded with `... IS NULL`, so a role an admin has already set through the new UI is
+  never overwritten — defense-in-depth on top of the ledger. The migration is one-time over existing
+  rows; per-create assignment for *new* users/members is a separate future slice.
+- Tests: `repositories/data_migrations_test.go` (assignment, idempotency, ledger short-circuit,
+  no-clobber).
 
 ### Permission checks (`PermissionService`)
 

--- a/api/internal/models/data_migration.go
+++ b/api/internal/models/data_migration.go
@@ -1,0 +1,16 @@
+package models
+
+import "time"
+
+// DataMigration records a one-time data migration that has been applied, so it
+// is not re-run on subsequent startups. It is distinct from the GORM schema
+// AutoMigrate handled by repositories.MakeMigrations: this ledger tracks
+// one-off transformations of existing rows.
+//
+// It deliberately does not embed BaseModel — a soft-deleted row would be hidden
+// by GORM's default scope and cause the migration to re-run.
+type DataMigration struct {
+	ID        uint      `gorm:"primaryKey" json:"id"`
+	Name      string    `gorm:"uniqueIndex;not null" json:"name"`
+	AppliedAt time.Time `gorm:"not null" json:"appliedAt"`
+}

--- a/api/internal/repositories/data_migrations.go
+++ b/api/internal/repositories/data_migrations.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // Name of the one-time migration that assigns the seeded legacy-equivalent roles
@@ -26,26 +27,27 @@ var dataMigrations = []dataMigration{
 }
 
 // RunDataMigrations applies any registered one-time data migrations that have
-// not yet been recorded in the data_migrations ledger. Each migration runs in
-// its own transaction together with the ledger insert, so a failure rolls back
-// cleanly and the migration retries on the next boot.
+// not yet been recorded in the data_migrations ledger. Each migration claims its
+// ledger row and runs in the same transaction, so a failure rolls back cleanly
+// and the migration retries on the next boot.
 func RunDataMigrations() error {
 	db := GetDB()
 
 	for _, migration := range dataMigrations {
-		var count int64
-		if err := db.Model(&models.DataMigration{}).Where("name = ?", migration.name).Count(&count).Error; err != nil {
-			return err
-		}
-		if count > 0 {
-			continue
-		}
-
 		err := db.Transaction(func(tx *gorm.DB) error {
-			if err := migration.run(tx); err != nil {
-				return err
+			// Atomically claim the migration. A conflict on the unique name means
+			// it was already applied (or claimed by a concurrent boot), so skip —
+			// this keeps concurrent startups from both running the migration or
+			// failing startup on the unique constraint.
+			claim := tx.Clauses(clause.OnConflict{DoNothing: true}).
+				Create(&models.DataMigration{Name: migration.name, AppliedAt: time.Now()})
+			if claim.Error != nil {
+				return claim.Error
 			}
-			return tx.Create(&models.DataMigration{Name: migration.name, AppliedAt: time.Now()}).Error
+			if claim.RowsAffected == 0 {
+				return nil
+			}
+			return migration.run(tx)
 		})
 		if err != nil {
 			return err

--- a/api/internal/repositories/data_migrations.go
+++ b/api/internal/repositories/data_migrations.go
@@ -1,0 +1,106 @@
+package repositories
+
+import (
+	"receipt-wrangler/api/internal/models"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// Name of the one-time migration that assigns the seeded legacy-equivalent roles
+// to existing users and group members.
+const assignLegacyEquivalentRolesMigration = "assign-legacy-equivalent-roles"
+
+// dataMigration is a single one-time data migration. Each runs at most once per
+// database; once applied it is recorded in the data_migrations ledger so it is
+// skipped on subsequent boots.
+type dataMigration struct {
+	name string
+	run  func(tx *gorm.DB) error
+}
+
+// dataMigrations is the ordered registry of one-time data migrations. New
+// migrations are appended here.
+var dataMigrations = []dataMigration{
+	{name: assignLegacyEquivalentRolesMigration, run: assignLegacyEquivalentRoles},
+}
+
+// RunDataMigrations applies any registered one-time data migrations that have
+// not yet been recorded in the data_migrations ledger. Each migration runs in
+// its own transaction together with the ledger insert, so a failure rolls back
+// cleanly and the migration retries on the next boot.
+func RunDataMigrations() error {
+	db := GetDB()
+
+	for _, migration := range dataMigrations {
+		var count int64
+		if err := db.Model(&models.DataMigration{}).Where("name = ?", migration.name).Count(&count).Error; err != nil {
+			return err
+		}
+		if count > 0 {
+			continue
+		}
+
+		err := db.Transaction(func(tx *gorm.DB) error {
+			if err := migration.run(tx); err != nil {
+				return err
+			}
+			return tx.Create(&models.DataMigration{Name: migration.name, AppliedAt: time.Now()}).Error
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// assignLegacyEquivalentRoles back-fills the new role assignments from the
+// legacy UserRole / GroupRole enums so existing installs upgrade with zero
+// behavior change: every user is assigned the app role and every group member
+// the group role that reproduces its legacy capabilities.
+//
+// Updates are guarded by "... IS NULL" so an assignment an administrator has
+// already made through the new role UI is never overwritten.
+func assignLegacyEquivalentRoles(tx *gorm.DB) error {
+	appRoleByLegacy := []struct {
+		legacyRole models.UserRole
+		roleName   string
+	}{
+		{models.ADMIN, LegacyAdminRoleName},
+		{models.USER, LegacyUserRoleName},
+	}
+	for _, mapping := range appRoleByLegacy {
+		var role models.AppRole
+		if err := tx.Where("name = ?", mapping.roleName).First(&role).Error; err != nil {
+			return err
+		}
+		if err := tx.Model(&models.User{}).
+			Where("user_role = ? AND app_role_id IS NULL", mapping.legacyRole).
+			Update("app_role_id", role.ID).Error; err != nil {
+			return err
+		}
+	}
+
+	groupRoleByLegacy := []struct {
+		legacyRole models.GroupRole
+		roleName   string
+	}{
+		{models.OWNER, LegacyOwnerRoleName},
+		{models.EDITOR, LegacyEditorRoleName},
+		{models.VIEWER, LegacyViewerRoleName},
+	}
+	for _, mapping := range groupRoleByLegacy {
+		var role models.GroupRoleDefinition
+		if err := tx.Where("name = ?", mapping.roleName).First(&role).Error; err != nil {
+			return err
+		}
+		if err := tx.Model(&models.GroupMember{}).
+			Where("group_role = ? AND group_role_id IS NULL", mapping.legacyRole).
+			Update("group_role_id", role.ID).Error; err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/api/internal/repositories/data_migrations_test.go
+++ b/api/internal/repositories/data_migrations_test.go
@@ -183,14 +183,31 @@ func TestRunDataMigrationsDoesNotClobberExistingAssignment(t *testing.T) {
 	}
 	db := GetDB()
 
-	customRole, err := NewRoleRepository(nil).CreateAppRole("Custom Role", "", []string{permissions.AppUsersRead})
+	roleRepository := NewRoleRepository(nil)
+	customAppRole, err := roleRepository.CreateAppRole("Custom Role", "", []string{permissions.AppUsersRead})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	customGroupRole, err := roleRepository.CreateGroupRole("Custom Group Role", "", []string{permissions.GroupReceiptsRead})
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
 	}
 
-	admin := models.User{Username: "admin", Password: "password", UserRole: models.ADMIN, AppRoleID: &customRole.ID}
+	admin := models.User{Username: "admin", Password: "password", UserRole: models.ADMIN, AppRoleID: &customAppRole.ID}
 	if err := db.Create(&admin).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	group := models.Group{Name: "no-clobber-group"}
+	if err := db.Create(&group).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	member := models.GroupMember{GroupID: group.ID, UserID: admin.ID, GroupRole: models.OWNER, GroupRoleID: &customGroupRole.ID}
+	if err := db.Create(&member).Error; err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
 	}
@@ -200,6 +217,41 @@ func TestRunDataMigrationsDoesNotClobberExistingAssignment(t *testing.T) {
 		return
 	}
 
-	// The IS NULL guard leaves the administrator's existing assignment intact.
-	assertAppRoleId(t, reloadUser(t, admin.ID), customRole.ID)
+	// The IS NULL guard leaves an administrator's existing assignments intact,
+	// for both the app role and the group role.
+	assertAppRoleId(t, reloadUser(t, admin.ID), customAppRole.ID)
+	assertGroupRoleId(t, reloadMember(t, admin.ID, group.ID), customGroupRole.ID)
+}
+
+func TestRunDataMigrationsRollsBackOnFailure(t *testing.T) {
+	defer TruncateTestDb()
+	db := GetDB()
+
+	// Intentionally skip SeedSystemRoles so the migration's first role lookup
+	// fails with ErrRecordNotFound, exercising the error path.
+	admin := models.User{Username: "admin", Password: "password", UserRole: models.ADMIN}
+	if err := db.Create(&admin).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if err := RunDataMigrations(); err == nil {
+		utils.PrintTestError(t, nil, "an error because the legacy roles are not seeded")
+	}
+
+	// The transaction rolls back: no ledger row is written, so the migration
+	// retries on the next boot.
+	var ledgerCount int64
+	if err := db.Model(&models.DataMigration{}).Where("name = ?", assignLegacyEquivalentRolesMigration).Count(&ledgerCount).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if ledgerCount != 0 {
+		utils.PrintTestError(t, ledgerCount, 0)
+	}
+
+	// And no partial assignment persisted.
+	if reloadUser(t, admin.ID).AppRoleID != nil {
+		utils.PrintTestError(t, reloadUser(t, admin.ID).AppRoleID, nil)
+	}
 }

--- a/api/internal/repositories/data_migrations_test.go
+++ b/api/internal/repositories/data_migrations_test.go
@@ -1,0 +1,205 @@
+package repositories
+
+import (
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/permissions"
+	"receipt-wrangler/api/internal/utils"
+	"testing"
+	"time"
+)
+
+func appRoleIdByName(t *testing.T, name string) uint {
+	var role models.AppRole
+	if err := GetDB().Where("name = ?", name).First(&role).Error; err != nil {
+		utils.PrintTestError(t, err, "an app role named "+name)
+	}
+	return role.ID
+}
+
+func groupRoleIdByName(t *testing.T, name string) uint {
+	var role models.GroupRoleDefinition
+	if err := GetDB().Where("name = ?", name).First(&role).Error; err != nil {
+		utils.PrintTestError(t, err, "a group role named "+name)
+	}
+	return role.ID
+}
+
+func reloadUser(t *testing.T, id uint) models.User {
+	var user models.User
+	if err := GetDB().First(&user, id).Error; err != nil {
+		utils.PrintTestError(t, err, "a user to reload")
+	}
+	return user
+}
+
+func reloadMember(t *testing.T, userId uint, groupId uint) models.GroupMember {
+	var member models.GroupMember
+	if err := GetDB().Where("user_id = ? AND group_id = ?", userId, groupId).First(&member).Error; err != nil {
+		utils.PrintTestError(t, err, "a group member")
+	}
+	return member
+}
+
+func assertAppRoleId(t *testing.T, user models.User, expected uint) {
+	if user.AppRoleID == nil || *user.AppRoleID != expected {
+		utils.PrintTestError(t, user.AppRoleID, expected)
+	}
+}
+
+func assertGroupRoleId(t *testing.T, member models.GroupMember, expected uint) {
+	if member.GroupRoleID == nil || *member.GroupRoleID != expected {
+		utils.PrintTestError(t, member.GroupRoleID, expected)
+	}
+}
+
+func TestRunDataMigrationsAssignsLegacyEquivalentRoles(t *testing.T) {
+	defer TruncateTestDb()
+	if err := SeedSystemRoles(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	db := GetDB()
+
+	admin := models.User{Username: "admin", Password: "password", UserRole: models.ADMIN}
+	standard := models.User{Username: "standard", Password: "password", UserRole: models.USER}
+	viewerUser := models.User{Username: "viewer", Password: "password", UserRole: models.USER}
+	for _, user := range []*models.User{&admin, &standard, &viewerUser} {
+		if err := db.Create(user).Error; err != nil {
+			utils.PrintTestError(t, err, nil)
+			return
+		}
+	}
+
+	group := models.Group{Name: "migration-group"}
+	if err := db.Create(&group).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	ownerMember := models.GroupMember{GroupID: group.ID, UserID: admin.ID, GroupRole: models.OWNER}
+	editorMember := models.GroupMember{GroupID: group.ID, UserID: standard.ID, GroupRole: models.EDITOR}
+	viewerMember := models.GroupMember{GroupID: group.ID, UserID: viewerUser.ID, GroupRole: models.VIEWER}
+	for _, member := range []*models.GroupMember{&ownerMember, &editorMember, &viewerMember} {
+		if err := db.Create(member).Error; err != nil {
+			utils.PrintTestError(t, err, nil)
+			return
+		}
+	}
+
+	if err := RunDataMigrations(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	assertAppRoleId(t, reloadUser(t, admin.ID), appRoleIdByName(t, LegacyAdminRoleName))
+	assertAppRoleId(t, reloadUser(t, standard.ID), appRoleIdByName(t, LegacyUserRoleName))
+	assertAppRoleId(t, reloadUser(t, viewerUser.ID), appRoleIdByName(t, LegacyUserRoleName))
+
+	assertGroupRoleId(t, reloadMember(t, admin.ID, group.ID), groupRoleIdByName(t, LegacyOwnerRoleName))
+	assertGroupRoleId(t, reloadMember(t, standard.ID, group.ID), groupRoleIdByName(t, LegacyEditorRoleName))
+	assertGroupRoleId(t, reloadMember(t, viewerUser.ID, group.ID), groupRoleIdByName(t, LegacyViewerRoleName))
+
+	var ledgerCount int64
+	if err := db.Model(&models.DataMigration{}).Where("name = ?", assignLegacyEquivalentRolesMigration).Count(&ledgerCount).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if ledgerCount != 1 {
+		utils.PrintTestError(t, ledgerCount, 1)
+	}
+}
+
+func TestRunDataMigrationsIsIdempotent(t *testing.T) {
+	defer TruncateTestDb()
+	if err := SeedSystemRoles(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	db := GetDB()
+
+	admin := models.User{Username: "admin", Password: "password", UserRole: models.ADMIN}
+	if err := db.Create(&admin).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if err := RunDataMigrations(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if err := RunDataMigrations(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	assertAppRoleId(t, reloadUser(t, admin.ID), appRoleIdByName(t, LegacyAdminRoleName))
+
+	var ledgerCount int64
+	if err := db.Model(&models.DataMigration{}).Where("name = ?", assignLegacyEquivalentRolesMigration).Count(&ledgerCount).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if ledgerCount != 1 {
+		utils.PrintTestError(t, ledgerCount, 1)
+	}
+}
+
+func TestRunDataMigrationsSkipsWhenAlreadyApplied(t *testing.T) {
+	defer TruncateTestDb()
+	if err := SeedSystemRoles(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	db := GetDB()
+
+	// Record the migration as already applied before any rows exist to assign.
+	if err := db.Create(&models.DataMigration{Name: assignLegacyEquivalentRolesMigration, AppliedAt: time.Now()}).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	admin := models.User{Username: "admin", Password: "password", UserRole: models.ADMIN}
+	if err := db.Create(&admin).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if err := RunDataMigrations(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	// The ledger short-circuits the run, so the user is left unassigned.
+	if reloadUser(t, admin.ID).AppRoleID != nil {
+		utils.PrintTestError(t, reloadUser(t, admin.ID).AppRoleID, nil)
+	}
+}
+
+func TestRunDataMigrationsDoesNotClobberExistingAssignment(t *testing.T) {
+	defer TruncateTestDb()
+	if err := SeedSystemRoles(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	db := GetDB()
+
+	customRole, err := NewRoleRepository(nil).CreateAppRole("Custom Role", "", []string{permissions.AppUsersRead})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	admin := models.User{Username: "admin", Password: "password", UserRole: models.ADMIN, AppRoleID: &customRole.ID}
+	if err := db.Create(&admin).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if err := RunDataMigrations(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	// The IS NULL guard leaves the administrator's existing assignment intact.
+	assertAppRoleId(t, reloadUser(t, admin.ID), customRole.ID)
+}

--- a/api/internal/repositories/db.go
+++ b/api/internal/repositories/db.go
@@ -120,6 +120,7 @@ func MakeMigrations() error {
 		&models.GroupReceiptSettings{},
 		&models.Pepper{},
 		&models.ApiKey{},
+		&models.DataMigration{},
 	)
 
 	return err
@@ -152,6 +153,12 @@ func InitDB() error {
 		if err != nil {
 			return err
 		}
+	}
+
+	// Runs after the bootstrap admin is created so a fresh install's first user
+	// is assigned its legacy-equivalent role by the same one-time migration.
+	if err := RunDataMigrations(); err != nil {
+		return err
 	}
 
 	return nil

--- a/api/internal/repositories/seed_roles.go
+++ b/api/internal/repositories/seed_roles.go
@@ -23,8 +23,8 @@ func SeedSystemRoles() error {
 		description string
 		permissions []string
 	}{
-		{"Legacy Admin", "Legacy administrator equivalent: full application access.", permissions.LegacyAppAdminKeys()},
-		{"Legacy User", "Legacy standard user equivalent.", permissions.LegacyAppUserKeys()},
+		{LegacyAdminRoleName, "Legacy administrator equivalent: full application access.", permissions.LegacyAppAdminKeys()},
+		{LegacyUserRoleName, "Legacy standard user equivalent.", permissions.LegacyAppUserKeys()},
 	}
 	for _, role := range appRoles {
 		if err := seedAppRole(db, role.name, role.description, role.permissions); err != nil {
@@ -37,9 +37,9 @@ func SeedSystemRoles() error {
 		description string
 		permissions []string
 	}{
-		{"Legacy Viewer", "Legacy group viewer equivalent.", permissions.LegacyGroupViewerKeys()},
-		{"Legacy Editor", "Legacy group editor equivalent.", permissions.LegacyGroupEditorKeys()},
-		{"Legacy Owner", "Legacy group owner equivalent: full group access.", permissions.LegacyGroupOwnerKeys()},
+		{LegacyViewerRoleName, "Legacy group viewer equivalent.", permissions.LegacyGroupViewerKeys()},
+		{LegacyEditorRoleName, "Legacy group editor equivalent.", permissions.LegacyGroupEditorKeys()},
+		{LegacyOwnerRoleName, "Legacy group owner equivalent: full group access.", permissions.LegacyGroupOwnerKeys()},
 	}
 	for _, role := range groupRoles {
 		if err := seedGroupRole(db, role.name, role.description, role.permissions); err != nil {

--- a/api/internal/repositories/system_role_names.go
+++ b/api/internal/repositories/system_role_names.go
@@ -1,0 +1,13 @@
+package repositories
+
+// Names of the five immutable, legacy-equivalent system roles seeded by
+// SeedSystemRoles. They are the shared source of truth keyed on by both the
+// seeder (which is idempotent on the role Name) and the data migration that
+// assigns these roles to existing users / group members.
+const (
+	LegacyAdminRoleName  = "Legacy Admin"
+	LegacyUserRoleName   = "Legacy User"
+	LegacyViewerRoleName = "Legacy Viewer"
+	LegacyEditorRoleName = "Legacy Editor"
+	LegacyOwnerRoleName  = "Legacy Owner"
+)


### PR DESCRIPTION
## Summary

Adds the one-time startup data migration that converts the legacy role enums into the new
configurable-role assignments, so existing installs upgrade with **zero behavior change**.

For every existing row it back-fills the new nullable FK from the legacy enum, mapping onto the
seeded legacy-equivalent system roles:

| Legacy value | New assignment |
|---|---|
| `User.UserRole = ADMIN` | `User.AppRoleID` → **Legacy Admin** |
| `User.UserRole = USER` | `User.AppRoleID` → **Legacy User** |
| `GroupMember.GroupRole = OWNER` | `GroupMember.GroupRoleID` → **Legacy Owner** |
| `GroupMember.GroupRole = EDITOR` | `GroupMember.GroupRoleID` → **Legacy Editor** |
| `GroupMember.GroupRole = VIEWER` | `GroupMember.GroupRoleID` → **Legacy Viewer** |

## Tracking whether a migration has run

One-time data migrations are recorded in a new `data_migrations` ledger (`models.DataMigration`,
keyed on a unique `name`) — distinct from GORM schema AutoMigrate. `RunDataMigrations` skips any
migration already in the ledger; otherwise it runs the migration **and** writes the ledger row in a
single transaction, so a failure rolls back cleanly and retries on the next boot. Future one-time
migrations just append to the registry slice.

## Details

- Wired into `InitDB` **after** the bootstrap-admin step (roles must be seeded first; this order also
  assigns a fresh install's first admin). `InitDB` is only called from `main.go`, never the test
  harness, so the migration does not auto-run during tests.
- Assignment updates are guarded with `... IS NULL`, so an assignment an administrator has already
  made through the role UI is never overwritten — defense-in-depth on top of the ledger.
- The five system-role names are shared constants (`repositories/system_role_names.go`) used by both
  the seeder and the migration.
- The migration is one-time over existing rows; per-create assignment for new users/members and
  permission enforcement remain separate follow-up slices.
- Schema change is purely additive (a new standalone `data_migrations` table), so no dev-DB recreate
  is required.

## Verification

- `go build ./...` clean; full `go test ./...` passes (no regressions).
- New unit tests (`repositories/data_migrations_test.go`): assignment correctness, idempotency,
  ledger short-circuit, and no-clobber of an existing assignment.
- End-to-end against a throwaway copy of a populated dev DB: first boot created the ledger row and
  assigned all users/members to the correct legacy-equivalent roles; a second boot left exactly one
  ledger row and made no further changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * One-time, ledger-backed migration maps legacy user/group role assignments into the new role system automatically during upgrade, running at most once.
* **Bug Fixes**
  * Migration is idempotent and will not overwrite existing custom role assignments or produce partial updates on failure.
* **Documentation**
  * Expanded Roles & Permissions notes clarifying seeded legacy-equivalent roles and migration behaviors.
* **Tests**
  * Added coverage ensuring correct assignment, idempotency, non-clobbering, and rollback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->