### PR TITLE
Resolve group-role category/tag grants with a cache

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -196,8 +196,9 @@ them.
   with **no** grant rows is **unrestricted** (sees every category/tag); a non-empty grant set
   restricts members to exactly those ids — restriction is opt-in, so legacy/system roles (no grants)
   keep seeing everything and no data migration is needed. Categories/tags are **global** (no
-  `GroupId`); a grant is a per-group-role slice of the global pool. Enforcement of these grants is
-  rolled out in later slices; Phase 1 only persists/returns them through role CRUD.
+  `GroupId`); a grant is a per-group-role slice of the global pool. CRUD persists/returns the grants
+  and `PermissionService` resolves them (see "Category/tag grant resolution" below); wiring the
+  resolved sets into AppData delivery and request enforcement is rolled out in later slices.
 - **Assignment:** nullable FKs `User.AppRoleID` and `GroupMember.GroupRoleID` (one app role per
   user; one group role per group membership). Nullable because per-create assignment is best-effort
   (the FK is left `nil` rather than failing creation when no role can be resolved, e.g. an unseeded
@@ -319,6 +320,22 @@ them.
   and invalidated in `RoleService.UpdateRole` / `DeleteRole`. Only a role's permission *list* is
   cached; a user's role *assignment* is resolved fresh on every check, so re-assigning a user takes
   effect immediately.
+
+### Category/tag grant resolution (`PermissionService`)
+
+- `services/grant.go` resolves a user's allowed category/tag ids for a group:
+  `GetGroupCategoryIdsForUser` / `GetGroupTagIdsForUser` return `(allowedSet, unrestricted, err)`,
+  where **`unrestricted == true` means see-all** (the role grants nothing for that resource) and the
+  set is then `nil`. A non-member, or a member whose group role has no grants, is **unrestricted** —
+  grants only *narrow* access within an already-permitted group; they never *grant* access (the
+  handler permission gate is the access control). Categories and tags are independent (a role may
+  restrict one and not the other). `GetVisibleCategoriesForUser` / `GetVisibleTagsForUser` filter a
+  full category/tag slice to the visible subset (pass-through when unrestricted) — used by AppData.
+- Backed by a grant cache (`services/grant_cache.go`) keyed by **group-role id** (grants are
+  group-only), same generation-counter invalidation as the permission cache, evicted in
+  `RoleService.UpdateRole` / `DeleteRole` for group scope. Only a role's grant *lists* are cached;
+  the user's role *assignment* is resolved fresh each call. A category/tag deleted out from under a
+  cached grant id is benign — a stale id simply never matches a real row when filtering.
 
 ### Enforcement status
 

--- a/api/internal/services/grant.go
+++ b/api/internal/services/grant.go
@@ -1,0 +1,137 @@
+package services
+
+import (
+	"errors"
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/repositories"
+
+	"gorm.io/gorm"
+)
+
+// GetGroupCategoryIdsForUser returns the set of category ids a user may use in a
+// group, plus an "unrestricted" flag. When unrestricted is true the returned set
+// is nil and the caller must treat every category as allowed (the empty-grants =
+// see-all rule). A non-member, or a member whose group role has no category
+// grants, is unrestricted — grants only NARROW access within an already-permitted
+// group; they never grant access (the handler permission gate is the access
+// control). The returned map is read-only shared cache state.
+func (service PermissionService) GetGroupCategoryIdsForUser(userId uint, groupId uint) (map[uint]struct{}, bool, error) {
+	entry, err := service.resolveGroupRoleGrants(userId, groupId)
+	if err != nil {
+		return nil, false, err
+	}
+	if entry == nil || len(entry.categoryIds) == 0 {
+		return nil, true, nil
+	}
+	return entry.categoryIds, false, nil
+}
+
+// GetGroupTagIdsForUser is the tag counterpart of GetGroupCategoryIdsForUser.
+func (service PermissionService) GetGroupTagIdsForUser(userId uint, groupId uint) (map[uint]struct{}, bool, error) {
+	entry, err := service.resolveGroupRoleGrants(userId, groupId)
+	if err != nil {
+		return nil, false, err
+	}
+	if entry == nil || len(entry.tagIds) == 0 {
+		return nil, true, nil
+	}
+	return entry.tagIds, false, nil
+}
+
+// GetVisibleCategoriesForUser filters allCategories down to the ones a user may
+// see in a group. Unrestricted users get allCategories unchanged. Used by
+// GetAppData to build the per-group category catalog.
+func (service PermissionService) GetVisibleCategoriesForUser(userId uint, groupId uint, allCategories []models.Category) ([]models.Category, error) {
+	allowed, unrestricted, err := service.GetGroupCategoryIdsForUser(userId, groupId)
+	if err != nil {
+		return nil, err
+	}
+	if unrestricted {
+		return allCategories, nil
+	}
+
+	visible := make([]models.Category, 0, len(allowed))
+	for _, category := range allCategories {
+		if _, ok := allowed[category.ID]; ok {
+			visible = append(visible, category)
+		}
+	}
+	return visible, nil
+}
+
+// GetVisibleTagsForUser is the tag counterpart of GetVisibleCategoriesForUser.
+func (service PermissionService) GetVisibleTagsForUser(userId uint, groupId uint, allTags []models.Tag) ([]models.Tag, error) {
+	allowed, unrestricted, err := service.GetGroupTagIdsForUser(userId, groupId)
+	if err != nil {
+		return nil, err
+	}
+	if unrestricted {
+		return allTags, nil
+	}
+
+	visible := make([]models.Tag, 0, len(allowed))
+	for _, tag := range allTags {
+		if _, ok := allowed[tag.ID]; ok {
+			visible = append(visible, tag)
+		}
+	}
+	return visible, nil
+}
+
+// resolveGroupRoleGrants returns the cached grant entry for a user's role in a
+// group, or nil when the user is not a member or the membership has no group role
+// (both mean "unrestricted").
+func (service PermissionService) resolveGroupRoleGrants(userId uint, groupId uint) (*grantEntry, error) {
+	roleRepository := repositories.NewRoleRepository(service.TX)
+
+	groupRoleId, err := roleRepository.GetGroupMemberRoleId(userId, groupId)
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if groupRoleId == nil {
+		return nil, nil
+	}
+
+	return loadGroupRoleGrants(roleRepository, *groupRoleId)
+}
+
+// loadGroupRoleGrants returns a group role's grant sets, consulting the cache
+// first and populating it on a miss (mirroring loadRolePermissions).
+func loadGroupRoleGrants(roleRepository repositories.RoleRepository, roleId uint) (*grantEntry, error) {
+	if cached, ok := getCachedGroupRoleGrants(roleId); ok {
+		return cached, nil
+	}
+
+	// Capture the eviction generation before reading so a concurrent grant
+	// update/delete invalidates this write instead of being undone by it.
+	observedGen := groupRoleGrantCacheGen()
+
+	categoryIds, err := roleRepository.GetGroupRoleCategoryIds(roleId)
+	if err != nil {
+		return nil, err
+	}
+	tagIds, err := roleRepository.GetGroupRoleTagIds(roleId)
+	if err != nil {
+		return nil, err
+	}
+
+	entry := &grantEntry{
+		categoryIds: uintSliceToSet(categoryIds),
+		tagIds:      uintSliceToSet(tagIds),
+	}
+
+	setCachedGroupRoleGrants(roleId, entry, observedGen)
+	return entry, nil
+}
+
+// uintSliceToSet converts a slice of ids to a set for O(1) membership tests.
+func uintSliceToSet(ids []uint) map[uint]struct{} {
+	set := make(map[uint]struct{}, len(ids))
+	for _, id := range ids {
+		set[id] = struct{}{}
+	}
+	return set
+}

--- a/api/internal/services/grant_cache.go
+++ b/api/internal/services/grant_cache.go
@@ -1,0 +1,91 @@
+package services
+
+import "sync"
+
+// grantEntry holds the category/tag ids a group role grants its members, as sets
+// for O(1) membership tests. An EMPTY set means that resource is unrestricted
+// (the role grants every category/tag) — so categories and tags are independent:
+// a role may restrict categories while leaving tags unrestricted, or vice versa.
+// Callers must treat the maps as read-only (they are shared cache state).
+type grantEntry struct {
+	categoryIds map[uint]struct{}
+	tagIds      map[uint]struct{}
+}
+
+// groupRoleGrantCache memoizes a group role's category/tag grant id sets, keyed
+// by group-role id (grants only exist on group roles). Like the permission
+// cache, only a role's grant *lists* are cached — a user's role *assignment* is
+// resolved fresh on every check, so re-assigning a user takes effect
+// immediately. Invalidated whenever a group role is updated or deleted.
+//
+// groupRoleGrantCacheGeneration is bumped on every eviction; a cache write
+// carries the generation observed before its DB read and is dropped if the
+// generation has since advanced, preventing an in-flight miss from resurrecting
+// stale grants after a concurrent eviction (which would otherwise leave a
+// just-removed restriction — or a just-added one — applied incorrectly).
+var (
+	groupRoleGrantCacheMutex      sync.RWMutex
+	groupRoleGrantCache           = map[uint]*grantEntry{}
+	groupRoleGrantCacheGeneration uint64
+)
+
+func getCachedGroupRoleGrants(roleId uint) (*grantEntry, bool) {
+	groupRoleGrantCacheMutex.RLock()
+	defer groupRoleGrantCacheMutex.RUnlock()
+
+	entry, ok := groupRoleGrantCache[roleId]
+	return entry, ok
+}
+
+// groupRoleGrantCacheGen returns the current eviction generation. Capture it
+// before reading grants from the database and pass it to setCachedGroupRoleGrants
+// so a concurrent eviction invalidates the write.
+func groupRoleGrantCacheGen() uint64 {
+	groupRoleGrantCacheMutex.RLock()
+	defer groupRoleGrantCacheMutex.RUnlock()
+
+	return groupRoleGrantCacheGeneration
+}
+
+// setCachedGroupRoleGrants stores entry only if no eviction has happened since
+// observedGen was captured; otherwise the value is considered potentially stale
+// and discarded (the next check re-reads from the database).
+func setCachedGroupRoleGrants(roleId uint, entry *grantEntry, observedGen uint64) {
+	groupRoleGrantCacheMutex.Lock()
+	defer groupRoleGrantCacheMutex.Unlock()
+
+	if groupRoleGrantCacheGeneration != observedGen {
+		return
+	}
+
+	groupRoleGrantCache[roleId] = entry
+}
+
+// clearGroupRoleGrantCache evicts a single group role's cached grants and bumps
+// the generation. Call this after a group role's grants change or the role is
+// deleted.
+func clearGroupRoleGrantCache(roleId uint) {
+	groupRoleGrantCacheMutex.Lock()
+	defer groupRoleGrantCacheMutex.Unlock()
+
+	groupRoleGrantCacheGeneration++
+	delete(groupRoleGrantCache, roleId)
+}
+
+// clearGroupRoleGrantCacheAll empties the cache entirely and bumps the
+// generation. Used by tests to keep cases independent.
+func clearGroupRoleGrantCacheAll() {
+	groupRoleGrantCacheMutex.Lock()
+	defer groupRoleGrantCacheMutex.Unlock()
+
+	groupRoleGrantCacheGeneration++
+	groupRoleGrantCache = map[uint]*grantEntry{}
+}
+
+// ClearGroupRoleGrantCacheForTests empties the entire grant cache. Exported so
+// tests in other packages can keep cases independent: a truncated test database
+// reuses role ids across cases, which would otherwise return another case's
+// cached grants.
+func ClearGroupRoleGrantCacheForTests() {
+	clearGroupRoleGrantCacheAll()
+}

--- a/api/internal/services/grant_test.go
+++ b/api/internal/services/grant_test.go
@@ -1,0 +1,312 @@
+package services
+
+import (
+	"receipt-wrangler/api/internal/commands"
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/permissions"
+	"receipt-wrangler/api/internal/repositories"
+	"slices"
+	"testing"
+)
+
+// seedMemberWithGroupRoleGrants creates a group, a group role granting
+// receipts.read plus the given category/tag grants, and a member assigned to it.
+// Returns the user id, group id, and role id.
+func seedMemberWithGroupRoleGrants(t *testing.T, username string, categoryGrantIds []uint, tagGrantIds []uint) (uint, uint, uint) {
+	t.Helper()
+	db := repositories.GetDB()
+
+	group := models.Group{Name: "grant-group-" + username}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("seed group: %v", err)
+	}
+
+	roleRepository := repositories.NewRoleRepository(nil)
+	role, err := roleRepository.CreateGroupRole("Grant Role "+username, "", []string{permissions.GroupReceiptsRead}, categoryGrantIds, tagGrantIds)
+	if err != nil {
+		t.Fatalf("seed group role: %v", err)
+	}
+
+	user := models.User{Username: username, Password: "password"}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	member := models.GroupMember{GroupID: group.ID, UserID: user.ID, GroupRoleID: &role.ID}
+	if err := db.Create(&member).Error; err != nil {
+		t.Fatalf("seed group member: %v", err)
+	}
+
+	return user.ID, group.ID, role.ID
+}
+
+func makeCategory(t *testing.T, name string) uint {
+	t.Helper()
+	category := models.Category{Name: name}
+	if err := repositories.GetDB().Create(&category).Error; err != nil {
+		t.Fatalf("seed category: %v", err)
+	}
+	return category.ID
+}
+
+func makeTag(t *testing.T, name string) uint {
+	t.Helper()
+	tag := models.Tag{Name: name}
+	if err := repositories.GetDB().Create(&tag).Error; err != nil {
+		t.Fatalf("seed tag: %v", err)
+	}
+	return tag.ID
+}
+
+func TestGetGroupCategoryIdsUnrestrictedWhenNoGrants(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-open", nil, nil)
+	service := NewPermissionService(nil)
+
+	allowed, unrestricted, err := service.GetGroupCategoryIdsForUser(userId, groupId)
+	if err != nil {
+		t.Fatalf("GetGroupCategoryIdsForUser: %v", err)
+	}
+	if !unrestricted {
+		t.Error("expected unrestricted when role has no category grants")
+	}
+	if allowed != nil {
+		t.Errorf("expected nil allowed set when unrestricted, got %v", allowed)
+	}
+}
+
+func TestGetGroupCategoryIdsRestricted(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	cat2 := makeCategory(t, "Utilities")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-restricted", []uint{cat1, cat2}, nil)
+	service := NewPermissionService(nil)
+
+	allowed, unrestricted, err := service.GetGroupCategoryIdsForUser(userId, groupId)
+	if err != nil {
+		t.Fatalf("GetGroupCategoryIdsForUser: %v", err)
+	}
+	if unrestricted {
+		t.Error("expected restricted when role has category grants")
+	}
+	if len(allowed) != 2 {
+		t.Fatalf("expected 2 allowed categories, got %d", len(allowed))
+	}
+	if _, ok := allowed[cat1]; !ok {
+		t.Error("expected cat1 in allowed set")
+	}
+	if _, ok := allowed[cat2]; !ok {
+		t.Error("expected cat2 in allowed set")
+	}
+}
+
+func TestGetGroupCategoryIdsNonMemberUnrestricted(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	_, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-member", []uint{cat1}, nil)
+
+	// A user who is NOT a member of the group resolves to unrestricted: grants
+	// only narrow access within an already-permitted group, never grant it.
+	outsider := models.User{Username: "outsider", Password: "password"}
+	if err := repositories.GetDB().Create(&outsider).Error; err != nil {
+		t.Fatalf("seed outsider: %v", err)
+	}
+
+	service := NewPermissionService(nil)
+	_, unrestricted, err := service.GetGroupCategoryIdsForUser(outsider.ID, groupId)
+	if err != nil {
+		t.Fatalf("GetGroupCategoryIdsForUser: %v", err)
+	}
+	if !unrestricted {
+		t.Error("expected a non-member to resolve as unrestricted")
+	}
+}
+
+func TestCategoryRestrictedLeavesTagsUnrestricted(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-cat-only", []uint{cat1}, nil)
+	service := NewPermissionService(nil)
+
+	_, catUnrestricted, err := service.GetGroupCategoryIdsForUser(userId, groupId)
+	if err != nil {
+		t.Fatalf("category resolve: %v", err)
+	}
+	if catUnrestricted {
+		t.Error("expected categories restricted")
+	}
+
+	_, tagUnrestricted, err := service.GetGroupTagIdsForUser(userId, groupId)
+	if err != nil {
+		t.Fatalf("tag resolve: %v", err)
+	}
+	if !tagUnrestricted {
+		t.Error("expected tags unrestricted when role grants no tags")
+	}
+}
+
+func TestGetVisibleCategoriesForUserFilters(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	makeCategory(t, "Utilities")
+	cat3 := makeCategory(t, "Travel")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-vis", []uint{cat1, cat3}, nil)
+	service := NewPermissionService(nil)
+
+	allCategories, err := repositories.NewCategoryRepository(nil).GetAllCategories("*")
+	if err != nil {
+		t.Fatalf("get all categories: %v", err)
+	}
+
+	visible, err := service.GetVisibleCategoriesForUser(userId, groupId, allCategories)
+	if err != nil {
+		t.Fatalf("GetVisibleCategoriesForUser: %v", err)
+	}
+	if len(visible) != 2 {
+		t.Fatalf("expected 2 visible categories, got %d", len(visible))
+	}
+
+	gotIds := []uint{visible[0].ID, visible[1].ID}
+	slices.Sort(gotIds)
+	want := []uint{cat1, cat3}
+	slices.Sort(want)
+	if !slices.Equal(gotIds, want) {
+		t.Errorf("visible ids = %v, want %v", gotIds, want)
+	}
+}
+
+func TestGetVisibleCategoriesUnrestrictedPassThrough(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	makeCategory(t, "Groceries")
+	makeCategory(t, "Utilities")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-open2", nil, nil)
+	service := NewPermissionService(nil)
+
+	allCategories, err := repositories.NewCategoryRepository(nil).GetAllCategories("*")
+	if err != nil {
+		t.Fatalf("get all categories: %v", err)
+	}
+
+	visible, err := service.GetVisibleCategoriesForUser(userId, groupId, allCategories)
+	if err != nil {
+		t.Fatalf("GetVisibleCategoriesForUser: %v", err)
+	}
+	if len(visible) != len(allCategories) {
+		t.Errorf("expected pass-through of all %d categories, got %d", len(allCategories), len(visible))
+	}
+}
+
+func TestGetVisibleTagsForUserFilters(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	tag1 := makeTag(t, "Reimbursable")
+	makeTag(t, "Personal")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-tagvis", nil, []uint{tag1})
+	service := NewPermissionService(nil)
+
+	allTags, err := repositories.NewTagsRepository(nil).GetAllTags("*")
+	if err != nil {
+		t.Fatalf("get all tags: %v", err)
+	}
+
+	visible, err := service.GetVisibleTagsForUser(userId, groupId, allTags)
+	if err != nil {
+		t.Fatalf("GetVisibleTagsForUser: %v", err)
+	}
+	if len(visible) != 1 || visible[0].ID != tag1 {
+		t.Errorf("expected only tag1 visible, got %v", visible)
+	}
+}
+
+func TestGrantCacheInvalidatedOnRoleUpdate(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	cat2 := makeCategory(t, "Utilities")
+	userId, groupId, roleId := seedMemberWithGroupRoleGrants(t, "u-cache", []uint{cat1}, nil)
+
+	permissionService := NewPermissionService(nil)
+
+	// Populate the cache with the initial grant set.
+	allowed, _, err := permissionService.GetGroupCategoryIdsForUser(userId, groupId)
+	if err != nil {
+		t.Fatalf("initial resolve: %v", err)
+	}
+	if _, ok := allowed[cat1]; !ok || len(allowed) != 1 {
+		t.Fatalf("expected initial allowed {cat1}, got %v", allowed)
+	}
+
+	// Replace the grants via the service — should evict the grant cache.
+	roleService := NewRoleService(nil)
+	_, err = roleService.UpdateRole(roleId, commands.UpsertRoleCommand{
+		Name:           "Grant Role u-cache",
+		Scope:          permissions.ScopeGroup,
+		Permissions:    []string{permissions.GroupReceiptsRead},
+		CategoryGrants: []uint{cat2},
+	})
+	if err != nil {
+		t.Fatalf("update role: %v", err)
+	}
+
+	allowed, _, err = permissionService.GetGroupCategoryIdsForUser(userId, groupId)
+	if err != nil {
+		t.Fatalf("re-resolve: %v", err)
+	}
+	if _, ok := allowed[cat2]; !ok || len(allowed) != 1 {
+		t.Errorf("expected allowed {cat2} after update, got %v", allowed)
+	}
+}
+
+func TestGrantCacheReturnsCachedUntilCleared(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	cat2 := makeCategory(t, "Utilities")
+	userId, groupId, roleId := seedMemberWithGroupRoleGrants(t, "u-cachehit", []uint{cat1}, nil)
+	service := NewPermissionService(nil)
+
+	// Populate the cache.
+	if _, _, err := service.GetGroupCategoryIdsForUser(userId, groupId); err != nil {
+		t.Fatalf("populate: %v", err)
+	}
+
+	// Mutate grant rows directly, bypassing the service so the cache is NOT
+	// invalidated.
+	db := repositories.GetDB()
+	db.Where("group_role_id = ?", roleId).Delete(&models.GroupRoleCategoryGrant{})
+	db.Omit("Category").Create(&models.GroupRoleCategoryGrant{GroupRoleID: roleId, CategoryID: cat2})
+
+	allowed, _, err := service.GetGroupCategoryIdsForUser(userId, groupId)
+	if err != nil {
+		t.Fatalf("cached resolve: %v", err)
+	}
+	if _, ok := allowed[cat1]; !ok || len(allowed) != 1 {
+		t.Errorf("expected cached {cat1}, got %v", allowed)
+	}
+
+	// After an explicit eviction, the fresh DB value {cat2} is read.
+	clearGroupRoleGrantCache(roleId)
+	allowed, _, err = service.GetGroupCategoryIdsForUser(userId, groupId)
+	if err != nil {
+		t.Fatalf("fresh resolve: %v", err)
+	}
+	if _, ok := allowed[cat2]; !ok || len(allowed) != 1 {
+		t.Errorf("expected fresh {cat2}, got %v", allowed)
+	}
+}

