### PR TITLE
IMAP ingestion + PDF render robustness fixes

### DIFF
--- a/api/imap-client/imap_client.py
+++ b/api/imap-client/imap_client.py
@@ -63,6 +63,13 @@ class ImapClient:
         skip_verify = os.environ.get("IMAP_TLS_SKIP_VERIFY", "").lower() in ("1", "true", "yes")
         ssl_context = None
         if skip_verify:
+            logging.warning(
+                "IMAP_TLS_SKIP_VERIFY is enabled: TLS certificate verification is "
+                "DISABLED for %s:%s. This exposes the connection to "
+                "man-in-the-middle attacks and should only be used for trusted "
+                "internal hosts with self-signed certificates.",
+                self.host, self.port,
+            )
             ssl_context = ssl.create_default_context()
             ssl_context.check_hostname = False
             ssl_context.verify_mode = ssl.CERT_NONE
@@ -100,8 +107,10 @@ class ImapClient:
             # message and re-raise to the Go caller as exit status 1).
             try:
                 formatted_data = self._get_formatted_message_data(data)
-            except Exception as e:
-                logging.error(f"Skipping message {message_id}: {e}")
+            except Exception:
+                # logging.exception preserves the traceback so the malformed
+                # message can be diagnosed, while we continue the poll.
+                logging.exception(f"Skipping message {message_id}")
                 continue
             if len(formatted_data) > 0:
                 formatted_data[message_id] = message_id
@@ -202,18 +211,22 @@ class ImapClient:
 
             logging.info(f"Filename: {filename} mime_type: {mime_type}")
 
-            if len(filename) > 0 and self.valid_mime_type(mime_type):
+            if filename and len(filename) > 0 and self.valid_mime_type(mime_type):
+                # Sanitize: the filename comes from untrusted email content and
+                # is used in a path join, so strip any directory components to
+                # prevent path traversal (e.g. "../../etc/...").
+                safe_filename = os.path.basename(filename)
                 payload = part.get_payload(decode=True)
                 if payload is None:
-                    logging.warning(f"Skipping attachment with undecodable payload: {filename}")
+                    logging.warning(f"Skipping attachment with undecodable payload: {safe_filename}")
                     continue
-                filePath = os.path.join(base_path, "temp", filename)
+                filePath = os.path.join(base_path, "temp", safe_filename)
                 with open(filePath, 'wb') as f:
                     f.write(payload)
 
                 size = os.path.getsize(filePath)
                 data = {
-                    "filename": filename,
+                    "filename": safe_filename,
                     "fileType": mime_type,
                     "size": size,
                 }

--- a/api/imap-client/imap_client.py
+++ b/api/imap-client/imap_client.py
@@ -95,8 +95,14 @@ class ImapClient:
 
         results = []
         for message_id, data in response.items():
-            formatted_data = self._get_formatted_message_data(
-                data)
+            # Process each message independently: a single malformed message
+            # must not abort the whole poll (which would drop every fetched
+            # message and re-raise to the Go caller as exit status 1).
+            try:
+                formatted_data = self._get_formatted_message_data(data)
+            except Exception as e:
+                logging.error(f"Skipping message {message_id}: {e}")
+                continue
             if len(formatted_data) > 0:
                 formatted_data[message_id] = message_id
                 results.append(formatted_data)
@@ -104,7 +110,11 @@ class ImapClient:
         return results
 
     def _get_formatted_message_data(self, data):
-        message_data = email.message_from_bytes(data[b"RFC822"])
+        raw_rfc822 = data.get(b"RFC822") if data else None
+        if not raw_rfc822:
+            logging.warning("Skipping message with empty RFC822 payload")
+            return {}
+        message_data = email.message_from_bytes(raw_rfc822)
 
         from_data = self._get_formatted_to_or_from_data(message_data, "From")
         if from_data["email"] is None:
@@ -193,9 +203,13 @@ class ImapClient:
             logging.info(f"Filename: {filename} mime_type: {mime_type}")
 
             if len(filename) > 0 and self.valid_mime_type(mime_type):
+                payload = part.get_payload(decode=True)
+                if payload is None:
+                    logging.warning(f"Skipping attachment with undecodable payload: {filename}")
+                    continue
                 filePath = os.path.join(base_path, "temp", filename)
                 with open(filePath, 'wb') as f:
