### PR TITLE
Send appRoleId from the mobile e2e createUser fixture

### DIFF
--- a/mobile/integration_test/helpers/permission_fixtures.dart
+++ b/mobile/integration_test/helpers/permission_fixtures.dart
@@ -61,9 +61,13 @@ Map<String, String> _auth(String jwt) => {'Cookie': 'jwt=$jwt'};
 
 String _unique() => DateTime.now().microsecondsSinceEpoch.toString();
 
-/// Resolves the id of a system group role by name (e.g. "Legacy Viewer",
-/// "Legacy Editor", "Legacy Owner") via `GET /role`.
-Future<int> groupRoleIdByName(String name, {required String jwt}) async {
+/// Resolves the id of a system role by [name] within [scope] (`APP` or `GROUP`)
+/// via `GET /role`.
+Future<int> _roleIdByName(
+  String name,
+  String scope, {
+  required String jwt,
+}) async {
   final res = await http
       .get(Uri.parse('${E2eEnv.baseUrl}/role'), headers: _auth(jwt))
       .timeout(const Duration(seconds: 10));
@@ -72,14 +76,24 @@ Future<int> groupRoleIdByName(String name, {required String jwt}) async {
   }
   final roles = (jsonDecode(res.body) as List).cast<Map<String, dynamic>>();
   final match = roles.firstWhere(
-    (r) => r['name'] == name && r['scope'] == 'GROUP',
+    (r) => r['name'] == name && r['scope'] == scope,
     orElse: () => throw StateError(
-      'No GROUP role named "$name". Available: '
-      '${roles.where((r) => r['scope'] == 'GROUP').map((r) => r['name']).toList()}',
+      'No $scope role named "$name". Available: '
+      '${roles.where((r) => r['scope'] == scope).map((r) => r['name']).toList()}',
     ),
   );
   return match['id'] as int;
 }
+
+/// Resolves the id of a system group role by name (e.g. "Legacy Viewer",
+/// "Legacy Editor", "Legacy Owner") via `GET /role`.
+Future<int> groupRoleIdByName(String name, {required String jwt}) =>
+    _roleIdByName(name, 'GROUP', jwt: jwt);
+
+/// Resolves the id of a system app role by name (e.g. "Legacy User",
+/// "Legacy Admin") via `GET /role`.
+Future<int> appRoleIdByName(String name, {required String jwt}) =>
+    _roleIdByName(name, 'APP', jwt: jwt);
 
 /// Resolves a user's id by username via `GET /user/` (admin only).
 Future<int> userIdByUsername(String username, {required String jwt}) async {
@@ -98,15 +112,17 @@ Future<int> userIdByUsername(String username, {required String jwt}) async {
   return match['id'] as int;
 }
 
-/// Creates a regular (USER-role) account and returns its id. The default app
-/// role (Legacy User) carries no group permissions, so the user only gets the
-/// group permissions a fixture grants it.
+/// Creates a regular account assigned the Legacy User app role and returns its
+/// id. Legacy User carries no group permissions, so the user only gets the
+/// group permissions a fixture grants it. The admin create endpoint requires an
+/// `appRoleId`, so we resolve Legacy User (the default app role) by name.
 Future<int> createUser({
   required String username,
   required String password,
   required String displayName,
   required String jwt,
 }) async {
+  final appRoleId = await appRoleIdByName('Legacy User', jwt: jwt);
   final res = await http
       .post(
         Uri.parse('${E2eEnv.baseUrl}/user/'),
@@ -115,7 +131,7 @@ Future<int> createUser({
           'username': username,
           'password': password,
           'displayName': displayName,
-          'userRole': 'USER',
+          'appRoleId': appRoleId,
           'isDummyUser': false,
         }),
       )


### PR DESCRIPTION
## What

The mobile e2e `createUser` fixture (`mobile/integration_test/helpers/permission_fixtures.dart`) still POSTed the removed legacy `userRole` field and never sent an `appRoleId`. With the role rework, the admin user-create endpoint requires `appRoleId` and ignores `userRole`, so the fixture failed provisioning with **HTTP 400 `{"appRoleId":"A role is required"}`** — breaking every spec that creates a user (`permission_receipt_edit_test.dart`, `permission_add_menu_test.dart`).

## Changes

- Drop the dead `userRole: 'USER'` field from `createUser`.
- Resolve the **Legacy User** app role by name and send it as `appRoleId`, mirroring how `createGroupWithMember` resolves group roles.
- Refactor `groupRoleIdByName` into a scope-parameterized `_roleIdByName(name, scope)` helper and add `appRoleIdByName`, so both scopes share one `GET /role` lookup.

## Verification

- `dart analyze` on the fixture and both dependent specs: no issues.
- Linux driver (`./run-e2e.sh`) against the running dev stack:
  - `permission_receipt_edit_test.dart` — 2/2 passed (Legacy Viewer / Legacy Editor swipe-edit + popup gates)
  - `permission_add_menu_test.dart` — 3/3 passed (Viewer/Editor/any-group add-menu gates)
- Confirmed directly against the live API: the old body returns 400; with `appRoleId` the create returns 200 and the user is assigned the Legacy User role.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal test fixture infrastructure for application role and user provisioning operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->