### PR TITLE
Survive a not-yet-ready database on startup; exit container when the API crashes

### DIFF
--- a/api/internal/repositories/db.go
+++ b/api/internal/repositories/db.go
@@ -3,9 +3,11 @@ package repositories
 import (
 	"fmt"
 	config "receipt-wrangler/api/internal/env"
+	"receipt-wrangler/api/internal/logging"
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/structs"
 	"receipt-wrangler/api/internal/utils"
+	"time"
 
 	"github.com/glebarez/sqlite"
 	"gorm.io/driver/mysql"
@@ -37,6 +39,17 @@ func BuildSqliteConnectionString(dbConfig structs.DatabaseConfig) (string, error
 	return connectionString, nil
 }
 
+const (
+	// dbConnectMaxAttempts and dbConnectRetryDelay control how long Connect waits
+	// for the database to become reachable before giving up. This lets the API
+	// survive the database not being ready yet at startup (e.g. when containers are
+	// brought up by Docker restart policies or an orchestrator that does not
+	// guarantee start order), instead of exiting fatally on the first connection
+	// error and leaving the container in a broken state.
+	dbConnectMaxAttempts = 10
+	dbConnectRetryDelay  = 3 * time.Second
+)
+
 func Connect() error {
 	dbConfig, err := config.GetDatabaseConfig()
 	if err != nil {
@@ -45,41 +58,63 @@ func Connect() error {
 
 	dbEngine := dbConfig.Engine
 
-	var connectedDb *gorm.DB
+	var dialector gorm.Dialector
 
-	if dbEngine == "mariadb" || dbEngine == "mysql" {
-		connectedDb, err = gorm.Open(mysql.Open(BuildMariaDbConnectionString(dbConfig)), &gorm.Config{})
-		if err != nil {
-			return err
+	// Network-backed engines can be transiently unreachable at startup, so they
+	// get connection retries. Sqlite is file-based — failures there are
+	// configuration problems, not races, and should surface immediately.
+	maxAttempts := dbConnectMaxAttempts
+
+	switch dbEngine {
+	case "mariadb", "mysql":
+		dialector = mysql.Open(BuildMariaDbConnectionString(dbConfig))
+	case "postgresql":
+		dialector = postgres.Open(BuildPostgresqlConnectionString(dbConfig))
+	case "sqlite":
+		connectionString, sqliteErr := BuildSqliteConnectionString(dbConfig)
+		if sqliteErr != nil {
+			return sqliteErr
 		}
-	}
-
-	if dbEngine == "postgresql" {
-		connectedDb, err = gorm.Open(postgres.Open(BuildPostgresqlConnectionString(dbConfig)), &gorm.Config{})
-		if err != nil {
-			return err
-		}
-	}
-
-	if dbEngine == "sqlite" {
-		connectionString, err := BuildSqliteConnectionString(dbConfig)
-		if err != nil {
-			return err
-		}
-
-		connectedDb, err = gorm.Open(sqlite.Open(connectionString), &gorm.Config{})
-		if err != nil {
-			return err
-
-		}
-	}
-
-	if connectedDb == nil {
+		dialector = sqlite.Open(connectionString)
+		maxAttempts = 1
+	default:
 		return fmt.Errorf("database engine of: %s! check your config to make sure it is correct", dbEngine)
+	}
+
+	connectedDb, err := openWithRetry(dialector, maxAttempts)
+	if err != nil {
+		return err
 	}
 
 	db = connectedDb
 	return nil
+}
+
+// openWithRetry opens the database connection, retrying transient failures so the
+// API does not exit fatally when the database is briefly unreachable at startup.
+func openWithRetry(dialector gorm.Dialector, maxAttempts int) (*gorm.DB, error) {
+	var lastErr error
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		connectedDb, err := gorm.Open(dialector, &gorm.Config{})
+		if err == nil {
+			return connectedDb, nil
+		}
+
+		lastErr = err
+		if attempt < maxAttempts {
+			logging.LogStd(
+				logging.LOG_LEVEL_INFO,
+				fmt.Sprintf(
+					"database not ready (attempt %d/%d): %s; retrying in %s",
+					attempt, maxAttempts, err.Error(), dbConnectRetryDelay,
+				),
+			)
+			time.Sleep(dbConnectRetryDelay)
+		}
+	}
+
+	return nil, fmt.Errorf("failed to connect to the database after %d attempts: %w", maxAttempts, lastErr)
 }
 
 func MakeMigrations() error {

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,10 +3,20 @@
 # Source venv
 source /app/receipt-wrangler-api/wranglervenv/bin/activate
 
-# Start api
 cd /app/receipt-wrangler-api
-./api --env prod &
 
-# Start nginx
-nginx -g 'daemon off;'
+# Forward TERM/INT to the children: bash runs as PID 1 here, and PID 1 ignores
+# SIGTERM by default, so `docker stop` previously waited out the full grace
+# period and then SIGKILLed everything.
+trap 'kill $(jobs -p) 2>/dev/null' TERM INT
+
+# Run the API and nginx as background jobs and exit the container if EITHER one
+# exits, so the restart policy / orchestrator can recover it. Previously the API
+# ran in the background while only nginx held the foreground, so a crashed API
+# left the container "up" serving 502s and the restart policy never fired.
+./api --env prod &
+nginx -g 'daemon off;' &
+
+wait -n
+exit $?
 


### PR DESCRIPTION
## Problem

When the API container (re)starts while its database isn't ready, the app exits fatally instead of waiting:

- `repositories.Connect()` calls `gorm.Open(...)` once and returns the first error; `main.go` logs it at FATAL and exits.
- This happens routinely under Docker `restart:` policies, because `depends_on: condition: service_healthy` is only honored by `docker compose up` — not by daemon/policy restarts. Any restart where the DB comes up a moment later hits `connection refused` and dies.
- Worse, `docker/entrypoint.sh` runs the API in the background while nginx holds the foreground — so when the API dies, nginx keeps the container "Up" serving 502s and the restart policy never fires. The container stays broken until manually restarted.

Related: #470.

## Changes

1. **`api/internal/repositories/db.go` — retry the connection at startup.** `Connect()` selects the gorm dialector via a `switch`, then `openWithRetry` attempts the connection up to 10× at 3s intervals (~30s), logging each retry at INFO. Sqlite intentionally does **not** retry — file-based failures are configuration problems, not startup races, and should surface immediately. Unknown-engine and DB-never-comes-up behavior is unchanged, just delayed by the retry window for network engines.
2. **`docker/entrypoint.sh` — exit the container when either process dies.** API and nginx both run as jobs with `wait -n`, so an API crash exits the container and `restart: always` / orchestrators can recover it. Also traps TERM/INT to forward shutdown to the children — bash is PID 1 here and ignores SIGTERM by default, so `docker stop` previously waited out the full grace period before SIGKILL.

## Validation

Built the image from this branch and tested against a clean Postgres compose stack (no `depends_on` conditions, no external healing):

- **Cold start with DB not yet ready:** API logs `database not ready (attempt N/10): ...; retrying in 3s` and connects when Postgres comes up, instead of exiting fatally.
- **Restart with DB stopped, DB started ~12s later:** same — retries, connects, serves normally.
- **API process killed inside the running container:** the container now exits and the `restart:` policy recovers it (previously nginx kept the container "Up" serving 502s indefinitely).
- **`docker stop`:** returns in under a second via the TERM trap (previously waited out the full grace period, then SIGKILL).

## Notes

- Retry count/delay are package constants (`10` / `3s`); happy to make them env-configurable if you'd prefer.
- `gofmt` clean; `go vet` and `go build ./internal/repositories/` pass; `bash -n` clean on the entrypoint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Database connection handling now includes automatic retry logic for transient startup failures on network-backed databases, enhancing deployment reliability.
  * Container process management refined to better handle system signals and accelerate failure detection for API and web server components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->