-                    f.write(part.get_payload(decode=True))
+                    f.write(payload)
 
                 size = os.path.getsize(filePath)
                 data = {

--- a/api/imap-client/imap_client.py
+++ b/api/imap-client/imap_client.py
@@ -3,6 +3,7 @@ import email
 import logging
 import os
 import re
+import ssl
 from html.parser import HTMLParser
 from io import StringIO
 from mailbox import Message
@@ -54,11 +55,23 @@ class ImapClient:
         self.email_whitelist = email_whitelist or []
 
     def connect(self):
+        # When connecting to a self-signed mail server (e.g. an internal
+        # homelab Dovecot), certificate verification will fail with an
+        # "unknown ca" alert. IMAP_TLS_SKIP_VERIFY=true disables verification
+        # for these trusted internal hosts. It defaults to off so public
+        # servers are still verified normally.
+        skip_verify = os.environ.get("IMAP_TLS_SKIP_VERIFY", "").lower() in ("1", "true", "yes")
+        ssl_context = None
+        if skip_verify:
+            ssl_context = ssl.create_default_context()
+            ssl_context.check_hostname = False
+            ssl_context.verify_mode = ssl.CERT_NONE
+
         if self.use_starttls:
             self.client = IMAPClient(self.host, self.port, ssl=False)
-            self.client.starttls()
+            self.client.starttls(ssl_context=ssl_context)
         else:
-            self.client = IMAPClient(self.host, self.port)
+            self.client = IMAPClient(self.host, self.port, ssl_context=ssl_context)
 
         self.client.login(self.username, self.password)
 

--- a/api/internal/services/html_to_pdf.go
+++ b/api/internal/services/html_to_pdf.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/chromedp/cdproto/network"
@@ -87,7 +89,10 @@ func (service HtmlToPdfService) Render(html string) ([]byte, commands.UpsertSyst
 	allocCtx, cancelAlloc := chromedp.NewExecAllocator(context.Background(), opts...)
 	defer cancelAlloc()
 
-	browserCtx, cancelBrowser := chromedp.NewContext(allocCtx)
+	browserCtx, cancelBrowser := chromedp.NewContext(
+		allocCtx,
+		chromedp.WithErrorf(filteredChromedpErrorf),
+	)
 	defer cancelBrowser()
 
 	timeoutCtx, cancelTimeout := context.WithTimeout(browserCtx, htmlToPdfTimeout)
@@ -175,4 +180,19 @@ func writeTempHtml(html string) (string, func(), error) {
 		return "", func() {}, err
 	}
 	return htmlPath, cleanup, nil
+}
+
+
+// filteredChromedpErrorf is the chromedp error logger. Newer Chrome builds emit
+// CDP network events whose enum values (e.g. an IPAddressSpace of "Loopback")
+// are not yet known to the pinned cdproto version, so chromedp fails to
+// unmarshal them and logs "could not unmarshal event" on every render. These
+// are harmless — PDF generation still succeeds — so they are dropped here while
+// any other chromedp error is still surfaced to the normal log.
+func filteredChromedpErrorf(format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	if strings.Contains(msg, "could not unmarshal event") {
+		return
+	}
+	logging.LogStd(logging.LOG_LEVEL_ERROR, msg)
 }

--- a/api/internal/services/html_to_pdf.go
+++ b/api/internal/services/html_to_pdf.go
@@ -190,7 +190,13 @@ func writeTempHtml(html string) (string, func(), error) {
 // are harmless — PDF generation still succeeds — so they are dropped here while
 // any other chromedp error is still surfaced to the normal log.
 func filteredChromedpErrorf(format string, args ...interface{}) {
+	// Fast path: the noisy line is identifiable from the format string alone,
+	// so skip the Sprintf allocation when we are going to drop it anyway.
+	if strings.Contains(format, "could not unmarshal event") {
+		return
+	}
 	msg := fmt.Sprintf(format, args...)
+	// Defensive: also drop it if the text only materialises after formatting.
 	if strings.Contains(msg, "could not unmarshal event") {
 		return
 	}


### PR DESCRIPTION
Three small, independent robustness fixes for IMAP receipt ingestion and HTML→PDF rendering. Each is self-contained and not coupled to my other open PRs (#577–#579).

### 1. IMAP: resilient message parsing (`api/imap-client/imap_client.py`)
A single malformed fetched message would raise `'NoneType' object has no attribute 'decode'` and abort the **entire** poll batch (exit 1 back to the Go caller), so no receipts were ingested at all. This adds three guards:
- Skip messages with an empty `RFC822` payload.
- Skip attachment parts whose decoded payload is `None` (the direct cause of the crash) instead of writing `None` to disk.
- Wrap per-message processing in `try/except` so one bad message is logged and skipped rather than sinking the whole poll.

### 2. IMAP: optional TLS skip-verify for self-signed servers (`api/imap-client/imap_client.py`)
Adds an opt-in `IMAP_TLS_SKIP_VERIFY` env var (default **off**). When enabled, the client connects with an unverified SSL context for both implicit-TLS and STARTTLS — useful for self-hosting against an internal mail server with a self-signed certificate, while public servers continue to be verified normally by default.

### 3. PDF: silence harmless chromedp event-decode noise (`api/internal/services/html_to_pdf.go`)
Newer Chrome emits CDP network events with enum values the pinned `cdproto` doesn't know (e.g. `could not unmarshal event ... unknown IPAddressSpace value: Loopback`), logged on **every** email render. Rendering still succeeds, so this routes chromedp's error logger through a filter that drops these specific lines while still surfacing any other chromedp error normally.

All three are low-risk; the TLS option is gated behind an env var that defaults to the existing verified behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional TLS certificate verification bypass for IMAP connections via configuration.

* **Bug Fixes**
  * Polling now continues when individual malformed emails cause parsing errors.
  * Attachment handling skips and logs attachments with missing or undecodable data.
  * Safeguards prevent empty message payloads from breaking processing.

* **Improvements**
  * Reduced noisy error logs from the PDF conversion service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->