--- a/api/internal/services/roles.go
+++ b/api/internal/services/roles.go
@@ -182,6 +182,12 @@ func (service RoleService) UpdateRole(id uint, command commands.UpsertRoleComman
 	// next permission check resolves the new set.
 	clearRolePermissionCache(command.Scope, id)
 
+	// Group roles also carry category/tag grants, which the update just
+	// replaced — evict the cached grant sets so enforcement uses the new grants.
+	if command.Scope == permissions.ScopeGroup {
+		clearGroupRoleGrantCache(id)
+	}
+
 	return roleView, nil
 }
 
@@ -315,6 +321,11 @@ func (service RoleService) DeleteRole(id uint, scope permissions.Scope) error {
 
 	// The role is gone; evict any cached permissions for it.
 	clearRolePermissionCache(scope, id)
+
+	// And its cached category/tag grants (group roles only).
+	if scope == permissions.ScopeGroup {
+		clearGroupRoleGrantCache(id)
+	}
 
 	return nil
 }


### PR DESCRIPTION
## What

Second slice of group-role-scoped category/tag visibility. Adds the **resolution layer** that later slices use to enforce grants and deliver the filtered set. **No request-level enforcement yet.**

> **Stacked on #593** (base = `feature/role-rework-grant-crud`). Review/merge that first; this targets it so the diff stays scoped. Rebase to `feature/role-rework` once #593 lands.

