### PR TITLE
Populate custom fields from AI extraction via @customFields prompt variable

### DIFF
--- a/api/internal/commands/upsert_prompt_command.go
+++ b/api/internal/commands/upsert_prompt_command.go
@@ -42,7 +42,7 @@ func (command *UpsertPromptCommand) Validate() structs.ValidatorError {
 		templateVariables := regex.FindAllString(command.Prompt, -1)
 		for i := 0; i < len(templateVariables); i++ {
 			variable := templateVariables[i]
-			if variable != string(structs.CATEGORIES) && variable != string(structs.TAGS) && variable != string(structs.OCR_TEXT) && variable != string(structs.CURRENT_YEAR) {
+			if variable != string(structs.CATEGORIES) && variable != string(structs.TAGS) && variable != string(structs.OCR_TEXT) && variable != string(structs.CURRENT_YEAR) && variable != string(structs.CUSTOM_FIELDS) {
 				errorMap["prompt"] = "Invalid template variables found"
 			}
 		}

--- a/api/internal/commands/upsert_prompt_command.go
+++ b/api/internal/commands/upsert_prompt_command.go
@@ -27,6 +27,14 @@ func (command *UpsertPromptCommand) LoadDataFromRequest(w http.ResponseWriter, r
 	return nil
 }
 
+var allowedTemplateVariables = map[structs.PromptTemplateVariable]bool{
+	structs.CATEGORIES:    true,
+	structs.TAGS:          true,
+	structs.OCR_TEXT:      true,
+	structs.CURRENT_YEAR:  true,
+	structs.CUSTOM_FIELDS: true,
+}
+
 func (command *UpsertPromptCommand) Validate() structs.ValidatorError {
 	vErr := structs.ValidatorError{}
 	errorMap := make(map[string]string)
@@ -42,8 +50,9 @@ func (command *UpsertPromptCommand) Validate() structs.ValidatorError {
 		templateVariables := regex.FindAllString(command.Prompt, -1)
 		for i := 0; i < len(templateVariables); i++ {
 			variable := templateVariables[i]
-			if variable != string(structs.CATEGORIES) && variable != string(structs.TAGS) && variable != string(structs.OCR_TEXT) && variable != string(structs.CURRENT_YEAR) && variable != string(structs.CUSTOM_FIELDS) {
+			if !allowedTemplateVariables[structs.PromptTemplateVariable(variable)] {
 				errorMap["prompt"] = "Invalid template variables found"
+				break
 			}
 		}
 	}

--- a/api/internal/commands/upsert_prompt_command_test.go
+++ b/api/internal/commands/upsert_prompt_command_test.go
@@ -18,7 +18,7 @@ func TestUpsertPromptCommand_Validate_ValidInputs(t *testing.T) {
 		"valid with all template vars": {
 			command: UpsertPromptCommand{
 				Name:   "Test Prompt",
-				Prompt: "Use @categories @tags @ocrText and @currentYear",
+				Prompt: "Use @categories @tags @ocrText @customFields and @currentYear",
 			},
 		},
 		"valid with single template var": {

--- a/api/internal/repositories/custom_fields.go
+++ b/api/internal/repositories/custom_fields.go
@@ -47,11 +47,14 @@ func (repository CustomFieldRepository) GetPagedCustomFields(
 	return customFields, count, nil
 }
 
-func (repository CustomFieldRepository) GetAllCustomFields(querySelect string) ([]models.CustomField, error) {
+func (repository CustomFieldRepository) GetAllCustomFields() ([]models.CustomField, error) {
 	db := repository.GetDB()
 	var customFields []models.CustomField
 
-	err := db.Table("custom_fields").Select(querySelect).Preload("Options").Find(&customFields).Error
+	err := db.Model(&models.CustomField{}).
+		Select("id", "name", "type", "description").
+		Preload("Options").
+		Find(&customFields).Error
 	if err != nil {
 		return nil, err
 	}

--- a/api/internal/repositories/custom_fields.go
+++ b/api/internal/repositories/custom_fields.go
@@ -47,6 +47,18 @@ func (repository CustomFieldRepository) GetPagedCustomFields(
 	return customFields, count, nil
 }
 
+func (repository CustomFieldRepository) GetAllCustomFields(querySelect string) ([]models.CustomField, error) {
+	db := repository.GetDB()
+	var customFields []models.CustomField
+
+	err := db.Table("custom_fields").Select(querySelect).Preload("Options").Find(&customFields).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return customFields, nil
+}
+
 func (repository CustomFieldRepository) CreateCustomField(
 	command commands.UpsertCustomFieldCommand,
 	createdBy *uint,

--- a/api/internal/services/receipt_processing.go
+++ b/api/internal/services/receipt_processing.go
@@ -502,10 +502,16 @@ func (service ReceiptProcessingService) buildTemplateVariableMap(ocrText string)
 		return result, err
 	}
 
+	customFieldsString, err := service.getCustomFieldsString()
+	if err != nil {
+		return result, err
+	}
+
 	currentYearString := utils.UintToString(uint(time.Now().Year()))
 
 	result[structs.CATEGORIES] = categoriesString
 	result[structs.TAGS] = tagsString
+	result[structs.CUSTOM_FIELDS] = customFieldsString
 	result[structs.OCR_TEXT] = ocrText
 	result[structs.CURRENT_YEAR] = currentYearString
 
@@ -540,4 +546,19 @@ func (service ReceiptProcessingService) getTagsString() (string, error) {
 	}
 
 	return string(tagsBytes), nil
+}
+
+func (service ReceiptProcessingService) getCustomFieldsString() (string, error) {
+	customFieldRepository := repositories.NewCustomFieldRepository(nil)
+	customFields, err := customFieldRepository.GetAllCustomFields("id, name, type, description")
+	if err != nil {
+		return "", err
+	}
+
+	customFieldsBytes, err := json.Marshal(customFields)
+	if err != nil {
+		return "", err
+	}
+
+	return string(customFieldsBytes), nil
 }

--- a/api/internal/services/receipt_processing.go
+++ b/api/internal/services/receipt_processing.go
@@ -466,7 +466,7 @@ func (service ReceiptProcessingService) buildPrompt(
 		return "", systemTaskCommand, err
 	}
 
-	templateVariableMap, err := service.buildTemplateVariableMap(ocrText)
+	templateVariableMap, err := service.buildTemplateVariableMap(ocrText, prompt.Prompt)
 	if err != nil {
 		systemTaskCommand.Status = models.SYSTEM_TASK_FAILED
 		systemTaskCommand.ResultDescription = err.Error()
@@ -489,7 +489,7 @@ func (service ReceiptProcessingService) buildPrompt(
 	return realPrompt, systemTaskCommand, nil
 }
 
-func (service ReceiptProcessingService) buildTemplateVariableMap(ocrText string) (map[structs.PromptTemplateVariable]string, error) {
+func (service ReceiptProcessingService) buildTemplateVariableMap(ocrText string, promptText string) (map[structs.PromptTemplateVariable]string, error) {
 	result := make(map[structs.PromptTemplateVariable]string)
 
 	categoriesString, err := service.getCategoriesString()
@@ -502,18 +502,23 @@ func (service ReceiptProcessingService) buildTemplateVariableMap(ocrText string)
 		return result, err
 	}
 
-	customFieldsString, err := service.getCustomFieldsString()
-	if err != nil {
-		return result, err
-	}
-
 	currentYearString := utils.UintToString(uint(time.Now().Year()))
 
 	result[structs.CATEGORIES] = categoriesString
 	result[structs.TAGS] = tagsString
-	result[structs.CUSTOM_FIELDS] = customFieldsString
 	result[structs.OCR_TEXT] = ocrText
 	result[structs.CURRENT_YEAR] = currentYearString
+
+	// Only hit the database for custom fields when the prompt actually uses the
+	// variable, avoiding an extra query (plus the Options preload) on every
+	// prompt build for the common case of prompts that don't reference it.
+	if strings.Contains(promptText, string(structs.CUSTOM_FIELDS)) {
+		customFieldsString, err := service.getCustomFieldsString()
+		if err != nil {
+			return result, err
+		}
+		result[structs.CUSTOM_FIELDS] = customFieldsString
+	}
 
 	return result, nil
 }
@@ -550,7 +555,7 @@ func (service ReceiptProcessingService) getTagsString() (string, error) {
 
 func (service ReceiptProcessingService) getCustomFieldsString() (string, error) {
 	customFieldRepository := repositories.NewCustomFieldRepository(nil)
-	customFields, err := customFieldRepository.GetAllCustomFields("id, name, type, description")
+	customFields, err := customFieldRepository.GetAllCustomFields()
 	if err != nil {
 		return "", err
 	}

--- a/api/internal/services/receipt_processing_test.go
+++ b/api/internal/services/receipt_processing_test.go
@@ -498,6 +498,52 @@ func TestBuildPrompt_InterpolatesVariables(t *testing.T) {
 	}
 }
 
+func TestBuildPrompt_InterpolatesCustomFields(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	db := repositories.GetDB()
+
+	customField := models.CustomField{
+		Name:        "VAT",
+		Type:        models.CURRENCY,
+		Description: "VAT amount",
+	}
+	if err := db.Create(&customField).Error; err != nil {
+		t.Fatalf("seed custom field: %v", err)
+	}
+
+	prompt := models.Prompt{
+		Name:   "bpcf",
+		Prompt: "customFields=@customFields",
+	}
+	if err := db.Create(&prompt).Error; err != nil {
+		t.Fatalf("seed prompt: %v", err)
+	}
+
+	service := ReceiptProcessingService{
+		ReceiptProcessingSettings: models.ReceiptProcessingSettings{PromptId: prompt.ID},
+	}
+	realPrompt, cmd, err := service.buildPrompt(service.ReceiptProcessingSettings, "ocr")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The @customFields variable must be substituted (no literal token left)
+	// and the substituted JSON must include the seeded field's name and type
+	// so the model knows what to extract.
+	if strings.Contains(realPrompt, "@customFields") {
+		t.Errorf("expected @customFields to be substituted, got: %q", realPrompt)
+	}
+	if !strings.Contains(realPrompt, "\"VAT\"") {
+		t.Errorf("expected custom field name in prompt, got: %q", realPrompt)
+	}
+	if !strings.Contains(realPrompt, "CURRENCY") {
+		t.Errorf("expected custom field type in prompt, got: %q", realPrompt)
+	}
+	if cmd.Status != models.SYSTEM_TASK_SUCCEEDED {
+		t.Errorf("expected SUCCEEDED, got: %s", cmd.Status)
+	}
+}
+
 func TestBuildPrompt_InvalidPromptId(t *testing.T) {
 	defer repositories.TruncateTestDb()
 

--- a/api/internal/services/receipt_processing_test.go
+++ b/api/internal/services/receipt_processing_test.go
@@ -14,6 +14,7 @@ import (
 	"receipt-wrangler/api/internal/commands"
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/repositories"
+	"receipt-wrangler/api/internal/structs"
 	"receipt-wrangler/api/internal/utils"
 )
 
@@ -527,17 +528,29 @@ func TestBuildPrompt_InterpolatesCustomFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// The @customFields variable must be substituted (no literal token left)
-	// and the substituted JSON must include the seeded field's name and type
-	// so the model knows what to extract.
-	if strings.Contains(realPrompt, "@customFields") {
+	// The @customFields token must be substituted (no literal token left).
+	if strings.Contains(realPrompt, string(structs.CUSTOM_FIELDS)) {
 		t.Errorf("expected @customFields to be substituted, got: %q", realPrompt)
 	}
-	if !strings.Contains(realPrompt, "\"VAT\"") {
-		t.Errorf("expected custom field name in prompt, got: %q", realPrompt)
+	// Parse the interpolated JSON rather than asserting on exact formatting:
+	// the prompt was "customFields=<json>", so everything after '=' is the
+	// serialised custom-field list.
+	_, jsonPart, found := strings.Cut(realPrompt, "=")
+	if !found {
+		t.Fatalf("could not locate interpolated JSON in prompt: %q", realPrompt)
 	}
-	if !strings.Contains(realPrompt, "CURRENCY") {
-		t.Errorf("expected custom field type in prompt, got: %q", realPrompt)
+	var fields []models.CustomField
+	if err := json.Unmarshal([]byte(strings.TrimSpace(jsonPart)), &fields); err != nil {
+		t.Fatalf("interpolated custom fields not valid JSON: %v (%q)", err, jsonPart)
+	}
+	if len(fields) != 1 {
+		t.Fatalf("expected 1 custom field, got %d", len(fields))
+	}
+	if fields[0].Name != "VAT" {
+		t.Errorf("expected field name VAT, got %q", fields[0].Name)
+	}
+	if fields[0].Type != models.CURRENCY {
+		t.Errorf("expected field type CURRENCY, got %q", fields[0].Type)
 	}
 	if cmd.Status != models.SYSTEM_TASK_SUCCEEDED {
 		t.Errorf("expected SUCCEEDED, got: %s", cmd.Status)

--- a/api/internal/structs/prompt_template_variable.go
+++ b/api/internal/structs/prompt_template_variable.go
@@ -3,8 +3,9 @@ package structs
 type PromptTemplateVariable string
 
 const (
-	CATEGORIES   PromptTemplateVariable = "@categories"
-	TAGS         PromptTemplateVariable = "@tags"
-	OCR_TEXT     PromptTemplateVariable = "@ocrText"
-	CURRENT_YEAR PromptTemplateVariable = "@currentYear"
+	CATEGORIES    PromptTemplateVariable = "@categories"
+	TAGS          PromptTemplateVariable = "@tags"
+	OCR_TEXT      PromptTemplateVariable = "@ocrText"
+	CURRENT_YEAR  PromptTemplateVariable = "@currentYear"
+	CUSTOM_FIELDS PromptTemplateVariable = "@customFields"
 )

--- a/desktop/src/prompt/prompt-form/prompt-form.component.ts
+++ b/desktop/src/prompt/prompt-form/prompt-form.component.ts
@@ -15,7 +15,7 @@ import { SnackbarService } from "../../services";
 export class PromptFormComponent extends BaseFormComponent implements OnInit {
   public originalPrompt?: Prompt;
 
-  public promptVariables = ["categories", "tags", "currentYear", "ocrText"];
+  public promptVariables = ["categories", "tags", "currentYear", "ocrText", "customFields"];
 
   constructor(
     private activatedRoute: ActivatedRoute,

--- a/docs/ai-custom-fields-prompt.md
+++ b/docs/ai-custom-fields-prompt.md
@@ -6,7 +6,7 @@ extraction prompt. To make the AI actually populate custom fields, the prompt
 must instruct it to return values. Add a block like the following to the prompt
 (it pairs with the `@customFields` variable):
 
-```
+```text
 Custom fields: from the list below, extract a value for each custom field where
 the receipt clearly provides one. Return them in a "customFields" array. Each
 entry MUST contain the field's "customFieldId" and exactly ONE typed value
@@ -24,6 +24,7 @@ Custom fields to populate: @customFields
 ```
 
 ## Notes
+
 - Custom-field values are NOT run through `UpsertReceiptCommand.Validate`, so the
   prompt must return well-typed values keyed by a valid `customFieldId`. The
   persistence path saves `Receipt.CustomFields []CustomFieldValue` via GORM

--- a/docs/ai-custom-fields-prompt.md
+++ b/docs/ai-custom-fields-prompt.md
@@ -1,0 +1,32 @@
+# AI population of custom fields — prompt guidance
+
+This change adds the `@customFields` prompt template variable, which serialises
+the configured custom fields (id, name, type, description) into the receipt
+extraction prompt. To make the AI actually populate custom fields, the prompt
+must instruct it to return values. Add a block like the following to the prompt
+(it pairs with the `@customFields` variable):
+
+```
+Custom fields: from the list below, extract a value for each custom field where
+the receipt clearly provides one. Return them in a "customFields" array. Each
+entry MUST contain the field's "customFieldId" and exactly ONE typed value
+property matching the field type:
+- CURRENCY: "currencyValue" as a number (e.g. 4.66). Use for VAT/tax amounts.
+- TEXT: "stringValue" as a string.
+- DATE: "dateValue" in ISO 8601 UTC.
+- BOOLEAN: "booleanValue".
+- SELECT: "selectValue" as the option id.
+Example: {"customFieldId": 1, "currencyValue": 4.66}. Omit a field entirely if
+the receipt does not provide its value (do not guess). Return an empty array if
+there are none.
+
+Custom fields to populate: @customFields
+```
+
+## Notes
+- Custom-field values are NOT run through `UpsertReceiptCommand.Validate`, so the
+  prompt must return well-typed values keyed by a valid `customFieldId`. The
+  persistence path saves `Receipt.CustomFields []CustomFieldValue` via GORM
+  association, same as categories/tags.
+- The prompt validator only accepts known template variables; `@customFields`
+  becomes valid once this change is deployed.


### PR DESCRIPTION
## Summary
This proposes **AI auto-population of custom fields**, building on the existing custom-fields feature (the "Custom Receipt Fields" roadmap item — models, API, web/mobile UI and the `CustomFieldType.Currency` type are already shipped). Today an admin can configure custom fields and the receipt-save path persists `Receipt.CustomFields` via GORM, but the **AI is never told the configured custom fields exist**, so they can only be filled in manually.

## Change
- Add a `@customFields` prompt template variable, populated (mirroring `getCategoriesString`) from a new `CustomFieldRepository.GetAllCustomFields`, serialising each field's `id`, `name`, `type`, `description` as JSON.
- Allow `@customFields` in both prompt validators — the Go `UpsertPromptCommand.Validate` allow-list and the Angular `prompt-form` `promptVariables` list (without this, saving a prompt that uses the variable fails validation).
- `docs/ai-custom-fields-prompt.md` documents the prompt block to instruct typed extraction (each value keyed by `customFieldId` with the correctly-typed property, e.g. `currencyValue`).

A prompt can then instruct the model to return values in the receipt's `customFields` array, where the existing persistence path saves them. Note custom-field values are not currently run through `UpsertReceiptCommand.Validate`, so the prompt must return well-typed values keyed by a valid `customFieldId`.

## Tests
Adds `TestBuildPrompt_InterpolatesCustomFields` (seeds a CURRENCY field, asserts `@customFields` is substituted with the field's name and type) and extends the prompt-validator test. Full suite passes. Behaviourally verified end-to-end: a forwarded receipt with a VAT line correctly populated a CURRENCY custom field.

## Note
This is offered as a proposal on top of your custom-fields design — happy to adjust the approach (prompt shape, where the field list is injected, validation of returned values) to fit your intent for the feature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom fields can now be referenced in AI prompt templates (via a new `@customFields` variable) to enrich receipt processing.

* **Bug Fixes / Validation**
  * Prompt template validator and prompt-building now recognize and validate the new custom-fields variable, rejecting unknown template variables.

* **Documentation**
  * Added guidance and examples for using `@customFields`, expected output formatting, and handling when no values exist.

* **Tests**
  * Added tests verifying interpolation and validation of custom fields in prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->