### PR TITLE
Add required default app and group roles

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -191,18 +191,21 @@ longer gate handler access.
 - **Assignment:** nullable FKs `User.AppRoleID` and `GroupMember.GroupRoleID` (one app role per
   user; one group role per group membership). Nullable because they coexist with the legacy enums
   during rollout.
-- `IsSystem` marks protected, non-editable/non-deletable roles; `IsDefault` (group roles) marks the
-  role auto-assignable to new members.
+- `IsSystem` marks protected, non-editable/non-deletable roles; `IsDefault` (on **both** `AppRole`
+  and `GroupRoleDefinition`) marks the single default role for that scope — the role assigned to new
+  accounts (app) or to group creators (group). See "Default roles" below.
 
 ### Role CRUD
 
 - Data access in `repositories/roles.go`; business logic in `services/roles.go`. Guards: system
-  roles are immutable/undeletable, a role's scope can't be changed (type-mismatch error), and an
-  assigned role can't be deleted.
-- Endpoints (`routers/role.go`, currently gated by `UserRole: models.ADMIN`): `GET /role`,
-  `POST /role`, `PUT /role/{roleId}`, `DELETE /role/{roleId}?scope=APP|GROUP`.
+  roles are immutable/undeletable, a role's scope can't be changed (type-mismatch error), an
+  assigned role can't be deleted, and the **default role for a scope can't be deleted**
+  (`ErrRoleIsDefault`) — pick another default first.
+- Endpoints (`routers/role.go`, gated by `app.roles.*`): `GET /role`, `POST /role`,
+  `PUT /role/{roleId}`, `PUT /role/{roleId}/default?scope=APP|GROUP` (make this role the scope's
+  default; allowed on system roles; gated by `app.roles.update`), `DELETE /role/{roleId}?scope=APP|GROUP`.
 - `commands.UpsertRoleCommand` validates that every permission exists in the registry and matches
-  the role's scope. `structs.RoleView` is the read model (includes `assignedCount`).
+  the role's scope. `structs.RoleView` is the read model (includes `assignedCount` and `isDefault`).
 
 ### Seeded system roles (legacy-equivalent)
 
@@ -215,9 +218,9 @@ longer gate handler access.
   EDITOR / OWNER tiers; Owner = every group permission). The sets live in
   `permissions/legacy.go` (`Legacy*Keys()` helpers) and were derived from the actual handler-level
   gating, not the desktop UI presets.
-- **Seeded only here — not enforced yet.** This step only creates the roles (group roles with
-  `IsDefault = false`); the one-time data migration below assigns them to existing users/members,
-  and enforcement is a later phase.
+- `SeedSystemRoles` creates the roles with `IsDefault = false`; the **default** per scope is set
+  separately by `EnsureDefaultRoles` (see "Default roles" below), the one-time data migration assigns
+  the roles to existing users/members, and enforcement is wired in `HandleRequest`.
 - Idempotent: keyed on role `Name` (a `uniqueIndex`), safe on every boot; a pre-existing
   same-named role is left untouched. The five role names are shared constants
   (`repositories/system_role_names.go`, `Legacy*RoleName`) used by both the seeder and the
@@ -225,6 +228,27 @@ longer gate handler access.
 - **Known limitation:** because system roles are immutable and seeding skips existing names, a
   permission added to the registry later will **not** flow into an already-seeded Legacy Admin /
   Legacy Owner. Re-syncing system roles would need a dedicated reconciliation step (out of scope).
+
+### Default roles
+
+- Exactly one app role and one group role are the **default** (`IsDefault = true`): the role assigned
+  to a new account on signup/admin-create, and to a group's creator on group creation. This is a
+  required invariant — there is always exactly one default per scope.
+- `repositories.EnsureDefaultRoles` (`repositories/seed_roles.go`) enforces it on every boot,
+  immediately after `SeedSystemRoles` in `InitDB`: if a scope has **no** default, it flags the
+  legacy-equivalent role (**Legacy User** for app, **Legacy Owner** for group), so upgrades and fresh
+  installs behave exactly as before. It only acts when no default exists, so it never overrides a
+  default an admin chose, and it self-heals dev DBs created before the `app_roles.is_default` column.
+- Admins change the default via `PUT /role/{roleId}/default?scope=…`
+  (`RoleService.SetDefaultRole` → `SetDefaultAppRole`/`SetDefaultGroupRole`), which clears the prior
+  default and sets the new one in one transaction. System roles are eligible (the legacy defaults are
+  system roles). The current default cannot be deleted (`ErrRoleIsDefault`).
+- **Per-create assignment** uses the defaults: `UserRepository.CreateUser` sets `User.AppRoleID`
+  (Legacy Admin for an `ADMIN`-resolved user so the bootstrap admin is never locked out; the default
+  app role otherwise), and `GroupRepository.CreateGroup` sets the creator's `GroupMember.GroupRoleID`
+  to the default group role. Both are **best-effort**: if the role can't be resolved (e.g. an
+  unseeded test DB), the FK is left `nil` rather than failing creation. Members added to *existing*
+  groups are a separate future slice.
 
 ### Legacy role assignment (one-time data migration)
 
@@ -243,7 +267,8 @@ longer gate handler access.
   test harness, so the migration does not auto-run in tests.
 - Updates are guarded with `... IS NULL`, so a role an admin has already set through the new UI is
   never overwritten — defense-in-depth on top of the ledger. The migration is one-time over existing
-  rows; per-create assignment for *new* users/members is a separate future slice.
+  rows; per-create assignment for *new* users / group creators is handled by the default-role wiring
+  (see "Default roles" above).
 - Tests: `repositories/data_migrations_test.go` (assignment, idempotency, ledger short-circuit,
   no-clobber).
 
@@ -288,15 +313,16 @@ lookup (used pre-auth during signup) and `ConvertToJpg` (a stateless image utili
 resource to scope against). The role/permission management endpoints (`/role`, `/permission`) are
 gated by `app.roles.*`.
 
-**Known follow-up (not yet implemented):** nothing assigns a modern role when a user signs up, is
-created by an admin, or is added to a group — only the one-time startup migration back-fills
-**existing** users/members. Until per-create assignment lands, an account created after that
-migration resolves to no permissions and is denied. Wiring per-create role assignment is the
-required next slice.
+**Per-create role assignment (done):** a new account (signup or admin-create) is assigned the
+default app role, and a group's creator is assigned the default group role, via the default-role
+wiring (see "Default roles" above), so accounts created after the one-time migration are no longer
+locked out. **Remaining follow-up:** members *added to an existing group* still get no modern group
+role — that is the next slice (group member-role assignment UI).
 
 ### Tests
 
 `permissions/matcher_test.go`, `permissions/registry_test.go`, `permissions/legacy_test.go`,
-`services/permission_test.go`, `services/roles_test.go`, `repositories/roles_test.go`, and the
-handler authorization tests in `handlers/generic_handler_test.go` (with shared helpers in
-`handlers/auth_test_helpers_test.go`).
+`services/permission_test.go`, `services/roles_test.go`, `repositories/roles_test.go`,
+`repositories/seed_roles_test.go` (default-role seeding), the per-create assignment tests in
+`repositories/users_test.go` / `repositories/groups_test.go`, and the handler authorization tests in
+`handlers/generic_handler_test.go` (with shared helpers in `handlers/auth_test_helpers_test.go`).

--- a/api/internal/handlers/roles.go
+++ b/api/internal/handlers/roles.go
@@ -193,6 +193,12 @@ func DeleteRole(w http.ResponseWriter, r *http.Request) {
 					}, http.StatusBadRequest)
 					return 0, nil
 				}
+				if errors.Is(err, services.ErrRoleIsDefault) {
+					structs.WriteValidatorErrorResponse(w, structs.ValidatorError{
+						Errors: map[string]string{"role": "The default role cannot be deleted; choose another default first"},
+					}, http.StatusBadRequest)
+					return 0, nil
+				}
 				if errors.Is(err, services.ErrRoleNotFound) {
 					utils.WriteCustomErrorResponse(w, "Role not found", http.StatusNotFound)
 					return 0, nil
@@ -201,6 +207,61 @@ func DeleteRole(w http.ResponseWriter, r *http.Request) {
 			}
 
 			w.WriteHeader(http.StatusOK)
+
+			return 0, nil
+		},
+	}
+
+	HandleRequest(handler)
+}
+
+func SetDefaultRole(w http.ResponseWriter, r *http.Request) {
+	handler := structs.Handler{
+		ErrorMessage:   "Error setting default role",
+		Writer:         w,
+		Request:        r,
+		AppPermissions: []string{permissions.AppRolesUpdate},
+		ResponseType:   constants.ApplicationJson,
+		HandlerFunction: func(w http.ResponseWriter, r *http.Request) (int, error) {
+			id, err := utils.StringToUint(chi.URLParam(r, "roleId"))
+			if err != nil {
+				structs.WriteValidatorErrorResponse(w, structs.ValidatorError{
+					Errors: map[string]string{"roleId": "Invalid role id"},
+				}, http.StatusBadRequest)
+				return 0, nil
+			}
+
+			scope := permissions.Scope(r.URL.Query().Get("scope"))
+			if scope != permissions.ScopeApp && scope != permissions.ScopeGroup {
+				structs.WriteValidatorErrorResponse(w, structs.ValidatorError{
+					Errors: map[string]string{"scope": "Scope must be either APP or GROUP"},
+				}, http.StatusBadRequest)
+				return 0, nil
+			}
+
+			roleService := services.NewRoleService(nil)
+			updatedRole, err := roleService.SetDefaultRole(id, scope)
+			if err != nil {
+				if errors.Is(err, services.ErrRoleTypeMismatch) {
+					structs.WriteValidatorErrorResponse(w, structs.ValidatorError{
+						Errors: map[string]string{"scope": "Role type cannot be changed"},
+					}, http.StatusBadRequest)
+					return 0, nil
+				}
+				if errors.Is(err, services.ErrRoleNotFound) {
+					utils.WriteCustomErrorResponse(w, "Role not found", http.StatusNotFound)
+					return 0, nil
+				}
+				return http.StatusInternalServerError, err
+			}
+
+			bytes, err := utils.MarshalResponseData(&updatedRole)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			w.WriteHeader(http.StatusOK)
+			w.Write(bytes)
 
 			return 0, nil
 		},

--- a/api/internal/handlers/roles_test.go
+++ b/api/internal/handlers/roles_test.go
@@ -574,3 +574,71 @@ func TestShouldNotDeleteAssignedGroupRole(t *testing.T) {
 		utils.PrintTestError(t, err, "assigned group role should be untouched")
 	}
 }
+
+func setDefaultRoleRequest(roleId string, scope string, claims *validator.ValidatedClaims) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("PUT", "/api?scope="+scope, nil)
+
+	ctx := chi.NewRouteContext()
+	ctx.URLParams.Add("roleId", roleId)
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, ctx))
+	r = r.WithContext(context.WithValue(r.Context(), jwtmiddleware.ContextKey{}, claims))
+
+	SetDefaultRole(w, r)
+	return w
+}
+
+func TestShouldSetDefaultRole(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	repositories.CreateTestRoles()
+	role := structs.RoleView{}
+
+	w := setDefaultRoleRequest("1", "APP", adminContext())
+
+	if w.Result().StatusCode != 200 {
+		utils.PrintTestError(t, w.Result().StatusCode, 200)
+		return
+	}
+
+	if err := json.Unmarshal(w.Body.Bytes(), &role); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if !role.IsDefault {
+		utils.PrintTestError(t, role.IsDefault, true)
+	}
+}
+
+func TestShouldNotSetDefaultRoleDueToRole(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	repositories.CreateTestRoles()
+
+	w := setDefaultRoleRequest("1", "APP", userContext())
+
+	if w.Result().StatusCode != 403 {
+		utils.PrintTestError(t, w.Result().StatusCode, 403)
+	}
+}
+
+func TestShouldReturnBadRequestForInvalidSetDefaultScope(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	repositories.CreateTestRoles()
+
+	for _, scope := range []string{"", "BOGUS"} {
+		w := setDefaultRoleRequest("1", scope, adminContext())
+		if w.Result().StatusCode != 400 {
+			utils.PrintTestError(t, w.Result().StatusCode, 400)
+		}
+	}
+}
+
+func TestShouldReturnNotFoundForMissingSetDefaultRole(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	w := setDefaultRoleRequest("999", "APP", adminContext())
+
+	if w.Result().StatusCode != 404 {
+		utils.PrintTestError(t, w.Result().StatusCode, 404)
+	}
+}

