### PR TITLE
Restrict AI prompt categories/tags to the triggering user

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -360,6 +360,13 @@ them.
   **receipt-level only** — receipt items have no stable id across an update (they are deleted and
   recreated), so hidden *item-level* categories/tags cannot be matched back and are dropped when a
   restricted user edits a receipt. Closing that needs item identity (a separate change).
+- **AI prompt:** `ReceiptProcessingService` carries a `UserId` (the user who triggered processing; 0
+  for system-initiated, e.g. email polling). When set together with a `Group`,
+  `getCategoriesString` / `getTagsString` restrict the candidate categories/tags fed to the model to
+  that user's grants (via `GetVisibleCategoriesForUser` / `GetVisibleTagsForUser`), so a quick scan
+  can't surface or auto-assign a category/tag the user isn't allowed to see. `MagicFillFromImage`
+  takes the triggering `userId` and sets it on the service; system/email processing passes 0 and
+  stays unrestricted (the resulting receipts are covered by read-stripping when any user views them).
 
 ### Enforcement status
 

--- a/api/internal/handlers/receipt_image.go
+++ b/api/internal/handlers/receipt_image.go
@@ -311,7 +311,7 @@ func MagicFillFromImage(w http.ResponseWriter, r *http.Request) {
 				}
 
 				startTimer = time.Now()
