### PR TITLE
Remove the legacy role system from the desktop frontend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,14 +125,15 @@ See `mobile/CLAUDE.md` for Flutter architecture, Provider state management, and 
   clients carry the `Permission` enum and role types). See `api/CLAUDE.md` → "Roles & Permissions".
 - The server **never trusts the JWT for authorization** — it re-checks a user's current permissions
   from the database on every request. The JWT no longer carries any role field.
-- **Backend rollout is complete; desktop is the remaining follow-up.** Handlers fully enforce the
-  permission system, and the legacy `UserRole`/`GroupRole` enums have been **removed from the
-  backend** (Go types, model fields, JWT role claim, and the `userRole`/`groupRole` API fields are
-  all gone; only the physical `user_role`/`group_role` DB columns are retained for the one-time
-  upgrade migration). Desktop still consumes the old role fields (user-list role column, group-form
-  owner gating, auth-state role selectors), so migrating it to permission-based gating — and
-  regenerating against the slimmed contract — is the next phase. See `api/CLAUDE.md` →
-  "Roles & Permissions" and `desktop/CLAUDE.md`.
+- **Role rollout is complete across backend and desktop.** Handlers fully enforce the permission
+  system, and the legacy `UserRole`/`GroupRole` enums have been **removed from the backend** (Go
+  types, model fields, JWT role claim, and the `userRole`/`groupRole` API fields are all gone; only
+  the physical `user_role`/`group_role` DB columns are retained for the one-time upgrade migration).
+  The **desktop** has likewise dropped every legacy-role consumer: the user-list and group-member
+  tables now resolve `appRoleId`/`groupRoleId` to a role **name** (via a shared `RoleNamePipe`), the
+  group-form "must have an owner" rule is gone (the backend no longer enforces an owner concept), and
+  the `AuthState.userRole`/`hasRole` selectors plus the group-member legacy-enum bridge are removed.
+  See `api/CLAUDE.md` → "Roles & Permissions" and `desktop/CLAUDE.md`.
 
 ### State Management Patterns
 - **Backend**: Service layer handles business logic, repositories handle data access

--- a/api/dev/seed-e2e-users.sh
+++ b/api/dev/seed-e2e-users.sh
@@ -5,13 +5,13 @@
 # Why this exists:
 #   - The API auto-creates a default `admin/admin` user on first startup
 #     (repositories/db.go -> CreateUserIfNoneExist) outside `deployEnv=test`.
-#   - The mobile e2e tests need `e2e-admin` (role ADMIN) and `e2e-user`
-#     (role USER) to log in. These are NOT auto-seeded.
+#   - The e2e tests need `e2e-admin` (the Legacy Admin app role) and `e2e-user`
+#     (the Legacy User app role) to log in. These are NOT auto-seeded.
 #   - The UI signup path is gated on `enableLocalSignUp`, which is `false`
-#     locally, AND would assign USER role anyway because the auto-admin
-#     already occupies the "first user = ADMIN" slot in CreateUser.
-#   - The admin-protected POST /user/ endpoint accepts an explicit `userRole`
-#     and creates whatever you ask for, so we use it to seed both.
+#     locally, AND would assign the default (Legacy User) app role anyway.
+#   - The admin-protected POST /user/ endpoint takes an explicit `appRoleId`
+#     (the legacy `userRole` enum was removed), so we resolve the seeded
+#     "Legacy Admin" / "Legacy User" app-role ids and create both.
 #
 # Usage:
 #   cd api && ./dev/seed-e2e-users.sh
@@ -71,6 +71,30 @@ if [[ -z "$jwt" ]]; then
   exit 1
 fi
 