## Changes

- `PermissionService.GetGroupCategoryIdsForUser` / `GetGroupTagIdsForUser` return `(allowedSet, unrestricted, err)`:
  - **`unrestricted == true` ⇒ see-all** (the role grants nothing for that resource); the set is then `nil`.
  - A **non-member**, or a member whose group role has no grants, is **unrestricted** — grants only *narrow* access within an already-permitted group, never *grant* it (the handler permission gate is the access control).
  - Categories and tags are independent (a role may restrict one, not the other).
- `GetVisibleCategoriesForUser` / `GetVisibleTagsForUser` filter a full category/tag slice to the visible subset (pass-through when unrestricted) — for AppData delivery in a later slice.
- `grant_cache.go`: caches a group role's grant id sets keyed by **group-role id**, with the same generation-counter invalidation as the permission cache; evicted on group-role update/delete in `RoleService` (group scope).

## Tests

- Resolution: unrestricted-when-no-grants (nil set), restricted subset, non-member → unrestricted, category-restricted-leaves-tags-unrestricted.
- Visible filtering: filters to subset; pass-through when unrestricted; tag variant.
- Cache: invalidated on role update via the service (new grants take effect); returns cached value until an explicit eviction (proves caching), then reads fresh.
- Full `go test ./internal/services/` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated group role grant documentation for clarity on enforcement timing and visibility resolution.

* **New Features**
  * Implemented category and tag visibility filtering based on user group roles and permissions.

* **Improvements**
  * Added caching layer for visibility calculations to enhance performance and reduce redundant processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->