### PR TITLE
Add shared category/tag grant enforcement helpers

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -336,6 +336,13 @@ them.
   `RoleService.UpdateRole` / `DeleteRole` for group scope. Only a role's grant *lists* are cached;
   the user's role *assignment* is resolved fresh each call. A category/tag deleted out from under a
   cached grant id is benign — a stale id simply never matches a real row when filtering.
+- `services/grant_filter.go` is the **single** shared enforcement mechanism, reused by every read and
+  write surface: `FilterReceiptCategoriesTags` / `FilterReceiptCategoriesTagsForReceipt` strip a
+  receipt's `Categories`/`Tags` in place to the visible subset (resolving each group's grants at most
+  once per pass); `ValidateCategoryTagSelection` checks receipt create/update ids against the allowed
+  set. Both short-circuit on unrestricted resources and on **admin bypass** — `userBypassesGrants`
+  treats a holder of `app.categories.read` / `app.tags.read` as exempt (they can already see the
+  whole pool), keeping their view consistent with the global lists.
 
 ### Enforcement status
 

--- a/api/internal/services/grant_filter.go
+++ b/api/internal/services/grant_filter.go
@@ -1,0 +1,217 @@
+package services
+
+import (
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/permissions"
+)
+
+// This file holds the shared category/tag grant enforcement used by every read
+// surface (list/search, single receipt, widgets, export, duplicate) and the
+// write surface (receipt create/update), so the rules live in exactly one place.
+
+// userBypassesGrants reports whether a user holds the app-level read permission
+// for a resource (app.categories.read / app.tags.read). Such users (admins,
+// category/tag managers) can already see the entire global pool, so grant
+// restrictions are not applied to them — keeping their view consistent with the
+// global lists they are entitled to.
+func (service PermissionService) userBypassesGrants(userId uint, appReadPermission string) (bool, error) {
+	return service.HasAppPermissions(userId, appReadPermission)
+}
+
+// FilterReceiptCategoriesTags strips every receipt's Categories/Tags down to the
+// set the user may see, in place. The allowed sets are resolved once per group
+// (cache-backed), so a page of receipts spanning N groups does at most N
+// resolutions. Receipts whose group is unrestricted (or where the user bypasses
+// grants) are left untouched.
+func (service PermissionService) FilterReceiptCategoriesTags(userId uint, receipts []models.Receipt) error {
+	if len(receipts) == 0 {
+		return nil
+	}
+
+	filter, err := service.newReceiptGrantFilter(userId)
+	if err != nil {
+		return err
+	}
+
+	for i := range receipts {
+		if err := filter.apply(&receipts[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// FilterReceiptCategoriesTagsForReceipt is the single-receipt variant of
+// FilterReceiptCategoriesTags (single GetReceipt, duplicate source, etc.).
+func (service PermissionService) FilterReceiptCategoriesTagsForReceipt(userId uint, receipt *models.Receipt) error {
+	if receipt == nil {
+		return nil
+	}
+
+	filter, err := service.newReceiptGrantFilter(userId)
+	if err != nil {
+		return err
+	}
+
+	return filter.apply(receipt)
+}
+
+// ValidateCategoryTagSelection reports whether every category/tag id is within
+// the user's allowed set for the group. Unrestricted resources, and users who
+// bypass grants, always pass. Used on receipt create/update for ids that
+// reference EXISTING categories/tags; new-by-name selections are not id-checked
+// here — they are gated by the create permission at the call site.
+func (service PermissionService) ValidateCategoryTagSelection(userId uint, groupId uint, categoryIds []uint, tagIds []uint) (bool, error) {
+	if len(categoryIds) > 0 {
+		ok, err := service.selectionWithinGrants(userId, groupId, permissions.AppCategoriesRead, categoryIds, service.GetGroupCategoryIdsForUser)
+		if err != nil || !ok {
+			return false, err
+		}
+	}
+
+	if len(tagIds) > 0 {
+		ok, err := service.selectionWithinGrants(userId, groupId, permissions.AppTagsRead, tagIds, service.GetGroupTagIdsForUser)
+		if err != nil || !ok {
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+// selectionWithinGrants checks that every id is allowed for the user in the
+// group, short-circuiting when the user bypasses grants or the resource is
+// unrestricted. resolve is the per-resource id resolver
+// (GetGroupCategoryIdsForUser / GetGroupTagIdsForUser).
+func (service PermissionService) selectionWithinGrants(
+	userId uint,
+	groupId uint,
+	appReadPermission string,
+	ids []uint,
+	resolve func(uint, uint) (map[uint]struct{}, bool, error),
+) (bool, error) {
+	bypass, err := service.userBypassesGrants(userId, appReadPermission)
+	if err != nil {
+		return false, err
+	}
+	if bypass {
+		return true, nil
+	}
+
+	allowed, unrestricted, err := resolve(userId, groupId)
+	if err != nil {
+		return false, err
+	}
+	if unrestricted {
+		return true, nil
+	}
+
+	for _, id := range ids {
+		if _, ok := allowed[id]; !ok {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// receiptGrantFilter caches a user's bypass flags and per-group allowed sets for
+// the lifetime of one filter pass, so a batch of receipts resolves each group's
+// grants at most once.
+type receiptGrantFilter struct {
+	service          PermissionService
+	userId           uint
+	bypassCategories bool
+	bypassTags       bool
+	groupCache       map[uint]receiptGroupGrants
+}
+
+type receiptGroupGrants struct {
+	categoryAllowed      map[uint]struct{}
+	categoryUnrestricted bool
+	tagAllowed           map[uint]struct{}
+	tagUnrestricted      bool
+}
+
+func (service PermissionService) newReceiptGrantFilter(userId uint) (*receiptGrantFilter, error) {
+	bypassCategories, err := service.userBypassesGrants(userId, permissions.AppCategoriesRead)
+	if err != nil {
+		return nil, err
+	}
+
+	bypassTags, err := service.userBypassesGrants(userId, permissions.AppTagsRead)
+	if err != nil {
+		return nil, err
+	}
+
+	return &receiptGrantFilter{
+		service:          service,
+		userId:           userId,
+		bypassCategories: bypassCategories,
+		bypassTags:       bypassTags,
+		groupCache:       map[uint]receiptGroupGrants{},
+	}, nil
+}
+
+func (filter *receiptGrantFilter) apply(receipt *models.Receipt) error {
+	if filter.bypassCategories && filter.bypassTags {
+		return nil
+	}
+
+	grants, err := filter.grantsForGroup(receipt.GroupId)
+	if err != nil {
+		return err
+	}
+
+	if !filter.bypassCategories && !grants.categoryUnrestricted {
+		receipt.Categories = filterCategoriesBySet(receipt.Categories, grants.categoryAllowed)
+	}
+	if !filter.bypassTags && !grants.tagUnrestricted {
+		receipt.Tags = filterTagsBySet(receipt.Tags, grants.tagAllowed)
+	}
+	return nil
+}
+
+func (filter *receiptGrantFilter) grantsForGroup(groupId uint) (receiptGroupGrants, error) {
+	if cached, ok := filter.groupCache[groupId]; ok {
+		return cached, nil
+	}
+
+	categoryAllowed, categoryUnrestricted, err := filter.service.GetGroupCategoryIdsForUser(filter.userId, groupId)
+	if err != nil {
+		return receiptGroupGrants{}, err
+	}
+
+	tagAllowed, tagUnrestricted, err := filter.service.GetGroupTagIdsForUser(filter.userId, groupId)
+	if err != nil {
+		return receiptGroupGrants{}, err
+	}
+
+	grants := receiptGroupGrants{
+		categoryAllowed:      categoryAllowed,
+		categoryUnrestricted: categoryUnrestricted,
+		tagAllowed:           tagAllowed,
+		tagUnrestricted:      tagUnrestricted,
+	}
+	filter.groupCache[groupId] = grants
+	return grants, nil
+}
+
+func filterCategoriesBySet(categories []models.Category, allowed map[uint]struct{}) []models.Category {
+	filtered := make([]models.Category, 0, len(categories))
+	for _, category := range categories {
+		if _, ok := allowed[category.ID]; ok {
+			filtered = append(filtered, category)
+		}
+	}
+	return filtered
+}
+
+func filterTagsBySet(tags []models.Tag, allowed map[uint]struct{}) []models.Tag {
+	filtered := make([]models.Tag, 0, len(tags))
+	for _, tag := range tags {
+		if _, ok := allowed[tag.ID]; ok {
+			filtered = append(filtered, tag)
+		}
+	}
+	return filtered
+}

--- a/api/internal/services/grant_filter_test.go
+++ b/api/internal/services/grant_filter_test.go
@@ -1,0 +1,242 @@
+package services
+
+import (
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/permissions"
+	"receipt-wrangler/api/internal/repositories"
+	"testing"
+)
+
+// categoryWithId / tagWithId build an in-memory association row referencing an
+// existing category/tag id (the grant filter only inspects ids).
+func categoryWithId(id uint) models.Category {
+	return models.Category{BaseModel: models.BaseModel{ID: id}}
+}
+
+func tagWithId(id uint) models.Tag {
+	return models.Tag{BaseModel: models.BaseModel{ID: id}}
+}
+
+func categoryIdSet(categories []models.Category) map[uint]struct{} {
+	set := make(map[uint]struct{}, len(categories))
+	for _, category := range categories {
+		set[category.ID] = struct{}{}
+	}
+	return set
+}
+
+// grantUserAppPermissions assigns userId an app role granting perms, so the
+// user bypasses grant filtering for those resources.
+func grantUserAppPermissions(t *testing.T, userId uint, perms []string) {
+	t.Helper()
+	role, err := repositories.NewRoleRepository(nil).CreateAppRole("Bypass Role", "", perms)
+	if err != nil {
+		t.Fatalf("create app role: %v", err)
+	}
+	if err := repositories.GetDB().Model(&models.User{}).Where("id = ?", userId).Update("app_role_id", role.ID).Error; err != nil {
+		t.Fatalf("assign app role: %v", err)
+	}
+	clearRolePermissionCacheAll()
+}
+
+func TestFilterReceiptStripsDisallowedCategories(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	cat2 := makeCategory(t, "Utilities")
+	tag1 := makeTag(t, "Reimbursable")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-strip", []uint{cat1}, nil)
+
+	receipts := []models.Receipt{{
+		GroupId:    groupId,
+		Categories: []models.Category{categoryWithId(cat1), categoryWithId(cat2)},
+		Tags:       []models.Tag{tagWithId(tag1)},
+	}}
+
+	service := NewPermissionService(nil)
+	if err := service.FilterReceiptCategoriesTags(userId, receipts); err != nil {
+		t.Fatalf("FilterReceiptCategoriesTags: %v", err)
+	}
+
+	if len(receipts[0].Categories) != 1 || receipts[0].Categories[0].ID != cat1 {
+		t.Errorf("expected only cat1 to survive, got %v", receipts[0].Categories)
+	}
+	// The role grants no tags, so tags are unrestricted and left untouched.
+	if len(receipts[0].Tags) != 1 || receipts[0].Tags[0].ID != tag1 {
+		t.Errorf("expected tags untouched (unrestricted), got %v", receipts[0].Tags)
+	}
+}
+
+func TestFilterReceiptUnrestrictedNoOp(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	cat2 := makeCategory(t, "Utilities")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-open", nil, nil)
+
+	receipts := []models.Receipt{{
+		GroupId:    groupId,
+		Categories: []models.Category{categoryWithId(cat1), categoryWithId(cat2)},
+	}}
+
+	service := NewPermissionService(nil)
+	if err := service.FilterReceiptCategoriesTags(userId, receipts); err != nil {
+		t.Fatalf("FilterReceiptCategoriesTags: %v", err)
+	}
+
+	if len(receipts[0].Categories) != 2 {
+		t.Errorf("expected unrestricted receipt untouched, got %v", receipts[0].Categories)
+	}
+}
+
+func TestFilterReceiptAdminBypass(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	cat2 := makeCategory(t, "Utilities")
+	// Restricted group role (only cat1) ...
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-admin", []uint{cat1}, nil)
+	// ... but the user holds app.categories.read, so grants do not apply.
+	grantUserAppPermissions(t, userId, []string{permissions.AppCategoriesRead})
+
+	receipts := []models.Receipt{{
+		GroupId:    groupId,
+		Categories: []models.Category{categoryWithId(cat1), categoryWithId(cat2)},
+	}}
+
+	service := NewPermissionService(nil)
+	if err := service.FilterReceiptCategoriesTags(userId, receipts); err != nil {
+		t.Fatalf("FilterReceiptCategoriesTags: %v", err)
+	}
+
+	if len(receipts[0].Categories) != 2 {
+		t.Errorf("expected admin (app.categories.read) to bypass stripping, got %v", receipts[0].Categories)
+	}
+}
+
+func TestFilterReceiptBatchPerGroup(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	catA := makeCategory(t, "A")
+	catB := makeCategory(t, "B")
+
+	// Same user restricted differently in two groups.
+	userId, groupA, _ := seedMemberWithGroupRoleGrants(t, "u-batch", []uint{catA}, nil)
+
+	db := repositories.GetDB()
+	groupB := models.Group{Name: "group-b"}
+	db.Create(&groupB)
+	roleB, err := repositories.NewRoleRepository(nil).CreateGroupRole("Role B", "", []string{permissions.GroupReceiptsRead}, []uint{catB}, nil)
+	if err != nil {
+		t.Fatalf("create role B: %v", err)
+	}
+	memberB := models.GroupMember{GroupID: groupB.ID, UserID: userId, GroupRoleID: &roleB.ID}
+	db.Create(&memberB)
+
+	receipts := []models.Receipt{
+		{GroupId: groupA, Categories: []models.Category{categoryWithId(catA), categoryWithId(catB)}},
+		{GroupId: groupB.ID, Categories: []models.Category{categoryWithId(catA), categoryWithId(catB)}},
+	}
+
+	service := NewPermissionService(nil)
+	if err := service.FilterReceiptCategoriesTags(userId, receipts); err != nil {
+		t.Fatalf("FilterReceiptCategoriesTags: %v", err)
+	}
+
+	if _, ok := categoryIdSet(receipts[0].Categories)[catA]; !ok || len(receipts[0].Categories) != 1 {
+		t.Errorf("group A receipt should keep only catA, got %v", receipts[0].Categories)
+	}
+	if _, ok := categoryIdSet(receipts[1].Categories)[catB]; !ok || len(receipts[1].Categories) != 1 {
+		t.Errorf("group B receipt should keep only catB, got %v", receipts[1].Categories)
+	}
+}
+
+func TestFilterReceiptForReceiptSingle(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	cat2 := makeCategory(t, "Utilities")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-single", []uint{cat1}, nil)
+
+	receipt := models.Receipt{
+		GroupId:    groupId,
+		Categories: []models.Category{categoryWithId(cat1), categoryWithId(cat2)},
+	}
+
+	service := NewPermissionService(nil)
+	if err := service.FilterReceiptCategoriesTagsForReceipt(userId, &receipt); err != nil {
+		t.Fatalf("FilterReceiptCategoriesTagsForReceipt: %v", err)
+	}
+
+	if len(receipt.Categories) != 1 || receipt.Categories[0].ID != cat1 {
+		t.Errorf("expected only cat1 to survive, got %v", receipt.Categories)
+	}
+}
+
+func TestValidateCategoryTagSelection(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	cat2 := makeCategory(t, "Utilities")
+	tag1 := makeTag(t, "Reimbursable")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-validate", []uint{cat1}, nil)
+
+	service := NewPermissionService(nil)
+
+	// In-set category passes.
+	ok, err := service.ValidateCategoryTagSelection(userId, groupId, []uint{cat1}, nil)
+	if err != nil {
+		t.Fatalf("validate in-set: %v", err)
+	}
+	if !ok {
+		t.Error("expected in-set category selection to be allowed")
+	}
+
+	// Out-of-set category fails.
+	ok, err = service.ValidateCategoryTagSelection(userId, groupId, []uint{cat2}, nil)
+	if err != nil {
+		t.Fatalf("validate out-of-set: %v", err)
+	}
+	if ok {
+		t.Error("expected out-of-set category selection to be rejected")
+	}
+
+	// Tags are unrestricted for this role, so any tag passes.
+	ok, err = service.ValidateCategoryTagSelection(userId, groupId, []uint{cat1}, []uint{tag1})
+	if err != nil {
+		t.Fatalf("validate tag: %v", err)
+	}
+	if !ok {
+		t.Error("expected tag selection allowed when tags unrestricted")
+	}
+}
+
+func TestValidateCategoryTagSelectionUnrestricted(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-validate-open", nil, nil)
+
+	service := NewPermissionService(nil)
+	// Unrestricted role: any id passes (here an id that does not even exist).
+	ok, err := service.ValidateCategoryTagSelection(userId, groupId, []uint{424242}, nil)
+	if err != nil {
+		t.Fatalf("validate unrestricted: %v", err)
+	}
+	if !ok {
+		t.Error("expected unrestricted role to allow any category selection")
+	}
+}


### PR DESCRIPTION
## What

Third slice. Adds the **single shared enforcement mechanism** (`services/grant_filter.go`) that the next slice wires into every read/write surface, so the grant rules live in exactly one place.

> **Stacked on #594** (base = `feature/role-rework-grant-resolution`). Review/merge #593 → #594 first.

## Helpers (all on `PermissionService`)

- `FilterReceiptCategoriesTags(userId, []Receipt)` / `FilterReceiptCategoriesTagsForReceipt(userId, *Receipt)` — strip a receipt's `Categories`/`Tags` **in place** to the visible subset, resolving each group's allowed sets at most once per pass (a page spanning N groups → ≤ N resolutions).
- `ValidateCategoryTagSelection(userId, groupId, categoryIds, tagIds)` — receipt create/update guard; rejects existing ids outside the allowed set. New-by-name ids are gated by the create permission at the call site (next slice), not here.
- `userBypassesGrants` — holders of `app.categories.read` / `app.tags.read` (admins/managers who can already see the whole pool) are exempt; unrestricted resources also short-circuit. **Categories and tags handled independently.**

## Tests

Strip disallowed categories (tags left untouched when unrestricted), unrestricted no-op, **admin bypass**, batch filtering with the same user restricted differently across two groups, single-receipt variant, and `ValidateCategoryTagSelection` allow/reject/unrestricted. `go test ./internal/services/` green.

## Note

Still **no call sites** wired — this PR only adds the reusable helpers. Enforcement at the receipt/widget/export/duplicate/AI surfaces lands in the next slice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified permission enforcement for receipt categories and tags with per-group access controls, role-based filtering, and admin bypass support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->