+echo "==> resolving app-role ids"
+roles_json="$(curl -fsS --max-time 10 "$api_base_url/role" -H "Authorization: Bearer $jwt")"
+
+# resolve_app_role_id <role-name> -> prints the id of the APP-scoped role
+resolve_app_role_id() {
+  printf '%s' "$roles_json" | python3 -c '
+import json, sys
+name = sys.argv[1]
+for r in json.load(sys.stdin):
+    if r.get("scope") == "APP" and r.get("name") == name:
+        print(r["id"]); break
+' "$1"
+}
+
+legacy_admin_role_id="$(resolve_app_role_id "Legacy Admin")"
+legacy_user_role_id="$(resolve_app_role_id "Legacy User")"
+
+if [[ -z "$legacy_admin_role_id" || -z "$legacy_user_role_id" ]]; then
+  echo "could not resolve 'Legacy Admin' / 'Legacy User' app-role ids" >&2
+  echo "roles: $roles_json" >&2
+  exit 1
+fi
+echo "    Legacy Admin id=$legacy_admin_role_id, Legacy User id=$legacy_user_role_id"
+
 echo "==> fetching existing users"
 existing_users_json="$(curl -fsS --max-time 10 \
   "$api_base_url/user/" \
@@ -81,21 +105,22 @@ existing_usernames="$(printf '%s' "$existing_users_json" \
 
 echo "    existing: $(echo "$existing_usernames" | tr '\n' ' ')"
 
-# create_user_if_missing <username> <password> <displayName> <role>
+# create_user_if_missing <username> <password> <displayName> <appRoleId> <label>
 create_user_if_missing() {
   local username="$1"
   local password="$2"
   local display_name="$3"
-  local role="$4"
+  local app_role_id="$4"
+  local label="$5"
 
   if printf '%s\n' "$existing_usernames" | grep -Fxq "$username"; then
-    printf '==> %-12s (%-5s) ... [exists]\n' "$username" "$role"
+    printf '==> %-12s (%-12s) ... [exists]\n' "$username" "$label"
     return 0
   fi
 
   local body
-  body="$(python3 -c 'import json,sys; print(json.dumps({"username":sys.argv[1],"password":sys.argv[2],"displayName":sys.argv[3],"userRole":sys.argv[4],"isDummyUser":False}))' \
-    "$username" "$password" "$display_name" "$role")"
+  body="$(python3 -c 'import json,sys; print(json.dumps({"username":sys.argv[1],"password":sys.argv[2],"displayName":sys.argv[3],"appRoleId":int(sys.argv[4]),"isDummyUser":False}))' \
+    "$username" "$password" "$display_name" "$app_role_id")"
 
   # Use mktemp instead of /tmp/...$$ -- the PID-based path is predictable and
   # vulnerable to a symlink race on shared machines.
@@ -111,16 +136,16 @@ create_user_if_missing() {
   rm -f "$response_file"
 
   if [[ "$http_code" == "200" ]]; then
-    printf '==> %-12s (%-5s) ... [created]\n' "$username" "$role"
+    printf '==> %-12s (%-12s) ... [created]\n' "$username" "$label"
   else
-    printf '==> %-12s (%-5s) ... [FAILED http %s] %s\n' \
-      "$username" "$role" "$http_code" "$body" >&2
+    printf '==> %-12s (%-12s) ... [FAILED http %s] %s\n' \
+      "$username" "$label" "$http_code" "$body" >&2
     return 1
   fi
 }
 
 rc=0
-create_user_if_missing "$e2e_admin_username" "$e2e_admin_password" "E2E Admin" "ADMIN" || rc=1
-create_user_if_missing "$e2e_user_username"  "$e2e_user_password"  "E2E User"  "USER"  || rc=1
+create_user_if_missing "$e2e_admin_username" "$e2e_admin_password" "E2E Admin" "$legacy_admin_role_id" "Legacy Admin" || rc=1
+create_user_if_missing "$e2e_user_username"  "$e2e_user_password"  "E2E User"  "$legacy_user_role_id"  "Legacy User"  || rc=1
 
 exit $rc

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -141,12 +141,14 @@ gated by `appPermissionGuard` requiring `app.roles.read` (see **Permission-based
   and permissions (grouped by resource using the `role-presets.ts` helpers). The `getRoles()` calls
   use `catchError` so a non-admin who lacks `app.roles.read` (see **Permission-based UI gating** below)
   gets an empty selector rather than an error.
-- **Group-member legacy bridge:** `group-form` (loaded by every group view, including non-admins)
-  deliberately does **not** call `getRoles()` — to avoid 403-driven logout for non-admins. Instead
-  the group-member dialog keeps the legacy `groupRole` in sync on submit
-  (`legacyGroupRoleFromRole` in `group-member.utils.ts`, mirroring the backend's name→enum mapping),
-  so `group-form`'s "keep an owner" check and its `groupRole | status` member-table column keep
-  working without reading roles. Remove this bridge when the legacy enum is retired.
+- **Member-table role display:** the admin user-list (`src/user/user-list/`) and `group-form`
+  (`src/group/group-form/`, loaded by every group view including non-admins) resolve each user's
+  `appRoleId` / each member's `groupRoleId` to the role **name** via the shared `RoleNamePipe`
+  (`src/pipes/role-name.pipe.ts` — `{{ id | roleName : roles() }}`). Both load roles with
+  `RoleService.getRoles()` wrapped in `catchError`, so a non-admin lacking `app.roles.read` sees a
+  blank name rather than a 403-driven logout. There is no longer any legacy `groupRole` enum sync,
+  and `group-form` no longer enforces a "keep an owner" rule — the backend dropped the owner concept,
+  so group management is governed entirely by `group.*` permissions.
 - **Permission-based UI gating.** The UI gates on the user's effective permissions, mirroring the
   backend's enforcement. Permissions are delivered on **AppData** (`appPermissions: string[]` and
   `groupPermissions: { [groupId]: string[] }`) and stored in `AuthState` via the dedicated
@@ -168,9 +170,9 @@ gated by `appPermissionGuard` requiring `app.roles.read` (see **Permission-based
     `receiptGuardGuard` is unchanged (server-checked per-receipt access); `system-settings-landing.guard`
     redirects `/system-settings` to the first tab the user can read.
   - **Retired** with this migration: `RoleGuard`, `GroupRoleGuard`, the `*appRole` `RoleDirective`, the
-    `groupRole` `GroupRolePipe`, and `GroupUtil.hasGroupAccess`. The **group-member legacy bridge** (see
-    above) and `AuthState.userRole`/`hasRole` are intentionally kept until the backend legacy enum is
-    retired.
+    `groupRole` `GroupRolePipe`, and `GroupUtil.hasGroupAccess`. The group-member legacy-enum bridge
+    (`legacyGroupRoleFromRole`) and `AuthState.userRole`/`hasRole` are now **removed** as well, since
+    the backend legacy `UserRole`/`GroupRole` enums (and the `userRole`/`groupRole` API fields) are gone.
   - **Behavior note:** create actions for categories/tags/custom-fields now gate on the granular
     `.create` permission, so a normal user (Legacy User holds `.create`) sees the **Add** button;
     **Edit/Delete** stay admin-only (`.update`/`.delete`).

--- a/desktop/src/group/group-form/group-form.component.html
+++ b/desktop/src/group/group-form/group-form.component.html
@@ -69,8 +69,8 @@
   {{ (element.userId | user)?.displayName }}
 </ng-template>
 
-<ng-template #groupRoleCell let-element="element">
-  {{ element.groupRole | status }}
+<ng-template #roleCell let-element="element">
+  {{ element.groupRoleId | roleName : roles() }}
 </ng-template>
 
 <ng-template #actionsCell let-index="index">

--- a/desktop/src/group/group-form/group-form.component.spec.ts
+++ b/desktop/src/group/group-form/group-form.component.spec.ts
@@ -18,7 +18,7 @@ import { UserAutocompleteModule } from "src/user-autocomplete/user-autocomplete.
 import { ButtonModule } from "../../button";
 import { InputModule } from "../../input";
 import { ApiModule, Group, GroupsService, GroupStatus } from "../../open-api";
-import { AddGroup, UpdateGroup } from "../../store";
+import { AddGroup, AuthState, UpdateGroup } from "../../store";
 import { AppInitService } from "../../services";
 import { GroupMemberFormComponent } from "../group-member-form/group-member-form.component";
 import { buildGroupMemberForm } from "../utils/group-member.utils";
@@ -39,7 +39,7 @@ describe("GroupFormComponent", () => {
         MatCardModule,
         MatDialogModule,
         MatSnackBarModule,
-        NgxsModule.forRoot([]),
+        NgxsModule.forRoot([AuthState]),
         NoopAnimationsModule,
         PipesModule,
         ReactiveFormsModule,

--- a/desktop/src/group/group-form/group-form.component.spec.ts
+++ b/desktop/src/group/group-form/group-form.component.spec.ts
@@ -17,7 +17,7 @@ import { TableModule } from "src/table/table.module";
 import { UserAutocompleteModule } from "src/user-autocomplete/user-autocomplete.module";
 import { ButtonModule } from "../../button";
 import { InputModule } from "../../input";
-import { ApiModule, Group, GroupRole, GroupsService, GroupStatus } from "../../open-api";
+import { ApiModule, Group, GroupsService, GroupStatus } from "../../open-api";
 import { AddGroup, UpdateGroup } from "../../store";
 import { AppInitService } from "../../services";
 import { GroupMemberFormComponent } from "../group-member-form/group-member-form.component";
@@ -86,7 +86,7 @@ describe("GroupFormComponent", () => {
     formGroup.patchValue({
       userId: "2",
       groupId: "1",
-      groupRole: GroupRole.Viewer,
+      groupRoleId: 10,
     });
     jest.spyOn(matDialog, "open").mockReturnValue({
       afterClosed: () => of(formGroup),
@@ -107,13 +107,11 @@ describe("GroupFormComponent", () => {
         userId: 2,
         groupRoleId: null,
         groupId: 1,
-        groupRole: GroupRole.Owner,
       },
       {
         userId: 3,
         groupRoleId: null,
         groupId: 1,
-        groupRole: GroupRole.Owner,
       },
     ];
     const matDialog = TestBed.inject(MatDialog);
@@ -121,7 +119,6 @@ describe("GroupFormComponent", () => {
     formGroup.patchValue({
       userId: 3,
       groupId: 1,
-      groupRole: GroupRole.Owner,
     });
     jest.spyOn(matDialog, "open").mockReturnValue({
       afterClosed: () => of(formGroup),
@@ -137,12 +134,10 @@ describe("GroupFormComponent", () => {
           {
             userId: 2,
             groupId: 1,
-            groupRole: GroupRole.Owner,
           },
           {
             userId: 1,
             groupId: 1,
-            groupRole: GroupRole.Viewer,
           },
         ],
       },
@@ -164,7 +159,6 @@ describe("GroupFormComponent", () => {
       userId: 1,
       groupRoleId: null,
       groupId: 1,
-      groupRole: GroupRole.Viewer,
     };
 
     route.snapshot.data = {
@@ -176,7 +170,6 @@ describe("GroupFormComponent", () => {
           {
             userId: 2,
             groupId: 1,
-            groupRole: GroupRole.Owner,
           },
           result,
         ],
@@ -262,13 +255,11 @@ describe("GroupFormComponent", () => {
           userId: 2,
           groupRoleId: 10,
           groupId: 1,
-          groupRole: GroupRole.Owner,
         },
         {
           userId: 1,
           groupRoleId: 11,
           groupId: 1,
-          groupRole: GroupRole.Viewer,
         },
       ],
       isAllGroup: false,
@@ -295,7 +286,6 @@ describe("GroupFormComponent", () => {
         userId: new FormControl(3),
         groupRoleId: new FormControl(12),
         groupId: new FormControl(1),
-        groupRole: new FormControl(GroupRole.Editor),
       })
     );
 
@@ -318,19 +308,16 @@ describe("GroupFormComponent", () => {
             userId: 2,
             groupRoleId: 10,
             groupId: 1,
-            groupRole: GroupRole.Owner,
           },
           {
             userId: 1,
             groupRoleId: 11,
             groupId: 1,
-            groupRole: GroupRole.Viewer,
           },
           {
             userId: 3,
             groupRoleId: 12,
             groupId: 1,
-            groupRole: GroupRole.Editor,
           },
         ],
       } as Group
@@ -341,5 +328,34 @@ describe("GroupFormComponent", () => {
         tab: "details",
       }
     });
+  });
+
+  it("submits in edit mode even when no member holds an owner role", () => {
+    // The legacy "must have at least one owner" guard was removed with the
+    // group-role enums; the backend no longer enforces an owner, so the client
+    // must save a non-owner-only membership without blocking.
+    const updateSpy = jest.spyOn(TestBed.inject(GroupsService), "updateGroup");
+    jest.spyOn(TestBed.inject(Router), "navigate").mockResolvedValue(true);
+    jest.spyOn(TestBed.inject(AppInitService), "getAppData").mockReturnValue(of([]));
+
+    const route = TestBed.inject(ActivatedRoute);
+    route.snapshot.data = {
+      group: {
+        id: 1,
+        name: "test",
+        status: GroupStatus.Active,
+        groupMembers: [{ userId: 2, groupRoleId: 11, groupId: 1 }],
+      },
+      formConfig: { mode: FormMode.edit },
+    };
+
+    component.ngOnInit();
+    component.ngAfterViewInit();
+
+    updateSpy.mockReturnValue(of({ id: 1 } as Group));
+
+    component.submit();
+
+    expect(updateSpy).toHaveBeenCalled();
   });
 });

--- a/desktop/src/group/group-form/group-form.component.ts
+++ b/desktop/src/group/group-form/group-form.component.ts
@@ -7,7 +7,7 @@ import {MatTableDataSource} from "@angular/material/table";
 import {ActivatedRoute, Router} from "@angular/router";
 import {UntilDestroy, untilDestroyed} from "@ngneat/until-destroy";
 import {Store} from "@ngxs/store";
-import {catchError, map, of, startWith, switchMap, take, tap} from "rxjs";
+import {map, startWith, switchMap, take, tap} from "rxjs";
 import {DEFAULT_HOST_CLASS} from "src/constants";
 import {GROUP_STATUS_OPTIONS} from "src/constants/receipt-status-options";
 import {FormMode} from "src/enums/form-mode.enum";
@@ -16,6 +16,7 @@ import {TableColumn} from "src/table/table-column.interface";
 import {TableComponent} from "src/table/table/table.component";
 import {SortByDisplayName} from "src/utils/sort-by-displayname";
 import {Group, GroupMember, GroupsService, GroupStatus, Permission, Role, RoleService} from "../../open-api";
+import {loadAssignableRoles} from "../../roles/role-loading.util";
 import {AppInitService, SnackbarService} from "../../services";
 import {AddGroup, AuthState, UpdateGroup} from "../../store";
 import {GroupMemberFormComponent} from "../group-member-form/group-member-form.component";
@@ -58,13 +59,12 @@ export class GroupFormComponent implements OnInit, AfterViewInit {
 
   public editLink: string = "";
 
-  // Roles load best-effort so the member table can resolve each member's
-  // groupRoleId to a role name; empty (and a blank cell) if app.roles.read is
-  // denied, mirroring the group-member form's selector.
+  // Roles resolve each member's groupRoleId to a role name. group-form is
+  // rendered for every group member (including non-admins), so the request is
+  // skipped entirely unless the caller holds app.roles.read — otherwise the 403
+  // would log them out (see loadAssignableRoles). Non-holders see a blank name.
   public readonly roles = toSignal(
-    inject(RoleService)
-      .getRoles()
-      .pipe(catchError(() => of([] as Role[]))),
+    loadAssignableRoles(inject(Store), inject(RoleService)),
     { initialValue: [] as Role[] }
   );
 

--- a/desktop/src/group/group-form/group-form.component.ts
+++ b/desktop/src/group/group-form/group-form.component.ts
@@ -1,4 +1,5 @@
-import {AfterViewInit, Component, OnInit, Signal, signal, TemplateRef, input, viewChild} from "@angular/core";
+import {AfterViewInit, Component, OnInit, Signal, signal, TemplateRef, inject, input, viewChild} from "@angular/core";
+import {toSignal} from "@angular/core/rxjs-interop";
 import {FormArray, FormBuilder, FormGroup, Validators} from "@angular/forms";
 import {MatDialog} from "@angular/material/dialog";
 import {Sort} from "@angular/material/sort";
@@ -6,7 +7,7 @@ import {MatTableDataSource} from "@angular/material/table";
 import {ActivatedRoute, Router} from "@angular/router";
 import {UntilDestroy, untilDestroyed} from "@ngneat/until-destroy";
 import {Store} from "@ngxs/store";
-import {map, startWith, switchMap, take, tap} from "rxjs";
+import {catchError, map, of, startWith, switchMap, take, tap} from "rxjs";
 import {DEFAULT_HOST_CLASS} from "src/constants";
 import {GROUP_STATUS_OPTIONS} from "src/constants/receipt-status-options";
 import {FormMode} from "src/enums/form-mode.enum";
@@ -14,7 +15,7 @@ import {FormConfig} from "src/interfaces/form-config.interface";
 import {TableColumn} from "src/table/table-column.interface";
 import {TableComponent} from "src/table/table/table.component";
 import {SortByDisplayName} from "src/utils/sort-by-displayname";
-import {Group, GroupMember, GroupRole, GroupsService, GroupStatus, Permission} from "../../open-api";
+import {Group, GroupMember, GroupsService, GroupStatus, Permission, Role, RoleService} from "../../open-api";
 import {AppInitService, SnackbarService} from "../../services";
 import {AddGroup, AuthState, UpdateGroup} from "../../store";
 import {GroupMemberFormComponent} from "../group-member-form/group-member-form.component";
@@ -31,7 +32,7 @@ import {buildGroupMemberForm} from "../utils/group-member.utils";
 export class GroupFormComponent implements OnInit, AfterViewInit {
   public readonly nameCell = viewChild.required<TemplateRef<any>>("nameCell");
 
-  public readonly groupRoleCell = viewChild.required<TemplateRef<any>>("groupRoleCell");
+  public readonly roleCell = viewChild.required<TemplateRef<any>>("roleCell");
 
   public readonly actionsCell = viewChild.required<TemplateRef<any>>("actionsCell");
 
@@ -57,7 +58,15 @@ export class GroupFormComponent implements OnInit, AfterViewInit {
 
   public editLink: string = "";
 
-  public groupRole = GroupRole;
+  // Roles load best-effort so the member table can resolve each member's
+  // groupRoleId to a role name; empty (and a blank cell) if app.roles.read is
+  // denied, mirroring the group-member form's selector.
+  public readonly roles = toSignal(
+    inject(RoleService)
+      .getRoles()
+      .pipe(catchError(() => of([] as Role[]))),
+    { initialValue: [] as Role[] }
+  );
 
   public groupStatusOptions = GROUP_STATUS_OPTIONS;
 
@@ -121,8 +130,8 @@ export class GroupFormComponent implements OnInit, AfterViewInit {
       },
       {
         columnHeader: "Group Role",
-        matColumnDef: "groupRole",
-        template: this.groupRoleCell(),
+        matColumnDef: "role",
+        template: this.roleCell(),
         sortable: true,
       },
       {
@@ -132,7 +141,7 @@ export class GroupFormComponent implements OnInit, AfterViewInit {
         sortable: true,
       },
     ];
-    this.displayedColumns = ["name", "groupRole"];
+    this.displayedColumns = ["name", "role"];
 
     if (this.formConfig.mode !== FormMode.view) {
       this.displayedColumns.push("actions");
@@ -232,13 +241,6 @@ export class GroupFormComponent implements OnInit, AfterViewInit {
 
   public submit(): void {
     if (this.form.valid) {
-      const owners = (this.groupMembers.value as GroupMember[]).filter(
-        (gm) => gm.groupRole === GroupRole.Owner
-      );
-      if (owners.length === 0 && this.formConfig.mode !== FormMode.add) {
-        this.snackbarService.error("Group must have at least one owner!");
-        return;
-      }
       switch (this.formConfig.mode) {
         case FormMode.add:
           this.createGroup();

--- a/desktop/src/group/group-member-form/group-member-form.component.spec.ts
+++ b/desktop/src/group/group-member-form/group-member-form.component.spec.ts
@@ -6,7 +6,7 @@ import { ReactiveFormsModule } from "@angular/forms";
 import { MatDialog, MatDialogModule, MatDialogRef } from "@angular/material/dialog";
 import { NgxsModule, Store } from "@ngxs/store";
 import { of, throwError } from "rxjs";
-import { GroupRole, PermissionScope, Role, RoleService } from "../../open-api";
+import { PermissionScope, Role, RoleService } from "../../open-api";
 import { PipesModule } from "../../pipes";
 import { AuthState } from "../../store";
 import { GroupMemberFormComponent } from "./group-member-form.component";
@@ -107,7 +107,7 @@ describe("GroupMemberFormComponent", () => {
     expect(openSpy.mock.calls[0][1]?.data?.role).toEqual(defaultGroupRole);
   });
 
-  it("syncs the legacy group role and returns the form on submit", async () => {
+  it("returns the form with the selected modern role on submit", async () => {
     getRolesMock.mockReturnValue(of([defaultGroupRole]));
     await createComponent();
 
@@ -116,8 +116,7 @@ describe("GroupMemberFormComponent", () => {
 
     component.submit();
 
-    // Legacy Owner → OWNER, carried so the parent group form's legacy readers work.
-    expect(component.form.get("groupRole")?.value).toBe(GroupRole.Owner);
+    expect(component.form.get("groupRoleId")?.value).toBe(10);
     expect(dialogRefMock.close).toHaveBeenCalledWith(component.form);
   });
 });

--- a/desktop/src/group/group-member-form/group-member-form.component.ts
+++ b/desktop/src/group/group-member-form/group-member-form.component.ts
@@ -7,7 +7,7 @@ import { catchError, of, startWith } from "rxjs";
 import { GroupMember, PermissionScope, Role, RoleService } from "../../open-api";
 import { openRolePreviewDialog } from "../../roles/role-preview/role-preview-dialog.component";
 import { AuthState } from "../../store";
-import { buildGroupMemberForm, legacyGroupRoleFromRole } from "../utils/group-member.utils";
+import { buildGroupMemberForm } from "../utils/group-member.utils";
 
 @Component({
     selector: "app-group-member-form",
@@ -106,14 +106,6 @@ export class GroupMemberFormComponent implements OnInit {
 
   public submit(): void {
     if (this.form.valid) {
-      // Keep the legacy enum in sync with the chosen modern role so the parent
-      // group form's member table and "keep an owner" check (which still read
-      // the legacy enum) work for newly assigned members. The backend re-derives
-      // it authoritatively on save.
-      const role = this.selectedRole();
-      if (role) {
-        this.form.get("groupRole")?.setValue(legacyGroupRoleFromRole(role));
-      }
       this.matDialogRef.close(this.form);
     }
   }

--- a/desktop/src/group/utils/group-member.utils.ts
+++ b/desktop/src/group/utils/group-member.utils.ts
@@ -1,36 +1,15 @@
 import { FormControl, FormGroup, Validators } from "@angular/forms";
-import { GroupMember, GroupRole, Role } from "../../open-api";
-
-// Maps a modern group role onto the legacy GroupRole enum by its (immutable)
-// system-role name. Transitional bridge so the group form's member table and its
-// "keep an owner" check — which still read the legacy enum — keep working for
-// newly assigned members; the backend derives the same value on save. Custom
-// roles fall back to the least-privilege VIEWER.
-export function legacyGroupRoleFromRole(role: Role): GroupRole {
-  switch (role.name) {
-    case "Legacy Owner":
-      return GroupRole.Owner;
-    case "Legacy Editor":
-      return GroupRole.Editor;
-    default:
-      return GroupRole.Viewer;
-  }
-}
+import { GroupMember } from "../../open-api";
 
 export function buildGroupMemberForm(groupMember?: GroupMember): FormGroup {
   return new FormGroup({
     userId: new FormControl(groupMember?.userId ?? "", Validators.required),
-    // The member's modern group role is what the user now selects; it is the
+    // The member's modern group role is what the user selects; it is the
     // required choice and is what the backend persists.
     groupRoleId: new FormControl(
       groupMember?.groupRoleId ?? null,
       Validators.required
     ),
-    // The legacy enum is retained transitionally — it is carried (not edited)
-    // for existing members so the parent group form's "must keep an owner" check
-    // and any other legacy readers keep working until those are migrated. The
-    // backend derives it from groupRoleId on save.
-    groupRole: new FormControl(groupMember?.groupRole ?? ""),
     groupId: new FormControl(groupMember?.groupId ?? undefined),
   });
 }

--- a/desktop/src/guards/group-permission.guard.ts
+++ b/desktop/src/guards/group-permission.guard.ts
@@ -9,9 +9,9 @@ import { AuthState, GroupState } from "../store";
  * optional `route.data['orAppPermissions']` app-scoped fallbacks). On deny,
  * redirects to the group dashboard.
  *
- * Group id resolution mirrors `GroupRoleGuard`: when `route.data['useRouteGroupId']`
- * is set the id comes from the `:id` route param (own or parent), otherwise from
- * the currently selected group in `GroupState`.
+ * Group id resolution: when `route.data['useRouteGroupId']` is set the id comes
+ * from the `:id` route param (own or parent), otherwise from the currently
+ * selected group in `GroupState`.
  */
 export const groupPermissionGuard: CanActivateFn = (route) => {
   const store: Store = inject(Store);

--- a/desktop/src/guards/receipt-guard.guard.spec.ts
+++ b/desktop/src/guards/receipt-guard.guard.spec.ts
@@ -75,9 +75,7 @@ describe("receiptGuardGuard", () => {
   //     of(throwError('')) as any
   //   );
   //   const route: any = {
-  //     data: {
-  //       groupRole: GroupRole.Viewer,
-  //     },
+  //     data: {},
   //     params: {
   //       id: 1,
   //     },

--- a/desktop/src/layout/header/header.component.ts
+++ b/desktop/src/layout/header/header.component.ts
@@ -4,7 +4,7 @@ import { Store } from "@ngxs/store";
 import { take, tap } from "rxjs";
 import { LayoutState } from "src/store/layout.state";
 import { ToggleIsSidebarOpen } from "src/store/layout.state.actions";
-import { AuthService, GroupRole, NotificationsService } from "../../open-api";
+import { AuthService, NotificationsService } from "../../open-api";
 import { AuthState, GroupState } from "../../store";
 
 @Component({
@@ -44,8 +44,6 @@ export class HeaderComponent {
     const group = this.store.selectSnapshot(GroupState.getGroupById(groupId));
     return group?.name as string ?? "";
   });
-
-  public groupRoleEnum = GroupRole;
 
   public notificationCount = signal<number | undefined>(undefined);
 

--- a/desktop/src/pipes/pipes.module.ts
+++ b/desktop/src/pipes/pipes.module.ts
@@ -11,6 +11,7 @@ import { InputReadonlyPipe } from "./input-readonly.pipe";
 import { MapGetPipe } from "./map-get.pipe";
 import { MapKeyPipe } from "./map-key.pipe";
 import { NamePipe } from "./name.pipe";
+import { RoleNamePipe } from "./role-name.pipe";
 import { StatusPipe } from "./status.pipe";
 import { UserPipe } from "./user.pipe";
 
@@ -27,6 +28,7 @@ import { UserPipe } from "./user.pipe";
     MapGetPipe,
     MapKeyPipe,
     NamePipe,
+    RoleNamePipe,
     StatusPipe,
     UserPipe,
   ],
@@ -43,6 +45,7 @@ import { UserPipe } from "./user.pipe";
     MapGetPipe,
     MapKeyPipe,
     NamePipe,
+    RoleNamePipe,
     StatusPipe,
     UserPipe,
   ],

--- a/desktop/src/pipes/role-name.pipe.spec.ts
+++ b/desktop/src/pipes/role-name.pipe.spec.ts
@@ -1,0 +1,48 @@
+import { PermissionScope, Role } from "../open-api";
+import { RoleNamePipe } from "./role-name.pipe";
+
+describe("RoleNamePipe", () => {
+  const roles: Role[] = [
+    {
+      id: 1,
+      name: "Legacy Admin",
+      scope: PermissionScope.App,
+      isDefault: false,
+      isSystem: true,
+      permissions: [],
+    },
+    {
+      id: 2,
+      name: "Legacy Owner",
+      scope: PermissionScope.Group,
+      isDefault: true,
+      isSystem: true,
+      permissions: [],
+    },
+  ];
+
+  it("creates an instance", () => {
+    expect(new RoleNamePipe()).toBeTruthy();
+  });
+
+  it("resolves the role name for a matching id", () => {
+    const pipe = new RoleNamePipe();
+    expect(pipe.transform(2, roles)).toEqual("Legacy Owner");
+  });
+
+  it("returns empty string for an unknown id", () => {
+    const pipe = new RoleNamePipe();
+    expect(pipe.transform(99, roles)).toEqual("");
+  });
+
+  it("returns empty string for a null/undefined id", () => {
+    const pipe = new RoleNamePipe();
+    expect(pipe.transform(null, roles)).toEqual("");
+    expect(pipe.transform(undefined, roles)).toEqual("");
+  });
+
+  it("returns empty string when roles are not yet loaded", () => {
+    const pipe = new RoleNamePipe();
+    expect(pipe.transform(1, [])).toEqual("");
+  });
+});

--- a/desktop/src/pipes/role-name.pipe.ts
+++ b/desktop/src/pipes/role-name.pipe.ts
@@ -1,0 +1,15 @@
+import { Pipe, PipeTransform } from "@angular/core";
+import { Role } from "../open-api";
+
+@Pipe({
+    name: "roleName",
+    standalone: false
+})
+export class RoleNamePipe implements PipeTransform {
+  public transform(id: number | undefined | null, roles: Role[]): string {
+    if (id == null) {
+      return "";
+    }
+    return roles.find((role) => role.id === id)?.name ?? "";
+  }
+}

--- a/desktop/src/receipts/share-list/share-list.component.spec.ts
+++ b/desktop/src/receipts/share-list/share-list.component.spec.ts
@@ -10,7 +10,7 @@ import { NgxsModule, Store } from "@ngxs/store";
 import { FormMode } from "src/enums/form-mode.enum";
 import { PipesModule } from "src/pipes/pipes.module";
 import { InputComponent } from "../../input";
-import { Category, Group, GroupRole, Item, ItemStatus, Receipt, Tag, User } from "../../open-api";
+import { Category, Group, Item, ItemStatus, Receipt, Tag, User } from "../../open-api";
 import { AuthState, UserState } from "../../store/index";
 import { SystemSettingsState } from "../../store/system-settings.state";
 import { UserTotalWithPercentagePipe } from "../user-total-with-percentage.pipe";
@@ -56,7 +56,6 @@ describe("ShareListComponent", () => {
   const mockGroup: Group = {
     id: 1,
     name: "Test Group",
-    groupRole: GroupRole.Owner,
   } as any as Group;
 
   const mockActivatedRoute = {

--- a/desktop/src/roles/role-loading.util.spec.ts
+++ b/desktop/src/roles/role-loading.util.spec.ts
@@ -1,0 +1,63 @@
+import { TestBed } from "@angular/core/testing";
+import { NgxsModule, Store } from "@ngxs/store";
+import { of, throwError } from "rxjs";
+import { PermissionScope, Role, RoleService } from "../open-api";
+import { AuthState } from "../store";
+import { SetPermissions } from "../store/auth.state.actions";
+import { loadAssignableRoles } from "./role-loading.util";
+
+describe("loadAssignableRoles", () => {
+  let store: Store;
+  let getRoles: jest.Mock;
+  let roleService: RoleService;
+
+  const roles: Role[] = [
+    {
+      id: 1,
+      name: "Legacy Admin",
+      scope: PermissionScope.App,
+      isDefault: false,
+      isSystem: true,
+      permissions: [],
+    },
+  ];
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [NgxsModule.forRoot([AuthState])],
+    });
+    store = TestBed.inject(Store);
+    getRoles = jest.fn().mockReturnValue(of(roles));
+    roleService = { getRoles } as unknown as RoleService;
+  });
+
+  function collect(done: (value: Role[]) => void): void {
+    loadAssignableRoles(store, roleService).subscribe(done);
+  }
+
+  it("does NOT call getRoles when app.roles.read is absent", (done) => {
+    collect((result) => {
+      expect(result).toEqual([]);
+      expect(getRoles).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it("loads roles when app.roles.read is held", (done) => {
+    store.dispatch(new SetPermissions(["app.roles.read"], {}));
+    collect((result) => {
+      expect(result).toEqual(roles);
+      expect(getRoles).toHaveBeenCalledTimes(1);
+      done();
+    });
+  });
+
+  it("degrades to an empty list when getRoles errors", (done) => {
+    store.dispatch(new SetPermissions(["app.roles.read"], {}));
+    getRoles.mockReturnValue(throwError(() => new Error("boom")));
+    collect((result) => {
+      expect(result).toEqual([]);
+      done();
+    });
+  });
+});

--- a/desktop/src/roles/role-loading.util.ts
+++ b/desktop/src/roles/role-loading.util.ts
@@ -1,0 +1,22 @@
+import { Store } from "@ngxs/store";
+import { catchError, Observable, of } from "rxjs";
+import { Permission, Role, RoleService } from "../open-api";
+import { AuthState } from "../store";
+
+/**
+ * Loads the roles a UI needs to resolve role ids to display names — but only
+ * when the caller holds `app.roles.read`. Non-holders get an empty list WITHOUT
+ * issuing `GET /role`: that request would 403, and the global HTTP interceptor
+ * turns a 403 into a forced logout. This matters because some role-name readers
+ * (the group-member table in `group-form`) are rendered for ordinary group
+ * members who are not admins. Request errors still degrade to an empty list.
+ */
+export function loadAssignableRoles(
+  store: Store,
+  roleService: RoleService
+): Observable<Role[]> {
+  if (!store.selectSnapshot(AuthState.hasAppPermission(Permission.AppRolesRead))) {
+    return of([]);
+  }
+  return roleService.getRoles().pipe(catchError(() => of([])));
+}

--- a/desktop/src/services/token-refresh.service.spec.ts
+++ b/desktop/src/services/token-refresh.service.spec.ts
@@ -4,7 +4,7 @@ import { Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { NgxsModule, Store } from "@ngxs/store";
 import { of, Subject, throwError } from "rxjs";
-import { ApiModule, AuthService, Claims, UserRole } from "../open-api";
+import { ApiModule, AuthService, Claims } from "../open-api";
 import { AuthState, Logout, SetAuthState } from "../store";
 import { TokenRefreshService } from "./token-refresh.service";
 import { provideHttpClient, withInterceptorsFromDi } from "@angular/common/http";
@@ -17,7 +17,6 @@ describe("TokenRefreshService", () => {
 
   const mockClaims: Claims = {
     userId: 1,
-    userRole: UserRole.Admin,
     displayName: "Test User",
     defaultAvatarColor: "#CD5C5C",
     username: "testuser",

--- a/desktop/src/store/auth-state.interface.ts
+++ b/desktop/src/store/auth-state.interface.ts
@@ -1,4 +1,4 @@
-import { Icon, UserRole } from "../open-api";
+import { Icon } from "../open-api";
 import { UserPreferences } from "../open-api/model/userPreferences";
 
 export interface AuthStateInterface {
@@ -6,7 +6,6 @@ export interface AuthStateInterface {
   displayname?: string;
   username?: string;
   expirationDate?: string;
-  userRole?: UserRole;
   defaultAvatarColor?: string;
   userPreferences?: UserPreferences;
   icons?: Icon[];

--- a/desktop/src/store/auth.state.spec.ts
+++ b/desktop/src/store/auth.state.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from "@angular/core/testing";
 import { NgxsModule, Store } from "@ngxs/store";
-import { Claims, UserRole } from "../open-api";
+import { Claims } from "../open-api";
 import { AuthState } from "./auth.state";
 import { Logout, SetAuthState, SetPermissions } from "./auth.state.actions";
 
@@ -40,7 +40,6 @@ describe("AuthState", () => {
 
     const claims = {
       userId: 5,
-      userRole: UserRole.User,
       displayName: "Tester",
       defaultAvatarColor: "#fff",
       username: "tester",

--- a/desktop/src/store/auth.state.ts
+++ b/desktop/src/store/auth.state.ts
@@ -27,11 +27,6 @@ export class AuthState {
   }
 
   @Selector()
-  static userRole(state: AuthStateInterface): string {
-    return state.userRole ?? "";
-  }
-
-  @Selector()
   static isLoggedIn(state: AuthStateInterface): boolean {
     return !AuthState.isTokenExpired(state);
   }
@@ -58,12 +53,6 @@ export class AuthState {
       id: Number(state.userId) ?? "",
       username: state.username ?? "",
     } as User;
-  }
-
-  static hasRole(role: string) {
-    return createSelector([AuthState], (state: AuthStateInterface) => {
-      return state.userRole === role;
-    });
   }
 
   @Selector()
@@ -119,7 +108,6 @@ export class AuthState {
       expirationDate: claims?.exp?.toString(),
       userId: claims?.userId?.toString(),
       username: claims?.username,
-      userRole: claims?.userRole,
     });
   }
 
@@ -142,7 +130,6 @@ export class AuthState {
       expirationDate: "",
       userId: "",
       username: "",
-      userRole: undefined,
       userPreferences: undefined,
       appPermissions: undefined,
       groupPermissions: undefined,

--- a/desktop/src/user/user-form/user-form.component.spec.ts
+++ b/desktop/src/user/user-form/user-form.component.spec.ts
@@ -6,7 +6,7 @@ import { MatDialog, MatDialogModule, MatDialogRef } from "@angular/material/dial
 import { MatSnackBarModule } from "@angular/material/snack-bar";
 import { NgxsModule, Store } from "@ngxs/store";
 import { of, throwError } from "rxjs";
-import { ApiModule, PermissionScope, Role, RoleService, User, UserRole, UserService } from "../../open-api";
+import { ApiModule, PermissionScope, Role, RoleService, User, UserService } from "../../open-api";
 import { PipesModule } from "../../pipes";
 import { SnackbarService, TokenRefreshService } from "../../services";
 import { AddUser, AuthState, UpdateUser, UserState } from "../../store";
@@ -104,7 +104,6 @@ describe("UserFormComponent", () => {
       displayName: "Pizza man",
       username: "Waffle guy",
       isDummyUser: false,
-      userRole: UserRole.Admin,
       appRoleId: 5,
     } as User;
 
@@ -149,7 +148,6 @@ describe("UserFormComponent", () => {
       displayName: "Pizza man",
       username: "Waffle guy",
       isDummyUser: false,
-      userRole: UserRole.Admin,
       appRoleId: 5,
     } as User;
 
@@ -209,7 +207,6 @@ describe("UserFormComponent", () => {
       displayName: "Pizza man",
       username: "Waffle guy",
       isDummyUser: false,
-      userRole: UserRole.Admin,
       appRoleId: 5,
     } as User;
 
@@ -250,7 +247,6 @@ describe("UserFormComponent", () => {
       displayName: "Pizza man",
       username: "Waffle guy",
       isDummyUser: false,
-      userRole: UserRole.Admin,
       appRoleId: 5,
     } as User;
 

--- a/desktop/src/user/user-list/user-list.component.html
+++ b/desktop/src/user/user-list/user-list.component.html
@@ -35,8 +35,8 @@
   {{ element.displayName }}
 </ng-template>
 
-<ng-template #userRoleCell let-element="element">
-  {{ element.userRole | status }}
+<ng-template #appRoleCell let-element="element">
+  {{ element.appRoleId | roleName : roles() }}
 </ng-template>
 
 <ng-template #createdAtCell let-element="element">

--- a/desktop/src/user/user-list/user-list.component.ts
+++ b/desktop/src/user/user-list/user-list.component.ts
@@ -4,13 +4,14 @@ import { MatDialog } from "@angular/material/dialog";
 import { MatTableDataSource } from "@angular/material/table";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { Store } from "@ngxs/store";
-import { catchError, of, take, tap } from "rxjs";
+import { take, tap } from "rxjs";
 import { DEFAULT_HOST_CLASS } from "src/constants";
 import { DEFAULT_DIALOG_CONFIG } from "src/constants/dialog.constant";
 import { ConfirmationDialogComponent } from "src/shared-ui/confirmation-dialog/confirmation-dialog.component";
 import { TableColumn } from "src/table/table-column.interface";
 import { TableComponent } from "src/table/table/table.component";
 import { BulkUserDeleteCommand, Permission, Role, RoleService, User, UserService } from "../../open-api";
+import { loadAssignableRoles } from "../../roles/role-loading.util";
 import { SnackbarService } from "../../services";
 import { AuthState, RemoveUser, RemoveUsers, UserState } from "../../store";
 import { DummyUserConversionDialogComponent } from "../dummy-user-conversion-dialog/dummy-user-conversion-dialog.component";
@@ -50,13 +51,11 @@ export class UserListComponent implements AfterViewInit {
 
   public dataSource = signal(new MatTableDataSource<User>([]));
 
-  // Roles load best-effort so the table can resolve each user's appRoleId to a
-  // role name. If app.roles.read is denied the list stays empty and the cell
-  // renders blank rather than erroring.
+  // Roles resolve each user's appRoleId to a role name. The request is skipped
+  // unless the caller holds app.roles.read (otherwise the 403 would log them
+  // out — see loadAssignableRoles); the cell then renders blank.
   public readonly roles = toSignal(
-    inject(RoleService)
-      .getRoles()
-      .pipe(catchError(() => of([] as Role[]))),
+    loadAssignableRoles(inject(Store), inject(RoleService)),
     { initialValue: [] as Role[] }
   );
 

--- a/desktop/src/user/user-list/user-list.component.ts
+++ b/desktop/src/user/user-list/user-list.component.ts
@@ -1,15 +1,16 @@
-import { AfterViewInit, Component, signal, TemplateRef, viewChild } from "@angular/core";
+import { AfterViewInit, Component, inject, signal, TemplateRef, viewChild } from "@angular/core";
+import { toSignal } from "@angular/core/rxjs-interop";
 import { MatDialog } from "@angular/material/dialog";
 import { MatTableDataSource } from "@angular/material/table";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { Store } from "@ngxs/store";
-import { take, tap } from "rxjs";
+import { catchError, of, take, tap } from "rxjs";
 import { DEFAULT_HOST_CLASS } from "src/constants";
 import { DEFAULT_DIALOG_CONFIG } from "src/constants/dialog.constant";
 import { ConfirmationDialogComponent } from "src/shared-ui/confirmation-dialog/confirmation-dialog.component";
 import { TableColumn } from "src/table/table-column.interface";
 import { TableComponent } from "src/table/table/table.component";
-import { BulkUserDeleteCommand, Permission, User, UserService } from "../../open-api";
+import { BulkUserDeleteCommand, Permission, Role, RoleService, User, UserService } from "../../open-api";
 import { SnackbarService } from "../../services";
 import { AuthState, RemoveUser, RemoveUsers, UserState } from "../../store";
 import { DummyUserConversionDialogComponent } from "../dummy-user-conversion-dialog/dummy-user-conversion-dialog.component";
@@ -33,7 +34,7 @@ export class UserListComponent implements AfterViewInit {
 
   public readonly displaynameCell = viewChild.required<TemplateRef<any>>("displayNameCell");
 
-  public readonly userRoleCell = viewChild.required<TemplateRef<any>>("userRoleCell");
+  public readonly appRoleCell = viewChild.required<TemplateRef<any>>("appRoleCell");
 
   public readonly createdAtCell = viewChild.required<TemplateRef<any>>("createdAtCell");
 
@@ -48,6 +49,16 @@ export class UserListComponent implements AfterViewInit {
   public columns: TableColumn[] = [];
 
   public dataSource = signal(new MatTableDataSource<User>([]));
+
+  // Roles load best-effort so the table can resolve each user's appRoleId to a
+  // role name. If app.roles.read is denied the list stays empty and the cell
+  // renders blank rather than erroring.
+  public readonly roles = toSignal(
+    inject(RoleService)
+      .getRoles()
+      .pipe(catchError(() => of([] as Role[]))),
+    { initialValue: [] as Role[] }
+  );
 
   public hasSelectedUsers: boolean = false;
 
@@ -85,8 +96,8 @@ export class UserListComponent implements AfterViewInit {
       },
       {
         columnHeader: "Role",
-        matColumnDef: "userRole",
-        template: this.userRoleCell(),
+        matColumnDef: "appRole",
+        template: this.appRoleCell(),
         sortable: true,
       },
       {
@@ -113,7 +124,7 @@ export class UserListComponent implements AfterViewInit {
       "select",
       "username",
       "displayName",
-      "userRole",
+      "appRole",
       "createdAt",
       "updatedAt",
       "actions",


### PR DESCRIPTION
## Summary

The backend removed the legacy `UserRole`/`GroupRole` enums and the
`userRole`/`groupRole` API fields (and the client was regenerated against the
slimmed contract). This PR removes every remaining **desktop** consumer of those
fields so the app builds against the new client and gates purely on the modern
permission system, which was already fully in place (`AuthState.hasAppPermission`
/ `hasGroupPermission`, the `*hasAppPermission` / `*hasGroupPermission` directives,
`appPermissionGuard` / `groupPermissionGuard`). No client regeneration was needed.

## What changed

- **Role display columns now show the assigned role's _name_.** New shared, pure
  `RoleNamePipe` (`src/pipes/role-name.pipe.ts`). The admin user list and the
  group-member table resolve `appRoleId` / `groupRoleId` to the role name, loading
  roles best-effort via `RoleService.getRoles()` (wrapped in `catchError`).
- **Removed the group-form "must have at least one owner" rule.** The backend
  dropped the owner concept entirely; group management is now governed by
  `group.*` permissions, so the client mirrors the backend and no longer blocks
  saving.
- **Removed the group-member legacy-enum bridge** (`legacyGroupRoleFromRole` and
  the hidden `groupRole` form control). Members are saved by their modern
  `groupRoleId` alone.
- **Deleted dead code:** `AuthState.userRole` / `hasRole` selectors, the
  `userRole` state field, and the unused `GroupRole` enum in the header.
- Updated the affected specs (and added `role-name.pipe.spec.ts`) and both
  `CLAUDE.md` files.

## Known limitation

A group member **without `app.roles.read`** viewing the member table sees a
**blank** role name (the roles list 403s → empty), since the name is resolved
client-side. This matches the existing group-member-form selector's graceful
degradation. Embedding the role name in the API response would be a future
backend enhancement.

## Verification

- `npm test` — full Jest suite green (**204 suites / 919 tests**).
- `npm run build` — production AOT build compiles cleanly (validates the new
  pipe in templates and that all legacy types are gone).
- **e2e not run** — the dev stack (API + Redis + desktop) was not running in this
  environment. Recommend running the group/user/role Playwright specs
  (`group-viewer-visibility`, role flows, user list) against a live stack, and
  manually confirming group create/update saves without an owner and the
  member/user tables show resolved role names for an admin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Role names now display consistently in user and group lists; non-admins see blank names when role data is unavailable.
  * Added a safe role-name resolver and role-loader that degrade gracefully on missing permissions or errors.

* **Refactor**
  * Modern role identifiers rolled out; legacy role constructs and the “must have an owner” group enforcement removed.

* **Documentation**
  * Updated authorization and Roles & Permissions guidance to reflect current behavior and sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->