### PR TITLE
Rasterize PDFs at configurable DPI (default 300) instead of 72

### DIFF
--- a/api/internal/commands/upsert_system_settings_command.go
+++ b/api/internal/commands/upsert_system_settings_command.go
@@ -21,6 +21,7 @@ type UpsertSystemSettingsCommand struct {
 	ReceiptProcessingSettingsId         *uint                                 `json:"receiptProcessingSettingsId"`
 	FallbackReceiptProcessingSettingsId *uint                                 `json:"fallbackReceiptProcessingSettingsId"`
 	TaskConcurrency                     int                                   `json:"taskConcurrency"`
+	PdfDpi                              int                                   `json:"pdfDpi"`
 	TaskQueueConfigurations             []UpsertTaskQueueConfigurationCommand `json:"taskQueueConfigurations"`
 }
 
@@ -76,6 +77,10 @@ func (command *UpsertSystemSettingsCommand) Validate() structs.ValidatorError {
 
 	if len(command.CurrencyDecimalSeparator) == 0 {
 		errorMap["currencyDecimalSeparator"] = "Currency decimal separator is required"
+	}
+
+	if command.PdfDpi != 0 && (command.PdfDpi < 72 || command.PdfDpi > 1200) {
+		errorMap["pdfDpi"] = "PDF DPI must be between 72 and 1200"
 	}
 
 	if command.TaskConcurrency < 0 {

--- a/api/internal/commands/upsert_system_settings_command_test.go
+++ b/api/internal/commands/upsert_system_settings_command_test.go
@@ -156,3 +156,27 @@ func TestUpsertSystemSettingsCommand_Validate_MultipleErrors(t *testing.T) {
 		utils.PrintTestError(t, len(vErr.Errors), "at least 5")
 	}
 }
+
+func TestUpsertSystemSettingsCommand_Validate_PdfDpi(t *testing.T) {
+	// 0 means "unset / use default" and must be allowed; in-range values pass;
+	// out-of-range values are rejected with a pdfDpi error.
+	validValues := []int{0, 72, 300, 1200}
+	for _, v := range validValues {
+		cmd := validSystemSettingsCommand()
+		cmd.PdfDpi = v
+		vErr := cmd.Validate()
+		if _, ok := vErr.Errors["pdfDpi"]; ok {
+			utils.PrintTestError(t, "pdfDpi error for valid value "+utils.UintToString(uint(v)), "no error")
+		}
+	}
+
+	invalidValues := []int{71, 1201, 5000}
+	for _, v := range invalidValues {
+		cmd := validSystemSettingsCommand()
+		cmd.PdfDpi = v
+		vErr := cmd.Validate()
+		if _, ok := vErr.Errors["pdfDpi"]; !ok {
+			utils.PrintTestError(t, "no pdfDpi error for invalid value "+utils.UintToString(uint(v)), "pdfDpi error")
+		}
+	}
+}

--- a/api/internal/models/system_settings.go
+++ b/api/internal/models/system_settings.go
@@ -16,5 +16,6 @@ type SystemSettings struct {
 	FallbackReceiptProcessingSettings   ReceiptProcessingSettings `json:"-"`
 	FallbackReceiptProcessingSettingsId *uint                     `json:"fallbackReceiptProcessingSettingsId"`
 	TaskConcurrency                     int                       `json:"taskConcurrency" gorm:"default:10"`
+	PdfDpi                              int                       `json:"pdfDpi" gorm:"default:300"`
 	TaskQueueConfigurations             []TaskQueueConfiguration  `json:"taskQueueConfigurations"`
 }

--- a/api/internal/repositories/files.go
+++ b/api/internal/repositories/files.go
@@ -13,6 +13,7 @@ import (
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/utils"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/gabriel-vasile/mimetype"
@@ -198,9 +199,37 @@ func (repository FileRepository) ConvertHeicToJpg(bytes []byte) ([]byte, error) 
 	return mw.GetImageBlob()
 }
 
+// pdfRasterizationDpi returns the DPI used to rasterize PDFs into images,
+// read from the PDF_DPI environment variable. It falls back to 300 when the
+// variable is unset, unparseable, or non-positive. 300 DPI is a common
+// document-scanning resolution that preserves small receipt text for OCR and
+// vision models while keeping output sizes reasonable.
+func pdfRasterizationDpi() float64 {
+	const defaultDpi = 300.0
+	raw := os.Getenv("PDF_DPI")
+	if raw == "" {
+		return defaultDpi
+	}
+	parsed, err := strconv.ParseFloat(raw, 64)
+	if err != nil || parsed <= 0 {
+		return defaultDpi
+	}
+	return parsed
+}
+
 func (repository FileRepository) ConvertPdfToJpg(bytes []byte) ([]byte, error) {
 	mw := imagick.NewMagickWand()
 	defer mw.Destroy()
+
+	// PDFs are vector documents with no inherent pixel resolution. ImageMagick
+	// rasterizes them at a default of 72 DPI unless a resolution is set BEFORE
+	// the blob is read, which produces low-resolution images that degrade OCR
+	// and vision-model accuracy. Set the rasterization density first; it is
+	// configurable via the PDF_DPI env var (default 300).
+	dpi := pdfRasterizationDpi()
+	if err := mw.SetResolution(dpi, dpi); err != nil {
+		return nil, err
+	}
 
 	if err := mw.ReadImageBlob(bytes); err != nil {
 		return nil, err

--- a/api/internal/repositories/files.go
+++ b/api/internal/repositories/files.go
@@ -13,7 +13,6 @@ import (
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/utils"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/gabriel-vasile/mimetype"
@@ -199,22 +198,29 @@ func (repository FileRepository) ConvertHeicToJpg(bytes []byte) ([]byte, error) 
 	return mw.GetImageBlob()
 }
 
-// pdfRasterizationDpi returns the DPI used to rasterize PDFs into images,
-// read from the PDF_DPI environment variable. It falls back to 300 when the
-// variable is unset, unparseable, or non-positive. 300 DPI is a common
+// pdfRasterizationDpi returns the DPI used to rasterize PDFs into images. It is
+// configured via the PdfDpi system setting; when unset (0) or out of the
+// supported range it falls back to defaultPdfDpi. 300 DPI is a common
 // document-scanning resolution that preserves small receipt text for OCR and
-// vision models while keeping output sizes reasonable.
-func pdfRasterizationDpi() float64 {
-	const defaultDpi = 300.0
-	raw := os.Getenv("PDF_DPI")
-	if raw == "" {
-		return defaultDpi
+// vision models while keeping output sizes and memory use reasonable.
+const (
+	defaultPdfDpi = 300.0
+	minPdfDpi     = 72.0
+	maxPdfDpi     = 1200.0
+)
+
+func (repository FileRepository) pdfRasterizationDpi() float64 {
+	systemSettingsRepository := NewSystemSettingsRepository(repository.DB)
+	systemSettings, err := systemSettingsRepository.GetSystemSettings()
+	if err != nil {
+		return defaultPdfDpi
 	}
-	parsed, err := strconv.ParseFloat(raw, 64)
-	if err != nil || parsed <= 0 {
-		return defaultDpi
+
+	dpi := float64(systemSettings.PdfDpi)
+	if dpi < minPdfDpi || dpi > maxPdfDpi {
+		return defaultPdfDpi
 	}
-	return parsed
+	return dpi
 }
 
 func (repository FileRepository) ConvertPdfToJpg(bytes []byte) ([]byte, error) {
@@ -225,8 +231,8 @@ func (repository FileRepository) ConvertPdfToJpg(bytes []byte) ([]byte, error) {
 	// rasterizes them at a default of 72 DPI unless a resolution is set BEFORE
 	// the blob is read, which produces low-resolution images that degrade OCR
 	// and vision-model accuracy. Set the rasterization density first; it is
-	// configurable via the PDF_DPI env var (default 300).
-	dpi := pdfRasterizationDpi()
+	// configurable via the PdfDpi system setting (default 300).
+	dpi := repository.pdfRasterizationDpi()
 	if err := mw.SetResolution(dpi, dpi); err != nil {
 		return nil, err
 	}
@@ -326,6 +332,10 @@ func (repository FileRepository) WriteTempFile(data []byte) (string, error) {
 
 func (repository FileRepository) BuildTempFilePath(fileType string) (string, error) {
 	tempPath := repository.GetTempDirectoryPath()
+	// Ensure the temp directory exists before returning a path under it.
+	// ConvertPdfToJpg writes here directly, and on a fresh checkout/runtime the
+	// directory may not exist yet, which would fail the subsequent write.
+	utils.MakeDirectory(tempPath)
 
 	filename, err := utils.GetRandomString(10)
 	if err != nil {

--- a/api/internal/repositories/files_test.go
+++ b/api/internal/repositories/files_test.go
@@ -3,6 +3,8 @@ package repositories
 import (
 	"archive/zip"
 	"bytes"
+	"image"
+	_ "image/jpeg"
 	"io"
 	"os"
 	"path/filepath"
@@ -537,52 +539,68 @@ func TestConvertPdfToJpg_InvalidBytes(t *testing.T) {
 	}
 }
 
-func TestPdfRasterizationDpi_DefaultsTo300(t *testing.T) {
-	t.Setenv("PDF_DPI", "")
-	if got := pdfRasterizationDpi(); got != 300 {
+func TestPdfRasterizationDpi_DefaultsWhenUnset(t *testing.T) {
+	defer TruncateTestDb()
+	setPdfDpiSetting(t, 0)
+	repository := NewFileRepository(nil)
+	if got := repository.pdfRasterizationDpi(); got != 300 {
 		utils.PrintTestError(t, got, 300)
 	}
 }
 
-func TestPdfRasterizationDpi_HonorsEnv(t *testing.T) {
-	t.Setenv("PDF_DPI", "150")
-	if got := pdfRasterizationDpi(); got != 150 {
+func TestPdfRasterizationDpi_HonorsSetting(t *testing.T) {
+	defer TruncateTestDb()
+	setPdfDpiSetting(t, 150)
+	repository := NewFileRepository(nil)
+	if got := repository.pdfRasterizationDpi(); got != 150 {
 		utils.PrintTestError(t, got, 150)
 	}
 }
 
-func TestPdfRasterizationDpi_FallsBackOnInvalid(t *testing.T) {
-	for _, bad := range []string{"abc", "0", "-100"} {
-		t.Setenv("PDF_DPI", bad)
-		if got := pdfRasterizationDpi(); got != 300 {
+func TestPdfRasterizationDpi_FallsBackOnOutOfRange(t *testing.T) {
+	defer TruncateTestDb()
+	repository := NewFileRepository(nil)
+	for _, bad := range []int{10, 5000, -100} {
+		setPdfDpiSetting(t, bad)
+		if got := repository.pdfRasterizationDpi(); got != 300 {
 			utils.PrintTestError(t, got, 300)
 		}
 	}
 }
 
-// Higher DPI must rasterize the same PDF into a physically larger image than
-// the previous hard-coded 72-DPI default, proving the resolution is applied
-// before ReadImageBlob. We compare encoded JPEG byte length as a proxy for
-// pixel dimensions; a 300-DPI raster of the same page is reliably larger.
+func decodeDimensions(t *testing.T, jpg []byte) (int, int) {
+	cfg, _, err := image.DecodeConfig(bytes.NewReader(jpg))
+	if err != nil {
+		utils.PrintTestError(t, err, "decodable JPEG")
+	}
+	return cfg.Width, cfg.Height
+}
+
 func TestConvertPdfToJpg_HigherDpiProducesLargerImage(t *testing.T) {
+	defer TruncateTestDb()
 	t.Setenv("BASE_PATH", testBasePath())
 	repository := NewFileRepository(nil)
 	pdf := makePdfFromJpg(t, readTestJpgBytes(t))
 
-	t.Setenv("PDF_DPI", "72")
+	setPdfDpiSetting(t, 72)
 	low, err := repository.ConvertPdfToJpg(pdf)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 	}
 
-	t.Setenv("PDF_DPI", "300")
+	setPdfDpiSetting(t, 300)
 	high, err := repository.ConvertPdfToJpg(pdf)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 	}
 
-	if !(len(high) > len(low)) {
-		utils.PrintTestError(t, len(high), "greater than "+utils.UintToString(uint(len(low))))
+	// Compare actual pixel dimensions, not encoded byte length: byte length is
+	// not a reliable proxy (JPEG compression varies across versions/settings).
+	lowW, lowH := decodeDimensions(t, low)
+	highW, highH := decodeDimensions(t, high)
+	if !(highW > lowW && highH > lowH) {
+		utils.PrintTestError(t, []int{highW, highH},
+			"dimensions greater than ("+utils.UintToString(uint(lowW))+"x"+utils.UintToString(uint(lowH))+")")
 	}
 }
 
@@ -850,5 +868,16 @@ func TestShouldValidateZipFilesInput(t *testing.T) {
 				utils.PrintTestError(t, "empty data", "non-empty zip data")
 			}
 		}
+	}
+}
+
+// setPdfDpiSetting seeds the singleton SystemSettings row with the given PdfDpi
+// so pdfRasterizationDpi() reads it during tests.
+func setPdfDpiSetting(t *testing.T, dpi int) {
+	db := GetDB()
+	db.Exec("DELETE FROM system_settings")
+	settings := models.SystemSettings{PdfDpi: dpi}
+	if err := db.Create(&settings).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
 	}
 }

--- a/api/internal/repositories/files_test.go
+++ b/api/internal/repositories/files_test.go
@@ -537,6 +537,55 @@ func TestConvertPdfToJpg_InvalidBytes(t *testing.T) {
 	}
 }
 
+func TestPdfRasterizationDpi_DefaultsTo300(t *testing.T) {
+	t.Setenv("PDF_DPI", "")
+	if got := pdfRasterizationDpi(); got != 300 {
+		utils.PrintTestError(t, got, 300)
+	}
+}
+
+func TestPdfRasterizationDpi_HonorsEnv(t *testing.T) {
+	t.Setenv("PDF_DPI", "150")
+	if got := pdfRasterizationDpi(); got != 150 {
+		utils.PrintTestError(t, got, 150)
+	}
+}
+
+func TestPdfRasterizationDpi_FallsBackOnInvalid(t *testing.T) {
+	for _, bad := range []string{"abc", "0", "-100"} {
+		t.Setenv("PDF_DPI", bad)
+		if got := pdfRasterizationDpi(); got != 300 {
+			utils.PrintTestError(t, got, 300)
+		}
+	}
+}
+
+// Higher DPI must rasterize the same PDF into a physically larger image than
+// the previous hard-coded 72-DPI default, proving the resolution is applied
+// before ReadImageBlob. We compare encoded JPEG byte length as a proxy for
+// pixel dimensions; a 300-DPI raster of the same page is reliably larger.
+func TestConvertPdfToJpg_HigherDpiProducesLargerImage(t *testing.T) {
+	t.Setenv("BASE_PATH", testBasePath())
+	repository := NewFileRepository(nil)
+	pdf := makePdfFromJpg(t, readTestJpgBytes(t))
+
+	t.Setenv("PDF_DPI", "72")
+	low, err := repository.ConvertPdfToJpg(pdf)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	t.Setenv("PDF_DPI", "300")
+	high, err := repository.ConvertPdfToJpg(pdf)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	if !(len(high) > len(low)) {
+		utils.PrintTestError(t, len(high), "greater than "+utils.UintToString(uint(len(low))))
+	}
+}
+
 func TestConvertHeicToJpg_InvalidBytes(t *testing.T) {
 	repository := NewFileRepository(nil)
 	_, err := repository.ConvertHeicToJpg([]byte("not heic"))

--- a/desktop/src/open-api/model/systemSettings.ts
+++ b/desktop/src/open-api/model/systemSettings.ts
@@ -60,6 +60,7 @@ export interface SystemSettings {
      * Concurrency for task worker
      */
     taskConcurrency?: number;
+    pdfDpi?: number;
     taskQueueConfigurations: Array<TaskQueueConfiguration>;
 }
 export namespace SystemSettings {

--- a/desktop/src/open-api/model/systemSettingsAllOf.ts
+++ b/desktop/src/open-api/model/systemSettingsAllOf.ts
@@ -32,6 +32,7 @@ export interface SystemSettingsAllOf {
      * Email polling interval
      */
     emailPollingInterval?: number;
+    pdfDpi?: number;
     /**
      * Receipt processing settings foreign key
      */

--- a/desktop/src/open-api/model/upsertSystemSettingsCommand.ts
+++ b/desktop/src/open-api/model/upsertSystemSettingsCommand.ts
@@ -49,6 +49,7 @@ export interface UpsertSystemSettingsCommand {
      * Concurrency for task worker
      */
     taskConcurrency: number;
+    pdfDpi?: number;
     taskQueueConfigurations?: Array<UpsertTaskQueueConfiguration>;
 }
 export namespace UpsertSystemSettingsCommand {

--- a/desktop/src/system-settings/system-settings-form/system-settings-form.component.html
+++ b/desktop/src/system-settings/system-settings-form/system-settings-form.component.html
@@ -57,6 +57,13 @@
       [displayWith]="displayWith.bind(this)"
       [readonly]="(formConfig.mode |  inputReadonly) || !(form | formGet:'receiptProcessingSettingsId').value"
     ></app-autocomlete>
+    <app-input
+      label="PDF rasterization DPI"
+      type="number"
+      hint="Resolution used when converting PDF receipts to images for OCR/AI. Higher values improve quality but increase processing time and memory. Default 300; allowed range 72-1200."
+      [inputFormControl]="form | formGet:'pdfDpi'"
+      [readonly]="formConfig.mode |  inputReadonly"
+    ></app-input>
   </app-form-section>
   <app-form-section
     headerText="Task Server Settings"

--- a/desktop/src/system-settings/system-settings-form/system-settings-form.component.ts
+++ b/desktop/src/system-settings/system-settings-form/system-settings-form.component.ts
@@ -136,6 +136,7 @@ export class SystemSettingsFormComponent extends BaseFormComponent implements On
       currencyHideDecimalPlaces: [this.originalSystemSettings.currencyHideDecimalPlaces],
       receiptProcessingSettingsId: [this.originalSystemSettings?.receiptProcessingSettingsId],
       fallbackReceiptProcessingSettingsId: [this.originalSystemSettings?.fallbackReceiptProcessingSettingsId],
+      pdfDpi: [this.originalSystemSettings?.pdfDpi, [Validators.min(72), Validators.max(1200)]],
       taskConcurrency: [this.originalSystemSettings?.taskConcurrency, [Validators.min(0), Validators.required]],
       taskQueueConfigurations: this.formBuilder.array(this.buildAsynqQueueConfigurations())
     });
@@ -218,6 +219,7 @@ export class SystemSettingsFormComponent extends BaseFormComponent implements On
     const formValue = this.form.getRawValue();
     formValue["emailPollingInterval"] = Number.parseInt(formValue["emailPollingInterval"]);
     formValue["taskConcurrency"] = Number.parseInt(formValue["taskConcurrency"]);
+    formValue["pdfDpi"] = Number.parseInt(formValue["pdfDpi"]);
     (formValue["taskQueueConfigurations"] as Array<any>).forEach(config => {
       config.priority = Number.parseInt(config.priority);
     });


### PR DESCRIPTION
## Problem
`ConvertPdfToJpg` calls `ReadImageBlob` without setting a resolution, so ImageMagick rasterizes PDF pages at its **72 DPI default**. The resulting low-resolution images degrade OCR and vision-model accuracy on PDF receipts (related to #529 and #409).

## Change
In `internal/repositories/files.go`, set the rasterization density via `SetResolution(dpi, dpi)` **before** `ReadImageBlob`.

Per review feedback, the DPI is configured as a **system setting** (not an env var):
- `PdfDpi` field added to `SystemSettings` (default 300) and the upsert command, validated to the range 72–1200.
- A **"PDF rasterization DPI"** number input in the system settings form, directly beneath the *Fallback Receipt Processing Settings* field.
- `pdfRasterizationDpi()` reads the setting via `SystemSettingsRepository`, falling back to 300 when unset or out of range (which also bounds the value to avoid pathologically large rasterizations).

## Also included
- The higher-DPI test now does a **deterministic pixel-dimension comparison** (decodes both JPEGs and compares width/height) instead of the previous byte-length proxy, and seeds the DPI via the system setting.
- `BuildTempFilePath` now ensures the temp directory exists before returning a path under it — `ConvertPdfToJpg` writes there directly and on a fresh checkout/runtime the directory may not exist yet.

The HEIC path is unaffected. Full Go test suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable PDF rasterization DPI exposed in system settings with a 300 DPI default; UI includes a numeric field to adjust it.

* **Bug Fixes**
  * PDF-to-image conversion now respects the configured DPI and ensures temporary storage is prepared before use.
  * Validation enforces DPI within the supported 72–1200 range.

* **Tests**
  * Added tests covering DPI defaults, range fallbacks, and that higher DPI yields larger output images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->