--- a/api/internal/handlers/sign_up.go
+++ b/api/internal/handlers/sign_up.go
@@ -27,6 +27,11 @@ func SignUp(w http.ResponseWriter, r *http.Request) {
 			}
 
 			userData := r.Context().Value("signUpCommand").(commands.SignUpCommand)
+			// Public sign-up must never let the caller choose their own role: the
+			// role is decided by CreateUser (first user becomes ADMIN, everyone
+			// else USER). Only the admin-protected POST /user endpoint may set a
+			// role explicitly.
+			userData.UserRole = ""
 			userRepository := repositories.NewUserRepository(nil)
 			_, err = userRepository.CreateUser(userData)
 

--- a/api/internal/handlers/sign_up_handler_test.go
+++ b/api/internal/handlers/sign_up_handler_test.go
@@ -1,8 +1,10 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
+	"receipt-wrangler/api/internal/commands"
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/repositories"
 	"receipt-wrangler/api/internal/utils"
@@ -29,6 +31,43 @@ func TestShouldNotAllowUserToSignUpIfDisabled(t *testing.T) {
 
 	if w.Result().StatusCode != expectedResponseCode {
 		utils.PrintTestError(t, w.Result().StatusCode, expectedResponseCode)
+	}
+}
+
+// Public sign-up must never honor a caller-supplied role: the role is decided by
+// CreateUser (first user ADMIN, everyone else USER). An existing user occupies
+// the first-user slot here, so an attacker supplying UserRole=ADMIN must still
+// end up a USER.
+func TestSignUpStripsCallerSuppliedRole(t *testing.T) {
+	defer teardownSignUpTests()
+	db := repositories.GetDB()
+	db.Create(&models.SystemSettings{EnableLocalSignUp: true})
+	db.Create(&models.User{Username: "existing", Password: "x"})
+
+	cmd := commands.SignUpCommand{
+		Username:    "escalate",
+		Password:    "password",
+		DisplayName: "Escalate",
+		UserRole:    models.ADMIN,
+	}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/api", nil)
+	r = r.WithContext(context.WithValue(r.Context(), "signUpCommand", cmd))
+
+	SignUp(w, r)
+
+	if w.Result().StatusCode != http.StatusOK {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusOK)
+		return
+	}
+
+	var created models.User
+	if err := db.Where("username = ?", "escalate").First(&created).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if created.UserRole != models.USER {
+		utils.PrintTestError(t, created.UserRole, models.USER)
 	}
 }
 

--- a/api/internal/models/app_role.go
+++ b/api/internal/models/app_role.go
@@ -4,6 +4,7 @@ type AppRole struct {
 	BaseModel
 	Name        string              `gorm:"not null;size:64;uniqueIndex" json:"name"`
 	Description string              `json:"description"`
+	IsDefault   bool                `gorm:"not null;default:false" json:"isDefault"`
 	IsSystem    bool                `gorm:"not null;default:false" json:"isSystem"`
 	Permissions []AppRolePermission `gorm:"foreignKey:AppRoleID;constraint:OnDelete:CASCADE" json:"permissions"`
 }

--- a/api/internal/repositories/db.go
+++ b/api/internal/repositories/db.go
@@ -147,6 +147,12 @@ func InitDB() error {
 		return err
 	}
 
+	// Must run after the roles are seeded and before the bootstrap admin /
+	// data migration so the default app and group roles exist for assignment.
+	if err := EnsureDefaultRoles(); err != nil {
+		return err
+	}
+
 	if config.GetDeployEnv() != "test" {
 		userRepository := NewUserRepository(nil)
 		err := userRepository.CreateUserIfNoneExist()

--- a/api/internal/repositories/groups.go
+++ b/api/internal/repositories/groups.go
@@ -108,10 +108,21 @@ func (repository GroupRepository) CreateGroup(command commands.UpsertGroupComman
 			return txErr
 		}
 
+		// Assign the creator the modern default group role so the membership is
+		// not locked out under permission enforcement. Best-effort: nil when no
+		// default is seeded (e.g. an unseeded test database).
+		roleRepository := NewRoleRepository(tx)
+		defaultGroupRoleId, txErr := roleRepository.GetDefaultGroupRoleId()
+		if txErr != nil {
+			repository.ClearTransaction()
+			return txErr
+		}
+
 		groupMember := models.GroupMember{
-			UserID:    userId,
-			GroupID:   groupToCreate.ID,
-			GroupRole: models.OWNER,
+			UserID:      userId,
+			GroupID:     groupToCreate.ID,
+			GroupRole:   models.OWNER,
+			GroupRoleID: defaultGroupRoleId,
 		}
 
 		txErr = tx.Model(&groupMember).Create(&groupMember).Error

--- a/api/internal/repositories/groups_test.go
+++ b/api/internal/repositories/groups_test.go
@@ -47,6 +47,63 @@ func TestShouldCreateGroupSuccessfully(t *testing.T) {
 	}
 }
 
