### PR TITLE
Enforce category/tag grants on receipt surfaces

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -343,6 +343,23 @@ them.
   set. Both short-circuit on unrestricted resources and on **admin bypass** — `userBypassesGrants`
   treats a holder of `app.categories.read` / `app.tags.read` as exempt (they can already see the
   whole pool), keeping their view consistent with the global lists.
+- **Receipt enforcement wiring:** every receipt surface that returns or accepts categories/tags is
+  gated. **Reads** strip via `FilterReceiptCategoriesTags` (receipt-, item-, and linked-item-level):
+  `GetReceipt`, `GetPagedReceiptsForGroup`, `GetReceiptsForGroupIds`, the pie-chart service, and both
+  CSV export handlers; `DuplicateReceipt` strips the source before copying. **Writes**
+  (`CreateReceipt` / `UpdateReceipt`) call `enforceReceiptGrantSelection` — existing ids must be in
+  the caller's grants (else 403) and a new-by-name category/tag requires `app.categories.create` /
+  `app.tags.create`. **List/pie/export filters** are narrowed by `IntersectReceiptFilterWithGrants`
+  so a restricted user can't probe receipt existence via a hidden category/tag filter. Search returns
+  no categories/tags (`SearchResult` omits them), so it needs no filtering.
+- **Update preserves hidden associations:** `UpdateReceipt` does a full association *replace*, so a
+  restricted user's submission (missing the categories/tags they can't see) would drop them.
+  `MergeHiddenReceiptCategoriesTags` re-adds the receipt-level hidden categories/tags before the
+  replace (and runs *after* the selection check, which would otherwise reject them); the response is
+  then stripped so the user still doesn't see them. **Known limitation:** this merge is
+  **receipt-level only** — receipt items have no stable id across an update (they are deleted and
+  recreated), so hidden *item-level* categories/tags cannot be matched back and are dropped when a
+  restricted user edits a receipt. Closing that needs item identity (a separate change).
 
 ### Enforcement status
 

