### PR TITLE
Add category/tag grant CRUD to group roles

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -192,7 +192,12 @@ them.
 
 - **App roles:** `AppRole` + `AppRolePermission` (permission strings in a child table).
 - **Group roles:** `GroupRoleDefinition` + `GroupRolePermission`, plus `GroupRoleCategoryGrant` /
-  `GroupRoleTagGrant` for per-role category/tag visibility.
+  `GroupRoleTagGrant` (composite-PK join rows) for per-role category/tag visibility. A group role
+  with **no** grant rows is **unrestricted** (sees every category/tag); a non-empty grant set
+  restricts members to exactly those ids — restriction is opt-in, so legacy/system roles (no grants)
+  keep seeing everything and no data migration is needed. Categories/tags are **global** (no
+  `GroupId`); a grant is a per-group-role slice of the global pool. Enforcement of these grants is
+  rolled out in later slices; Phase 1 only persists/returns them through role CRUD.
 - **Assignment:** nullable FKs `User.AppRoleID` and `GroupMember.GroupRoleID` (one app role per
   user; one group role per group membership). Nullable because per-create assignment is best-effort
   (the FK is left `nil` rather than failing creation when no role can be resolved, e.g. an unseeded
@@ -211,7 +216,14 @@ them.
   `PUT /role/{roleId}`, `PUT /role/{roleId}/default?scope=APP|GROUP` (make this role the scope's
   default; allowed on system roles; gated by `app.roles.update`), `DELETE /role/{roleId}?scope=APP|GROUP`.
 - `commands.UpsertRoleCommand` validates that every permission exists in the registry and matches
-  the role's scope. `structs.RoleView` is the read model (includes `assignedCount` and `isDefault`).
+  the role's scope. It also carries `categoryGrants` / `tagGrants` (category/tag ids): grants are
+  rejected on APP scope and dedup-checked in `Validate()`, and their existence is verified against
+  the DB in `RoleService` (`ErrInvalidGrant` → 400). `repositories/roles.go` syncs grant rows with
+  the same delete-then-insert pattern as permissions (`replaceGroupRoleGrants`, with the nested
+  Category/Tag association `Omit`-ted so only join rows are written), preloads them in
+  `GetGroupRoleById` / `GetAllRoles`, and cascades them on role delete. `structs.RoleView` is the
+  read model (includes `assignedCount`, `isDefault`, and `categoryGrants` / `tagGrants` — empty
+  slices for app roles).
 
 ### Seeded system roles (legacy-equivalent)
 

--- a/api/internal/commands/upsert_role_command.go
+++ b/api/internal/commands/upsert_role_command.go
@@ -14,6 +14,13 @@ type UpsertRoleCommand struct {
 	Description string            `json:"description"`
 	Scope       permissions.Scope `json:"scope"`
 	Permissions []string          `json:"permissions"`
+	// CategoryGrants / TagGrants restrict which categories/tags members of a
+	// group role may read and use. They are only valid on GROUP-scoped roles. An
+	// empty set means "unrestricted" (see every category/tag) — restriction is
+	// opt-in. The values are category/tag ids; their existence is validated
+	// against the database in the role service.
+	CategoryGrants []uint `json:"categoryGrants"`
+	TagGrants      []uint `json:"tagGrants"`
 }
 
 func (command *UpsertRoleCommand) LoadDataFromRequest(w http.ResponseWriter, r *http.Request) error {
@@ -62,6 +69,32 @@ func (command *UpsertRoleCommand) Validate() structs.ValidatorError {
 		}
 	}
 
+	// Category/tag grants are a group-role concept (they slice the global pool
+	// per group role); they make no sense on an app role.
+	if command.Scope == permissions.ScopeApp && (len(command.CategoryGrants) > 0 || len(command.TagGrants) > 0) {
+		errors["grants"] = "Category and tag grants are only valid on group roles"
+	}
+
+	if hasDuplicateUint(command.CategoryGrants) {
+		errors["categoryGrants"] = "Duplicate category grant"
+	}
+
+	if hasDuplicateUint(command.TagGrants) {
+		errors["tagGrants"] = "Duplicate tag grant"
+	}
+
 	vErr.Errors = errors
 	return vErr
+}
+
+// hasDuplicateUint reports whether ids contains the same value more than once.
+func hasDuplicateUint(ids []uint) bool {
+	seen := make(map[uint]bool, len(ids))
+	for _, id := range ids {
+		if seen[id] {
+			return true
+		}
+		seen[id] = true
+	}
+	return false
 }

--- a/api/internal/commands/upsert_role_command_test.go
+++ b/api/internal/commands/upsert_role_command_test.go
@@ -96,3 +96,60 @@ func TestUpsertRoleCommandDuplicatePermission(t *testing.T) {
 		t.Errorf("expected permissions error, got %+v", vErr.Errors)
 	}
 }
+
+func TestUpsertRoleCommandGrantsOnGroupScopeValid(t *testing.T) {
+	command := UpsertRoleCommand{
+		Name:           "Restricted Group Role",
+		Scope:          permissions.ScopeGroup,
+		Permissions:    []string{permissions.GroupReceiptsRead},
+		CategoryGrants: []uint{1, 2},
+		TagGrants:      []uint{3},
+	}
+
+	vErr := command.Validate()
+	if len(vErr.Errors) > 0 {
+		t.Errorf("expected no errors, got %+v", vErr.Errors)
+	}
+}
+
+func TestUpsertRoleCommandGrantsRejectedOnAppScope(t *testing.T) {
+	command := UpsertRoleCommand{
+		Name:           "App Role With Grants",
+		Scope:          permissions.ScopeApp,
+		Permissions:    []string{permissions.AppUsersRead},
+		CategoryGrants: []uint{1},
+	}
+
+	vErr := command.Validate()
+	if _, ok := vErr.Errors["grants"]; !ok {
+		t.Errorf("expected grants error, got %+v", vErr.Errors)
+	}
+}
+
+func TestUpsertRoleCommandDuplicateCategoryGrant(t *testing.T) {
+	command := UpsertRoleCommand{
+		Name:           "Dup Category Grant",
+		Scope:          permissions.ScopeGroup,
+		Permissions:    []string{permissions.GroupReceiptsRead},
+		CategoryGrants: []uint{1, 1},
+	}
+
+	vErr := command.Validate()
+	if _, ok := vErr.Errors["categoryGrants"]; !ok {
+		t.Errorf("expected categoryGrants error, got %+v", vErr.Errors)
+	}
+}
+
+func TestUpsertRoleCommandDuplicateTagGrant(t *testing.T) {
+	command := UpsertRoleCommand{
+		Name:        "Dup Tag Grant",
+		Scope:       permissions.ScopeGroup,
+		Permissions: []string{permissions.GroupReceiptsRead},
+		TagGrants:   []uint{5, 5},
+	}
+
+	vErr := command.Validate()
+	if _, ok := vErr.Errors["tagGrants"]; !ok {
+		t.Errorf("expected tagGrants error, got %+v", vErr.Errors)
+	}
+}