+func TestCreateGroupAssignsDefaultGroupRole(t *testing.T) {
+	defer teardownGroupTest()
+
+	if err := SeedSystemRoles(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if err := EnsureDefaultRoles(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	CreateTestUser()
+
+	groupRepository := setupGroupRepository()
+	created, err := groupRepository.CreateGroup(commands.UpsertGroupCommand{Name: "test"}, 1)
+	if err != nil {
+		utils.PrintTestError(t, err, "Expected no error")
+		return
+	}
+
+	if len(created.GroupMembers) != 1 {
+		utils.PrintTestError(t, len(created.GroupMembers), 1)
+		return
+	}
+
+	member := created.GroupMembers[0]
+	roleRepository := NewRoleRepository(nil)
+	defaultId, err := roleRepository.GetDefaultGroupRoleId()
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if member.GroupRoleID == nil || defaultId == nil || *member.GroupRoleID != *defaultId {
+		utils.PrintTestError(t, member.GroupRoleID, defaultId)
+	}
+}
+
+func TestCreateGroupLeavesGroupRoleNilWhenUnseeded(t *testing.T) {
+	defer teardownGroupTest()
+	CreateTestUser()
+
+	groupRepository := setupGroupRepository()
+	created, err := groupRepository.CreateGroup(commands.UpsertGroupCommand{Name: "test"}, 1)
+	if err != nil {
+		utils.PrintTestError(t, err, "Expected no error")
+		return
+	}
+
+	if len(created.GroupMembers) != 1 {
+		utils.PrintTestError(t, len(created.GroupMembers), 1)
+		return
+	}
+	if created.GroupMembers[0].GroupRoleID != nil {
+		utils.PrintTestError(t, created.GroupMembers[0].GroupRoleID, nil)
+	}
+}
+
 func TestShouldGetGroupById(t *testing.T) {
 	defer teardownGroupTest()
 	CreateTestGroup()

--- a/api/internal/repositories/roles.go
+++ b/api/internal/repositories/roles.go
@@ -1,6 +1,7 @@
 package repositories
 
 import (
+	"errors"
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/permissions"
 	"receipt-wrangler/api/internal/structs"
@@ -188,6 +189,7 @@ func (repository RoleRepository) GetAllRoles() ([]structs.RoleView, error) {
 			Name:          role.Name,
 			Description:   role.Description,
 			Scope:         permissions.ScopeApp,
+			IsDefault:     role.IsDefault,
 			IsSystem:      role.IsSystem,
 			Permissions:   perms,
 			AssignedCount: appRoleCounts[role.ID],
@@ -205,6 +207,7 @@ func (repository RoleRepository) GetAllRoles() ([]structs.RoleView, error) {
 			Name:          role.Name,
 			Description:   role.Description,
 			Scope:         permissions.ScopeGroup,
+			IsDefault:     role.IsDefault,
 			IsSystem:      role.IsSystem,
 			Permissions:   perms,
 			AssignedCount: groupRoleCounts[role.ID],
@@ -364,4 +367,82 @@ func (repository RoleRepository) DeleteAppRole(id uint) error {
 func (repository RoleRepository) DeleteGroupRole(id uint) error {
 	db := repository.GetDB()
 	return db.Delete(&models.GroupRoleDefinition{}, id).Error
+}
+
+// SetDefaultAppRole makes the given app role the single default: it clears the
+// flag on every other app role, then sets it on id. Callers run this inside a
+// transaction so the "exactly one default" invariant holds atomically.
+func (repository RoleRepository) SetDefaultAppRole(id uint) error {
+	db := repository.GetDB()
+
+	err := db.Model(&models.AppRole{}).Where("id <> ?", id).Update("is_default", false).Error
+	if err != nil {
+		return err
+	}
+
+	return db.Model(&models.AppRole{}).Where("id = ?", id).Update("is_default", true).Error
+}
+
+// SetDefaultGroupRole makes the given group role the single default: it clears
+// the flag on every other group role, then sets it on id.
+func (repository RoleRepository) SetDefaultGroupRole(id uint) error {
+	db := repository.GetDB()
+
+	err := db.Model(&models.GroupRoleDefinition{}).Where("id <> ?", id).Update("is_default", false).Error
+	if err != nil {
+		return err
+	}
+
+	return db.Model(&models.GroupRoleDefinition{}).Where("id = ?", id).Update("is_default", true).Error
+}
+
+// GetAppRoleIdByName returns the id of the app role with the given name, or nil
+// when no such role exists (e.g. an unseeded test database).
+func (repository RoleRepository) GetAppRoleIdByName(name string) (*uint, error) {
+	db := repository.GetDB()
+
+	var role models.AppRole
+	err := db.Select("id").Where("name = ?", name).First(&role).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return &role.ID, nil
+}
+
+// GetDefaultAppRoleId returns the id of the default app role, or nil when none
+// is flagged default (e.g. an unseeded test database).
+func (repository RoleRepository) GetDefaultAppRoleId() (*uint, error) {
+	db := repository.GetDB()
+
+	var role models.AppRole
+	err := db.Select("id").Where("is_default = ?", true).First(&role).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return &role.ID, nil
+}
+
+// GetDefaultGroupRoleId returns the id of the default group role, or nil when
+// none is flagged default (e.g. an unseeded test database).
+func (repository RoleRepository) GetDefaultGroupRoleId() (*uint, error) {
+	db := repository.GetDB()
+
+	var role models.GroupRoleDefinition
+	err := db.Select("id").Where("is_default = ?", true).First(&role).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return &role.ID, nil
 }

--- a/api/internal/repositories/roles_test.go
+++ b/api/internal/repositories/roles_test.go
@@ -329,3 +329,159 @@ func TestGetGroupMemberRoleId(t *testing.T) {
 		utils.PrintTestError(t, err, gorm.ErrRecordNotFound)
 	}
 }
+
+func TestSetDefaultAppRoleClearsOthers(t *testing.T) {
+	defer TruncateTestDb()
+	repository := NewRoleRepository(nil)
+
+	first, err := repository.CreateAppRole("First", "", []string{permissions.AppUsersRead})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	second, err := repository.CreateAppRole("Second", "", []string{permissions.AppUsersRead})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if err := repository.SetDefaultAppRole(first.ID); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if err := repository.SetDefaultAppRole(second.ID); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	defaultId, err := repository.GetDefaultAppRoleId()
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if defaultId == nil || *defaultId != second.ID {
+		utils.PrintTestError(t, defaultId, second.ID)
+	}
+
+	// Exactly one app role is the default.
+	var count int64
+	GetDB().Model(&models.AppRole{}).Where("is_default = ?", true).Count(&count)
+	if count != 1 {
+		utils.PrintTestError(t, count, 1)
+	}
+}
+
+func TestSetDefaultGroupRoleClearsOthers(t *testing.T) {
+	defer TruncateTestDb()
+	repository := NewRoleRepository(nil)
+
+	first, err := repository.CreateGroupRole("First", "", []string{permissions.GroupReceiptsRead})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	second, err := repository.CreateGroupRole("Second", "", []string{permissions.GroupReceiptsRead})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if err := repository.SetDefaultGroupRole(first.ID); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if err := repository.SetDefaultGroupRole(second.ID); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	defaultId, err := repository.GetDefaultGroupRoleId()
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if defaultId == nil || *defaultId != second.ID {
+		utils.PrintTestError(t, defaultId, second.ID)
+	}
+
+	var count int64
+	GetDB().Model(&models.GroupRoleDefinition{}).Where("is_default = ?", true).Count(&count)
+	if count != 1 {
+		utils.PrintTestError(t, count, 1)
+	}
+}
+
+func TestGetDefaultAppRoleIdNilWhenUnset(t *testing.T) {
+	defer TruncateTestDb()
+	repository := NewRoleRepository(nil)
+
+	if _, err := repository.CreateAppRole("Role", "", []string{permissions.AppUsersRead}); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	id, err := repository.GetDefaultAppRoleId()
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if id != nil {
+		utils.PrintTestError(t, id, nil)
+	}
+}
+
+func TestGetAppRoleIdByName(t *testing.T) {
+	defer TruncateTestDb()
+	repository := NewRoleRepository(nil)
+
+	created, err := repository.CreateAppRole("Named Role", "", []string{permissions.AppUsersRead})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	id, err := repository.GetAppRoleIdByName("Named Role")
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if id == nil || *id != created.ID {
+		utils.PrintTestError(t, id, created.ID)
+	}
+
+	// An unknown name resolves to nil, not an error.
+	missing, err := repository.GetAppRoleIdByName("Nope")
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if missing != nil {
+		utils.PrintTestError(t, missing, nil)
+	}
+}
+
+func TestGetAllRolesReturnsIsDefault(t *testing.T) {
+	defer TruncateTestDb()
+	repository := NewRoleRepository(nil)
+
+	role, err := repository.CreateAppRole("Default App", "", []string{permissions.AppUsersRead})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if err := repository.SetDefaultAppRole(role.ID); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	roles, err := repository.GetAllRoles()
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	found, ok := findRole(roles, "Default App")
+	if !ok || !found.IsDefault {
+		utils.PrintTestError(t, "Default App IsDefault", true)
+	}
+}

--- a/api/internal/repositories/roles_test.go
+++ b/api/internal/repositories/roles_test.go
@@ -365,7 +365,10 @@ func TestSetDefaultAppRoleClearsOthers(t *testing.T) {
 
 	// Exactly one app role is the default.
 	var count int64
-	GetDB().Model(&models.AppRole{}).Where("is_default = ?", true).Count(&count)
+	if err := GetDB().Model(&models.AppRole{}).Where("is_default = ?", true).Count(&count).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
 	if count != 1 {
 		utils.PrintTestError(t, count, 1)
 	}
@@ -405,7 +408,10 @@ func TestSetDefaultGroupRoleClearsOthers(t *testing.T) {
 	}
 
 	var count int64
-	GetDB().Model(&models.GroupRoleDefinition{}).Where("is_default = ?", true).Count(&count)
+	if err := GetDB().Model(&models.GroupRoleDefinition{}).Where("is_default = ?", true).Count(&count).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
 	if count != 1 {
 		utils.PrintTestError(t, count, 1)
 	}

--- a/api/internal/repositories/seed_roles.go
+++ b/api/internal/repositories/seed_roles.go
@@ -1,6 +1,7 @@
 package repositories
 
 import (
+	"fmt"
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/permissions"
 
@@ -134,9 +135,16 @@ func ensureDefaultAppRole(db *gorm.DB) error {
 		return nil
 	}
 
-	return db.Model(&models.AppRole{}).
+	result := db.Model(&models.AppRole{}).
 		Where("name = ?", LegacyUserRoleName).
-		Update("is_default", true).Error
+		Update("is_default", true)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("legacy app role %q not found; cannot set default", LegacyUserRoleName)
+	}
+	return nil
 }
 
 // ensureDefaultGroupRole sets the Legacy Owner role as the default group role
@@ -150,7 +158,14 @@ func ensureDefaultGroupRole(db *gorm.DB) error {
 		return nil
 	}
 
-	return db.Model(&models.GroupRoleDefinition{}).
+	result := db.Model(&models.GroupRoleDefinition{}).
 		Where("name = ?", LegacyOwnerRoleName).
-		Update("is_default", true).Error
+		Update("is_default", true)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("legacy group role %q not found; cannot set default", LegacyOwnerRoleName)
+	}
+	return nil
 }

--- a/api/internal/repositories/seed_roles.go
+++ b/api/internal/repositories/seed_roles.go
@@ -102,3 +102,55 @@ func seedGroupRole(db *gorm.DB, name string, description string, perms []string)
 
 	return db.Create(&role).Error
 }
+
+// EnsureDefaultRoles guarantees that exactly one app role and one group role are
+// flagged as the default — the role newly-created accounts (app) and group
+// creators (group) are assigned. It is the single source of truth for "the
+// default role": the legacy-equivalent roles (Legacy User / Legacy Owner) are
+// the seeded defaults so upgrading installs behave exactly as before.
+//
+// It only acts when a scope has no default yet, so it is idempotent and never
+// overrides a default an administrator has set through the UI. Run on every boot
+// after SeedSystemRoles (a fresh database self-heals on the next boot, and an
+// existing dev database that predates the IsDefault column gets backfilled).
+func EnsureDefaultRoles() error {
+	db := GetDB()
+
+	if err := ensureDefaultAppRole(db); err != nil {
+		return err
+	}
+
+	return ensureDefaultGroupRole(db)
+}
+
+// ensureDefaultAppRole sets the Legacy User role as the default app role when no
+// app role is currently flagged default.
+func ensureDefaultAppRole(db *gorm.DB) error {
+	var count int64
+	if err := db.Model(&models.AppRole{}).Where("is_default = ?", true).Count(&count).Error; err != nil {
+		return err
+	}
+	if count > 0 {
+		return nil
+	}
+
+	return db.Model(&models.AppRole{}).
+		Where("name = ?", LegacyUserRoleName).
+		Update("is_default", true).Error
+}
+
+// ensureDefaultGroupRole sets the Legacy Owner role as the default group role
+// when no group role is currently flagged default.
+func ensureDefaultGroupRole(db *gorm.DB) error {
+	var count int64
+	if err := db.Model(&models.GroupRoleDefinition{}).Where("is_default = ?", true).Count(&count).Error; err != nil {
+		return err
+	}
+	if count > 0 {
+		return nil
+	}
+
+	return db.Model(&models.GroupRoleDefinition{}).
+		Where("name = ?", LegacyOwnerRoleName).
+		Update("is_default", true).Error
+}

--- a/api/internal/repositories/seed_roles_test.go
+++ b/api/internal/repositories/seed_roles_test.go
@@ -272,12 +272,18 @@ func TestEnsureDefaultRolesIsIdempotent(t *testing.T) {
 	}
 
 	var appDefaults int64
-	GetDB().Model(&models.AppRole{}).Where("is_default = ?", true).Count(&appDefaults)
+	if err := GetDB().Model(&models.AppRole{}).Where("is_default = ?", true).Count(&appDefaults).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
 	if appDefaults != 1 {
 		utils.PrintTestError(t, appDefaults, 1)
 	}
 	var groupDefaults int64
-	GetDB().Model(&models.GroupRoleDefinition{}).Where("is_default = ?", true).Count(&groupDefaults)
+	if err := GetDB().Model(&models.GroupRoleDefinition{}).Where("is_default = ?", true).Count(&groupDefaults).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
 	if groupDefaults != 1 {
 		utils.PrintTestError(t, groupDefaults, 1)
 	}
@@ -322,5 +328,16 @@ func TestEnsureDefaultRolesPreservesCustomDefault(t *testing.T) {
 	legacyUser, ok := findRole(roles, LegacyUserRoleName)
 	if !ok || legacyUser.IsDefault {
 		utils.PrintTestError(t, "Legacy User became default", "Legacy User not default")
+	}
+}
+
+func TestEnsureDefaultRolesErrorsWhenLegacyRoleMissing(t *testing.T) {
+	defer TruncateTestDb()
+
+	// No roles seeded, so the legacy default roles do not exist. EnsureDefaultRoles
+	// must fail loudly rather than silently leaving no default (which would lock out
+	// every account created afterward).
+	if err := EnsureDefaultRoles(); err == nil {
+		utils.PrintTestError(t, "no error", "error: legacy role not found")
 	}
 }

--- a/api/internal/repositories/seed_roles_test.go
+++ b/api/internal/repositories/seed_roles_test.go
@@ -208,3 +208,119 @@ func TestSeedSystemRolesPreservesExisting(t *testing.T) {
 		utils.PrintTestError(t, role.Permissions, []string{permissions.AppUsersRead})
 	}
 }
+
+func TestEnsureDefaultRolesSetsLegacyDefaults(t *testing.T) {
+	defer TruncateTestDb()
+
+	if err := SeedSystemRoles(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if err := EnsureDefaultRoles(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	repository := NewRoleRepository(nil)
+	roles, err := repository.GetAllRoles()
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	appDefaults := 0
+	groupDefaults := 0
+	for _, role := range roles {
+		if !role.IsDefault {
+			continue
+		}
+		if role.Scope == permissions.ScopeApp {
+			appDefaults++
+			if role.Name != LegacyUserRoleName {
+				utils.PrintTestError(t, role.Name, LegacyUserRoleName)
+			}
+		} else {
+			groupDefaults++
+			if role.Name != LegacyOwnerRoleName {
+				utils.PrintTestError(t, role.Name, LegacyOwnerRoleName)
+			}
+		}
+	}
+
+	if appDefaults != 1 {
+		utils.PrintTestError(t, appDefaults, 1)
+	}
+	if groupDefaults != 1 {
+		utils.PrintTestError(t, groupDefaults, 1)
+	}
+}
+
+func TestEnsureDefaultRolesIsIdempotent(t *testing.T) {
+	defer TruncateTestDb()
+
+	if err := SeedSystemRoles(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if err := EnsureDefaultRoles(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if err := EnsureDefaultRoles(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	var appDefaults int64
+	GetDB().Model(&models.AppRole{}).Where("is_default = ?", true).Count(&appDefaults)
+	if appDefaults != 1 {
+		utils.PrintTestError(t, appDefaults, 1)
+	}
+	var groupDefaults int64
+	GetDB().Model(&models.GroupRoleDefinition{}).Where("is_default = ?", true).Count(&groupDefaults)
+	if groupDefaults != 1 {
+		utils.PrintTestError(t, groupDefaults, 1)
+	}
+}
+
+func TestEnsureDefaultRolesPreservesCustomDefault(t *testing.T) {
+	defer TruncateTestDb()
+
+	if err := SeedSystemRoles(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	// An administrator picked a custom app role as the default before this runs.
+	repository := NewRoleRepository(nil)
+	custom, err := repository.CreateAppRole("Custom Default", "", []string{permissions.AppUsersRead})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if err := repository.SetDefaultAppRole(custom.ID); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if err := EnsureDefaultRoles(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	roles, err := repository.GetAllRoles()
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	// The custom default must be preserved; Legacy User must not be promoted.
+	customRole, ok := findRole(roles, "Custom Default")
+	if !ok || !customRole.IsDefault {
+		utils.PrintTestError(t, "Custom Default not default", "default preserved")
+	}
+	legacyUser, ok := findRole(roles, LegacyUserRoleName)
+	if !ok || legacyUser.IsDefault {
+		utils.PrintTestError(t, "Legacy User became default", "Legacy User not default")
+	}
+}

--- a/api/internal/repositories/users.go
+++ b/api/internal/repositories/users.go
@@ -56,6 +56,17 @@ func (repository UserRepository) CreateUser(userData commands.SignUpCommand) (mo
 			}
 		}
 
+		// Assign the modern app role so the account is not locked out under
+		// permission enforcement: Legacy Admin for admins (the first/bootstrap
+		// user is never the configurable default), the configurable default app
+		// role otherwise.
+		appRoleId, roleErr := repository.resolveAppRoleId(tx, user.UserRole)
+		if roleErr != nil {
+			repository.ClearTransaction()
+			return roleErr
+		}
+		user.AppRoleID = appRoleId
+
 		err = repository.GetDB().Create(&user).Error
 
 		if err != nil {
@@ -95,6 +106,20 @@ func (repository UserRepository) CreateUser(userData commands.SignUpCommand) (mo
 	}
 
 	return user, nil
+}
+
+// resolveAppRoleId picks the modern app role for a newly-created user: the
+// Legacy Admin role for admins (so the first/bootstrap admin is never assigned
+// the configurable default and locked out of administration) and the
+// configurable default app role for everyone else. Returns nil when the role
+// can't be resolved (e.g. an unseeded test database), leaving the user without
+// a modern role rather than failing creation.
+func (repository UserRepository) resolveAppRoleId(tx *gorm.DB, userRole models.UserRole) (*uint, error) {
+	roleRepository := NewRoleRepository(tx)
+	if userRole == models.ADMIN {
+		return roleRepository.GetAppRoleIdByName(LegacyAdminRoleName)
+	}
+	return roleRepository.GetDefaultAppRoleId()
 }
 
 func (repository UserRepository) CreateUserIfNoneExist() error {

--- a/api/internal/repositories/users.go
+++ b/api/internal/repositories/users.go
@@ -29,6 +29,7 @@ func (repository UserRepository) CreateUser(userData commands.SignUpCommand) (mo
 		DisplayName:        userData.DisplayName,
 		Password:           userData.Password,
 		IsDummyUser:        userData.IsDummyUser,
+		UserRole:           userData.UserRole,
 		DefaultAvatarColor: "#27b1ff",
 	}
 

--- a/api/internal/repositories/users_test.go
+++ b/api/internal/repositories/users_test.go
@@ -53,6 +53,74 @@ func TestShouldCreateNonAdminUserWithGroup(t *testing.T) {
 	validateGroup(t, group, 2, 2)
 }
 
+func TestCreateUserAssignsDefaultAppRole(t *testing.T) {
+	defer TruncateTestDb()
+
+	if err := SeedSystemRoles(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if err := EnsureDefaultRoles(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	userRepository := NewUserRepository(nil)
+	roleRepository := NewRoleRepository(nil)
+
+	// The first user becomes ADMIN and must get the Legacy Admin role (never the
+	// configurable default), so the bootstrap admin is never locked out.
+	admin, err := userRepository.CreateUser(commands.SignUpCommand{
+		Username: "admin", DisplayName: "admin", Password: "a really secure password",
+	})
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+	legacyAdminId, err := roleRepository.GetAppRoleIdByName(LegacyAdminRoleName)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if admin.AppRoleID == nil || legacyAdminId == nil || *admin.AppRoleID != *legacyAdminId {
+		utils.PrintTestError(t, admin.AppRoleID, legacyAdminId)
+	}
+
+	// Subsequent users become USER and must get the configurable default app role.
+	user, err := userRepository.CreateUser(commands.SignUpCommand{
+		Username: "user", DisplayName: "user", Password: "a really secure password",
+	})
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+	defaultId, err := roleRepository.GetDefaultAppRoleId()
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if user.AppRoleID == nil || defaultId == nil || *user.AppRoleID != *defaultId {
+		utils.PrintTestError(t, user.AppRoleID, defaultId)
+	}
+}
+
+func TestCreateUserLeavesAppRoleNilWhenUnseeded(t *testing.T) {
+	defer TruncateTestDb()
+
+	userRepository := NewUserRepository(nil)
+	created, err := userRepository.CreateUser(commands.SignUpCommand{
+		Username: "noroles", DisplayName: "n", Password: "a really secure password",
+	})
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+
+	if created.AppRoleID != nil {
+		utils.PrintTestError(t, created.AppRoleID, nil)
+	}
+}
+
 func TestShouldReturnErrorWhenCreatingUserWithDuplicateUsername(t *testing.T) {
 	defer TruncateTestDb()
 	CreateTestUser()

--- a/api/internal/repositories/users_test.go
+++ b/api/internal/repositories/users_test.go
@@ -104,6 +104,55 @@ func TestCreateUserAssignsDefaultAppRole(t *testing.T) {
 	}
 }
 
+func TestCreateUserHonorsExplicitRole(t *testing.T) {
+	defer TruncateTestDb()
+
+	if err := SeedSystemRoles(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if err := EnsureDefaultRoles(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	userRepository := NewUserRepository(nil)
+	roleRepository := NewRoleRepository(nil)
+
+	// A bootstrap user already occupies the "first user" slot, so the count-based
+	// fallback would make the next account a USER. An explicit ADMIN role on the
+	// command (the admin-create path) must override that.
+	if _, err := userRepository.CreateUser(commands.SignUpCommand{
+		Username: "bootstrap", DisplayName: "b", Password: "a really secure password",
+	}); err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+
+	admin, err := userRepository.CreateUser(commands.SignUpCommand{
+		Username: "explicit-admin", DisplayName: "a", Password: "a really secure password",
+		UserRole: models.ADMIN,
+	})
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+
+	if admin.UserRole != models.ADMIN {
+		utils.PrintTestError(t, admin.UserRole, models.ADMIN)
+	}
+
+	// An explicit ADMIN must also resolve to the Legacy Admin modern role.
+	legacyAdminId, err := roleRepository.GetAppRoleIdByName(LegacyAdminRoleName)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if admin.AppRoleID == nil || legacyAdminId == nil || *admin.AppRoleID != *legacyAdminId {
+		utils.PrintTestError(t, admin.AppRoleID, legacyAdminId)
+	}
+}
+
 func TestCreateUserLeavesAppRoleNilWhenUnseeded(t *testing.T) {
 	defer TruncateTestDb()
 

--- a/api/internal/routers/role.go
+++ b/api/internal/routers/role.go
@@ -15,6 +15,7 @@ func BuildRoleRouter() *chi.Mux {
 	roleRouter.Get("/", handlers.GetRoles)
 	roleRouter.Post("/", handlers.CreateRole)
 	roleRouter.Put("/{roleId}", handlers.UpdateRole)
+	roleRouter.Put("/{roleId}/default", handlers.SetDefaultRole)
 	roleRouter.Delete("/{roleId}", handlers.DeleteRole)
 
 	return roleRouter

--- a/api/internal/services/roles.go
+++ b/api/internal/services/roles.go
@@ -3,6 +3,7 @@ package services
 import (
 	"errors"
 	"receipt-wrangler/api/internal/commands"
+	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/permissions"
 	"receipt-wrangler/api/internal/repositories"
 	"receipt-wrangler/api/internal/structs"
@@ -16,6 +17,7 @@ var (
 	ErrSystemRoleImmutable   = errors.New("system roles cannot be modified")
 	ErrSystemRoleUndeletable = errors.New("system roles cannot be deleted")
 	ErrRoleAssigned          = errors.New("role is assigned and cannot be deleted")
+	ErrRoleIsDefault         = errors.New("the default role cannot be deleted")
 )
 
 type RoleService struct {
@@ -115,6 +117,7 @@ func (service RoleService) UpdateRole(id uint, command commands.UpsertRoleComman
 				Name:        role.Name,
 				Description: role.Description,
 				Scope:       permissions.ScopeApp,
+				IsDefault:   role.IsDefault,
 				IsSystem:    role.IsSystem,
 				Permissions: perms,
 			}
@@ -143,6 +146,7 @@ func (service RoleService) UpdateRole(id uint, command commands.UpsertRoleComman
 			Name:        role.Name,
 			Description: role.Description,
 			Scope:       permissions.ScopeGroup,
+			IsDefault:   role.IsDefault,
 			IsSystem:    role.IsSystem,
 			Permissions: perms,
 		}
@@ -206,6 +210,10 @@ func (service RoleService) DeleteRole(id uint, scope permissions.Scope) error {
 				return ErrSystemRoleUndeletable
 			}
 
+			if existing.IsDefault {
+				return ErrRoleIsDefault
+			}
+
 			count, txErr := roleRepository.CountUsersWithAppRole(id)
 			if txErr != nil {
 				return txErr
@@ -228,6 +236,10 @@ func (service RoleService) DeleteRole(id uint, scope permissions.Scope) error {
 			return ErrSystemRoleUndeletable
 		}
 
+		if existing.IsDefault {
+			return ErrRoleIsDefault
+		}
+
 		count, txErr := roleRepository.CountGroupMembersWithGroupRole(id)
 		if txErr != nil {
 			return txErr
@@ -246,4 +258,93 @@ func (service RoleService) DeleteRole(id uint, scope permissions.Scope) error {
 	clearRolePermissionCache(scope, id)
 
 	return nil
+}
+
+// SetDefaultRole makes the given role the default for its scope (the role
+// assigned to new accounts for APP, or to group creators for GROUP), clearing
+// the previous default. The scope disambiguates the id (app and group role ids
+// overlap). System roles are allowed — the seeded legacy roles are the initial
+// defaults. The role's permission list is unchanged, so no cache eviction is
+// needed.
+func (service RoleService) SetDefaultRole(id uint, scope permissions.Scope) (structs.RoleView, error) {
+	var roleView structs.RoleView
+
+	err := repositories.GetDB().Transaction(func(tx *gorm.DB) error {
+		roleRepository := repositories.NewRoleRepository(tx)
+
+		if scope == permissions.ScopeApp {
+			existing, txErr := roleRepository.GetAppRoleById(id)
+			if errors.Is(txErr, gorm.ErrRecordNotFound) {
+				return resolveMissingRoleError(roleRepository, permissions.ScopeGroup, id)
+			}
+			if txErr != nil {
+				return txErr
+			}
+
+			if txErr := roleRepository.SetDefaultAppRole(id); txErr != nil {
+				return txErr
+			}
+
+			roleView = appRoleToView(existing, true)
+			return nil
+		}
+
+		existing, txErr := roleRepository.GetGroupRoleById(id)
+		if errors.Is(txErr, gorm.ErrRecordNotFound) {
+			return resolveMissingRoleError(roleRepository, permissions.ScopeApp, id)
+		}
+		if txErr != nil {
+			return txErr
+		}
+
+		if txErr := roleRepository.SetDefaultGroupRole(id); txErr != nil {
+			return txErr
+		}
+
+		roleView = groupRoleToView(existing, true)
+		return nil
+	})
+	if err != nil {
+		return structs.RoleView{}, err
+	}
+
+	return roleView, nil
+}
+
+// appRoleToView builds the read model for an app role, overriding IsDefault with
+// the post-update value (the loaded row predates the flag change).
+func appRoleToView(role models.AppRole, isDefault bool) structs.RoleView {
+	perms := make([]string, 0, len(role.Permissions))
+	for _, permission := range role.Permissions {
+		perms = append(perms, permission.Permission)
+	}
+
+	return structs.RoleView{
+		Id:          role.ID,
+		Name:        role.Name,
+		Description: role.Description,
+		Scope:       permissions.ScopeApp,
+		IsDefault:   isDefault,
+		IsSystem:    role.IsSystem,
+		Permissions: perms,
+	}
+}
+
+// groupRoleToView builds the read model for a group role, overriding IsDefault
+// with the post-update value.
+func groupRoleToView(role models.GroupRoleDefinition, isDefault bool) structs.RoleView {
+	perms := make([]string, 0, len(role.Permissions))
+	for _, permission := range role.Permissions {
+		perms = append(perms, permission.Permission)
+	}
+
+	return structs.RoleView{
+		Id:          role.ID,
+		Name:        role.Name,
+		Description: role.Description,
+		Scope:       permissions.ScopeGroup,
+		IsDefault:   isDefault,
+		IsSystem:    role.IsSystem,
+		Permissions: perms,
+	}
 }

--- a/api/internal/services/roles_test.go
+++ b/api/internal/services/roles_test.go
@@ -115,3 +115,114 @@ func TestUpdateRoleNotFound(t *testing.T) {
 		utils.PrintTestError(t, err, ErrRoleNotFound)
 	}
 }
+
+func TestSetDefaultRoleApp(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	roleRepository := repositories.NewRoleRepository(nil)
+
+	created, err := roleRepository.CreateAppRole("App Role", "", []string{permissions.AppUsersRead})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	service := NewRoleService(nil)
+	view, err := service.SetDefaultRole(created.ID, permissions.ScopeApp)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if !view.IsDefault {
+		utils.PrintTestError(t, view.IsDefault, true)
+	}
+
+	defaultId, err := roleRepository.GetDefaultAppRoleId()
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if defaultId == nil || *defaultId != created.ID {
+		utils.PrintTestError(t, defaultId, created.ID)
+	}
+}
+
+func TestSetDefaultRoleAllowsSystemRole(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	db := repositories.GetDB()
+
+	systemRole := models.GroupRoleDefinition{
+		Name:     "System Group Role",
+		IsSystem: true,
+		Permissions: []models.GroupRolePermission{
+			{Permission: permissions.GroupReceiptsRead},
+		},
+	}
+	if err := db.Create(&systemRole).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	service := NewRoleService(nil)
+	view, err := service.SetDefaultRole(systemRole.ID, permissions.ScopeGroup)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if !view.IsDefault {
+		utils.PrintTestError(t, view.IsDefault, true)
+	}
+}
+
+func TestSetDefaultRoleTypeMismatch(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	roleRepository := repositories.NewRoleRepository(nil)
+
+	created, err := roleRepository.CreateAppRole("App Role", "", []string{permissions.AppUsersRead})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	service := NewRoleService(nil)
+	// The id exists under APP, so requesting it under GROUP is a type mismatch.
+	_, err = service.SetDefaultRole(created.ID, permissions.ScopeGroup)
+	if !errors.Is(err, ErrRoleTypeMismatch) {
+		utils.PrintTestError(t, err, ErrRoleTypeMismatch)
+	}
+}
+
+func TestSetDefaultRoleNotFound(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	service := NewRoleService(nil)
+	_, err := service.SetDefaultRole(999, permissions.ScopeApp)
+	if !errors.Is(err, ErrRoleNotFound) {
+		utils.PrintTestError(t, err, ErrRoleNotFound)
+	}
+}
+
+func TestDeleteRoleRejectsDefault(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	roleRepository := repositories.NewRoleRepository(nil)
+
+	created, err := roleRepository.CreateAppRole("Default App Role", "", []string{permissions.AppUsersRead})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if err := roleRepository.SetDefaultAppRole(created.ID); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	service := NewRoleService(nil)
+	err = service.DeleteRole(created.ID, permissions.ScopeApp)
+	if !errors.Is(err, ErrRoleIsDefault) {
+		utils.PrintTestError(t, err, ErrRoleIsDefault)
+	}
+
+	// The default role must be untouched.
+	if _, err := roleRepository.GetAppRoleById(created.ID); err != nil {
+		utils.PrintTestError(t, err, "default role should be untouched")
+	}
+}

--- a/api/internal/structs/role_view.go
+++ b/api/internal/structs/role_view.go
@@ -7,6 +7,7 @@ type RoleView struct {
 	Name          string            `json:"name"`
 	Description   string            `json:"description"`
 	Scope         permissions.Scope `json:"scope"`
+	IsDefault     bool              `json:"isDefault"`
 	IsSystem      bool              `json:"isSystem"`
 	Permissions   []string          `json:"permissions"`
 	AssignedCount int               `json:"assignedCount"`

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -2822,6 +2822,47 @@ paths:
       security:
         - bearerAuth: [ ]
         - apiKeyAuth: [ ]
+  /role/{roleId}/default:
+    parameters:
+      - in: path
+        name: roleId
+        schema:
+          type: integer
+        required: true
+        description: Id of the role to make the default for its scope
+    put:
+      tags:
+        - Role
+      summary: Set default role
+      description: >-
+        Makes the role the default for its scope — the role assigned to new
+        accounts (APP) or to group creators (GROUP) — clearing the previous
+        default. The scope query parameter disambiguates the role id, since app
+        and group role ids overlap. System roles may be made default.
+      operationId: setDefaultRole
+      parameters:
+        - in: query
+          name: scope
+          required: true
+          schema:
+            $ref: "#/components/schemas/PermissionScope"
+          description: Scope of the role to make default
+      responses:
+        200:
+          description: The updated role
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Role"
+        400:
+          $ref: "#/components/responses/BadRequest"
+        404:
+          $ref: "#/components/responses/NotFound"
+        500:
+          $ref: "#/components/responses/Internal"
+      security:
+        - bearerAuth: [ ]
+        - apiKeyAuth: [ ]
 components:
   securitySchemes:
     bearerAuth:
@@ -3009,6 +3050,7 @@ components:
         - id
         - name
         - scope
+        - isDefault
         - isSystem
         - permissions
       properties:
@@ -3021,6 +3063,12 @@ components:
           type: string
         scope:
           $ref: "#/components/schemas/PermissionScope"
+        isDefault:
+          type: boolean
+          description: >-
+            Whether this role is the default for its scope — assigned to new
+            accounts (APP) or to group creators (GROUP). Exactly one role per
+            scope is the default.
         isSystem:
           type: boolean
         permissions:

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -125,6 +125,12 @@ global `UserRole.Admin` check in `RoleGuard` (`src/guards/role.guard.ts`).
   `src/open-api/` — regenerate it from `swagger.yml` instead.
 - Built on existing shared patterns: `app-breadcrumb` and the segmented `app-filter-bar` (see "Use
   Established Patterns" above).
+- **Default roles:** the role-list page shows two `app-select` controls above the filter bar —
+  "Default application role" and "Default group role". Each is pre-selected from the role flagged
+  `isDefault` for its scope and, on change, calls `RoleService.setDefaultRole(scope, roleId)` then
+  reloads (setting one default clears the previous one). The default role per scope is what new
+  accounts / group creators receive (see `api/CLAUDE.md` → "Default roles"); the current default
+  cannot be deleted. Default rows also carry a "Default" badge next to the System badge.
 - **Permission-based UI gating is not implemented yet.** There is no `*hasPermission` directive or
   `permissionService.has(...)` helper; UI access is still gated by the global admin `RoleGuard` and
   the legacy `UserRole`. When permission-driven gating is added, document the directive/guard here.

--- a/desktop/e2e/role-defaults.spec.ts
+++ b/desktop/e2e/role-defaults.spec.ts
@@ -127,13 +127,13 @@ test.describe('group creation assigns the default group role (user)', () => {
 });
 
 // Deletes a group from the list by name. The delete button is an icon-only
-// control (no accessible name), so it is located by its "delete" mat-icon; the
-// confirmation dialog's confirm button carries a data-testid.
+// control (no accessible name), so it carries a data-testid; the confirmation
+// dialog's confirm button likewise carries a data-testid.
 async function deleteGroupByName(page: Page, name: string) {
   await page.goto('/groups');
   const row = page.getByRole('row').filter({ hasText: name }).first();
   await expect(row).toBeVisible();
-  await row.locator('button:has(mat-icon:has-text("delete"))').click();
+  await row.getByTestId('group-delete').click();
 
   const dialog = page.getByRole('dialog');
   await expect(dialog).toBeVisible();

--- a/desktop/e2e/role-defaults.spec.ts
+++ b/desktop/e2e/role-defaults.spec.ts
@@ -1,0 +1,143 @@
+import { expect, test, type Page } from '@playwright/test';
+import { stubTokenRefresh } from './helpers/auth';
+
+function uniqueName(tag: string) {
+  return `e2e-${tag}-${Date.now()}`;
+}
+
+// The role-list table row whose text contains `name`. Role names are unique, so
+// the first match is the role's row.
+function roleRow(page: Page, name: string) {
+  return page.getByRole('row').filter({ hasText: name }).first();
+}
+
+// The `app-select` trigger (a mat-select) addressed by its label. Use the
+// combobox role rather than getByLabel: while the option panel is open (and
+// during its close animation) the listbox panel shares the same aria label, so
+// getByLabel would match two elements.
+function defaultSelect(page: Page, label: string) {
+  return page.getByRole('combobox', { name: label });
+}
+
+// Opens a default-role selector and picks an option by its exact text.
+async function selectDefault(page: Page, label: string, optionName: string) {
+  await defaultSelect(page, label).click();
+  await page.getByRole('option', { name: optionName, exact: true }).click();
+}
+
+test.describe('default roles (admin)', () => {
+  test.use({ storageState: 'e2e/.auth/admin.json' });
+  // The default per scope is global, mutable server state. Run serially and
+  // restore after each test so the tests don't race each other.
+  test.describe.configure({ mode: 'serial' });
+
+  test.beforeEach(async ({ page }) => {
+    await stubTokenRefresh(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    // Restore the seeded default app role even if a test failed mid-way.
+    // Re-selecting the already-active option is a no-op (mat-select emits no
+    // change), so this is safe whether or not the test already restored it.
+    try {
+      await page.goto('/roles');
+      await selectDefault(page, 'Default application role', 'Legacy User');
+    } catch {
+      // Best-effort — don't mask the test's own failure.
+    }
+  });
+
+  test('seeded defaults are preselected and badged', async ({ page }) => {
+    await page.goto('/roles');
+
+    // The two selectors reflect the legacy-equivalent defaults seeded on boot.
+    await expect(defaultSelect(page, 'Default application role')).toContainText('Legacy User');
+    await expect(defaultSelect(page, 'Default group role')).toContainText('Legacy Owner');
+
+    // The same roles carry a "Default" badge in the table.
+    await expect(roleRow(page, 'Legacy User')).toContainText('Default');
+    await expect(roleRow(page, 'Legacy Owner')).toContainText('Default');
+  });
+
+  test('changing the default application role persists and moves the badge', async ({ page }) => {
+    await page.goto('/roles');
+
+    await selectDefault(page, 'Default application role', 'Legacy Admin');
+
+    await expect(page.getByText('Default role updated')).toBeVisible();
+    await expect(defaultSelect(page, 'Default application role')).toContainText('Legacy Admin');
+    await expect(roleRow(page, 'Legacy Admin')).toContainText('Default');
+    await expect(roleRow(page, 'Legacy User')).not.toContainText('Default');
+
+    // The change persists across a reload (it was written server-side).
+    await page.goto('/roles');
+    await expect(defaultSelect(page, 'Default application role')).toContainText('Legacy Admin');
+    await expect(roleRow(page, 'Legacy Admin')).toContainText('Default');
+    await expect(roleRow(page, 'Legacy User')).not.toContainText('Default');
+
+    // Restore so the group-creation test (and reruns) see the seeded default.
+    await selectDefault(page, 'Default application role', 'Legacy User');
+    await expect(defaultSelect(page, 'Default application role')).toContainText('Legacy User');
+    await expect(roleRow(page, 'Legacy User')).toContainText('Default');
+  });
+});
+
+test.describe('group creation assigns the default group role (user)', () => {
+  test.use({ storageState: 'e2e/.auth/user.json' });
+
+  // Set after a group is created so afterEach can reap it if the test fails
+  // before its own cleanup runs.
+  let createdGroupName: string | null = null;
+
+  test.beforeEach(async ({ page }) => {
+    await stubTokenRefresh(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    if (!createdGroupName) return;
+    const leftover = createdGroupName;
+    createdGroupName = null;
+    try {
+      await deleteGroupByName(page, leftover);
+    } catch {
+      // Best-effort — the test already failed and we don't want to mask it.
+    }
+  });
+
+  test('a regular user can create a group and open it', async ({ page }) => {
+    const name = uniqueName('grp');
+
+    await page.goto('/groups/create');
+    await expect(page.getByLabel('Group Name')).toBeVisible();
+    await page.getByLabel('Group Name').fill(name);
+    // The app-form submits on Enter from a field (the submit button is an
+    // icon-only control with no accessible name).
+    await page.getByLabel('Group Name').press('Enter');
+
+    // Landing on the group's detail view means the modern, permission-gated
+    // group resolver succeeded — i.e. the creator was assigned the default
+    // group role and is not locked out of the group they just created.
+    await expect(page).toHaveURL(/\/groups\/\d+\/details\/view/);
+    createdGroupName = name;
+    await expect(page.getByLabel('Group Name')).toHaveValue(name);
+
+    await deleteGroupByName(page, name);
+    createdGroupName = null;
+  });
+});
+
+// Deletes a group from the list by name. The delete button is an icon-only
+// control (no accessible name), so it is located by its "delete" mat-icon; the
+// confirmation dialog's confirm button carries a data-testid.
+async function deleteGroupByName(page: Page, name: string) {
+  await page.goto('/groups');
+  const row = page.getByRole('row').filter({ hasText: name }).first();
+  await expect(row).toBeVisible();
+  await row.locator('button:has(mat-icon:has-text("delete"))').click();
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  await dialog.getByTestId('dialog-submit-button').click();
+
+  await expect(page.getByRole('row').filter({ hasText: name })).toHaveCount(0);
+}

--- a/desktop/src/group/group-table/group-table.component.html
+++ b/desktop/src/group/group-table/group-table.component.html
@@ -60,6 +60,7 @@
     ></app-edit-button>
     <app-delete-button
       *ngIf="element.id | groupRole : groupRole.Owner"
+      data-testid="group-delete"
       tooltip="Delete Group"
       [disabled]="groups()?.length === 1"
       (clicked)="deleteGroup(index)"

--- a/desktop/src/open-api/api/role.service.ts
+++ b/desktop/src/open-api/api/role.service.ts
@@ -348,6 +348,95 @@ export class RoleService {
     }
 
     /**
+     * Set default role
+     * Makes the role the default for its scope — the role assigned to new accounts (APP) or to group creators (GROUP) — clearing the previous default. The scope query parameter disambiguates the role id, since app and group role ids overlap. System roles may be made default.
+     * @param scope Scope of the role to make default
+     * @param roleId Id of the role to make the default for its scope
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
+     */
+    public setDefaultRole(scope: PermissionScope, roleId: number, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<Role>;
+    public setDefaultRole(scope: PermissionScope, roleId: number, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<Role>>;
+    public setDefaultRole(scope: PermissionScope, roleId: number, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<Role>>;
+    public setDefaultRole(scope: PermissionScope, roleId: number, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
+        if (scope === null || scope === undefined) {
+            throw new Error('Required parameter scope was null or undefined when calling setDefaultRole.');
+        }
+        if (roleId === null || roleId === undefined) {
+            throw new Error('Required parameter roleId was null or undefined when calling setDefaultRole.');
+        }
+
+        let localVarQueryParameters = new HttpParams({encoder: this.encoder});
+        if (scope !== undefined && scope !== null) {
+          localVarQueryParameters = this.addToHttpParams(localVarQueryParameters,
+            <any>scope, 'scope');
+        }
+
+        let localVarHeaders = this.defaultHeaders;
+
+        let localVarCredential: string | undefined;
+        // authentication (apiKeyAuth) required
+        localVarCredential = this.configuration.lookupCredential('apiKeyAuth');
+        if (localVarCredential) {
+            localVarHeaders = localVarHeaders.set('Authorization', localVarCredential);
+        }
+
+        // authentication (bearerAuth) required
+        localVarCredential = this.configuration.lookupCredential('bearerAuth');
+        if (localVarCredential) {
+            localVarHeaders = localVarHeaders.set('Authorization', 'Bearer ' + localVarCredential);
+        }
+
+        let localVarHttpHeaderAcceptSelected: string | undefined = options && options.httpHeaderAccept;
+        if (localVarHttpHeaderAcceptSelected === undefined) {
+            // to determine the Accept header
+            const httpHeaderAccepts: string[] = [
+                'application/json'
+            ];
+            localVarHttpHeaderAcceptSelected = this.configuration.selectHeaderAccept(httpHeaderAccepts);
+        }
+        if (localVarHttpHeaderAcceptSelected !== undefined) {
+            localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
+        }
+
+        let localVarHttpContext: HttpContext | undefined = options && options.context;
+        if (localVarHttpContext === undefined) {
+            localVarHttpContext = new HttpContext();
+        }
+
+        let localVarTransferCache: boolean | undefined = options && options.transferCache;
+        if (localVarTransferCache === undefined) {
+            localVarTransferCache = true;
+        }
+
+
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
+            }
+        }
+
+        let localVarPath = `/role/${this.configuration.encodeParam({name: "roleId", value: roleId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: undefined})}/default`;
+        return this.httpClient.request<Role>('put', `${this.configuration.basePath}${localVarPath}`,
+            {
+                context: localVarHttpContext,
+                params: localVarQueryParameters,
+                responseType: <any>responseType_,
+                withCredentials: this.configuration.withCredentials,
+                headers: localVarHeaders,
+                observe: observe,
+                transferCache: localVarTransferCache,
+                reportProgress: reportProgress
+            }
+        );
+    }
+
+    /**
      * Update role
      * Updates an existing app-scoped or group-scoped role. A role\&#39;s type cannot be changed: the scope in the request must match the existing role\&#39;s scope. System roles cannot be modified.
      * @param roleId Id of the role to update

--- a/desktop/src/open-api/model/role.ts
+++ b/desktop/src/open-api/model/role.ts
@@ -16,6 +16,10 @@ export interface Role {
     name: string;
     description?: string;
     scope: PermissionScope;
+    /**
+     * Whether this role is the default for its scope — assigned to new accounts (APP) or to group creators (GROUP). Exactly one role per scope is the default.
+     */
+    isDefault: boolean;
     isSystem: boolean;
     permissions: Array<Permission>;
     /**

--- a/desktop/src/roles/role-form/role-form.component.spec.ts
+++ b/desktop/src/roles/role-form/role-form.component.spec.ts
@@ -124,6 +124,7 @@ async function setup(
     id: 1,
     name: "Created",
     scope: "APP",
+    isDefault: false,
     isSystem: false,
     permissions: [],
   };
@@ -134,7 +135,7 @@ async function setup(
   const updateRoleSpy = jest
     .spyOn(roleService, "updateRole")
     .mockImplementation((_id: number, command: any) =>
-      of({ id: 1, isSystem: false, ...command } as Role) as any,
+      of({ id: 1, isDefault: false, isSystem: false, ...command } as Role) as any,
     );
   jest
     .spyOn(roleService, "getRoles")
@@ -157,6 +158,7 @@ const EDITABLE_APP_ROLE: Role = {
   name: "App Manager",
   description: "Manages the app",
   scope: "APP",
+  isDefault: false,
   isSystem: false,
   permissions: ["app.users.create", "app.users.read"],
 };
@@ -166,6 +168,7 @@ const SYSTEM_APP_ROLE: Role = {
   name: "Administrator",
   description: "Built in",
   scope: "APP",
+  isDefault: false,
   isSystem: true,
   permissions: ["app.users.create"],
 };
@@ -388,6 +391,7 @@ describe("RoleFormComponent", () => {
         id: 7,
         name: "Group Role 7",
         scope: "GROUP",
+        isDefault: false,
         isSystem: false,
         permissions: ["group.view"],
       };

--- a/desktop/src/roles/role-list/role-list-item.interface.ts
+++ b/desktop/src/roles/role-list/role-list-item.interface.ts
@@ -13,6 +13,7 @@ export interface RoleListItem {
   scope: RoleScope;
   permissionCount: number;
   userCount: number;
+  isDefault: boolean;
   isSystem: boolean;
   icon: string;
   iconColor: string;

--- a/desktop/src/roles/role-list/role-list.component.html
+++ b/desktop/src/roles/role-list/role-list.component.html
@@ -34,6 +34,25 @@
       ></app-button>
     </div>
   } @else {
+    <div class="default-roles">
+      <app-select
+        label="Default application role"
+        optionValueKey="id"
+        optionDisplayKey="name"
+        hint="Assigned to new accounts when they sign up."
+        [options]="appRoleOptions()"
+        [inputFormControl]="defaultAppRoleControl"
+      ></app-select>
+      <app-select
+        label="Default group role"
+        optionValueKey="id"
+        optionDisplayKey="name"
+        hint="Assigned to the creator when a group is created."
+        [options]="groupRoleOptions()"
+        [inputFormControl]="defaultGroupRoleControl"
+      ></app-select>
+    </div>
+
     <app-filter-bar
       [tabs]="filterTabs()"
       [value]="filter()"
@@ -60,6 +79,9 @@
     <div>
       <div class="nm">
         {{ role.name }}
+        @if (role.isDefault) {
+          <span class="badge-default"><mat-icon>star</mat-icon>Default</span>
+        }
         @if (role.isSystem) {
           <span class="badge-lock"><mat-icon>lock</mat-icon>System</span>
         }

--- a/desktop/src/roles/role-list/role-list.component.scss
+++ b/desktop/src/roles/role-list/role-list.component.scss
@@ -45,6 +45,19 @@ $group-accent-bar: #a78bfa;
   }
 }
 
+/* ---------- Default-role selectors ---------- */
+.default-roles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: variables.$spacing-lg;
+  margin-bottom: variables.$spacing-md;
+
+  app-select {
+    flex: 1 1 280px;
+    max-width: 360px;
+  }
+}
+
 /* ---------- Type filter ---------- */
 app-filter-bar {
   display: inline-block;
@@ -147,6 +160,25 @@ app-filter-bar {
     font-size: 15px;
     width: 15px;
     height: 15px;
+  }
+}
+
+.badge-default {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 20px;
+  padding: 0 8px;
+  border-radius: 9999px;
+  font-size: 11.5px;
+  font-weight: 600;
+  background: map.get(variables.$primary-palette, 50);
+  color: map.get(variables.$primary-palette, 800);
+
+  mat-icon {
+    font-size: 14px;
+    width: 14px;
+    height: 14px;
   }
 }
 

--- a/desktop/src/roles/role-list/role-list.component.spec.ts
+++ b/desktop/src/roles/role-list/role-list.component.spec.ts
@@ -26,6 +26,7 @@ function listItem(overrides: Partial<RoleListItem> = {}): RoleListItem {
     scope: "app" as RoleScope,
     permissionCount: 0,
     userCount: 0,
+    isDefault: false,
     isSystem: false,
     icon: "apps",
     iconColor: "",
@@ -48,6 +49,7 @@ const ROLES: Role[] = [
     name: "Administrator",
     description: "Full access",
     scope: "APP",
+    isDefault: true,
     isSystem: true,
     permissions: ["app.users.create", "app.users.read"],
   },
@@ -56,6 +58,7 @@ const ROLES: Role[] = [
     name: "Group Manager",
     description: "Runs groups",
     scope: "GROUP",
+    isDefault: true,
     isSystem: false,
     permissions: ["group.view", "group.receipts.read"],
   },
@@ -97,6 +100,7 @@ async function setup(
   const roleService = TestBed.inject(RoleService);
   jest.spyOn(roleService, "getRoles").mockReturnValue(of(roles) as any);
   jest.spyOn(roleService, "deleteRole").mockReturnValue(of({}) as any);
+  jest.spyOn(roleService, "setDefaultRole").mockReturnValue(of({}) as any);
   jest
     .spyOn(TestBed.inject(PermissionService), "getPermissions")
     .mockReturnValue(
@@ -282,5 +286,60 @@ describe("RoleListComponent", () => {
 
     expect(snackbar.error).toHaveBeenCalledWith("Failed to delete role");
     expect(reloadSpy.mock.calls.length).toBe(callsBefore);
+  });
+
+  it("preselects each default selector from the role marked default for its scope", async () => {
+    const { component } = await setup();
+    // ROLES marks the APP role (id 1) and the GROUP role (id 2) as default.
+    expect(component.defaultAppRoleControl.value).toBe(1);
+    expect(component.defaultGroupRoleControl.value).toBe(2);
+  });
+
+  it("offers each scope's roles as options for its selector", async () => {
+    const { component } = await setup();
+    expect(component.appRoleOptions()).toEqual([{ id: 1, name: "Administrator" }]);
+    expect(component.groupRoleOptions()).toEqual([{ id: 2, name: "Group Manager" }]);
+  });
+
+  it("sets the new default for the scope and reloads when a selector changes", async () => {
+    const roles: Role[] = [
+      { ...ROLES[0], id: 1, isDefault: true },
+      { ...ROLES[0], id: 9, name: "Restricted", isDefault: false, isSystem: false },
+    ];
+    const { component, roleService, snackbar } = await setup(roles);
+    const reloadSpy = jest.spyOn(roleService, "getRoles");
+    const callsBefore = reloadSpy.mock.calls.length;
+
+    component.defaultAppRoleControl.setValue(9);
+
+    expect(roleService.setDefaultRole).toHaveBeenCalledWith(PermissionScope.App, 9);
+    expect(snackbar.success).toHaveBeenCalledWith("Default role updated");
+    expect(reloadSpy.mock.calls.length).toBe(callsBefore + 1);
+  });
+
+  it("does not call the API when syncing selectors from the server", async () => {
+    const { roleService } = await setup();
+    // The constructor loads roles and patches the selectors with emitEvent:false,
+    // so no set-default request is made just from rendering.
+    expect(roleService.setDefaultRole).not.toHaveBeenCalled();
+  });
+
+  it("shows an error and reverts the selector when setting the default fails", async () => {
+    const roles: Role[] = [
+      { ...ROLES[0], id: 1, isDefault: true },
+      { ...ROLES[0], id: 9, name: "Restricted", isDefault: false, isSystem: false },
+    ];
+    const { component, roleService, snackbar } = await setup(roles);
+    const reloadSpy = jest.spyOn(roleService, "getRoles");
+    const callsBefore = reloadSpy.mock.calls.length;
+    (roleService.setDefaultRole as jest.Mock).mockReturnValueOnce(
+      throwError(() => new Error("boom")) as any,
+    );
+
+    component.defaultAppRoleControl.setValue(9);
+
+    expect(snackbar.error).toHaveBeenCalledWith("Failed to update default role");
+    // Reloaded to revert the selector to the server's current default.
+    expect(reloadSpy.mock.calls.length).toBe(callsBefore + 1);
   });
 });

--- a/desktop/src/roles/role-list/role-list.component.ts
+++ b/desktop/src/roles/role-list/role-list.component.ts
@@ -9,6 +9,7 @@ import {
   viewChild,
 } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { FormControl } from "@angular/forms";
 import { MatDialog } from "@angular/material/dialog";
 import { MatTableDataSource } from "@angular/material/table";
 import { Router } from "@angular/router";
@@ -107,6 +108,25 @@ export class RoleListComponent implements AfterViewInit {
     () => new MatTableDataSource(this.filteredRoles()),
   );
 
+  // Options for the two "default role" selectors: roles of each scope, valued by
+  // id and displayed by name.
+  public readonly appRoleOptions = computed(() =>
+    this.roles()
+      .filter((role) => role.scope === "app")
+      .map((role) => ({ id: Number(role.id), name: role.name })),
+  );
+  public readonly groupRoleOptions = computed(() =>
+    this.roles()
+      .filter((role) => role.scope === "group")
+      .map((role) => ({ id: Number(role.id), name: role.name })),
+  );
+
+  // The two default-role selectors. Exactly one role per scope is the default,
+  // so there is no empty option. Values are patched from the server with
+  // emitEvent:false; a genuine user selection drives setDefaultRole.
+  public readonly defaultAppRoleControl = new FormControl<number | null>(null);
+  public readonly defaultGroupRoleControl = new FormControl<number | null>(null);
+
   // Per-scope permission totals from the registry — the denominator for each
   // role's meter (a role's bar is relative to its own scope's total).
   private readonly scopeTotals = signal<Record<RoleScope, number>>({ app: 0, group: 0 });
@@ -114,6 +134,16 @@ export class RoleListComponent implements AfterViewInit {
   constructor() {
     this.loadScopeTotals();
     this.loadRoles();
+
+    // A user picking a different role in either selector makes it the new default
+    // for that scope. Programmatic sync from the server uses emitEvent:false, so
+    // those updates do not re-trigger the API call.
+    this.defaultAppRoleControl.valueChanges
+      .pipe(takeUntilDestroyed())
+      .subscribe((roleId) => this.onDefaultChange("app", roleId));
+    this.defaultGroupRoleControl.valueChanges
+      .pipe(takeUntilDestroyed())
+      .subscribe((roleId) => this.onDefaultChange("group", roleId));
   }
 
   public ngAfterViewInit(): void {
@@ -246,16 +276,60 @@ export class RoleListComponent implements AfterViewInit {
     return scope === "group" ? PermissionScope.Group : PermissionScope.App;
   }
 
+  // Makes the chosen role the default for its scope, then reloads so every
+  // selector and the Default badges reflect the server (setting one default
+  // clears the previous one). A null value (no selection) is ignored.
+  private onDefaultChange(scope: RoleScope, roleId: number | null): void {
+    if (roleId == null) {
+      return;
+    }
+
+    this.roleService
+      .setDefaultRole(this.toScopeEnum(scope), roleId)
+      .pipe(
+        take(1),
+        tap(() => {
+          this.snackbarService.success("Default role updated");
+          this.loadRoles();
+        }),
+        catchError(() => {
+          this.snackbarService.error("Failed to update default role");
+          // Revert the selector to the server's current default.
+          this.loadRoles();
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
   private loadRoles(): void {
     this.roleService
       .getRoles()
       .pipe(
         take(1),
-        tap((roles) => this.roles.set(roles.map((role) => this.toListItem(role)))),
+        tap((roles) => {
+          this.roles.set(roles.map((role) => this.toListItem(role)));
+          this.syncDefaultControls();
+        }),
         catchError(() => EMPTY),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
+  }
+
+  // Patches the two selectors to the server's current default per scope without
+  // emitting (so it never re-triggers setDefaultRole).
+  private syncDefaultControls(): void {
+    const appDefault = this.roles().find((role) => role.scope === "app" && role.isDefault);
+    const groupDefault = this.roles().find((role) => role.scope === "group" && role.isDefault);
+
+    this.defaultAppRoleControl.setValue(appDefault ? Number(appDefault.id) : null, {
+      emitEvent: false,
+    });
+    this.defaultGroupRoleControl.setValue(groupDefault ? Number(groupDefault.id) : null, {
+      emitEvent: false,
+    });
   }
 
   private toListItem(role: Role): RoleListItem {
@@ -268,6 +342,7 @@ export class RoleListComponent implements AfterViewInit {
       scope,
       permissionCount: role.permissions?.length ?? 0,
       userCount: role.assignedCount ?? 0,
+      isDefault: role.isDefault,
       isSystem: role.isSystem,
       icon: visual.icon,
       iconColor: visual.color,

--- a/desktop/src/roles/roles.module.ts
+++ b/desktop/src/roles/roles.module.ts
@@ -7,6 +7,7 @@ import { RouterModule } from "@angular/router";
 import { PipesModule } from "src/pipes/pipes.module";
 import { ButtonModule } from "../button";
 import { InputModule } from "../input";
+import { SelectModule } from "../select/select.module";
 import { SharedUiModule } from "../shared-ui/shared-ui.module";
 import { TableModule } from "../table/table.module";
 import { TextareaModule } from "../textarea/textarea.module";
@@ -25,6 +26,7 @@ import { RolesRoutingModule } from "./roles-routing.module";
     PipesModule,
     ReactiveFormsModule,
     RouterModule,
+    SelectModule,
     SharedUiModule,
     TableModule,
     TextareaModule,


### PR DESCRIPTION
## What

Adds a **required, configurable default role per scope** and wires it into account/group creation, so principals created after the one-time legacy migration are no longer left without a modern role (the previously-documented lockout follow-up).

- **Default application role** — assigned to a user on signup / admin-create.
- **Default group role** — assigned to the creator when a group is created.

The seeded legacy roles are the initial defaults (**Legacy User** for app, **Legacy Owner** for group), so upgrades see no behavior change.

## Backend

- `AppRole` gains `IsDefault` (`GroupRoleDefinition` already had it). `EnsureDefaultRoles` runs after `SeedSystemRoles` in `InitDB`: if a scope has no default it flags the legacy equivalent. Idempotent, self-healing, never overrides an admin's choice.
- New `PUT /role/{roleId}/default?scope=APP|GROUP` (`RoleService.SetDefaultRole`) clears the prior default and sets the new one in one transaction; allowed on system roles. The current default cannot be deleted (`ErrRoleIsDefault`).
- `CreateUser` sets `User.AppRoleID` (Legacy Admin for an `ADMIN`-resolved user so the bootstrap admin is never locked out; the default app role otherwise). `CreateGroup` sets the creator's `GroupMember.GroupRoleID` to the default group role. Both best-effort — `nil` when unseeded (e.g. test DBs), never failing creation.
- `Role` view + `swagger.yml` expose `isDefault`.

## Desktop

- Manage Roles list shows two `app-select` controls above the filter bar ("Default application role" / "Default group role"), pre-selected from the role flagged default and applying immediately via `setDefaultRole` then reload. Default rows carry a "Default" badge.
- Generated client regenerated for `Role.isDefault` and `setDefaultRole`.

## Out of scope

- Members added to *existing* groups (group member-role assignment) — next slice.
- Mobile client regen — deferred (assignment is server-side).

## Testing

- `go test ./...` — full suite passes, incl. new tests for `EnsureDefaultRoles`, `SetDefault*` repo/service, the `SetDefaultRole` handler (authz + scope + 404), the delete-default guard, and per-create assignment (seeded + unseeded).
- `npm test` — 843 desktop tests pass, incl. role-list selector/badge coverage. `npm run build` passes.
- Verified the running dev stack's login API returns 200 with valid cookies. Live Playwright e2e of the feature requires the API running this branch's binary (the running dev API predates these changes); the shared dev stack's UI-login setup step is blocked by its `Secure`-cookie config over `http://localhost`, unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can mark a role as the default per scope via UI selectors and a new API; default roles are shown with a “Default” badge.

* **Bug Fixes**
  * Prevent deleting the current default role; public sign-up can no longer set a role.

* **Behavior Changes**
  * New accounts and group creators receive the configured defaults; startup now ensures legacy defaults are backfilled.

* **Tests**
  * Added unit, integration, and e2e coverage for default-role flows.

* **Documentation**
  * Updated docs and OpenAPI to describe default-role behavior and UI guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->