-				command, metadata, err := services.MagicFillFromImage(magicFillCommand, "")
+				command, metadata, err := services.MagicFillFromImage(magicFillCommand, "", token.UserId)
 				endTimer = time.Now()
 
 				_, taskErr := systemTaskService.CreateSystemTasksFromMetadata(

--- a/api/internal/services/receipt_image.go
+++ b/api/internal/services/receipt_image.go
@@ -104,12 +104,15 @@ func ReadReceiptFromTextOnly(bodyText string, groupId string) (commands.UpsertRe
 	return receiptProcessingService.ReadReceiptText(bodyText)
 }
 
-func MagicFillFromImage(command commands.MagicFillCommand, groupId string) (commands.UpsertReceiptCommand, commands.ReceiptProcessingMetadata, error) {
+func MagicFillFromImage(command commands.MagicFillCommand, groupId string, userId uint) (commands.UpsertReceiptCommand, commands.ReceiptProcessingMetadata, error) {
 	fileRepository := repositories.NewFileRepository(nil)
 	receiptProcessingService, err := NewSystemReceiptProcessingService(nil, groupId)
 	if err != nil {
 		return commands.UpsertReceiptCommand{}, commands.ReceiptProcessingMetadata{}, err
 	}
+	// Restrict the AI prompt's candidate categories/tags to this user's grants
+	// (0 when there is no triggering user, e.g. system processing).
+	receiptProcessingService.UserId = userId
 
 	bytes, err := fileRepository.GetBytesFromImageBytes(command.ImageData)
 	if err != nil {

--- a/api/internal/services/receipt_image_test.go
+++ b/api/internal/services/receipt_image_test.go
@@ -292,7 +292,7 @@ func TestMagicFillFromImage_HappyPath(t *testing.T) {
 	}
 
 	cmd := commands.MagicFillCommand{ImageData: jpg}
-	receipt, _, err := MagicFillFromImage(cmd, utils.UintToString(group.ID))
+	receipt, _, err := MagicFillFromImage(cmd, utils.UintToString(group.ID), 0)
 	if err != nil {
 		t.Fatalf("MagicFillFromImage: %v", err)
 	}
@@ -308,7 +308,7 @@ func TestMagicFillFromImage_InvalidImageData(t *testing.T) {
 	_, group, _ := seedReceiptImagePipeline(t, server.URL)
 
 	cmd := commands.MagicFillCommand{ImageData: []byte("not an image")}
-	_, _, err := MagicFillFromImage(cmd, utils.UintToString(group.ID))
+	_, _, err := MagicFillFromImage(cmd, utils.UintToString(group.ID), 0)
 	if err == nil {
 		t.Fatal("expected invalid file type error")
 	}

--- a/api/internal/services/receipt_processing.go
+++ b/api/internal/services/receipt_processing.go
@@ -20,6 +20,12 @@ type ReceiptProcessingService struct {
 	ReceiptProcessingSettings         models.ReceiptProcessingSettings
 	FallbackReceiptProcessingSettings models.ReceiptProcessingSettings
 	Group                             models.Group
+	// UserId is the user who triggered processing, when there is one (e.g. a
+	// quick scan). 0 means system-initiated (e.g. email polling) with no user
+	// context. When set together with a Group, the candidate categories/tags fed
+	// to the AI prompt are restricted to that user's grants so the model cannot
+	// suggest a category/tag the user is not allowed to see.
+	UserId uint
 }
 
 func NewSystemReceiptProcessingService(tx *gorm.DB, groupId string) (ReceiptProcessingService, error) {
@@ -464,6 +470,16 @@ func (service ReceiptProcessingService) getCategoriesString() (string, error) {
 		return "", err
 	}
 
+	// Restrict the candidate categories to the triggering user's grants (no-op
+	// for system-initiated processing or an unrestricted user).
+	if service.UserId > 0 && service.Group.ID > 0 {
+		permissionService := NewPermissionService(service.TX)
+		categories, err = permissionService.GetVisibleCategoriesForUser(service.UserId, service.Group.ID, categories)
+		if err != nil {
+			return "", err
+		}
+	}
+
 	categoriesBytes, err := json.Marshal(categories)
 	if err != nil {
 		return "", err
@@ -477,6 +493,14 @@ func (service ReceiptProcessingService) getTagsString() (string, error) {
 	tags, err := tagsRepository.GetAllTags("id, name")
 	if err != nil {
 		return "", err
+	}
+
+	if service.UserId > 0 && service.Group.ID > 0 {
+		permissionService := NewPermissionService(service.TX)
+		tags, err = permissionService.GetVisibleTagsForUser(service.UserId, service.Group.ID, tags)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	tagsBytes, err := json.Marshal(tags)

--- a/api/internal/services/receipt_processing_grant_test.go
+++ b/api/internal/services/receipt_processing_grant_test.go
@@ -1,0 +1,89 @@
+package services
+
+import (
+	"encoding/json"
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/repositories"
+	"testing"
+)
+
+func TestGetCategoriesStringRestrictedToUserGrants(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	grantedCategory := makeCategory(t, "Groceries")
+	makeCategory(t, "Salary")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-ai-cat", []uint{grantedCategory}, nil)
+
+	service := ReceiptProcessingService{
+		Group:  models.Group{BaseModel: models.BaseModel{ID: groupId}},
+		UserId: userId,
+	}
+
+	result, err := service.getCategoriesString()
+	if err != nil {
+		t.Fatalf("getCategoriesString: %v", err)
+	}
+
+	var categories []models.Category
+	if err := json.Unmarshal([]byte(result), &categories); err != nil {
+		t.Fatalf("unmarshal categories: %v", err)
+	}
+	if len(categories) != 1 || categories[0].ID != grantedCategory {
+		t.Errorf("expected the AI prompt to see only the granted category, got %v", categories)
+	}
+}
+
+func TestGetCategoriesStringUnrestrictedForSystemProcessing(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	makeCategory(t, "Groceries")
+	makeCategory(t, "Salary")
+
+	// UserId 0 = system-initiated (e.g. email polling): no restriction.
+	service := ReceiptProcessingService{}
+
+	result, err := service.getCategoriesString()
+	if err != nil {
+		t.Fatalf("getCategoriesString: %v", err)
+	}
+
+	var categories []models.Category
+	if err := json.Unmarshal([]byte(result), &categories); err != nil {
+		t.Fatalf("unmarshal categories: %v", err)
+	}
+	if len(categories) != 2 {
+		t.Errorf("expected all categories for system processing, got %d", len(categories))
+	}
+}
+
+func TestGetTagsStringRestrictedToUserGrants(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	grantedTag := makeTag(t, "Reimbursable")
+	makeTag(t, "Personal")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-ai-tag", nil, []uint{grantedTag})
+
+	service := ReceiptProcessingService{
+		Group:  models.Group{BaseModel: models.BaseModel{ID: groupId}},
+		UserId: userId,
+	}
+
+	result, err := service.getTagsString()
+	if err != nil {
+		t.Fatalf("getTagsString: %v", err)
+	}
+
+	var tags []models.Tag
+	if err := json.Unmarshal([]byte(result), &tags); err != nil {
+		t.Fatalf("unmarshal tags: %v", err)
+	}
+	if len(tags) != 1 || tags[0].ID != grantedTag {
+		t.Errorf("expected the AI prompt to see only the granted tag, got %v", tags)
+	}
+}

--- a/api/internal/services/receipts.go
+++ b/api/internal/services/receipts.go
@@ -141,7 +141,7 @@ func (service ReceiptService) QuickScan(
 	groupIdString := utils.UintToString(groupId)
 
 	now := time.Now()
-	receiptCommand, receiptProcessingMetadata, magicFillErr := MagicFillFromImage(magicFillCommand, groupIdString)
+	receiptCommand, receiptProcessingMetadata, magicFillErr := MagicFillFromImage(magicFillCommand, groupIdString, token.UserId)
 	finishedAt := time.Now()
 
 	quickScanSystemTasks, taskErr := systemTaskService.CreateSystemTasksFromMetadata(


### PR DESCRIPTION
## What

Completes the receipt enforcement: the AI prompt for quick scan / magic fill previously listed **every** category/tag globally, so a restricted user could have the model surface or auto-assign a category/tag they aren't allowed to see (both a read leak in the draft and a UX trap on save).

> **Stacked on #596** (base = `feature/role-rework-grant-surfaces`). Review/merge #593 → #594 → #595 → #596 first.

## Changes

- `ReceiptProcessingService` gains a `UserId` field — the user who triggered processing, or `0` for system-initiated processing (e.g. email polling).
- When `UserId` and `Group` are both set, `getCategoriesString` / `getTagsString` restrict the candidate list to that user's grants via `GetVisibleCategoriesForUser` / `GetVisibleTagsForUser`.
- `MagicFillFromImage(command, groupId, userId)` sets it on the service; the quick-scan service and the magic-fill handler thread the caller's id. System/email processing passes `0` and stays unrestricted — those receipts are still covered by read-stripping when any user views them.

## Tests

- Restricted user → `getCategoriesString` / `getTagsString` return only granted ids.
- System (`UserId == 0`) → all categories returned.
- Full `go test ./internal/services/ ./internal/handlers/` green.

This closes Phase 4 (enforcement). Remaining: AppData delivery + global lock-down (backend), then the desktop UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI-generated suggestions for receipt categories and tags are now restricted to permissions the user has been granted, providing more relevant and accurate auto-fill recommendations based on individual access levels.

* **Tests**
  * Added test coverage for permission-based filtering of AI-generated suggestions in receipt processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->