--- a/api/internal/handlers/auth_test_helpers_test.go
+++ b/api/internal/handlers/auth_test_helpers_test.go
@@ -54,7 +54,7 @@ func grantGroupPerms(t *testing.T, userId uint, groupId uint, perms ...string) {
 	db := repositories.GetDB()
 
 	roleRepository := repositories.NewRoleRepository(nil)
-	role, err := roleRepository.CreateGroupRole(fmt.Sprintf("Test Group Role %d-%d", userId, groupId), "", perms)
+	role, err := roleRepository.CreateGroupRole(fmt.Sprintf("Test Group Role %d-%d", userId, groupId), "", perms, nil, nil)
 	if err != nil {
 		t.Fatalf("create group role: %v", err)
 	}

--- a/api/internal/handlers/roles.go
+++ b/api/internal/handlers/roles.go
@@ -65,6 +65,12 @@ func CreateRole(w http.ResponseWriter, r *http.Request) {
 			roleService := services.NewRoleService(nil)
 			createdRole, err := roleService.CreateRole(command)
 			if err != nil {
+				if errors.Is(err, services.ErrInvalidGrant) {
+					structs.WriteValidatorErrorResponse(w, structs.ValidatorError{
+						Errors: map[string]string{"grants": "One or more category or tag grants do not exist"},
+					}, http.StatusBadRequest)
+					return 0, nil
+				}
 				return http.StatusInternalServerError, err
 			}
 
@@ -128,6 +134,12 @@ func UpdateRole(w http.ResponseWriter, r *http.Request) {
 				}
 				if errors.Is(err, services.ErrRoleNotFound) {
 					utils.WriteCustomErrorResponse(w, "Role not found", http.StatusNotFound)
+					return 0, nil
+				}
+				if errors.Is(err, services.ErrInvalidGrant) {
+					structs.WriteValidatorErrorResponse(w, structs.ValidatorError{
+						Errors: map[string]string{"grants": "One or more category or tag grants do not exist"},
+					}, http.StatusBadRequest)
 					return 0, nil
 				}
 				return http.StatusInternalServerError, err

--- a/api/internal/handlers/roles_test.go
+++ b/api/internal/handlers/roles_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http/httptest"
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/permissions"
@@ -123,6 +124,62 @@ func TestShouldCreateGroupRole(t *testing.T) {
 
 	if role.Scope != permissions.ScopeGroup {
 		utils.PrintTestError(t, role.Scope, permissions.ScopeGroup)
+	}
+}
+
+func TestShouldCreateGroupRoleWithGrants(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	category := models.Category{Name: "Groceries"}
+	repositories.GetDB().Create(&category)
+	tag := models.Tag{Name: "Reimbursable"}
+	repositories.GetDB().Create(&tag)
+
+	role := structs.RoleView{}
+	body := fmt.Sprintf(
+		`{"name": "Restricted Role", "scope": "GROUP", "permissions": ["group.receipts.read"], "categoryGrants": [%d], "tagGrants": [%d]}`,
+		category.ID, tag.ID,
+	)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/api", strings.NewReader(body))
+
+	newContext := context.WithValue(r.Context(), jwtmiddleware.ContextKey{}, adminContext())
+	r = r.WithContext(newContext)
+
+	CreateRole(w, r)
+
+	if w.Result().StatusCode != 200 {
+		utils.PrintTestError(t, w.Result().StatusCode, 200)
+		return
+	}
+
+	if err := json.Unmarshal(w.Body.Bytes(), &role); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if len(role.CategoryGrants) != 1 || role.CategoryGrants[0] != category.ID {
+		utils.PrintTestError(t, role.CategoryGrants, []uint{category.ID})
+	}
+	if len(role.TagGrants) != 1 || role.TagGrants[0] != tag.ID {
+		utils.PrintTestError(t, role.TagGrants, []uint{tag.ID})
+	}
+}
+
+func TestShouldNotCreateGroupRoleDueToInvalidGrant(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	reader := strings.NewReader(`{"name": "Bad Grant", "scope": "GROUP", "permissions": ["group.receipts.read"], "categoryGrants": [999999]}`)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/api", reader)
+
+	newContext := context.WithValue(r.Context(), jwtmiddleware.ContextKey{}, adminContext())
+	r = r.WithContext(newContext)
+
+	CreateRole(w, r)
+
+	if w.Result().StatusCode != 400 {
+		utils.PrintTestError(t, w.Result().StatusCode, 400)
 	}
 }
 
@@ -535,7 +592,7 @@ func TestShouldNotDeleteAssignedAppRole(t *testing.T) {
 func TestShouldNotDeleteAssignedGroupRole(t *testing.T) {
 	defer repositories.TruncateTestDb()
 	roleRepository := repositories.NewRoleRepository(nil)
-	created, err := roleRepository.CreateGroupRole("Group Role", "desc", []string{permissions.GroupReceiptsCreate})
+	created, err := roleRepository.CreateGroupRole("Group Role", "desc", []string{permissions.GroupReceiptsCreate}, nil, nil)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return

--- a/api/internal/repositories/categories.go
+++ b/api/internal/repositories/categories.go
@@ -31,6 +31,21 @@ func (repository CategoryRepository) GetAllCategories(querySelect string) ([]mod
 	return categories, nil
 }
 
+// CountByIds returns how many of the given category ids exist. Used to validate
+// that a role's category grants reference real categories. Duplicate ids in the
+// input are de-duplicated by the IN clause, so callers should pass a unique set.
+func (repository CategoryRepository) CountByIds(ids []uint) (int64, error) {
+	db := repository.GetDB()
+
+	var count int64
+	err := db.Model(&models.Category{}).Where("id IN ?", ids).Count(&count).Error
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
 func (repository CategoryRepository) CreateCategory(category models.Category) (models.Category, error) {
 	db := repository.GetDB()
 

--- a/api/internal/repositories/data_migrations_test.go
+++ b/api/internal/repositories/data_migrations_test.go
@@ -268,7 +268,7 @@ func TestRunDataMigrationsDoesNotClobberExistingAssignment(t *testing.T) {
 		utils.PrintTestError(t, err, nil)
 		return
 	}
-	customGroupRole, err := roleRepository.CreateGroupRole("Custom Group Role", "", []string{permissions.GroupReceiptsRead})
+	customGroupRole, err := roleRepository.CreateGroupRole("Custom Group Role", "", []string{permissions.GroupReceiptsRead}, nil, nil)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return

--- a/api/internal/repositories/roles.go
+++ b/api/internal/repositories/roles.go
@@ -43,7 +43,7 @@ func (repository RoleRepository) CreateAppRole(name string, description string, 
 	return role, nil
 }
 
-func (repository RoleRepository) CreateGroupRole(name string, description string, perms []string) (models.GroupRoleDefinition, error) {
+func (repository RoleRepository) CreateGroupRole(name string, description string, perms []string, categoryGrantIds []uint, tagGrantIds []uint) (models.GroupRoleDefinition, error) {
 	db := repository.GetDB()
 
 	rolePermissions := make([]models.GroupRolePermission, 0, len(perms))
@@ -62,7 +62,12 @@ func (repository RoleRepository) CreateGroupRole(name string, description string
 		return models.GroupRoleDefinition{}, err
 	}
 
-	return role, nil
+	err = repository.replaceGroupRoleGrants(role.ID, categoryGrantIds, tagGrantIds)
+	if err != nil {
+		return models.GroupRoleDefinition{}, err
+	}
+
+	return repository.GetGroupRoleById(role.ID)
 }
 
 func (repository RoleRepository) GetAppRoleById(id uint) (models.AppRole, error) {
@@ -81,7 +86,10 @@ func (repository RoleRepository) GetGroupRoleById(id uint) (models.GroupRoleDefi
 	db := repository.GetDB()
 
 	var role models.GroupRoleDefinition
-	err := db.Preload("Permissions").First(&role, id).Error
+	err := db.Preload("Permissions").
+		Preload("CategoryGrants").
+		Preload("TagGrants").
+		First(&role, id).Error
 	if err != nil {
 		return models.GroupRoleDefinition{}, err
 	}
@@ -120,7 +128,7 @@ func (repository RoleRepository) UpdateAppRole(id uint, name string, description
 	return repository.GetAppRoleById(id)
 }
 
-func (repository RoleRepository) UpdateGroupRole(id uint, name string, description string, perms []string) (models.GroupRoleDefinition, error) {
+func (repository RoleRepository) UpdateGroupRole(id uint, name string, description string, perms []string, categoryGrantIds []uint, tagGrantIds []uint) (models.GroupRoleDefinition, error) {
 	db := repository.GetDB()
 
 	err := db.Where("group_role_id = ?", id).Delete(&models.GroupRolePermission{}).Error
@@ -148,7 +156,57 @@ func (repository RoleRepository) UpdateGroupRole(id uint, name string, descripti
 		}
 	}
 
+	err = repository.replaceGroupRoleGrants(id, categoryGrantIds, tagGrantIds)
+	if err != nil {
+		return models.GroupRoleDefinition{}, err
+	}
+
 	return repository.GetGroupRoleById(id)
+}
+
+// replaceGroupRoleGrants resets a group role's category and tag grants to exactly
+// the given id sets (delete-all-then-insert, mirroring the permission sync). The
+// nested Category/Tag belongs-to associations are Omit-ted so GORM never tries to
+// upsert a zero-valued category/tag from the grant rows — only the join rows are
+// written.
+func (repository RoleRepository) replaceGroupRoleGrants(groupRoleId uint, categoryGrantIds []uint, tagGrantIds []uint) error {
+	db := repository.GetDB()
+
+	err := db.Where("group_role_id = ?", groupRoleId).Delete(&models.GroupRoleCategoryGrant{}).Error
+	if err != nil {
+		return err
+	}
+
+	err = db.Where("group_role_id = ?", groupRoleId).Delete(&models.GroupRoleTagGrant{}).Error
+	if err != nil {
+		return err
+	}
+
+	if len(categoryGrantIds) > 0 {
+		categoryGrants := make([]models.GroupRoleCategoryGrant, 0, len(categoryGrantIds))
+		for _, categoryId := range categoryGrantIds {
+			categoryGrants = append(categoryGrants, models.GroupRoleCategoryGrant{GroupRoleID: groupRoleId, CategoryID: categoryId})
+		}
+
+		err = db.Omit("Category").Create(&categoryGrants).Error
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(tagGrantIds) > 0 {
+		tagGrants := make([]models.GroupRoleTagGrant, 0, len(tagGrantIds))
+		for _, tagId := range tagGrantIds {
+			tagGrants = append(tagGrants, models.GroupRoleTagGrant{GroupRoleID: groupRoleId, TagID: tagId})
+		}
+
+		err = db.Omit("Tag").Create(&tagGrants).Error
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (repository RoleRepository) GetAllRoles() ([]structs.RoleView, error) {
@@ -161,7 +219,10 @@ func (repository RoleRepository) GetAllRoles() ([]structs.RoleView, error) {
 	}
 
 	var groupRoles []models.GroupRoleDefinition
-	err = db.Preload("Permissions").Find(&groupRoles).Error
+	err = db.Preload("Permissions").
+		Preload("CategoryGrants").
+		Preload("TagGrants").
+		Find(&groupRoles).Error
 	if err != nil {
 		return nil, err
 	}
@@ -185,14 +246,16 @@ func (repository RoleRepository) GetAllRoles() ([]structs.RoleView, error) {
 		}
 
 		roles = append(roles, structs.RoleView{
-			Id:            role.ID,
-			Name:          role.Name,
-			Description:   role.Description,
-			Scope:         permissions.ScopeApp,
-			IsDefault:     role.IsDefault,
-			IsSystem:      role.IsSystem,
-			Permissions:   perms,
-			AssignedCount: appRoleCounts[role.ID],
+			Id:             role.ID,
+			Name:           role.Name,
+			Description:    role.Description,
+			Scope:          permissions.ScopeApp,
+			IsDefault:      role.IsDefault,
+			IsSystem:       role.IsSystem,
+			Permissions:    perms,
+			AssignedCount:  appRoleCounts[role.ID],
+			CategoryGrants: []uint{},
+			TagGrants:      []uint{},
 		})
 	}
 
@@ -203,18 +266,40 @@ func (repository RoleRepository) GetAllRoles() ([]structs.RoleView, error) {
 		}
 
 		roles = append(roles, structs.RoleView{
-			Id:            role.ID,
-			Name:          role.Name,
-			Description:   role.Description,
-			Scope:         permissions.ScopeGroup,
-			IsDefault:     role.IsDefault,
-			IsSystem:      role.IsSystem,
-			Permissions:   perms,
-			AssignedCount: groupRoleCounts[role.ID],
+			Id:             role.ID,
+			Name:           role.Name,
+			Description:    role.Description,
+			Scope:          permissions.ScopeGroup,
+			IsDefault:      role.IsDefault,
+			IsSystem:       role.IsSystem,
+			Permissions:    perms,
+			AssignedCount:  groupRoleCounts[role.ID],
+			CategoryGrants: categoryGrantIdsFromRole(role),
+			TagGrants:      tagGrantIdsFromRole(role),
 		})
 	}
 
 	return roles, nil
+}
+
+// categoryGrantIdsFromRole extracts the category-grant ids from a loaded group
+// role's preloaded CategoryGrants, normalized to a non-nil slice.
+func categoryGrantIdsFromRole(role models.GroupRoleDefinition) []uint {
+	ids := make([]uint, 0, len(role.CategoryGrants))
+	for _, grant := range role.CategoryGrants {
+		ids = append(ids, grant.CategoryID)
+	}
+	return ids
+}
+
+// tagGrantIdsFromRole extracts the tag-grant ids from a loaded group role's
+// preloaded TagGrants, normalized to a non-nil slice.
+func tagGrantIdsFromRole(role models.GroupRoleDefinition) []uint {
+	ids := make([]uint, 0, len(role.TagGrants))
+	for _, grant := range role.TagGrants {
+		ids = append(ids, grant.TagID)
+	}
+	return ids
 }
 
 // roleAssignmentCount is the row shape returned by the grouped assignment-count
@@ -380,6 +465,38 @@ func (repository RoleRepository) GetGroupRolePermissions(groupRoleId uint) ([]st
 	}
 
 	return perms, nil
+}
+
+// GetGroupRoleCategoryIds returns the category ids a group role grants its
+// members. An empty result means the role is unrestricted (see all categories).
+func (repository RoleRepository) GetGroupRoleCategoryIds(groupRoleId uint) ([]uint, error) {
+	db := repository.GetDB()
+
+	ids := make([]uint, 0)
+	err := db.Model(&models.GroupRoleCategoryGrant{}).
+		Where("group_role_id = ?", groupRoleId).
+		Pluck("category_id", &ids).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return ids, nil
+}
+
+// GetGroupRoleTagIds returns the tag ids a group role grants its members. An
+// empty result means the role is unrestricted (see all tags).
+func (repository RoleRepository) GetGroupRoleTagIds(groupRoleId uint) ([]uint, error) {
+	db := repository.GetDB()
+
+	ids := make([]uint, 0)
+	err := db.Model(&models.GroupRoleTagGrant{}).
+		Where("group_role_id = ?", groupRoleId).
+		Pluck("tag_id", &ids).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return ids, nil
 }
 
 // GetUserAppRoleId returns the app role id assigned to a user, or nil when the

--- a/api/internal/repositories/roles_grants_test.go
+++ b/api/internal/repositories/roles_grants_test.go
@@ -1,0 +1,202 @@
+package repositories
+
+import (
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/permissions"
+	"receipt-wrangler/api/internal/utils"
+	"slices"
+	"testing"
+)
+
+// makeTestCategory inserts a category and returns its id.
+func makeTestCategory(t *testing.T, name string) uint {
+	category := models.Category{Name: name}
+	if err := GetDB().Create(&category).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	return category.ID
+}
+
+// makeTestTag inserts a tag and returns its id.
+func makeTestTag(t *testing.T, name string) uint {
+	tag := models.Tag{Name: name}
+	if err := GetDB().Create(&tag).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	return tag.ID
+}
+
+func TestCreateGroupRolePersistsCategoryAndTagGrants(t *testing.T) {
+	defer TruncateTestDb()
+	repository := NewRoleRepository(nil)
+
+	cat1 := makeTestCategory(t, "Groceries")
+	cat2 := makeTestCategory(t, "Utilities")
+	tag1 := makeTestTag(t, "Reimbursable")
+
+	role, err := repository.CreateGroupRole(
+		"Restricted Role",
+		"",
+		[]string{permissions.GroupReceiptsRead},
+		[]uint{cat1, cat2},
+		[]uint{tag1},
+	)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if len(role.CategoryGrants) != 2 {
+		utils.PrintTestError(t, len(role.CategoryGrants), 2)
+	}
+	if len(role.TagGrants) != 1 {
+		utils.PrintTestError(t, len(role.TagGrants), 1)
+	}
+
+	categoryIds, err := repository.GetGroupRoleCategoryIds(role.ID)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	slices.Sort(categoryIds)
+	expected := []uint{cat1, cat2}
+	slices.Sort(expected)
+	if !slices.Equal(categoryIds, expected) {
+		utils.PrintTestError(t, categoryIds, expected)
+	}
+
+	tagIds, err := repository.GetGroupRoleTagIds(role.ID)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if !slices.Equal(tagIds, []uint{tag1}) {
+		utils.PrintTestError(t, tagIds, []uint{tag1})
+	}
+}
+
+func TestCreateGroupRoleWithNoGrantsIsUnrestricted(t *testing.T) {
+	defer TruncateTestDb()
+	repository := NewRoleRepository(nil)
+
+	role, err := repository.CreateGroupRole("Open Role", "", []string{permissions.GroupReceiptsRead}, nil, nil)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	categoryIds, err := repository.GetGroupRoleCategoryIds(role.ID)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if len(categoryIds) != 0 {
+		utils.PrintTestError(t, len(categoryIds), 0)
+	}
+}
+
+func TestUpdateGroupRoleReplacesGrants(t *testing.T) {
+	defer TruncateTestDb()
+	repository := NewRoleRepository(nil)
+
+	cat1 := makeTestCategory(t, "Groceries")
+	cat2 := makeTestCategory(t, "Utilities")
+	cat3 := makeTestCategory(t, "Travel")
+	tag1 := makeTestTag(t, "Reimbursable")
+
+	created, err := repository.CreateGroupRole("Role", "", []string{permissions.GroupReceiptsRead}, []uint{cat1, cat2}, []uint{tag1})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	// Replace the grant sets entirely with cat3 and no tags.
+	updated, err := repository.UpdateGroupRole(created.ID, "Role", "", []string{permissions.GroupReceiptsRead}, []uint{cat3}, nil)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if len(updated.CategoryGrants) != 1 || updated.CategoryGrants[0].CategoryID != cat3 {
+		utils.PrintTestError(t, updated.CategoryGrants, []uint{cat3})
+	}
+	if len(updated.TagGrants) != 0 {
+		utils.PrintTestError(t, len(updated.TagGrants), 0)
+	}
+
+	categoryIds, err := repository.GetGroupRoleCategoryIds(created.ID)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if !slices.Equal(categoryIds, []uint{cat3}) {
+		utils.PrintTestError(t, categoryIds, []uint{cat3})
+	}
+}
+
+func TestDeleteGroupRoleCascadesGrants(t *testing.T) {
+	defer TruncateTestDb()
+	repository := NewRoleRepository(nil)
+
+	cat1 := makeTestCategory(t, "Groceries")
+	tag1 := makeTestTag(t, "Reimbursable")
+
+	created, err := repository.CreateGroupRole("Role", "", []string{permissions.GroupReceiptsRead}, []uint{cat1}, []uint{tag1})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if err := repository.DeleteGroupRole(created.ID); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	var categoryGrantCount int64
+	GetDB().Model(&models.GroupRoleCategoryGrant{}).Where("group_role_id = ?", created.ID).Count(&categoryGrantCount)
+	if categoryGrantCount != 0 {
+		utils.PrintTestError(t, categoryGrantCount, 0)
+	}
+
+	var tagGrantCount int64
+	GetDB().Model(&models.GroupRoleTagGrant{}).Where("group_role_id = ?", created.ID).Count(&tagGrantCount)
+	if tagGrantCount != 0 {
+		utils.PrintTestError(t, tagGrantCount, 0)
+	}
+}
+
+func TestCategoryAndTagCountByIds(t *testing.T) {
+	defer TruncateTestDb()
+
+	cat1 := makeTestCategory(t, "Groceries")
+	cat2 := makeTestCategory(t, "Utilities")
+	tag1 := makeTestTag(t, "Reimbursable")
+
+	categoryCount, err := NewCategoryRepository(nil).CountByIds([]uint{cat1, cat2})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if categoryCount != 2 {
+		utils.PrintTestError(t, categoryCount, 2)
+	}
+
+	// A non-existent id should not be counted.
+	categoryCount, err = NewCategoryRepository(nil).CountByIds([]uint{cat1, 999999})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if categoryCount != 1 {
+		utils.PrintTestError(t, categoryCount, 1)
+	}
+
+	tagCount, err := NewTagsRepository(nil).CountByIds([]uint{tag1})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if tagCount != 1 {
+		utils.PrintTestError(t, tagCount, 1)
+	}
+}

--- a/api/internal/repositories/roles_test.go
+++ b/api/internal/repositories/roles_test.go
@@ -49,7 +49,7 @@ func TestCreateGroupRolePersistsPermissions(t *testing.T) {
 	repository := NewRoleRepository(nil)
 
 	perms := []string{permissions.GroupReceiptsCreate}
-	role, err := repository.CreateGroupRole("Group Role", "Description", perms)
+	role, err := repository.CreateGroupRole("Group Role", "Description", perms, nil, nil)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -93,13 +93,13 @@ func TestUpdateGroupRolePersistsChanges(t *testing.T) {
 	defer TruncateTestDb()
 	repository := NewRoleRepository(nil)
 
-	created, err := repository.CreateGroupRole("Group Role", "Description", []string{permissions.GroupReceiptsCreate})
+	created, err := repository.CreateGroupRole("Group Role", "Description", []string{permissions.GroupReceiptsCreate}, nil, nil)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
 	}
 
-	updated, err := repository.UpdateGroupRole(created.ID, "Renamed Group Role", "New description", []string{permissions.GroupReceiptsRead})
+	updated, err := repository.UpdateGroupRole(created.ID, "Renamed Group Role", "New description", []string{permissions.GroupReceiptsRead}, nil, nil)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -228,7 +228,7 @@ func TestGetGroupRolePermissions(t *testing.T) {
 	repository := NewRoleRepository(nil)
 
 	perms := []string{permissions.GroupReceiptsRead}
-	role, err := repository.CreateGroupRole("Group Role", "", perms)
+	role, err := repository.CreateGroupRole("Group Role", "", perms, nil, nil)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -298,7 +298,7 @@ func TestGetGroupMemberRoleId(t *testing.T) {
 		utils.PrintTestError(t, err, nil)
 		return
 	}
-	role, err := repository.CreateGroupRole("Group Role", "", []string{permissions.GroupReceiptsRead})
+	role, err := repository.CreateGroupRole("Group Role", "", []string{permissions.GroupReceiptsRead}, nil, nil)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -378,12 +378,12 @@ func TestSetDefaultGroupRoleClearsOthers(t *testing.T) {
 	defer TruncateTestDb()
 	repository := NewRoleRepository(nil)
 
-	first, err := repository.CreateGroupRole("First", "", []string{permissions.GroupReceiptsRead})
+	first, err := repository.CreateGroupRole("First", "", []string{permissions.GroupReceiptsRead}, nil, nil)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
 	}
-	second, err := repository.CreateGroupRole("Second", "", []string{permissions.GroupReceiptsRead})
+	second, err := repository.CreateGroupRole("Second", "", []string{permissions.GroupReceiptsRead}, nil, nil)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return

--- a/api/internal/repositories/tags.go
+++ b/api/internal/repositories/tags.go
@@ -32,6 +32,21 @@ func (repository TagsRepository) GetAllTags(querySelect string) ([]models.Tag, e
 	return tags, nil
 }
 
+// CountByIds returns how many of the given tag ids exist. Used to validate that
+// a role's tag grants reference real tags. Duplicate ids in the input are
+// de-duplicated by the IN clause, so callers should pass a unique set.
+func (repository TagsRepository) CountByIds(ids []uint) (int64, error) {
+	db := repository.GetDB()
+
+	var count int64
+	err := db.Model(&models.Tag{}).Where("id IN ?", ids).Count(&count).Error
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
 func (repository TagsRepository) CreateTag(command commands.UpsertTagCommand) (models.Tag, error) {
 	db := repository.GetDB()
 	tag := models.Tag{}

--- a/api/internal/services/auth_test.go
+++ b/api/internal/services/auth_test.go
@@ -498,7 +498,7 @@ func TestGetAppData_PopulatesPermissions(t *testing.T) {
 	}
 
 	groupPerms := []string{permissions.GroupReceiptsRead, permissions.GroupReceiptsUpdate}
-	groupRole, err := roleRepository.CreateGroupRole("AppData Group Role", "", groupPerms)
+	groupRole, err := roleRepository.CreateGroupRole("AppData Group Role", "", groupPerms, nil, nil)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 	}

--- a/api/internal/services/permission_test.go
+++ b/api/internal/services/permission_test.go
@@ -42,7 +42,7 @@ func seedMemberWithGroupRole(t *testing.T, username string, perms []string) (uin
 	}
 
 	roleRepository := repositories.NewRoleRepository(nil)
-	role, err := roleRepository.CreateGroupRole("Group Role", "", perms)
+	role, err := roleRepository.CreateGroupRole("Group Role", "", perms, nil, nil)
 	if err != nil {
 		t.Fatalf("seed group role: %v", err)
 	}

--- a/api/internal/services/roles.go
+++ b/api/internal/services/roles.go
@@ -18,6 +18,7 @@ var (
 	ErrSystemRoleUndeletable = errors.New("system roles cannot be deleted")
 	ErrRoleAssigned          = errors.New("role is assigned and cannot be deleted")
 	ErrRoleIsDefault         = errors.New("the default role cannot be deleted")
+	ErrInvalidGrant          = errors.New("a category or tag grant references a non-existent category or tag")
 )
 
 type RoleService struct {
@@ -39,6 +40,8 @@ func (service RoleService) CreateRole(command commands.UpsertRoleCommand) (struc
 	if perms == nil {
 		perms = []string{}
 	}
+	categoryGrants := normalizeUintSlice(command.CategoryGrants)
+	tagGrants := normalizeUintSlice(command.TagGrants)
 
 	err := repositories.GetDB().Transaction(func(tx *gorm.DB) error {
 		roleRepository := repositories.NewRoleRepository(tx)
@@ -50,29 +53,37 @@ func (service RoleService) CreateRole(command commands.UpsertRoleCommand) (struc
 			}
 
 			roleView = structs.RoleView{
-				Id:          role.ID,
-				Name:        role.Name,
-				Description: role.Description,
-				Scope:       permissions.ScopeApp,
-				IsSystem:    role.IsSystem,
-				Permissions: perms,
+				Id:             role.ID,
+				Name:           role.Name,
+				Description:    role.Description,
+				Scope:          permissions.ScopeApp,
+				IsSystem:       role.IsSystem,
+				Permissions:    perms,
+				CategoryGrants: []uint{},
+				TagGrants:      []uint{},
 			}
 
 			return nil
 		}
 
-		role, txErr := roleRepository.CreateGroupRole(command.Name, command.Description, perms)
+		if txErr := validateGrantsExist(tx, categoryGrants, tagGrants); txErr != nil {
+			return txErr
+		}
+
+		role, txErr := roleRepository.CreateGroupRole(command.Name, command.Description, perms, categoryGrants, tagGrants)
 		if txErr != nil {
 			return txErr
 		}
 
 		roleView = structs.RoleView{
-			Id:          role.ID,
-			Name:        role.Name,
-			Description: role.Description,
-			Scope:       permissions.ScopeGroup,
-			IsSystem:    role.IsSystem,
-			Permissions: perms,
+			Id:             role.ID,
+			Name:           role.Name,
+			Description:    role.Description,
+			Scope:          permissions.ScopeGroup,
+			IsSystem:       role.IsSystem,
+			Permissions:    perms,
+			CategoryGrants: categoryGrants,
+			TagGrants:      tagGrants,
 		}
 
 		return nil
@@ -91,6 +102,8 @@ func (service RoleService) UpdateRole(id uint, command commands.UpsertRoleComman
 	if perms == nil {
 		perms = []string{}
 	}
+	categoryGrants := normalizeUintSlice(command.CategoryGrants)
+	tagGrants := normalizeUintSlice(command.TagGrants)
 
 	err := repositories.GetDB().Transaction(func(tx *gorm.DB) error {
 		roleRepository := repositories.NewRoleRepository(tx)
@@ -113,13 +126,15 @@ func (service RoleService) UpdateRole(id uint, command commands.UpsertRoleComman
 			}
 
 			roleView = structs.RoleView{
-				Id:          role.ID,
-				Name:        role.Name,
-				Description: role.Description,
-				Scope:       permissions.ScopeApp,
-				IsDefault:   role.IsDefault,
-				IsSystem:    role.IsSystem,
-				Permissions: perms,
+				Id:             role.ID,
+				Name:           role.Name,
+				Description:    role.Description,
+				Scope:          permissions.ScopeApp,
+				IsDefault:      role.IsDefault,
+				IsSystem:       role.IsSystem,
+				Permissions:    perms,
+				CategoryGrants: []uint{},
+				TagGrants:      []uint{},
 			}
 
 			return nil
@@ -136,19 +151,25 @@ func (service RoleService) UpdateRole(id uint, command commands.UpsertRoleComman
 			return ErrSystemRoleImmutable
 		}
 
-		role, txErr := roleRepository.UpdateGroupRole(id, command.Name, command.Description, perms)
+		if txErr := validateGrantsExist(tx, categoryGrants, tagGrants); txErr != nil {
+			return txErr
+		}
+
+		role, txErr := roleRepository.UpdateGroupRole(id, command.Name, command.Description, perms, categoryGrants, tagGrants)
 		if txErr != nil {
 			return txErr
 		}
 
 		roleView = structs.RoleView{
-			Id:          role.ID,
-			Name:        role.Name,
-			Description: role.Description,
-			Scope:       permissions.ScopeGroup,
-			IsDefault:   role.IsDefault,
-			IsSystem:    role.IsSystem,
-			Permissions: perms,
+			Id:             role.ID,
+			Name:           role.Name,
+			Description:    role.Description,
+			Scope:          permissions.ScopeGroup,
+			IsDefault:      role.IsDefault,
+			IsSystem:       role.IsSystem,
+			Permissions:    perms,
+			CategoryGrants: categoryGrants,
+			TagGrants:      tagGrants,
 		}
 
 		return nil
@@ -162,6 +183,44 @@ func (service RoleService) UpdateRole(id uint, command commands.UpsertRoleComman
 	clearRolePermissionCache(command.Scope, id)
 
 	return roleView, nil
+}
+
+// normalizeUintSlice returns a non-nil slice so empty grant sets serialize as
+// [] rather than null and never alias the caller's nil.
+func normalizeUintSlice(ids []uint) []uint {
+	if ids == nil {
+		return []uint{}
+	}
+	return ids
+}
+
+// validateGrantsExist confirms every category/tag grant id references a real
+// row. Because UpsertRoleCommand.Validate already rejects duplicate grant ids, a
+// matching count means all ids exist. Returns ErrInvalidGrant otherwise.
+func validateGrantsExist(tx *gorm.DB, categoryGrants []uint, tagGrants []uint) error {
+	if len(categoryGrants) > 0 {
+		categoryRepository := repositories.NewCategoryRepository(tx)
+		count, err := categoryRepository.CountByIds(categoryGrants)
+		if err != nil {
+			return err
+		}
+		if int(count) != len(categoryGrants) {
+			return ErrInvalidGrant
+		}
+	}
+
+	if len(tagGrants) > 0 {
+		tagsRepository := repositories.NewTagsRepository(tx)
+		count, err := tagsRepository.CountByIds(tagGrants)
+		if err != nil {
+			return err
+		}
+		if int(count) != len(tagGrants) {
+			return ErrInvalidGrant
+		}
+	}
+
+	return nil
 }
 
 // resolveMissingRoleError distinguishes a genuine not-found from a forbidden
@@ -320,31 +379,46 @@ func appRoleToView(role models.AppRole, isDefault bool) structs.RoleView {
 	}
 
 	return structs.RoleView{
-		Id:          role.ID,
-		Name:        role.Name,
-		Description: role.Description,
-		Scope:       permissions.ScopeApp,
-		IsDefault:   isDefault,
-		IsSystem:    role.IsSystem,
-		Permissions: perms,
+		Id:             role.ID,
+		Name:           role.Name,
+		Description:    role.Description,
+		Scope:          permissions.ScopeApp,
+		IsDefault:      isDefault,
+		IsSystem:       role.IsSystem,
+		Permissions:    perms,
+		CategoryGrants: []uint{},
+		TagGrants:      []uint{},
 	}
 }
 
 // groupRoleToView builds the read model for a group role, overriding IsDefault
-// with the post-update value.
+// with the post-update value. Grant ids are read from the role's preloaded
+// CategoryGrants/TagGrants (GetGroupRoleById preloads them).
 func groupRoleToView(role models.GroupRoleDefinition, isDefault bool) structs.RoleView {
 	perms := make([]string, 0, len(role.Permissions))
 	for _, permission := range role.Permissions {
 		perms = append(perms, permission.Permission)
 	}
 
+	categoryGrants := make([]uint, 0, len(role.CategoryGrants))
+	for _, grant := range role.CategoryGrants {
+		categoryGrants = append(categoryGrants, grant.CategoryID)
+	}
+
+	tagGrants := make([]uint, 0, len(role.TagGrants))
+	for _, grant := range role.TagGrants {
+		tagGrants = append(tagGrants, grant.TagID)
+	}
+
 	return structs.RoleView{
-		Id:          role.ID,
-		Name:        role.Name,
-		Description: role.Description,
-		Scope:       permissions.ScopeGroup,
-		IsDefault:   isDefault,
-		IsSystem:    role.IsSystem,
-		Permissions: perms,
+		Id:             role.ID,
+		Name:           role.Name,
+		Description:    role.Description,
+		Scope:          permissions.ScopeGroup,
+		IsDefault:      isDefault,
+		IsSystem:       role.IsSystem,
+		Permissions:    perms,
+		CategoryGrants: categoryGrants,
+		TagGrants:      tagGrants,
 	}
 }

--- a/api/internal/services/roles_test.go
+++ b/api/internal/services/roles_test.go
@@ -10,6 +10,88 @@ import (
 	"testing"
 )
 
+func TestCreateGroupRoleWithGrantsExposesGrantIds(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	category := models.Category{Name: "Groceries"}
+	repositories.GetDB().Create(&category)
+	tag := models.Tag{Name: "Reimbursable"}
+	repositories.GetDB().Create(&tag)
+
+	service := NewRoleService(nil)
+	command := commands.UpsertRoleCommand{
+		Name:           "Restricted Group Role",
+		Scope:          permissions.ScopeGroup,
+		Permissions:    []string{permissions.GroupReceiptsRead},
+		CategoryGrants: []uint{category.ID},
+		TagGrants:      []uint{tag.ID},
+	}
+
+	roleView, err := service.CreateRole(command)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if len(roleView.CategoryGrants) != 1 || roleView.CategoryGrants[0] != category.ID {
+		utils.PrintTestError(t, roleView.CategoryGrants, []uint{category.ID})
+	}
+	if len(roleView.TagGrants) != 1 || roleView.TagGrants[0] != tag.ID {
+		utils.PrintTestError(t, roleView.TagGrants, []uint{tag.ID})
+	}
+}
+
+func TestCreateGroupRoleRejectsNonExistentGrant(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	service := NewRoleService(nil)
+	command := commands.UpsertRoleCommand{
+		Name:           "Bad Grant Role",
+		Scope:          permissions.ScopeGroup,
+		Permissions:    []string{permissions.GroupReceiptsRead},
+		CategoryGrants: []uint{999999},
+	}
+
+	_, err := service.CreateRole(command)
+	if !errors.Is(err, ErrInvalidGrant) {
+		utils.PrintTestError(t, err, ErrInvalidGrant)
+	}
+}
+
+func TestUpdateGroupRoleServiceReplacesGrants(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	roleRepository := repositories.NewRoleRepository(nil)
+
+	catA := models.Category{Name: "A"}
+	repositories.GetDB().Create(&catA)
+	catB := models.Category{Name: "B"}
+	repositories.GetDB().Create(&catB)
+
+	created, err := roleRepository.CreateGroupRole("Role", "", []string{permissions.GroupReceiptsRead}, []uint{catA.ID}, nil)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	service := NewRoleService(nil)
+	command := commands.UpsertRoleCommand{
+		Name:           "Role",
+		Scope:          permissions.ScopeGroup,
+		Permissions:    []string{permissions.GroupReceiptsRead},
+		CategoryGrants: []uint{catB.ID},
+	}
+
+	roleView, err := service.UpdateRole(created.ID, command)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if len(roleView.CategoryGrants) != 1 || roleView.CategoryGrants[0] != catB.ID {
+		utils.PrintTestError(t, roleView.CategoryGrants, []uint{catB.ID})
+	}
+}
+
 func TestUpdateRolePersistsChanges(t *testing.T) {
 	defer repositories.TruncateTestDb()
 	roleRepository := repositories.NewRoleRepository(nil)

--- a/api/internal/structs/role_view.go
+++ b/api/internal/structs/role_view.go
@@ -11,4 +11,9 @@ type RoleView struct {
 	IsSystem      bool              `json:"isSystem"`
 	Permissions   []string          `json:"permissions"`
 	AssignedCount int               `json:"assignedCount"`
+	// CategoryGrants / TagGrants are the category/tag ids a group role restricts
+	// its members to. Empty means unrestricted (see all). Always group-scoped;
+	// app roles serialize empty slices.
+	CategoryGrants []uint `json:"categoryGrants"`
+	TagGrants      []uint `json:"tagGrants"`
 }

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -3068,6 +3068,23 @@ components:
         assignedCount:
           type: integer
           description: Number of users or group members currently assigned this role
+        categoryGrants:
+          type: array
+          description: >-
+            Category ids a GROUP role restricts its members to. Empty means
+            unrestricted (members may use every category). Always empty for app
+            roles.
+          items:
+            type: integer
+            format: uint64
+        tagGrants:
+          type: array
+          description: >-
+            Tag ids a GROUP role restricts its members to. Empty means
+            unrestricted (members may use every tag). Always empty for app roles.
+          items:
+            type: integer
+            format: uint64
     UpsertRoleCommand:
       type: object
       required:
@@ -3085,6 +3102,22 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Permission"
+        categoryGrants:
+          type: array
+          description: >-
+            Category ids to restrict a GROUP role's members to. Only valid on
+            group roles; omit or leave empty for unrestricted access.
+          items:
+            type: integer
+            format: uint64
+        tagGrants:
+          type: array
+          description: >-
+            Tag ids to restrict a GROUP role's members to. Only valid on group
+            roles; omit or leave empty for unrestricted access.
+          items:
+            type: integer
+            format: uint64
     SortDirection:
       type: string
       enum:

--- a/desktop/src/open-api/model/role.ts
+++ b/desktop/src/open-api/model/role.ts
@@ -26,6 +26,14 @@ export interface Role {
      * Number of users or group members currently assigned this role
      */
     assignedCount?: number;
+    /**
+     * Category ids a GROUP role restricts its members to. Empty means unrestricted (members may use every category). Always empty for app roles.
+     */
+    categoryGrants?: Array<number>;
+    /**
+     * Tag ids a GROUP role restricts its members to. Empty means unrestricted (members may use every tag). Always empty for app roles.
+     */
+    tagGrants?: Array<number>;
 }
 export namespace Role {
 }

--- a/desktop/src/open-api/model/upsertRoleCommand.ts
+++ b/desktop/src/open-api/model/upsertRoleCommand.ts
@@ -16,6 +16,14 @@ export interface UpsertRoleCommand {
     description?: string;
     scope: PermissionScope;
     permissions: Array<Permission>;
+    /**
+     * Category ids to restrict a GROUP role\'s members to. Only valid on group roles; omit or leave empty for unrestricted access.
+     */
+    categoryGrants?: Array<number>;
+    /**
+     * Tag ids to restrict a GROUP role\'s members to. Only valid on group roles; omit or leave empty for unrestricted access.
+     */
+    tagGrants?: Array<number>;
 }
 export namespace UpsertRoleCommand {
 }


### PR DESCRIPTION
## What

First slice of group-role-scoped category/tag visibility. Group roles can now carry **category and tag grants** that (in later slices) will restrict which categories/tags their members may read and use. This PR wires up the previously-**dead** `GroupRoleCategoryGrant` / `GroupRoleTagGrant` join tables through the role CRUD path. **No enforcement yet** — grants are stored and returned only.

## Key design

- **Empty grants = unrestricted (opt-in lock-down).** A group role with no grant rows sees everything (today's behavior); a non-empty set restricts to exactly those ids. Legacy/system roles have no grants, so they're unaffected and **no data migration is needed**.
- Categories/tags are **global** (no `GroupId`); a grant is a per-group-role slice of the global pool.

## Changes

- `UpsertRoleCommand` carries `categoryGrants` / `tagGrants`; `Validate()` rejects grants on APP scope and dedups them. `RoleView` exposes the grant ids (empty slices for app roles).
- `repositories.CreateGroupRole` / `UpdateGroupRole` sync grant rows via the same delete-then-insert pattern as permissions (`replaceGroupRoleGrants`, with the nested `Category`/`Tag` belongs-to association `Omit`-ted so only join rows are written). Grants are preloaded in `GetGroupRoleById` / `GetAllRoles` and cascade on role delete.
- `RoleService` validates grant-id existence against the DB (`ErrInvalidGrant` → 400) and threads grants through create/update.
- New `RoleRepository.GetGroupRoleCategoryIds` / `GetGroupRoleTagIds` and `Category/TagsRepository.CountByIds` (used by the resolution + validation in this and later slices).
- swagger: `categoryGrants` / `tagGrants` on `Role` and `UpsertRoleCommand`; desktop client regenerated (only `role.ts` / `upsertRoleCommand.ts`).

## Tests

- Repo: grant persistence, delete-then-insert replacement, empty = unrestricted, FK cascade on role delete, `CountByIds`.
- Command: grants valid on group scope, rejected on app scope, duplicate category/tag grant.
- Service: grants exposed in view, `ErrInvalidGrant` on non-existent id, update replaces grants.
- Handler: create group role with grants (200 + grants echoed), invalid grant → 400.
- `go test ./internal/commands/ ./internal/repositories/ ./internal/services/ ./internal/handlers/` all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Group roles can now be restricted to specific categories and tags, providing granular control over member access to content resources. App-scoped roles remain unrestricted.

* **Bug Fixes**
  * Role creation and updates now validate category and tag restrictions, rejecting invalid references with appropriate error feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->