--- a/api/internal/handlers/export.go
+++ b/api/internal/handlers/export.go
@@ -8,6 +8,7 @@ import (
 	"receipt-wrangler/api/internal/repositories"
 	"receipt-wrangler/api/internal/services"
 	"receipt-wrangler/api/internal/structs"
+	"receipt-wrangler/api/internal/utils"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -35,6 +36,16 @@ func ExportAllReceiptsFromGroup(w http.ResponseWriter, r *http.Request) {
 			}
 
 			token := structs.GetClaims(r)
+			permissionService := services.NewPermissionService(nil)
+
+			uintGroupId, err := utils.StringToUint(groupId)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+			err = permissionService.IntersectReceiptFilterWithGrants(token.UserId, uintGroupId, &pagedRequest.Filter)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
 
 			receiptRepository := repositories.NewReceiptRepository(nil)
 			receipts, _, err := receiptRepository.
@@ -44,6 +55,11 @@ func ExportAllReceiptsFromGroup(w http.ResponseWriter, r *http.Request) {
 					pagedRequest,
 					getExportReceiptAssociations(),
 				)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			err = permissionService.FilterReceiptCategoriesTags(token.UserId, receipts)
 			if err != nil {
 				return http.StatusInternalServerError, err
 			}
@@ -81,8 +97,14 @@ func ExportReceiptsById(w http.ResponseWriter, r *http.Request) {
 				return http.StatusInternalServerError, err
 			}
 
+			token := structs.GetClaims(r)
 			receiptRepository := repositories.NewReceiptRepository(nil)
 			receipts, err := receiptRepository.GetReceiptsByIds(receiptIds, getExportReceiptAssociations())
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			err = services.NewPermissionService(nil).FilterReceiptCategoriesTags(token.UserId, receipts)
 			if err != nil {
 				return http.StatusInternalServerError, err
 			}

--- a/api/internal/handlers/receipt_grant_enforcement.go
+++ b/api/internal/handlers/receipt_grant_enforcement.go
@@ -1,0 +1,88 @@
+package handlers
+
+import (
+	"receipt-wrangler/api/internal/commands"
+	"receipt-wrangler/api/internal/permissions"
+	"receipt-wrangler/api/internal/services"
+)
+
+// enforceReceiptGrantSelection checks a receipt upsert command against the
+// caller's category/tag grants for the group: every EXISTING category/tag id
+// (receipt-level and item-level) must be within the allowed set, and any NEW
+// (by-name) category/tag requires the matching app create permission. It returns
+// (allowed, denyMessage, error); when allowed is false the caller should respond
+// 403 with denyMessage.
+func enforceReceiptGrantSelection(userId uint, groupId uint, command commands.UpsertReceiptCommand) (bool, string, error) {
+	permissionService := services.NewPermissionService(nil)
+
+	categoryIds, tagIds, hasNewCategory, hasNewTag := collectReceiptSelection(command)
+
+	if hasNewCategory {
+		ok, err := permissionService.HasAppPermissions(userId, permissions.AppCategoriesCreate)
+		if err != nil {
+			return false, "", err
+		}
+		if !ok {
+			return false, "You do not have permission to create new categories", nil
+		}
+	}
+
+	if hasNewTag {
+		ok, err := permissionService.HasAppPermissions(userId, permissions.AppTagsCreate)
+		if err != nil {
+			return false, "", err
+		}
+		if !ok {
+			return false, "You do not have permission to create new tags", nil
+		}
+	}
+
+	ok, err := permissionService.ValidateCategoryTagSelection(userId, groupId, categoryIds, tagIds)
+	if err != nil {
+		return false, "", err
+	}
+	if !ok {
+		return false, "You do not have access to one or more selected categories or tags", nil
+	}
+
+	return true, "", nil
+}
+
+// collectReceiptSelection walks a receipt command (receipt-level, item-level, and
+// linked-item-level) and returns the existing category/tag ids referenced plus
+// whether any new-by-name category/tag is present.
+func collectReceiptSelection(command commands.UpsertReceiptCommand) (categoryIds []uint, tagIds []uint, hasNewCategory bool, hasNewTag bool) {
+	addCategories := func(categories []commands.UpsertCategoryCommand) {
+		for _, category := range categories {
+			if category.Id != nil && *category.Id != 0 {
+				categoryIds = append(categoryIds, *category.Id)
+			} else {
+				hasNewCategory = true
+			}
+		}
+	}
+
+	addTags := func(tags []commands.UpsertTagCommand) {
+		for _, tag := range tags {
+			if tag.Id != nil && *tag.Id != 0 {
+				tagIds = append(tagIds, *tag.Id)
+			} else {
+				hasNewTag = true
+			}
+		}
+	}
+
+	addCategories(command.Categories)
+	addTags(command.Tags)
+
+	for _, item := range command.Items {
+		addCategories(item.Categories)
+		addTags(item.Tags)
+		for _, linkedItem := range item.LinkedItems {
+			addCategories(linkedItem.Categories)
+			addTags(linkedItem.Tags)
+		}
+	}
+
+	return categoryIds, tagIds, hasNewCategory, hasNewTag
+}

--- a/api/internal/handlers/receipt_grant_enforcement_test.go
+++ b/api/internal/handlers/receipt_grant_enforcement_test.go
@@ -1,0 +1,133 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/permissions"
+	"receipt-wrangler/api/internal/repositories"
+	"receipt-wrangler/api/internal/services"
+	"receipt-wrangler/api/internal/structs"
+	"receipt-wrangler/api/internal/utils"
+	"strings"
+	"testing"
+
+	jwtmiddleware "github.com/auth0/go-jwt-middleware/v2"
+	"github.com/auth0/go-jwt-middleware/v2/validator"
+)
+
+func claimsForUser(userId uint) *validator.ValidatedClaims {
+	return &validator.ValidatedClaims{CustomClaims: &structs.Claims{UserId: userId}}
+}
+
+// seedRestrictedReceiptCreator creates a group plus a member whose group role
+// grants receipts create/read/update restricted to categoryGrantIds, and returns
+// the user id and group id.
+func seedRestrictedReceiptCreator(t *testing.T, categoryGrantIds []uint) (uint, uint) {
+	t.Helper()
+	services.ClearRolePermissionCacheForTests()
+	services.ClearGroupRoleGrantCacheForTests()
+	db := repositories.GetDB()
+
+	group := models.Group{Name: "grant-handler-group"}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("seed group: %v", err)
+	}
+
+	role, err := repositories.NewRoleRepository(nil).CreateGroupRole(
+		"Restricted Creator",
+		"",
+		[]string{permissions.GroupReceiptsCreate, permissions.GroupReceiptsRead, permissions.GroupReceiptsUpdate},
+		categoryGrantIds,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("seed group role: %v", err)
+	}
+
+	user := models.User{Username: "restricted-creator", Password: "password"}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	member := models.GroupMember{GroupID: group.ID, UserID: user.ID, GroupRoleID: &role.ID}
+	if err := db.Create(&member).Error; err != nil {
+		t.Fatalf("seed member: %v", err)
+	}
+
+	return user.ID, group.ID
+}
+
+func TestCreateReceiptDeniedForDisallowedCategory(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	allowedCategory := models.Category{Name: "Groceries"}
+	repositories.GetDB().Create(&allowedCategory)
+	disallowedCategory := models.Category{Name: "Salary"}
+	repositories.GetDB().Create(&disallowedCategory)
+
+	userId, groupId := seedRestrictedReceiptCreator(t, []uint{allowedCategory.ID})
+
+	body := fmt.Sprintf(
+		`{"name":"R","amount":"5","date":"2024-01-01T00:00:00Z","groupId":%d,"paidByUserId":%d,"status":"OPEN","categories":[{"id":%d,"name":"Salary"}]}`,
+		groupId, userId, disallowedCategory.ID,
+	)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/api", strings.NewReader(body))
+	r = r.WithContext(context.WithValue(r.Context(), jwtmiddleware.ContextKey{}, claimsForUser(userId)))
+
+	CreateReceipt(w, r)
+
+	if w.Result().StatusCode != 403 {
+		utils.PrintTestError(t, w.Result().StatusCode, 403)
+	}
+}
+
+func TestCreateReceiptDeniedForNewCategoryWithoutCreatePermission(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	allowedCategory := models.Category{Name: "Groceries"}
+	repositories.GetDB().Create(&allowedCategory)
+
+	// The member's group role grants receipts.create but the user has no app
+	// role, so it holds no app.categories.create — a new-by-name category is denied.
+	userId, groupId := seedRestrictedReceiptCreator(t, []uint{allowedCategory.ID})
+
+	body := fmt.Sprintf(
+		`{"name":"R","amount":"5","date":"2024-01-01T00:00:00Z","groupId":%d,"paidByUserId":%d,"status":"OPEN","categories":[{"name":"Brand New"}]}`,
+		groupId, userId,
+	)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/api", strings.NewReader(body))
+	r = r.WithContext(context.WithValue(r.Context(), jwtmiddleware.ContextKey{}, claimsForUser(userId)))
+
+	CreateReceipt(w, r)
+
+	if w.Result().StatusCode != 403 {
+		utils.PrintTestError(t, w.Result().StatusCode, 403)
+	}
+}
+
+func TestCreateReceiptAllowedForGrantedCategory(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	allowedCategory := models.Category{Name: "Groceries"}
+	repositories.GetDB().Create(&allowedCategory)
+
+	userId, groupId := seedRestrictedReceiptCreator(t, []uint{allowedCategory.ID})
+
+	body := fmt.Sprintf(
+		`{"name":"R","amount":"5","date":"2024-01-01T00:00:00Z","groupId":%d,"paidByUserId":%d,"status":"OPEN","categories":[{"id":%d,"name":"Groceries"}]}`,
+		groupId, userId, allowedCategory.ID,
+	)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/api", strings.NewReader(body))
+	r = r.WithContext(context.WithValue(r.Context(), jwtmiddleware.ContextKey{}, claimsForUser(userId)))
+
+	CreateReceipt(w, r)
+
+	if w.Result().StatusCode != 200 {
+		utils.PrintTestError(t, w.Result().StatusCode, 200)
+	}
+}

--- a/api/internal/handlers/receipts.go
+++ b/api/internal/handlers/receipts.go
@@ -45,6 +45,19 @@ func GetPagedReceiptsForGroup(w http.ResponseWriter, r *http.Request) {
 				associations = constants.FULL_RECEIPT_ASSOCIATIONS
 			}
 
+			permissionService := services.NewPermissionService(nil)
+
+			// Narrow any category/tag filter to what the caller may see, so a
+			// restricted user cannot probe receipt existence via a hidden filter.
+			uintGroupId, err := utils.StringToUint(groupId)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+			err = permissionService.IntersectReceiptFilterWithGrants(token.UserId, uintGroupId, &pagedRequest.Filter)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
 			receiptRepository := repositories.NewReceiptRepository(nil)
 			receipts, count, err := receiptRepository.GetPagedReceiptsByGroupId(
 				token.UserId,
@@ -52,6 +65,12 @@ func GetPagedReceiptsForGroup(w http.ResponseWriter, r *http.Request) {
 				pagedRequest,
 				associations,
 			)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			// Strip categories/tags the caller may not see from the results.
+			err = permissionService.FilterReceiptCategoriesTags(token.UserId, receipts)
 			if err != nil {
 				return http.StatusInternalServerError, err
 			}
@@ -91,8 +110,14 @@ func GetReceiptsForGroupIds(w http.ResponseWriter, r *http.Request) {
 		GroupPermissions: []string{permissions.GroupReceiptsRead},
 		ResponseType:     constants.ApplicationJson,
 		HandlerFunction: func(w http.ResponseWriter, r *http.Request) (int, error) {
+			token := structs.GetClaims(r)
 			receiptRepository := repositories.NewReceiptRepository(nil)
 			receipts, err := receiptRepository.GetReceiptsByGroupIds(groupIds, "*", clause.Associations)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			err = services.NewPermissionService(nil).FilterReceiptCategoriesTags(token.UserId, receipts)
 			if err != nil {
 				return http.StatusInternalServerError, err
 			}
@@ -140,8 +165,22 @@ func CreateReceipt(w http.ResponseWriter, r *http.Request) {
 		GroupPermissions: []string{permissions.GroupReceiptsCreate},
 		ResponseType:     constants.ApplicationJson,
 		HandlerFunction: func(w http.ResponseWriter, r *http.Request) (int, error) {
+			allowed, denyMessage, err := enforceReceiptGrantSelection(token.UserId, command.GroupId, command)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+			if !allowed {
+				utils.WriteCustomErrorResponse(w, denyMessage, http.StatusForbidden)
+				return 0, nil
+			}
+
 			receiptRepository := repositories.NewReceiptRepository(nil)
 			createdReceipt, err := receiptRepository.CreateReceipt(command, token.UserId, true)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			err = services.NewPermissionService(nil).FilterReceiptCategoriesTagsForReceipt(token.UserId, &createdReceipt)
 			if err != nil {
 				return http.StatusInternalServerError, err
 			}
@@ -250,9 +289,15 @@ func GetReceipt(w http.ResponseWriter, r *http.Request) {
 		ResponseType:     constants.ApplicationJson,
 		HandlerFunction: func(w http.ResponseWriter, r *http.Request) (int, error) {
 			id := chi.URLParam(r, "id")
+			token := structs.GetClaims(r)
 			receiptRepository := repositories.NewReceiptRepository(nil)
 
 			receipt, err := receiptRepository.GetFullyLoadedReceiptById(id)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			err = services.NewPermissionService(nil).FilterReceiptCategoriesTagsForReceipt(token.UserId, &receipt)
 			if err != nil {
 				return http.StatusInternalServerError, err
 			}
@@ -297,7 +342,38 @@ func UpdateReceipt(w http.ResponseWriter, r *http.Request) {
 				return 0, nil
 			}
 
+			permissionService := services.NewPermissionService(nil)
+
+			// Load the current receipt to resolve its real group and the
+			// associations the caller may not see.
+			currentReceipt, err := receiptRepository.GetFullyLoadedReceiptById(receiptId)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			allowed, denyMessage, err := enforceReceiptGrantSelection(token.UserId, currentReceipt.GroupId, command)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+			if !allowed {
+				utils.WriteCustomErrorResponse(w, denyMessage, http.StatusForbidden)
+				return 0, nil
+			}
+
+			// Preserve receipt-level categories/tags the caller cannot see so the
+			// full-replace update does not silently drop them. (Must run AFTER
+			// the selection check, which would otherwise reject the re-added ids.)
+			err = permissionService.MergeHiddenReceiptCategoriesTags(token.UserId, currentReceipt.GroupId, currentReceipt.Categories, currentReceipt.Tags, &command)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
 			updatedReceipt, err := receiptRepository.UpdateReceipt(receiptId, command, token.UserId)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			err = permissionService.FilterReceiptCategoriesTagsForReceipt(token.UserId, &updatedReceipt)
 			if err != nil {
 				return http.StatusInternalServerError, err
 			}

--- a/api/internal/services/grant_filter.go
+++ b/api/internal/services/grant_filter.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"receipt-wrangler/api/internal/commands"
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/permissions"
 )
@@ -114,6 +115,154 @@ func (service PermissionService) selectionWithinGrants(
 	return true, nil
 }
 
+// MergeHiddenReceiptCategoriesTags appends to an update command the
+// receipt-level categories/tags that exist on the current receipt but are
+// outside the user's grants (and so were hidden from them on read). Without this
+// a restricted user's full-replace update would silently delete categories/tags
+// they could not see. No-op when the user is unrestricted or bypasses grants.
+//
+// NOTE: this only merges RECEIPT-level associations. Receipt items have no stable
+// id across an update (UpdateReceipt recreates them), so hidden item-level
+// categories/tags cannot be matched back and are not preserved.
+func (service PermissionService) MergeHiddenReceiptCategoriesTags(
+	userId uint,
+	groupId uint,
+	currentCategories []models.Category,
+	currentTags []models.Tag,
+	command *commands.UpsertReceiptCommand,
+) error {
+	bypassCategories, err := service.userBypassesGrants(userId, permissions.AppCategoriesRead)
+	if err != nil {
+		return err
+	}
+	if !bypassCategories {
+		allowed, unrestricted, err := service.GetGroupCategoryIdsForUser(userId, groupId)
+		if err != nil {
+			return err
+		}
+		if !unrestricted {
+			for i := range currentCategories {
+				category := currentCategories[i]
+				if _, ok := allowed[category.ID]; !ok {
+					categoryId := category.ID
+					command.Categories = append(command.Categories, commands.UpsertCategoryCommand{
+						Id:          &categoryId,
+						Name:        category.Name,
+						Description: category.Description,
+					})
+				}
+			}
+		}
+	}
+
+	bypassTags, err := service.userBypassesGrants(userId, permissions.AppTagsRead)
+	if err != nil {
+		return err
+	}
+	if !bypassTags {
+		allowed, unrestricted, err := service.GetGroupTagIdsForUser(userId, groupId)
+		if err != nil {
+			return err
+		}
+		if !unrestricted {
+			for i := range currentTags {
+				tag := currentTags[i]
+				if _, ok := allowed[tag.ID]; !ok {
+					tagId := tag.ID
+					command.Tags = append(command.Tags, commands.UpsertTagCommand{
+						Id:          &tagId,
+						Name:        tag.Name,
+						Description: tag.Description,
+					})
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// IntersectReceiptFilterWithGrants narrows a paged-request category/tag filter to
+// the ids the user may see, so a restricted user cannot probe receipt existence
+// by filtering on a category/tag they have no access to. When a filter is made
+// up entirely of disallowed ids it is forced to a no-match sentinel rather than
+// dropped (dropping would widen the result set). No-op for unrestricted/bypass.
+func (service PermissionService) IntersectReceiptFilterWithGrants(userId uint, groupId uint, filter *commands.ReceiptPagedRequestFilter) error {
+	bypassCategories, err := service.userBypassesGrants(userId, permissions.AppCategoriesRead)
+	if err != nil {
+		return err
+	}
+	if !bypassCategories {
+		allowed, unrestricted, err := service.GetGroupCategoryIdsForUser(userId, groupId)
+		if err != nil {
+			return err
+		}
+		if !unrestricted {
+			intersectFilterFieldWithGrants(&filter.Categories, allowed)
+		}
+	}
+
+	bypassTags, err := service.userBypassesGrants(userId, permissions.AppTagsRead)
+	if err != nil {
+		return err
+	}
+	if !bypassTags {
+		allowed, unrestricted, err := service.GetGroupTagIdsForUser(userId, groupId)
+		if err != nil {
+			return err
+		}
+		if !unrestricted {
+			intersectFilterFieldWithGrants(&filter.Tags, allowed)
+		}
+	}
+
+	return nil
+}
+
+func intersectFilterFieldWithGrants(field *commands.PagedRequestField, allowed map[uint]struct{}) {
+	if field.Value == nil {
+		return
+	}
+	values, ok := field.Value.([]interface{})
+	if !ok || len(values) == 0 {
+		return
+	}
+
+	filtered := make([]interface{}, 0, len(values))
+	for _, value := range values {
+		id, ok := filterValueToUint(value)
+		if !ok {
+			continue
+		}
+		if _, allowedOk := allowed[id]; allowedOk {
+			filtered = append(filtered, value)
+		}
+	}
+
+	if len(filtered) == 0 {
+		// The user filtered entirely by ids they cannot see; force a no-match so
+		// receipt existence is not revealed. Category/tag ids start at 1, so 0
+		// matches nothing.
+		filtered = []interface{}{float64(0)}
+	}
+
+	field.Value = filtered
+}
+
+// filterValueToUint coerces a JSON-decoded filter id (typically float64) to uint.
+func filterValueToUint(value interface{}) (uint, bool) {
+	switch typed := value.(type) {
+	case float64:
+		return uint(typed), true
+	case int:
+		return uint(typed), true
+	case uint:
+		return typed, true
+	default:
+		return 0, false
+	}
+}
+
 // receiptGrantFilter caches a user's bypass flags and per-group allowed sets for
 // the lifetime of one filter pass, so a batch of receipts resolves each group's
 // grants at most once.
@@ -162,13 +311,30 @@ func (filter *receiptGrantFilter) apply(receipt *models.Receipt) error {
 		return err
 	}
 
-	if !filter.bypassCategories && !grants.categoryUnrestricted {
-		receipt.Categories = filterCategoriesBySet(receipt.Categories, grants.categoryAllowed)
-	}
-	if !filter.bypassTags && !grants.tagUnrestricted {
-		receipt.Tags = filterTagsBySet(receipt.Tags, grants.tagAllowed)
+	filter.stripCategoriesTags(&receipt.Categories, &receipt.Tags, grants)
+
+	// Receipt items (and their linked items) carry their own categories/tags —
+	// strip them with the same rule so item-level associations don't leak.
+	for i := range receipt.ReceiptItems {
+		item := &receipt.ReceiptItems[i]
+		filter.stripCategoriesTags(&item.Categories, &item.Tags, grants)
+		for j := range item.LinkedItems {
+			linkedItem := &item.LinkedItems[j]
+			filter.stripCategoriesTags(&linkedItem.Categories, &linkedItem.Tags, grants)
+		}
 	}
 	return nil
+}
+
+// stripCategoriesTags rewrites a categories/tags pair in place to the allowed
+// subset, honoring the per-resource bypass and unrestricted flags.
+func (filter *receiptGrantFilter) stripCategoriesTags(categories *[]models.Category, tags *[]models.Tag, grants receiptGroupGrants) {
+	if !filter.bypassCategories && !grants.categoryUnrestricted {
+		*categories = filterCategoriesBySet(*categories, grants.categoryAllowed)
+	}
+	if !filter.bypassTags && !grants.tagUnrestricted {
+		*tags = filterTagsBySet(*tags, grants.tagAllowed)
+	}
 }
 
 func (filter *receiptGrantFilter) grantsForGroup(groupId uint) (receiptGroupGrants, error) {

--- a/api/internal/services/grant_filter_test.go
+++ b/api/internal/services/grant_filter_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"receipt-wrangler/api/internal/commands"
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/permissions"
 	"receipt-wrangler/api/internal/repositories"
@@ -220,6 +221,143 @@ func TestValidateCategoryTagSelection(t *testing.T) {
 	}
 	if !ok {
 		t.Error("expected tag selection allowed when tags unrestricted")
+	}
+}
+
+func TestFilterReceiptStripsItemCategories(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	cat2 := makeCategory(t, "Utilities")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-item-strip", []uint{cat1}, nil)
+
+	receipts := []models.Receipt{{
+		GroupId: groupId,
+		ReceiptItems: []models.Item{{
+			Categories: []models.Category{categoryWithId(cat1), categoryWithId(cat2)},
+			LinkedItems: []models.Item{{
+				Categories: []models.Category{categoryWithId(cat1), categoryWithId(cat2)},
+			}},
+		}},
+	}}
+
+	service := NewPermissionService(nil)
+	if err := service.FilterReceiptCategoriesTags(userId, receipts); err != nil {
+		t.Fatalf("FilterReceiptCategoriesTags: %v", err)
+	}
+
+	item := receipts[0].ReceiptItems[0]
+	if len(item.Categories) != 1 || item.Categories[0].ID != cat1 {
+		t.Errorf("expected item categories stripped to cat1, got %v", item.Categories)
+	}
+	if len(item.LinkedItems[0].Categories) != 1 || item.LinkedItems[0].Categories[0].ID != cat1 {
+		t.Errorf("expected linked-item categories stripped to cat1, got %v", item.LinkedItems[0].Categories)
+	}
+}
+
+func TestMergeHiddenReceiptCategoriesTags(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	allowedCat := makeCategory(t, "Groceries")
+	hiddenCat := makeCategory(t, "Salary")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-merge", []uint{allowedCat}, nil)
+
+	// The current receipt has both an allowed and a hidden category; the user's
+	// submitted command only carries the allowed one (they couldn't see hidden).
+	currentCategories := []models.Category{
+		{BaseModel: models.BaseModel{ID: allowedCat}, Name: "Groceries"},
+		{BaseModel: models.BaseModel{ID: hiddenCat}, Name: "Salary"},
+	}
+	command := commands.UpsertReceiptCommand{
+		GroupId:    groupId,
+		Categories: []commands.UpsertCategoryCommand{{Id: &allowedCat, Name: "Groceries"}},
+	}
+
+	service := NewPermissionService(nil)
+	if err := service.MergeHiddenReceiptCategoriesTags(userId, groupId, currentCategories, nil, &command); err != nil {
+		t.Fatalf("MergeHiddenReceiptCategoriesTags: %v", err)
+	}
+
+	// The hidden category must be re-added so the update does not drop it.
+	foundHidden := false
+	for _, category := range command.Categories {
+		if category.Id != nil && *category.Id == hiddenCat {
+			foundHidden = true
+		}
+	}
+	if !foundHidden {
+		t.Errorf("expected hidden category to be merged back, got %v", command.Categories)
+	}
+	if len(command.Categories) != 2 {
+		t.Errorf("expected 2 categories after merge, got %d", len(command.Categories))
+	}
+}
+
+func TestMergeHiddenReceiptCategoriesTagsUnrestrictedNoOp(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-merge-open", nil, nil)
+
+	currentCategories := []models.Category{{BaseModel: models.BaseModel{ID: cat1}, Name: "Groceries"}}
+	command := commands.UpsertReceiptCommand{GroupId: groupId}
+
+	service := NewPermissionService(nil)
+	if err := service.MergeHiddenReceiptCategoriesTags(userId, groupId, currentCategories, nil, &command); err != nil {
+		t.Fatalf("MergeHiddenReceiptCategoriesTags: %v", err)
+	}
+
+	// Unrestricted users hide nothing, so nothing is merged back.
+	if len(command.Categories) != 0 {
+		t.Errorf("expected no merge for unrestricted user, got %v", command.Categories)
+	}
+}
+
+func TestIntersectReceiptFilterWithGrants(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	allowedCat := makeCategory(t, "Groceries")
+	hiddenCat := makeCategory(t, "Salary")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-filter", []uint{allowedCat}, nil)
+
+	service := NewPermissionService(nil)
+
+	// Mixed filter -> only the allowed id remains.
+	filter := commands.ReceiptPagedRequestFilter{
+		Categories: commands.PagedRequestField{
+			Operation: commands.CONTAINS,
+			Value:     []interface{}{float64(allowedCat), float64(hiddenCat)},
+		},
+	}
+	if err := service.IntersectReceiptFilterWithGrants(userId, groupId, &filter); err != nil {
+		t.Fatalf("IntersectReceiptFilterWithGrants: %v", err)
+	}
+	values := filter.Categories.Value.([]interface{})
+	if len(values) != 1 || uint(values[0].(float64)) != allowedCat {
+		t.Errorf("expected filter narrowed to allowed category, got %v", values)
+	}
+
+	// Filter made entirely of disallowed ids -> no-match sentinel (0).
+	filter = commands.ReceiptPagedRequestFilter{
+		Categories: commands.PagedRequestField{
+			Operation: commands.CONTAINS,
+			Value:     []interface{}{float64(hiddenCat)},
+		},
+	}
+	if err := service.IntersectReceiptFilterWithGrants(userId, groupId, &filter); err != nil {
+		t.Fatalf("IntersectReceiptFilterWithGrants: %v", err)
+	}
+	values = filter.Categories.Value.([]interface{})
+	if len(values) != 1 || uint(values[0].(float64)) != 0 {
+		t.Errorf("expected no-match sentinel [0], got %v", values)
 	}
 }
 

--- a/api/internal/services/pie_chart.go
+++ b/api/internal/services/pie_chart.go
@@ -6,6 +6,7 @@ import (
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/repositories"
 	"receipt-wrangler/api/internal/structs"
+	"receipt-wrangler/api/internal/utils"
 
 	"github.com/shopspring/decimal"
 )
@@ -28,6 +29,12 @@ func (service PieChartService) GetPieChartData(
 	command commands.PieChartDataCommand,
 ) (structs.PieChartData, error) {
 	receiptRepository := repositories.NewReceiptRepository(service.TX)
+	permissionService := NewPermissionService(service.TX)
+
+	uintGroupId, err := utils.StringToUint(groupId)
+	if err != nil {
+		return structs.PieChartData{}, err
+	}
 
 	pagedRequest := commands.ReceiptPagedRequestCommand{
 		PagedRequestCommand: commands.PagedRequestCommand{
@@ -39,12 +46,25 @@ func (service PieChartService) GetPieChartData(
 		Filter: command.Filter,
 	}
 
+	// Restrict any category/tag filter to what the caller may see (anti-probing).
+	err = permissionService.IntersectReceiptFilterWithGrants(userId, uintGroupId, &pagedRequest.Filter)
+	if err != nil {
+		return structs.PieChartData{}, err
+	}
+
 	receipts, _, err := receiptRepository.GetPagedReceiptsByGroupId(
 		userId,
 		groupId,
 		pagedRequest,
 		[]string{"Categories", "Tags"},
 	)
+	if err != nil {
+		return structs.PieChartData{}, err
+	}
+
+	// Strip categories/tags the caller cannot see so they are not aggregated into
+	// the chart (a disallowed category collapses to Uncategorized/Untagged).
+	err = permissionService.FilterReceiptCategoriesTags(userId, receipts)
 	if err != nil {
 		return structs.PieChartData{}, err
 	}

--- a/api/internal/services/receipts.go
+++ b/api/internal/services/receipts.go
@@ -255,6 +255,14 @@ func (service ReceiptService) DuplicateReceipt(
 
 	systemTaskCommand.GroupId = &receipt.GroupId
 
+	// Strip categories/tags the duplicating user cannot see so they are not
+	// copied onto the new receipt.
+	permissionService := NewPermissionService(nil)
+	err = permissionService.FilterReceiptCategoriesTagsForReceipt(userId, &receipt)
+	if err != nil {
+		return models.Receipt{}, err
+	}
+
 	copier.Copy(&newReceipt, receipt)
 
 	newReceipt.ID = 0


### PR DESCRIPTION
## What

Fourth slice — wires the shared grant helpers (#595) into **every receipt surface** that returns or accepts categories/tags. This is where the lock-down becomes real.

> **Stacked on #595** (base = `feature/role-rework-grant-enforcement-helpers`). Review/merge #593 → #594 → #595 first.

## Reads (strip to visible subset — receipt-, item-, and linked-item-level)

`GetReceipt`, `GetPagedReceiptsForGroup`, `GetReceiptsForGroupIds`, the pie-chart service, both CSV export handlers, and the `DuplicateReceipt` source. `Search` returns no categories/tags (`SearchResult` omits them) → no change needed.

## Writes (create / update)

- Existing category/tag ids outside the caller's grants → **403**.
- New-by-name category/tag requires `app.categories.create` / `app.tags.create` (per the agreed inline-create rule).

## Anti-probing

List / pie / export category-tag **filters** are intersected with the caller's allowed set (`IntersectReceiptFilterWithGrants`), with a no-match sentinel when a filter is entirely disallowed — so a restricted user can't infer receipt existence via a hidden category/tag filter.

## Update preserves hidden associations

`UpdateReceipt` does a full association *replace*, so a restricted user's submission (missing what they can't see) would drop hidden categories/tags. `MergeHiddenReceiptCategoriesTags` re-adds the **receipt-level** hidden ones before the replace (after the selection check), and the response is stripped so they still aren't shown.

**Known limitation (by design, flagged):** the merge is **receipt-level only**. Receipt *items* have no stable id across an update (they're deleted and recreated), so hidden *item-level* categories/tags can't be matched back and are dropped when a restricted user edits a receipt. Item READ-stripping and write-validation are fully in place; closing the item write-merge needs item identity — a separate change. (The item READ leak — the primary concern — is closed.)

## Tests

- Service: item/linked-item strip, merge re-adds hidden (and no-op when unrestricted), filter intersection (narrow + no-match sentinel).
- Handler: create denied for disallowed existing category (403), denied for new category without create permission (403), allowed for granted category (200).
- Full `go test ./internal/handlers/ ./internal/services/` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Categories and tags hidden under user permissions are now properly filtered from receipt displays, exports, and charts.
  * Receipt creation and updates now enforce permission checks for category and tag access.
  * Receipt duplication respects user permission boundaries.

* **Documentation**
  * Added documentation describing category and tag permission enforcement.

* **Tests**
  * Added tests for receipt permission enforcement and category/tag filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->