### PR TITLE
Group-role-scoped category & tag visibility (lock-down)

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -336,6 +336,13 @@ them.
   `RoleService.UpdateRole` / `DeleteRole` for group scope. Only a role's grant *lists* are cached;
   the user's role *assignment* is resolved fresh each call. A category/tag deleted out from under a
   cached grant id is benign — a stale id simply never matches a real row when filtering.
+- `services/grant_filter.go` is the **single** shared enforcement mechanism, reused by every read and
+  write surface: `FilterReceiptCategoriesTags` / `FilterReceiptCategoriesTagsForReceipt` strip a
+  receipt's `Categories`/`Tags` in place to the visible subset (resolving each group's grants at most
+  once per pass); `ValidateCategoryTagSelection` checks receipt create/update ids against the allowed
+  set. Both short-circuit on unrestricted resources and on **admin bypass** — `userBypassesGrants`
+  treats a holder of `app.categories.read` / `app.tags.read` as exempt (they can already see the
+  whole pool), keeping their view consistent with the global lists.
 
 ### Enforcement status
 

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -192,7 +192,12 @@ them.
 
 - **App roles:** `AppRole` + `AppRolePermission` (permission strings in a child table).
 - **Group roles:** `GroupRoleDefinition` + `GroupRolePermission`, plus `GroupRoleCategoryGrant` /
-  `GroupRoleTagGrant` for per-role category/tag visibility.
+  `GroupRoleTagGrant` (composite-PK join rows) for per-role category/tag visibility. A group role
+  with **no** grant rows is **unrestricted** (sees every category/tag); a non-empty grant set
+  restricts members to exactly those ids — restriction is opt-in, so legacy/system roles (no grants)
+  keep seeing everything and no data migration is needed. Categories/tags are **global** (no
+  `GroupId`); a grant is a per-group-role slice of the global pool. Enforcement of these grants is
+  rolled out in later slices; Phase 1 only persists/returns them through role CRUD.
 - **Assignment:** nullable FKs `User.AppRoleID` and `GroupMember.GroupRoleID` (one app role per
   user; one group role per group membership). Nullable because per-create assignment is best-effort
   (the FK is left `nil` rather than failing creation when no role can be resolved, e.g. an unseeded
@@ -211,7 +216,14 @@ them.
   `PUT /role/{roleId}`, `PUT /role/{roleId}/default?scope=APP|GROUP` (make this role the scope's
   default; allowed on system roles; gated by `app.roles.update`), `DELETE /role/{roleId}?scope=APP|GROUP`.
 - `commands.UpsertRoleCommand` validates that every permission exists in the registry and matches
-  the role's scope. `structs.RoleView` is the read model (includes `assignedCount` and `isDefault`).
+  the role's scope. It also carries `categoryGrants` / `tagGrants` (category/tag ids): grants are
+  rejected on APP scope and dedup-checked in `Validate()`, and their existence is verified against
+  the DB in `RoleService` (`ErrInvalidGrant` → 400). `repositories/roles.go` syncs grant rows with
+  the same delete-then-insert pattern as permissions (`replaceGroupRoleGrants`, with the nested
+  Category/Tag association `Omit`-ted so only join rows are written), preloads them in
+  `GetGroupRoleById` / `GetAllRoles`, and cascades them on role delete. `structs.RoleView` is the
+  read model (includes `assignedCount`, `isDefault`, and `categoryGrants` / `tagGrants` — empty
+  slices for app roles).
 
 ### Seeded system roles (legacy-equivalent)
 

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -236,10 +236,13 @@ them.
   User** (the app actions a plain `USER` could do), **Legacy Viewer** / **Legacy Editor** / **Legacy
   Owner** (the group VIEWER / EDITOR / OWNER tiers; Owner = every group permission). The sets live in
   `permissions/legacy.go` (`Legacy*Keys()` helpers) and were derived from the actual handler-level
-  gating, not the desktop UI presets. **One deliberate exception:** `app.users.read` is omitted from
-  Legacy User — it gates only the admin `GET /user/` listing, which no client calls (user dropdowns read
-  from AppData via `app.account.read`), so granting it would only expose the admin "Manage Users" page to
-  normal users. Removing it keeps normal users off that page with zero functional loss.
+  gating, not the desktop UI presets. **Deliberate exceptions** (Legacy User omits these): `app.users.read`
+  — it gates only the admin `GET /user/` listing, which no client calls (user dropdowns read from AppData via
+  `app.account.read`), so granting it would only expose the admin "Manage Users" page to normal users; and
+  `app.categories.read` / `app.tags.read` — omitted as part of the category/tag grant lock-down, since they
+  gate the GLOBAL category/tag lists; normal users now get only the per-group filtered catalogs (the
+  `app.categories.create` / `app.tags.create` permissions are retained for inline creation). See
+  "Category/tag delivery on AppData" below.
 - `SeedSystemRoles` creates the roles with `IsDefault = false`; the **default** per scope is set
   separately by `EnsureDefaultRoles` (see "Default roles" below), the one-time data migration assigns
   the roles to existing users/members, and enforcement is wired in `HandleRequest`.
@@ -400,6 +403,16 @@ caller's resolved permissions so the desktop can gate UI with them — `AppPermi
 the cached `resolveAppPermissions` / `resolveGroupPermissions`). The JWT no longer carries any role
 field at all (it holds only identity claims); the server always re-checks real permissions from the
 DB on every request.
+
+**Category/tag delivery on AppData (grant lock-down):** `GetAppData` also returns `GroupCategories
+map[uint][]Category` and `GroupTags map[uint][]Tag` (keyed by group id) — each group's catalog
+filtered to the caller's grants (the full pool when unrestricted), built via
+`GetVisibleCategoriesForUser` / `GetVisibleTagsForUser`. The flat `Categories` / `Tags` arrays (and
+the global `GET /category` / `GET /tag` endpoints) are **admin-only**: they're populated solely for
+callers holding `app.categories.read` / `app.tags.read`, and empty otherwise. Because
+`LegacyAppUserKeys` no longer grants those reads (only the create permissions remain), normal users
+receive categories/tags **only** through the per-group `GroupCategories` / `GroupTags` maps — the
+desktop receipt form sources its pickers from there.
 
 **`app.api-keys.read-any` (Security):** listing *all* users' API keys (`GetPagedApiKeys` with
 `associatedApiKeys=ALL`) requires `app.api-keys.read-any`, checked in the handler body via the

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -343,6 +343,23 @@ them.
   set. Both short-circuit on unrestricted resources and on **admin bypass** — `userBypassesGrants`
   treats a holder of `app.categories.read` / `app.tags.read` as exempt (they can already see the
   whole pool), keeping their view consistent with the global lists.
+- **Receipt enforcement wiring:** every receipt surface that returns or accepts categories/tags is
+  gated. **Reads** strip via `FilterReceiptCategoriesTags` (receipt-, item-, and linked-item-level):
+  `GetReceipt`, `GetPagedReceiptsForGroup`, `GetReceiptsForGroupIds`, the pie-chart service, and both
+  CSV export handlers; `DuplicateReceipt` strips the source before copying. **Writes**
+  (`CreateReceipt` / `UpdateReceipt`) call `enforceReceiptGrantSelection` — existing ids must be in
+  the caller's grants (else 403) and a new-by-name category/tag requires `app.categories.create` /
+  `app.tags.create`. **List/pie/export filters** are narrowed by `IntersectReceiptFilterWithGrants`
+  so a restricted user can't probe receipt existence via a hidden category/tag filter. Search returns
+  no categories/tags (`SearchResult` omits them), so it needs no filtering.
+- **Update preserves hidden associations:** `UpdateReceipt` does a full association *replace*, so a
+  restricted user's submission (missing the categories/tags they can't see) would drop them.
+  `MergeHiddenReceiptCategoriesTags` re-adds the receipt-level hidden categories/tags before the
+  replace (and runs *after* the selection check, which would otherwise reject them); the response is
+  then stripped so the user still doesn't see them. **Known limitation:** this merge is
+  **receipt-level only** — receipt items have no stable id across an update (they are deleted and
+  recreated), so hidden *item-level* categories/tags cannot be matched back and are dropped when a
+  restricted user edits a receipt. Closing that needs item identity (a separate change).
 
 ### Enforcement status
 

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -196,8 +196,9 @@ them.
   with **no** grant rows is **unrestricted** (sees every category/tag); a non-empty grant set
   restricts members to exactly those ids — restriction is opt-in, so legacy/system roles (no grants)
   keep seeing everything and no data migration is needed. Categories/tags are **global** (no
-  `GroupId`); a grant is a per-group-role slice of the global pool. Enforcement of these grants is
-  rolled out in later slices; Phase 1 only persists/returns them through role CRUD.
+  `GroupId`); a grant is a per-group-role slice of the global pool. CRUD persists/returns the grants
+  and `PermissionService` resolves them (see "Category/tag grant resolution" below); wiring the
+  resolved sets into AppData delivery and request enforcement is rolled out in later slices.
 - **Assignment:** nullable FKs `User.AppRoleID` and `GroupMember.GroupRoleID` (one app role per
   user; one group role per group membership). Nullable because per-create assignment is best-effort
   (the FK is left `nil` rather than failing creation when no role can be resolved, e.g. an unseeded
@@ -319,6 +320,22 @@ them.
   and invalidated in `RoleService.UpdateRole` / `DeleteRole`. Only a role's permission *list* is
   cached; a user's role *assignment* is resolved fresh on every check, so re-assigning a user takes
   effect immediately.
+
+### Category/tag grant resolution (`PermissionService`)
+
+- `services/grant.go` resolves a user's allowed category/tag ids for a group:
+  `GetGroupCategoryIdsForUser` / `GetGroupTagIdsForUser` return `(allowedSet, unrestricted, err)`,
+  where **`unrestricted == true` means see-all** (the role grants nothing for that resource) and the
+  set is then `nil`. A non-member, or a member whose group role has no grants, is **unrestricted** —
+  grants only *narrow* access within an already-permitted group; they never *grant* access (the
+  handler permission gate is the access control). Categories and tags are independent (a role may
+  restrict one and not the other). `GetVisibleCategoriesForUser` / `GetVisibleTagsForUser` filter a
+  full category/tag slice to the visible subset (pass-through when unrestricted) — used by AppData.
+- Backed by a grant cache (`services/grant_cache.go`) keyed by **group-role id** (grants are
+  group-only), same generation-counter invalidation as the permission cache, evicted in
+  `RoleService.UpdateRole` / `DeleteRole` for group scope. Only a role's grant *lists* are cached;
+  the user's role *assignment* is resolved fresh each call. A category/tag deleted out from under a
+  cached grant id is benign — a stale id simply never matches a real row when filtering.
 
 ### Enforcement status
 

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -360,6 +360,13 @@ them.
   **receipt-level only** — receipt items have no stable id across an update (they are deleted and
   recreated), so hidden *item-level* categories/tags cannot be matched back and are dropped when a
   restricted user edits a receipt. Closing that needs item identity (a separate change).
+- **AI prompt:** `ReceiptProcessingService` carries a `UserId` (the user who triggered processing; 0
+  for system-initiated, e.g. email polling). When set together with a `Group`,
+  `getCategoriesString` / `getTagsString` restrict the candidate categories/tags fed to the model to
+  that user's grants (via `GetVisibleCategoriesForUser` / `GetVisibleTagsForUser`), so a quick scan
+  can't surface or auto-assign a category/tag the user isn't allowed to see. `MagicFillFromImage`
+  takes the triggering `userId` and sets it on the service; system/email processing passes 0 and
+  stays unrestricted (the resulting receipts are covered by read-stripping when any user views them).
 
 ### Enforcement status
 

--- a/api/internal/commands/upsert_role_command.go
+++ b/api/internal/commands/upsert_role_command.go
@@ -14,6 +14,13 @@ type UpsertRoleCommand struct {
 	Description string            `json:"description"`
 	Scope       permissions.Scope `json:"scope"`
 	Permissions []string          `json:"permissions"`
+	// CategoryGrants / TagGrants restrict which categories/tags members of a
+	// group role may read and use. They are only valid on GROUP-scoped roles. An
+	// empty set means "unrestricted" (see every category/tag) — restriction is
+	// opt-in. The values are category/tag ids; their existence is validated
+	// against the database in the role service.
+	CategoryGrants []uint `json:"categoryGrants"`
+	TagGrants      []uint `json:"tagGrants"`
 }
 
 func (command *UpsertRoleCommand) LoadDataFromRequest(w http.ResponseWriter, r *http.Request) error {
@@ -62,6 +69,32 @@ func (command *UpsertRoleCommand) Validate() structs.ValidatorError {
 		}
 	}
 
+	// Category/tag grants are a group-role concept (they slice the global pool
+	// per group role); they make no sense on an app role.
+	if command.Scope == permissions.ScopeApp && (len(command.CategoryGrants) > 0 || len(command.TagGrants) > 0) {
+		errors["grants"] = "Category and tag grants are only valid on group roles"
+	}
+
+	if hasDuplicateUint(command.CategoryGrants) {
+		errors["categoryGrants"] = "Duplicate category grant"
+	}
+
+	if hasDuplicateUint(command.TagGrants) {
+		errors["tagGrants"] = "Duplicate tag grant"
+	}
+
 	vErr.Errors = errors
 	return vErr
+}
+
+// hasDuplicateUint reports whether ids contains the same value more than once.
+func hasDuplicateUint(ids []uint) bool {
+	seen := make(map[uint]bool, len(ids))
+	for _, id := range ids {
+		if seen[id] {
+			return true
+		}
+		seen[id] = true
+	}
+	return false
 }

--- a/api/internal/commands/upsert_role_command_test.go
+++ b/api/internal/commands/upsert_role_command_test.go
@@ -96,3 +96,60 @@ func TestUpsertRoleCommandDuplicatePermission(t *testing.T) {
 		t.Errorf("expected permissions error, got %+v", vErr.Errors)
 	}
 }
+
+func TestUpsertRoleCommandGrantsOnGroupScopeValid(t *testing.T) {
+	command := UpsertRoleCommand{
+		Name:           "Restricted Group Role",
+		Scope:          permissions.ScopeGroup,
+		Permissions:    []string{permissions.GroupReceiptsRead},
+		CategoryGrants: []uint{1, 2},
+		TagGrants:      []uint{3},
+	}
+
+	vErr := command.Validate()
+	if len(vErr.Errors) > 0 {
+		t.Errorf("expected no errors, got %+v", vErr.Errors)
+	}
+}
+
+func TestUpsertRoleCommandGrantsRejectedOnAppScope(t *testing.T) {
+	command := UpsertRoleCommand{
+		Name:           "App Role With Grants",
+		Scope:          permissions.ScopeApp,
+		Permissions:    []string{permissions.AppUsersRead},
+		CategoryGrants: []uint{1},
+	}
+
+	vErr := command.Validate()
+	if _, ok := vErr.Errors["grants"]; !ok {
+		t.Errorf("expected grants error, got %+v", vErr.Errors)
+	}
+}
+
+func TestUpsertRoleCommandDuplicateCategoryGrant(t *testing.T) {
+	command := UpsertRoleCommand{
+		Name:           "Dup Category Grant",
+		Scope:          permissions.ScopeGroup,
+		Permissions:    []string{permissions.GroupReceiptsRead},
+		CategoryGrants: []uint{1, 1},
+	}
+
+	vErr := command.Validate()
+	if _, ok := vErr.Errors["categoryGrants"]; !ok {
+		t.Errorf("expected categoryGrants error, got %+v", vErr.Errors)
+	}
+}
+
+func TestUpsertRoleCommandDuplicateTagGrant(t *testing.T) {
+	command := UpsertRoleCommand{
+		Name:        "Dup Tag Grant",
+		Scope:       permissions.ScopeGroup,
+		Permissions: []string{permissions.GroupReceiptsRead},
+		TagGrants:   []uint{5, 5},
+	}
+
+	vErr := command.Validate()
+	if _, ok := vErr.Errors["tagGrants"]; !ok {
+		t.Errorf("expected tagGrants error, got %+v", vErr.Errors)
+	}
+}

--- a/api/internal/handlers/auth_test_helpers_test.go
+++ b/api/internal/handlers/auth_test_helpers_test.go
@@ -54,7 +54,7 @@ func grantGroupPerms(t *testing.T, userId uint, groupId uint, perms ...string) {
 	db := repositories.GetDB()
 
 	roleRepository := repositories.NewRoleRepository(nil)
-	role, err := roleRepository.CreateGroupRole(fmt.Sprintf("Test Group Role %d-%d", userId, groupId), "", perms)
+	role, err := roleRepository.CreateGroupRole(fmt.Sprintf("Test Group Role %d-%d", userId, groupId), "", perms, nil, nil)
 	if err != nil {
 		t.Fatalf("create group role: %v", err)
 	}

--- a/api/internal/handlers/export.go
+++ b/api/internal/handlers/export.go
@@ -8,6 +8,7 @@ import (
 	"receipt-wrangler/api/internal/repositories"
 	"receipt-wrangler/api/internal/services"
 	"receipt-wrangler/api/internal/structs"
+	"receipt-wrangler/api/internal/utils"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -35,6 +36,16 @@ func ExportAllReceiptsFromGroup(w http.ResponseWriter, r *http.Request) {
 			}
 
 			token := structs.GetClaims(r)
+			permissionService := services.NewPermissionService(nil)
+
+			uintGroupId, err := utils.StringToUint(groupId)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+			err = permissionService.IntersectReceiptFilterWithGrants(token.UserId, uintGroupId, &pagedRequest.Filter)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
 
 			receiptRepository := repositories.NewReceiptRepository(nil)
 			receipts, _, err := receiptRepository.
@@ -44,6 +55,11 @@ func ExportAllReceiptsFromGroup(w http.ResponseWriter, r *http.Request) {
 					pagedRequest,
 					getExportReceiptAssociations(),
 				)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			err = permissionService.FilterReceiptCategoriesTags(token.UserId, receipts)
 			if err != nil {
 				return http.StatusInternalServerError, err
 			}
@@ -81,8 +97,14 @@ func ExportReceiptsById(w http.ResponseWriter, r *http.Request) {
 				return http.StatusInternalServerError, err
 			}
 
+			token := structs.GetClaims(r)
 			receiptRepository := repositories.NewReceiptRepository(nil)
 			receipts, err := receiptRepository.GetReceiptsByIds(receiptIds, getExportReceiptAssociations())
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			err = services.NewPermissionService(nil).FilterReceiptCategoriesTags(token.UserId, receipts)
 			if err != nil {
 				return http.StatusInternalServerError, err
 			}

--- a/api/internal/handlers/receipt_grant_enforcement.go
+++ b/api/internal/handlers/receipt_grant_enforcement.go
@@ -1,0 +1,88 @@
+package handlers
+
+import (
+	"receipt-wrangler/api/internal/commands"
+	"receipt-wrangler/api/internal/permissions"
+	"receipt-wrangler/api/internal/services"
+)
+
+// enforceReceiptGrantSelection checks a receipt upsert command against the
+// caller's category/tag grants for the group: every EXISTING category/tag id
+// (receipt-level and item-level) must be within the allowed set, and any NEW
+// (by-name) category/tag requires the matching app create permission. It returns
+// (allowed, denyMessage, error); when allowed is false the caller should respond
+// 403 with denyMessage.
+func enforceReceiptGrantSelection(userId uint, groupId uint, command commands.UpsertReceiptCommand) (bool, string, error) {
+	permissionService := services.NewPermissionService(nil)
+
+	categoryIds, tagIds, hasNewCategory, hasNewTag := collectReceiptSelection(command)
+
+	if hasNewCategory {
+		ok, err := permissionService.HasAppPermissions(userId, permissions.AppCategoriesCreate)
+		if err != nil {
+			return false, "", err
+		}
+		if !ok {
+			return false, "You do not have permission to create new categories", nil
+		}
+	}
+
+	if hasNewTag {
+		ok, err := permissionService.HasAppPermissions(userId, permissions.AppTagsCreate)
+		if err != nil {
+			return false, "", err
+		}
+		if !ok {
+			return false, "You do not have permission to create new tags", nil
+		}
+	}
+
+	ok, err := permissionService.ValidateCategoryTagSelection(userId, groupId, categoryIds, tagIds)
+	if err != nil {
+		return false, "", err
+	}
+	if !ok {
+		return false, "You do not have access to one or more selected categories or tags", nil
+	}
+
+	return true, "", nil
+}
+
+// collectReceiptSelection walks a receipt command (receipt-level, item-level, and
+// linked-item-level) and returns the existing category/tag ids referenced plus
+// whether any new-by-name category/tag is present.
+func collectReceiptSelection(command commands.UpsertReceiptCommand) (categoryIds []uint, tagIds []uint, hasNewCategory bool, hasNewTag bool) {
+	addCategories := func(categories []commands.UpsertCategoryCommand) {
+		for _, category := range categories {
+			if category.Id != nil && *category.Id != 0 {
+				categoryIds = append(categoryIds, *category.Id)
+			} else {
+				hasNewCategory = true
+			}
+		}
+	}
+
+	addTags := func(tags []commands.UpsertTagCommand) {
+		for _, tag := range tags {
+			if tag.Id != nil && *tag.Id != 0 {
+				tagIds = append(tagIds, *tag.Id)
+			} else {
+				hasNewTag = true
+			}
+		}
+	}
+
+	addCategories(command.Categories)
+	addTags(command.Tags)
+
+	for _, item := range command.Items {
+		addCategories(item.Categories)
+		addTags(item.Tags)
+		for _, linkedItem := range item.LinkedItems {
+			addCategories(linkedItem.Categories)
+			addTags(linkedItem.Tags)
+		}
+	}
+
+	return categoryIds, tagIds, hasNewCategory, hasNewTag
+}

--- a/api/internal/handlers/receipt_grant_enforcement_test.go
+++ b/api/internal/handlers/receipt_grant_enforcement_test.go
@@ -1,0 +1,133 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/permissions"
+	"receipt-wrangler/api/internal/repositories"
+	"receipt-wrangler/api/internal/services"
+	"receipt-wrangler/api/internal/structs"
+	"receipt-wrangler/api/internal/utils"
+	"strings"
+	"testing"
+
+	jwtmiddleware "github.com/auth0/go-jwt-middleware/v2"
+	"github.com/auth0/go-jwt-middleware/v2/validator"
+)
+
+func claimsForUser(userId uint) *validator.ValidatedClaims {
+	return &validator.ValidatedClaims{CustomClaims: &structs.Claims{UserId: userId}}
+}
+
+// seedRestrictedReceiptCreator creates a group plus a member whose group role
+// grants receipts create/read/update restricted to categoryGrantIds, and returns
+// the user id and group id.
+func seedRestrictedReceiptCreator(t *testing.T, categoryGrantIds []uint) (uint, uint) {
+	t.Helper()
+	services.ClearRolePermissionCacheForTests()
+	services.ClearGroupRoleGrantCacheForTests()
+	db := repositories.GetDB()
+
+	group := models.Group{Name: "grant-handler-group"}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("seed group: %v", err)
+	}
+
+	role, err := repositories.NewRoleRepository(nil).CreateGroupRole(
+		"Restricted Creator",
+		"",
+		[]string{permissions.GroupReceiptsCreate, permissions.GroupReceiptsRead, permissions.GroupReceiptsUpdate},
+		categoryGrantIds,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("seed group role: %v", err)
+	}
+
+	user := models.User{Username: "restricted-creator", Password: "password"}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	member := models.GroupMember{GroupID: group.ID, UserID: user.ID, GroupRoleID: &role.ID}
+	if err := db.Create(&member).Error; err != nil {
+		t.Fatalf("seed member: %v", err)
+	}
+
+	return user.ID, group.ID
+}
+
+func TestCreateReceiptDeniedForDisallowedCategory(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	allowedCategory := models.Category{Name: "Groceries"}
+	repositories.GetDB().Create(&allowedCategory)
+	disallowedCategory := models.Category{Name: "Salary"}
+	repositories.GetDB().Create(&disallowedCategory)
+
+	userId, groupId := seedRestrictedReceiptCreator(t, []uint{allowedCategory.ID})
+
+	body := fmt.Sprintf(
+		`{"name":"R","amount":"5","date":"2024-01-01T00:00:00Z","groupId":%d,"paidByUserId":%d,"status":"OPEN","categories":[{"id":%d,"name":"Salary"}]}`,
+		groupId, userId, disallowedCategory.ID,
+	)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/api", strings.NewReader(body))
+	r = r.WithContext(context.WithValue(r.Context(), jwtmiddleware.ContextKey{}, claimsForUser(userId)))
+
+	CreateReceipt(w, r)
+
+	if w.Result().StatusCode != 403 {
+		utils.PrintTestError(t, w.Result().StatusCode, 403)
+	}
+}
+
+func TestCreateReceiptDeniedForNewCategoryWithoutCreatePermission(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	allowedCategory := models.Category{Name: "Groceries"}
+	repositories.GetDB().Create(&allowedCategory)
+
+	// The member's group role grants receipts.create but the user has no app
+	// role, so it holds no app.categories.create — a new-by-name category is denied.
+	userId, groupId := seedRestrictedReceiptCreator(t, []uint{allowedCategory.ID})
+
+	body := fmt.Sprintf(
+		`{"name":"R","amount":"5","date":"2024-01-01T00:00:00Z","groupId":%d,"paidByUserId":%d,"status":"OPEN","categories":[{"name":"Brand New"}]}`,
+		groupId, userId,
+	)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/api", strings.NewReader(body))
+	r = r.WithContext(context.WithValue(r.Context(), jwtmiddleware.ContextKey{}, claimsForUser(userId)))
+
+	CreateReceipt(w, r)
+
+	if w.Result().StatusCode != 403 {
+		utils.PrintTestError(t, w.Result().StatusCode, 403)
+	}
+}
+
+func TestCreateReceiptAllowedForGrantedCategory(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	allowedCategory := models.Category{Name: "Groceries"}
+	repositories.GetDB().Create(&allowedCategory)
+
+	userId, groupId := seedRestrictedReceiptCreator(t, []uint{allowedCategory.ID})
+
+	body := fmt.Sprintf(
+		`{"name":"R","amount":"5","date":"2024-01-01T00:00:00Z","groupId":%d,"paidByUserId":%d,"status":"OPEN","categories":[{"id":%d,"name":"Groceries"}]}`,
+		groupId, userId, allowedCategory.ID,
+	)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/api", strings.NewReader(body))
+	r = r.WithContext(context.WithValue(r.Context(), jwtmiddleware.ContextKey{}, claimsForUser(userId)))
+
+	CreateReceipt(w, r)
+
+	if w.Result().StatusCode != 200 {
+		utils.PrintTestError(t, w.Result().StatusCode, 200)
+	}
+}

--- a/api/internal/handlers/receipt_image.go
+++ b/api/internal/handlers/receipt_image.go
@@ -311,7 +311,7 @@ func MagicFillFromImage(w http.ResponseWriter, r *http.Request) {
 				}
 
 				startTimer = time.Now()
-				command, metadata, err := services.MagicFillFromImage(magicFillCommand, "")
+				command, metadata, err := services.MagicFillFromImage(magicFillCommand, "", token.UserId)
 				endTimer = time.Now()
 
 				_, taskErr := systemTaskService.CreateSystemTasksFromMetadata(

--- a/api/internal/handlers/receipts.go
+++ b/api/internal/handlers/receipts.go
@@ -45,6 +45,19 @@ func GetPagedReceiptsForGroup(w http.ResponseWriter, r *http.Request) {
 				associations = constants.FULL_RECEIPT_ASSOCIATIONS
 			}
 
+			permissionService := services.NewPermissionService(nil)
+
+			// Narrow any category/tag filter to what the caller may see, so a
+			// restricted user cannot probe receipt existence via a hidden filter.
+			uintGroupId, err := utils.StringToUint(groupId)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+			err = permissionService.IntersectReceiptFilterWithGrants(token.UserId, uintGroupId, &pagedRequest.Filter)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
 			receiptRepository := repositories.NewReceiptRepository(nil)
 			receipts, count, err := receiptRepository.GetPagedReceiptsByGroupId(
 				token.UserId,
@@ -52,6 +65,12 @@ func GetPagedReceiptsForGroup(w http.ResponseWriter, r *http.Request) {
 				pagedRequest,
 				associations,
 			)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			// Strip categories/tags the caller may not see from the results.
+			err = permissionService.FilterReceiptCategoriesTags(token.UserId, receipts)
 			if err != nil {
 				return http.StatusInternalServerError, err
 			}
@@ -91,8 +110,14 @@ func GetReceiptsForGroupIds(w http.ResponseWriter, r *http.Request) {
 		GroupPermissions: []string{permissions.GroupReceiptsRead},
 		ResponseType:     constants.ApplicationJson,
 		HandlerFunction: func(w http.ResponseWriter, r *http.Request) (int, error) {
+			token := structs.GetClaims(r)
 			receiptRepository := repositories.NewReceiptRepository(nil)
 			receipts, err := receiptRepository.GetReceiptsByGroupIds(groupIds, "*", clause.Associations)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			err = services.NewPermissionService(nil).FilterReceiptCategoriesTags(token.UserId, receipts)
 			if err != nil {
 				return http.StatusInternalServerError, err
 			}
@@ -140,8 +165,22 @@ func CreateReceipt(w http.ResponseWriter, r *http.Request) {
 		GroupPermissions: []string{permissions.GroupReceiptsCreate},
 		ResponseType:     constants.ApplicationJson,
 		HandlerFunction: func(w http.ResponseWriter, r *http.Request) (int, error) {
+			allowed, denyMessage, err := enforceReceiptGrantSelection(token.UserId, command.GroupId, command)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+			if !allowed {
+				utils.WriteCustomErrorResponse(w, denyMessage, http.StatusForbidden)
+				return 0, nil
+			}
+
 			receiptRepository := repositories.NewReceiptRepository(nil)
 			createdReceipt, err := receiptRepository.CreateReceipt(command, token.UserId, true)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			err = services.NewPermissionService(nil).FilterReceiptCategoriesTagsForReceipt(token.UserId, &createdReceipt)
 			if err != nil {
 				return http.StatusInternalServerError, err
 			}
@@ -250,9 +289,15 @@ func GetReceipt(w http.ResponseWriter, r *http.Request) {
 		ResponseType:     constants.ApplicationJson,
 		HandlerFunction: func(w http.ResponseWriter, r *http.Request) (int, error) {
 			id := chi.URLParam(r, "id")
+			token := structs.GetClaims(r)
 			receiptRepository := repositories.NewReceiptRepository(nil)
 
 			receipt, err := receiptRepository.GetFullyLoadedReceiptById(id)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			err = services.NewPermissionService(nil).FilterReceiptCategoriesTagsForReceipt(token.UserId, &receipt)
 			if err != nil {
 				return http.StatusInternalServerError, err
 			}
@@ -297,7 +342,38 @@ func UpdateReceipt(w http.ResponseWriter, r *http.Request) {
 				return 0, nil
 			}
 
+			permissionService := services.NewPermissionService(nil)
+
+			// Load the current receipt to resolve its real group and the
+			// associations the caller may not see.
+			currentReceipt, err := receiptRepository.GetFullyLoadedReceiptById(receiptId)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			allowed, denyMessage, err := enforceReceiptGrantSelection(token.UserId, currentReceipt.GroupId, command)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+			if !allowed {
+				utils.WriteCustomErrorResponse(w, denyMessage, http.StatusForbidden)
+				return 0, nil
+			}
+
+			// Preserve receipt-level categories/tags the caller cannot see so the
+			// full-replace update does not silently drop them. (Must run AFTER
+			// the selection check, which would otherwise reject the re-added ids.)
+			err = permissionService.MergeHiddenReceiptCategoriesTags(token.UserId, currentReceipt.GroupId, currentReceipt.Categories, currentReceipt.Tags, &command)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
 			updatedReceipt, err := receiptRepository.UpdateReceipt(receiptId, command, token.UserId)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			err = permissionService.FilterReceiptCategoriesTagsForReceipt(token.UserId, &updatedReceipt)
 			if err != nil {
 				return http.StatusInternalServerError, err
 			}

--- a/api/internal/handlers/roles.go
+++ b/api/internal/handlers/roles.go
@@ -65,6 +65,12 @@ func CreateRole(w http.ResponseWriter, r *http.Request) {
 			roleService := services.NewRoleService(nil)
 			createdRole, err := roleService.CreateRole(command)
 			if err != nil {
+				if errors.Is(err, services.ErrInvalidGrant) {
+					structs.WriteValidatorErrorResponse(w, structs.ValidatorError{
+						Errors: map[string]string{"grants": "One or more category or tag grants do not exist"},
+					}, http.StatusBadRequest)
+					return 0, nil
+				}
 				return http.StatusInternalServerError, err
 			}
 
@@ -128,6 +134,12 @@ func UpdateRole(w http.ResponseWriter, r *http.Request) {
 				}
 				if errors.Is(err, services.ErrRoleNotFound) {
 					utils.WriteCustomErrorResponse(w, "Role not found", http.StatusNotFound)
+					return 0, nil
+				}
+				if errors.Is(err, services.ErrInvalidGrant) {
+					structs.WriteValidatorErrorResponse(w, structs.ValidatorError{
+						Errors: map[string]string{"grants": "One or more category or tag grants do not exist"},
+					}, http.StatusBadRequest)
 					return 0, nil
 				}
 				return http.StatusInternalServerError, err

--- a/api/internal/handlers/roles_test.go
+++ b/api/internal/handlers/roles_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http/httptest"
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/permissions"
@@ -123,6 +124,62 @@ func TestShouldCreateGroupRole(t *testing.T) {
 
 	if role.Scope != permissions.ScopeGroup {
 		utils.PrintTestError(t, role.Scope, permissions.ScopeGroup)
+	}
+}
+
+func TestShouldCreateGroupRoleWithGrants(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	category := models.Category{Name: "Groceries"}
+	repositories.GetDB().Create(&category)
+	tag := models.Tag{Name: "Reimbursable"}
+	repositories.GetDB().Create(&tag)
+
+	role := structs.RoleView{}
+	body := fmt.Sprintf(
+		`{"name": "Restricted Role", "scope": "GROUP", "permissions": ["group.receipts.read"], "categoryGrants": [%d], "tagGrants": [%d]}`,
+		category.ID, tag.ID,
+	)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/api", strings.NewReader(body))
+
+	newContext := context.WithValue(r.Context(), jwtmiddleware.ContextKey{}, adminContext())
+	r = r.WithContext(newContext)
+
+	CreateRole(w, r)
+
+	if w.Result().StatusCode != 200 {
+		utils.PrintTestError(t, w.Result().StatusCode, 200)
+		return
+	}
+
+	if err := json.Unmarshal(w.Body.Bytes(), &role); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if len(role.CategoryGrants) != 1 || role.CategoryGrants[0] != category.ID {
+		utils.PrintTestError(t, role.CategoryGrants, []uint{category.ID})
+	}
+	if len(role.TagGrants) != 1 || role.TagGrants[0] != tag.ID {
+		utils.PrintTestError(t, role.TagGrants, []uint{tag.ID})
+	}
+}
+
+func TestShouldNotCreateGroupRoleDueToInvalidGrant(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	reader := strings.NewReader(`{"name": "Bad Grant", "scope": "GROUP", "permissions": ["group.receipts.read"], "categoryGrants": [999999]}`)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/api", reader)
+
+	newContext := context.WithValue(r.Context(), jwtmiddleware.ContextKey{}, adminContext())
+	r = r.WithContext(newContext)
+
+	CreateRole(w, r)
+
+	if w.Result().StatusCode != 400 {
+		utils.PrintTestError(t, w.Result().StatusCode, 400)
 	}
 }
 
@@ -535,7 +592,7 @@ func TestShouldNotDeleteAssignedAppRole(t *testing.T) {
 func TestShouldNotDeleteAssignedGroupRole(t *testing.T) {
 	defer repositories.TruncateTestDb()
 	roleRepository := repositories.NewRoleRepository(nil)
-	created, err := roleRepository.CreateGroupRole("Group Role", "desc", []string{permissions.GroupReceiptsCreate})
+	created, err := roleRepository.CreateGroupRole("Group Role", "desc", []string{permissions.GroupReceiptsCreate}, nil, nil)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return

--- a/api/internal/permissions/legacy.go
+++ b/api/internal/permissions/legacy.go
@@ -37,12 +37,18 @@ func LegacyAppAdminKeys() []string {
 // "Manage Users" listing), which no client calls — every user dropdown reads
 // users from AppData (gated by app.account.read). Granting it would expose the
 // admin Users page to normal users without giving them any capability they use.
+//
+// app.categories.read / app.tags.read are deliberately excluded as part of the
+// category/tag grant lock-down: those gate the GLOBAL GET /category, GET /tag and
+// the flat AppData category/tag lists, which return the entire pool. Normal users
+// now receive only the per-group filtered catalogs (AppData groupCategories /
+// groupTags), so granting the global read would leak categories/tags outside
+// their grants. The create permissions are retained so inline category/tag
+// creation in the receipt form still works (the create-permission gate).
 func LegacyAppUserKeys() []string {
 	return []string{
 		AppCategoriesCreate,
-		AppCategoriesRead,
 		AppTagsCreate,
-		AppTagsRead,
 		AppCustomFieldsCreate,
 		AppCustomFieldsRead,
 		AppGroupsCreate,

--- a/api/internal/permissions/legacy_test.go
+++ b/api/internal/permissions/legacy_test.go
@@ -32,9 +32,7 @@ func countScope(scope Scope) int {
 func TestLegacyAppUserKeys(t *testing.T) {
 	expected := []string{
 		AppCategoriesCreate,
-		AppCategoriesRead,
 		AppTagsCreate,
-		AppTagsRead,
 		AppCustomFieldsCreate,
 		AppCustomFieldsRead,
 		AppGroupsCreate,
@@ -90,6 +88,30 @@ func TestLegacyAppUserExcludesUsersRead(t *testing.T) {
 	// reach the admin Users page.
 	if slices.Contains(LegacyAppUserKeys(), AppUsersRead) {
 		utilPrint(t, "Legacy User contains "+AppUsersRead, "absent")
+	}
+}
+
+func TestLegacyAppUserExcludesGlobalCategoryTagRead(t *testing.T) {
+	// app.categories.read / app.tags.read gate the GLOBAL category/tag lists
+	// (GET /category, GET /tag, and the flat AppData arrays). Legacy User must NOT
+	// hold them — normal users receive only the per-group filtered catalogs, so
+	// granting global read would leak categories/tags outside their grants.
+	if slices.Contains(LegacyAppUserKeys(), AppCategoriesRead) {
+		utilPrint(t, "Legacy User contains "+AppCategoriesRead, "absent")
+	}
+	if slices.Contains(LegacyAppUserKeys(), AppTagsRead) {
+		utilPrint(t, "Legacy User contains "+AppTagsRead, "absent")
+	}
+}
+
+func TestLegacyAppUserRetainsCategoryTagCreate(t *testing.T) {
+	// The create permissions are retained so inline category/tag creation in the
+	// receipt form still works (gated on create, per the lock-down rules).
+	if !slices.Contains(LegacyAppUserKeys(), AppCategoriesCreate) {
+		utilPrint(t, "Legacy User missing "+AppCategoriesCreate, "present")
+	}
+	if !slices.Contains(LegacyAppUserKeys(), AppTagsCreate) {
+		utilPrint(t, "Legacy User missing "+AppTagsCreate, "present")
 	}
 }
 

--- a/api/internal/repositories/categories.go
+++ b/api/internal/repositories/categories.go
@@ -31,6 +31,21 @@ func (repository CategoryRepository) GetAllCategories(querySelect string) ([]mod
 	return categories, nil
 }
 
+// CountByIds returns how many of the given category ids exist. Used to validate
+// that a role's category grants reference real categories. Duplicate ids in the
+// input are de-duplicated by the IN clause, so callers should pass a unique set.
+func (repository CategoryRepository) CountByIds(ids []uint) (int64, error) {
+	db := repository.GetDB()
+
+	var count int64
+	err := db.Model(&models.Category{}).Where("id IN ?", ids).Count(&count).Error
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
 func (repository CategoryRepository) CreateCategory(category models.Category) (models.Category, error) {
 	db := repository.GetDB()
 

--- a/api/internal/repositories/data_migrations_test.go
+++ b/api/internal/repositories/data_migrations_test.go
@@ -268,7 +268,7 @@ func TestRunDataMigrationsDoesNotClobberExistingAssignment(t *testing.T) {
 		utils.PrintTestError(t, err, nil)
 		return
 	}
-	customGroupRole, err := roleRepository.CreateGroupRole("Custom Group Role", "", []string{permissions.GroupReceiptsRead})
+	customGroupRole, err := roleRepository.CreateGroupRole("Custom Group Role", "", []string{permissions.GroupReceiptsRead}, nil, nil)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return

--- a/api/internal/repositories/roles.go
+++ b/api/internal/repositories/roles.go
@@ -43,7 +43,7 @@ func (repository RoleRepository) CreateAppRole(name string, description string, 
 	return role, nil
 }
 
-func (repository RoleRepository) CreateGroupRole(name string, description string, perms []string) (models.GroupRoleDefinition, error) {
+func (repository RoleRepository) CreateGroupRole(name string, description string, perms []string, categoryGrantIds []uint, tagGrantIds []uint) (models.GroupRoleDefinition, error) {
 	db := repository.GetDB()
 
 	rolePermissions := make([]models.GroupRolePermission, 0, len(perms))
@@ -62,7 +62,12 @@ func (repository RoleRepository) CreateGroupRole(name string, description string
 		return models.GroupRoleDefinition{}, err
 	}
 
-	return role, nil
+	err = repository.replaceGroupRoleGrants(role.ID, categoryGrantIds, tagGrantIds)
+	if err != nil {
+		return models.GroupRoleDefinition{}, err
+	}
+
+	return repository.GetGroupRoleById(role.ID)
 }
 
 func (repository RoleRepository) GetAppRoleById(id uint) (models.AppRole, error) {
@@ -81,7 +86,10 @@ func (repository RoleRepository) GetGroupRoleById(id uint) (models.GroupRoleDefi
 	db := repository.GetDB()
 
 	var role models.GroupRoleDefinition
-	err := db.Preload("Permissions").First(&role, id).Error
+	err := db.Preload("Permissions").
+		Preload("CategoryGrants").
+		Preload("TagGrants").
+		First(&role, id).Error
 	if err != nil {
 		return models.GroupRoleDefinition{}, err
 	}
@@ -120,7 +128,7 @@ func (repository RoleRepository) UpdateAppRole(id uint, name string, description
 	return repository.GetAppRoleById(id)
 }
 
-func (repository RoleRepository) UpdateGroupRole(id uint, name string, description string, perms []string) (models.GroupRoleDefinition, error) {
+func (repository RoleRepository) UpdateGroupRole(id uint, name string, description string, perms []string, categoryGrantIds []uint, tagGrantIds []uint) (models.GroupRoleDefinition, error) {
 	db := repository.GetDB()
 
 	err := db.Where("group_role_id = ?", id).Delete(&models.GroupRolePermission{}).Error
@@ -148,7 +156,57 @@ func (repository RoleRepository) UpdateGroupRole(id uint, name string, descripti
 		}
 	}
 
+	err = repository.replaceGroupRoleGrants(id, categoryGrantIds, tagGrantIds)
+	if err != nil {
+		return models.GroupRoleDefinition{}, err
+	}
+
 	return repository.GetGroupRoleById(id)
+}
+
+// replaceGroupRoleGrants resets a group role's category and tag grants to exactly
+// the given id sets (delete-all-then-insert, mirroring the permission sync). The
+// nested Category/Tag belongs-to associations are Omit-ted so GORM never tries to
+// upsert a zero-valued category/tag from the grant rows — only the join rows are
+// written.
+func (repository RoleRepository) replaceGroupRoleGrants(groupRoleId uint, categoryGrantIds []uint, tagGrantIds []uint) error {
+	db := repository.GetDB()
+
+	err := db.Where("group_role_id = ?", groupRoleId).Delete(&models.GroupRoleCategoryGrant{}).Error
+	if err != nil {
+		return err
+	}
+
+	err = db.Where("group_role_id = ?", groupRoleId).Delete(&models.GroupRoleTagGrant{}).Error
+	if err != nil {
+		return err
+	}
+
+	if len(categoryGrantIds) > 0 {
+		categoryGrants := make([]models.GroupRoleCategoryGrant, 0, len(categoryGrantIds))
+		for _, categoryId := range categoryGrantIds {
+			categoryGrants = append(categoryGrants, models.GroupRoleCategoryGrant{GroupRoleID: groupRoleId, CategoryID: categoryId})
+		}
+
+		err = db.Omit("Category").Create(&categoryGrants).Error
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(tagGrantIds) > 0 {
+		tagGrants := make([]models.GroupRoleTagGrant, 0, len(tagGrantIds))
+		for _, tagId := range tagGrantIds {
+			tagGrants = append(tagGrants, models.GroupRoleTagGrant{GroupRoleID: groupRoleId, TagID: tagId})
+		}
+
+		err = db.Omit("Tag").Create(&tagGrants).Error
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (repository RoleRepository) GetAllRoles() ([]structs.RoleView, error) {
@@ -161,7 +219,10 @@ func (repository RoleRepository) GetAllRoles() ([]structs.RoleView, error) {
 	}
 
 	var groupRoles []models.GroupRoleDefinition
-	err = db.Preload("Permissions").Find(&groupRoles).Error
+	err = db.Preload("Permissions").
+		Preload("CategoryGrants").
+		Preload("TagGrants").
+		Find(&groupRoles).Error
 	if err != nil {
 		return nil, err
 	}
@@ -185,14 +246,16 @@ func (repository RoleRepository) GetAllRoles() ([]structs.RoleView, error) {
 		}
 
 		roles = append(roles, structs.RoleView{
-			Id:            role.ID,
-			Name:          role.Name,
-			Description:   role.Description,
-			Scope:         permissions.ScopeApp,
-			IsDefault:     role.IsDefault,
-			IsSystem:      role.IsSystem,
-			Permissions:   perms,
-			AssignedCount: appRoleCounts[role.ID],
+			Id:             role.ID,
+			Name:           role.Name,
+			Description:    role.Description,
+			Scope:          permissions.ScopeApp,
+			IsDefault:      role.IsDefault,
+			IsSystem:       role.IsSystem,
+			Permissions:    perms,
+			AssignedCount:  appRoleCounts[role.ID],
+			CategoryGrants: []uint{},
+			TagGrants:      []uint{},
 		})
 	}
 
@@ -203,18 +266,40 @@ func (repository RoleRepository) GetAllRoles() ([]structs.RoleView, error) {
 		}
 
 		roles = append(roles, structs.RoleView{
-			Id:            role.ID,
-			Name:          role.Name,
-			Description:   role.Description,
-			Scope:         permissions.ScopeGroup,
-			IsDefault:     role.IsDefault,
-			IsSystem:      role.IsSystem,
-			Permissions:   perms,
-			AssignedCount: groupRoleCounts[role.ID],
+			Id:             role.ID,
+			Name:           role.Name,
+			Description:    role.Description,
+			Scope:          permissions.ScopeGroup,
+			IsDefault:      role.IsDefault,
+			IsSystem:       role.IsSystem,
+			Permissions:    perms,
+			AssignedCount:  groupRoleCounts[role.ID],
+			CategoryGrants: categoryGrantIdsFromRole(role),
+			TagGrants:      tagGrantIdsFromRole(role),
 		})
 	}
 
 	return roles, nil
+}
+
+// categoryGrantIdsFromRole extracts the category-grant ids from a loaded group
+// role's preloaded CategoryGrants, normalized to a non-nil slice.
+func categoryGrantIdsFromRole(role models.GroupRoleDefinition) []uint {
+	ids := make([]uint, 0, len(role.CategoryGrants))
+	for _, grant := range role.CategoryGrants {
+		ids = append(ids, grant.CategoryID)
+	}
+	return ids
+}
+
+// tagGrantIdsFromRole extracts the tag-grant ids from a loaded group role's
+// preloaded TagGrants, normalized to a non-nil slice.
+func tagGrantIdsFromRole(role models.GroupRoleDefinition) []uint {
+	ids := make([]uint, 0, len(role.TagGrants))
+	for _, grant := range role.TagGrants {
+		ids = append(ids, grant.TagID)
+	}
+	return ids
 }
 
 // roleAssignmentCount is the row shape returned by the grouped assignment-count
@@ -380,6 +465,38 @@ func (repository RoleRepository) GetGroupRolePermissions(groupRoleId uint) ([]st
 	}
 
 	return perms, nil
+}
+
+// GetGroupRoleCategoryIds returns the category ids a group role grants its
+// members. An empty result means the role is unrestricted (see all categories).
+func (repository RoleRepository) GetGroupRoleCategoryIds(groupRoleId uint) ([]uint, error) {
+	db := repository.GetDB()
+
+	ids := make([]uint, 0)
+	err := db.Model(&models.GroupRoleCategoryGrant{}).
+		Where("group_role_id = ?", groupRoleId).
+		Pluck("category_id", &ids).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return ids, nil
+}
+
+// GetGroupRoleTagIds returns the tag ids a group role grants its members. An
+// empty result means the role is unrestricted (see all tags).
+func (repository RoleRepository) GetGroupRoleTagIds(groupRoleId uint) ([]uint, error) {
+	db := repository.GetDB()
+
+	ids := make([]uint, 0)
+	err := db.Model(&models.GroupRoleTagGrant{}).
+		Where("group_role_id = ?", groupRoleId).
+		Pluck("tag_id", &ids).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return ids, nil
 }
 
 // GetUserAppRoleId returns the app role id assigned to a user, or nil when the

--- a/api/internal/repositories/roles_grants_test.go
+++ b/api/internal/repositories/roles_grants_test.go
@@ -1,0 +1,202 @@
+package repositories
+
+import (
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/permissions"
+	"receipt-wrangler/api/internal/utils"
+	"slices"
+	"testing"
+)
+
+// makeTestCategory inserts a category and returns its id.
+func makeTestCategory(t *testing.T, name string) uint {
+	category := models.Category{Name: name}
+	if err := GetDB().Create(&category).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	return category.ID
+}
+
+// makeTestTag inserts a tag and returns its id.
+func makeTestTag(t *testing.T, name string) uint {
+	tag := models.Tag{Name: name}
+	if err := GetDB().Create(&tag).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	return tag.ID
+}
+
+func TestCreateGroupRolePersistsCategoryAndTagGrants(t *testing.T) {
+	defer TruncateTestDb()
+	repository := NewRoleRepository(nil)
+
+	cat1 := makeTestCategory(t, "Groceries")
+	cat2 := makeTestCategory(t, "Utilities")
+	tag1 := makeTestTag(t, "Reimbursable")
+
+	role, err := repository.CreateGroupRole(
+		"Restricted Role",
+		"",
+		[]string{permissions.GroupReceiptsRead},
+		[]uint{cat1, cat2},
+		[]uint{tag1},
+	)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if len(role.CategoryGrants) != 2 {
+		utils.PrintTestError(t, len(role.CategoryGrants), 2)
+	}
+	if len(role.TagGrants) != 1 {
+		utils.PrintTestError(t, len(role.TagGrants), 1)
+	}
+
+	categoryIds, err := repository.GetGroupRoleCategoryIds(role.ID)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	slices.Sort(categoryIds)
+	expected := []uint{cat1, cat2}
+	slices.Sort(expected)
+	if !slices.Equal(categoryIds, expected) {
+		utils.PrintTestError(t, categoryIds, expected)
+	}
+
+	tagIds, err := repository.GetGroupRoleTagIds(role.ID)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if !slices.Equal(tagIds, []uint{tag1}) {
+		utils.PrintTestError(t, tagIds, []uint{tag1})
+	}
+}
+
+func TestCreateGroupRoleWithNoGrantsIsUnrestricted(t *testing.T) {
+	defer TruncateTestDb()
+	repository := NewRoleRepository(nil)
+
+	role, err := repository.CreateGroupRole("Open Role", "", []string{permissions.GroupReceiptsRead}, nil, nil)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	categoryIds, err := repository.GetGroupRoleCategoryIds(role.ID)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if len(categoryIds) != 0 {
+		utils.PrintTestError(t, len(categoryIds), 0)
+	}
+}
+
+func TestUpdateGroupRoleReplacesGrants(t *testing.T) {
+	defer TruncateTestDb()
+	repository := NewRoleRepository(nil)
+
+	cat1 := makeTestCategory(t, "Groceries")
+	cat2 := makeTestCategory(t, "Utilities")
+	cat3 := makeTestCategory(t, "Travel")
+	tag1 := makeTestTag(t, "Reimbursable")
+
+	created, err := repository.CreateGroupRole("Role", "", []string{permissions.GroupReceiptsRead}, []uint{cat1, cat2}, []uint{tag1})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	// Replace the grant sets entirely with cat3 and no tags.
+	updated, err := repository.UpdateGroupRole(created.ID, "Role", "", []string{permissions.GroupReceiptsRead}, []uint{cat3}, nil)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if len(updated.CategoryGrants) != 1 || updated.CategoryGrants[0].CategoryID != cat3 {
+		utils.PrintTestError(t, updated.CategoryGrants, []uint{cat3})
+	}
+	if len(updated.TagGrants) != 0 {
+		utils.PrintTestError(t, len(updated.TagGrants), 0)
+	}
+
+	categoryIds, err := repository.GetGroupRoleCategoryIds(created.ID)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if !slices.Equal(categoryIds, []uint{cat3}) {
+		utils.PrintTestError(t, categoryIds, []uint{cat3})
+	}
+}
+
+func TestDeleteGroupRoleCascadesGrants(t *testing.T) {
+	defer TruncateTestDb()
+	repository := NewRoleRepository(nil)
+
+	cat1 := makeTestCategory(t, "Groceries")
+	tag1 := makeTestTag(t, "Reimbursable")
+
+	created, err := repository.CreateGroupRole("Role", "", []string{permissions.GroupReceiptsRead}, []uint{cat1}, []uint{tag1})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if err := repository.DeleteGroupRole(created.ID); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	var categoryGrantCount int64
+	GetDB().Model(&models.GroupRoleCategoryGrant{}).Where("group_role_id = ?", created.ID).Count(&categoryGrantCount)
+	if categoryGrantCount != 0 {
+		utils.PrintTestError(t, categoryGrantCount, 0)
+	}
+
+	var tagGrantCount int64
+	GetDB().Model(&models.GroupRoleTagGrant{}).Where("group_role_id = ?", created.ID).Count(&tagGrantCount)
+	if tagGrantCount != 0 {
+		utils.PrintTestError(t, tagGrantCount, 0)
+	}
+}
+
+func TestCategoryAndTagCountByIds(t *testing.T) {
+	defer TruncateTestDb()
+
+	cat1 := makeTestCategory(t, "Groceries")
+	cat2 := makeTestCategory(t, "Utilities")
+	tag1 := makeTestTag(t, "Reimbursable")
+
+	categoryCount, err := NewCategoryRepository(nil).CountByIds([]uint{cat1, cat2})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if categoryCount != 2 {
+		utils.PrintTestError(t, categoryCount, 2)
+	}
+
+	// A non-existent id should not be counted.
+	categoryCount, err = NewCategoryRepository(nil).CountByIds([]uint{cat1, 999999})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if categoryCount != 1 {
+		utils.PrintTestError(t, categoryCount, 1)
+	}
+
+	tagCount, err := NewTagsRepository(nil).CountByIds([]uint{tag1})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if tagCount != 1 {
+		utils.PrintTestError(t, tagCount, 1)
+	}
+}

--- a/api/internal/repositories/roles_test.go
+++ b/api/internal/repositories/roles_test.go
@@ -49,7 +49,7 @@ func TestCreateGroupRolePersistsPermissions(t *testing.T) {
 	repository := NewRoleRepository(nil)
 
 	perms := []string{permissions.GroupReceiptsCreate}
-	role, err := repository.CreateGroupRole("Group Role", "Description", perms)
+	role, err := repository.CreateGroupRole("Group Role", "Description", perms, nil, nil)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -93,13 +93,13 @@ func TestUpdateGroupRolePersistsChanges(t *testing.T) {
 	defer TruncateTestDb()
 	repository := NewRoleRepository(nil)
 
-	created, err := repository.CreateGroupRole("Group Role", "Description", []string{permissions.GroupReceiptsCreate})
+	created, err := repository.CreateGroupRole("Group Role", "Description", []string{permissions.GroupReceiptsCreate}, nil, nil)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
 	}
 
-	updated, err := repository.UpdateGroupRole(created.ID, "Renamed Group Role", "New description", []string{permissions.GroupReceiptsRead})
+	updated, err := repository.UpdateGroupRole(created.ID, "Renamed Group Role", "New description", []string{permissions.GroupReceiptsRead}, nil, nil)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -228,7 +228,7 @@ func TestGetGroupRolePermissions(t *testing.T) {
 	repository := NewRoleRepository(nil)
 
 	perms := []string{permissions.GroupReceiptsRead}
-	role, err := repository.CreateGroupRole("Group Role", "", perms)
+	role, err := repository.CreateGroupRole("Group Role", "", perms, nil, nil)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -298,7 +298,7 @@ func TestGetGroupMemberRoleId(t *testing.T) {
 		utils.PrintTestError(t, err, nil)
 		return
 	}
-	role, err := repository.CreateGroupRole("Group Role", "", []string{permissions.GroupReceiptsRead})
+	role, err := repository.CreateGroupRole("Group Role", "", []string{permissions.GroupReceiptsRead}, nil, nil)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -378,12 +378,12 @@ func TestSetDefaultGroupRoleClearsOthers(t *testing.T) {
 	defer TruncateTestDb()
 	repository := NewRoleRepository(nil)
 
-	first, err := repository.CreateGroupRole("First", "", []string{permissions.GroupReceiptsRead})
+	first, err := repository.CreateGroupRole("First", "", []string{permissions.GroupReceiptsRead}, nil, nil)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
 	}
-	second, err := repository.CreateGroupRole("Second", "", []string{permissions.GroupReceiptsRead})
+	second, err := repository.CreateGroupRole("Second", "", []string{permissions.GroupReceiptsRead}, nil, nil)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return

--- a/api/internal/repositories/tags.go
+++ b/api/internal/repositories/tags.go
@@ -32,6 +32,21 @@ func (repository TagsRepository) GetAllTags(querySelect string) ([]models.Tag, e
 	return tags, nil
 }
 
+// CountByIds returns how many of the given tag ids exist. Used to validate that
+// a role's tag grants reference real tags. Duplicate ids in the input are
+// de-duplicated by the IN clause, so callers should pass a unique set.
+func (repository TagsRepository) CountByIds(ids []uint) (int64, error) {
+	db := repository.GetDB()
+
+	var count int64
+	err := db.Model(&models.Tag{}).Where("id IN ?", ids).Count(&count).Error
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
 func (repository TagsRepository) CreateTag(command commands.UpsertTagCommand) (models.Tag, error) {
 	db := repository.GetDB()
 	tag := models.Tag{}

--- a/api/internal/services/auth.go
+++ b/api/internal/services/auth.go
@@ -238,12 +238,49 @@ func GetAppData(userId uint, r *http.Request) (structs.AppData, error) {
 	}
 
 	groupPermissions := make(map[uint][]string, len(groups))
+	groupCategories := make(map[uint][]models.Category, len(groups))
+	groupTags := make(map[uint][]models.Tag, len(groups))
 	for _, group := range groups {
 		perms, err := permissionService.GetGroupPermissionsForUser(userId, group.ID)
 		if err != nil {
 			return appData, err
 		}
 		groupPermissions[group.ID] = perms
+
+		// Per-group category/tag catalog filtered to the caller's grants
+		// (full pool when unrestricted). This is how non-admins receive
+		// categories/tags now that the flat lists are admin-only.
+		visibleCategories, err := permissionService.GetVisibleCategoriesForUser(userId, group.ID, categories)
+		if err != nil {
+			return appData, err
+		}
+		groupCategories[group.ID] = visibleCategories
+
+		visibleTags, err := permissionService.GetVisibleTagsForUser(userId, group.ID, tags)
+		if err != nil {
+			return appData, err
+		}
+		groupTags[group.ID] = visibleTags
+	}
+
+	// The flat global category/tag lists are only for callers who may read the
+	// whole pool (app.categories.read / app.tags.read — admins, the category/tag
+	// management pages, the role editor). Everyone else receives an empty list
+	// and uses the per-group filtered catalogs above.
+	canReadAllCategories, err := permissionService.HasAppPermissions(userId, permissions.AppCategoriesRead)
+	if err != nil {
+		return appData, err
+	}
+	if !canReadAllCategories {
+		categories = []models.Category{}
+	}
+
+	canReadAllTags, err := permissionService.HasAppPermissions(userId, permissions.AppTagsRead)
+	if err != nil {
+		return appData, err
+	}
+	if !canReadAllTags {
+		tags = []models.Tag{}
 	}
 
 	appData.About = about
@@ -253,6 +290,8 @@ func GetAppData(userId uint, r *http.Request) (structs.AppData, error) {
 	appData.FeatureConfig = featureConfig
 	appData.Categories = categories
 	appData.Tags = tags
+	appData.GroupCategories = groupCategories
+	appData.GroupTags = groupTags
 	appData.CurrencyDisplay = systemSettings.CurrencyDisplay
 	appData.CurrencyThousandthsSeparator = systemSettings.CurrencyThousandthsSeparator
 	appData.CurrencyDecimalSeparator = systemSettings.CurrencyDecimalSeparator

--- a/api/internal/services/auth_test.go
+++ b/api/internal/services/auth_test.go
@@ -529,6 +529,106 @@ func TestGetAppData_PopulatesPermissions(t *testing.T) {
 	}
 }
 
+// GetAppData filters the per-group category catalog to the caller's grants and
+// withholds the flat global list from a non-admin (no app.categories.read).
+func TestGetAppData_GroupCategoriesFilteredByGrants(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	ClearRolePermissionCacheForTests()
+	ClearGroupRoleGrantCacheForTests()
+
+	db := repositories.GetDB()
+	roleRepository := repositories.NewRoleRepository(nil)
+
+	grantedCategory := models.Category{Name: "Groceries"}
+	db.Create(&grantedCategory)
+	hiddenCategory := models.Category{Name: "Salary"}
+	db.Create(&hiddenCategory)
+
+	// Legacy-User-like app role: create but not read.
+	appRole, err := roleRepository.CreateAppRole("AppData User Role", "", []string{permissions.AppCategoriesCreate})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	user := models.User{Username: "appdata-grant-user", Password: "password", AppRoleID: &appRole.ID}
+	if err := db.Create(&user).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	groupRole, err := roleRepository.CreateGroupRole("AppData Restricted Role", "", []string{permissions.GroupReceiptsRead}, []uint{grantedCategory.ID}, nil)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	group := models.Group{Name: "appdata-grant-group"}
+	if err := db.Create(&group).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if err := db.Create(&models.GroupMember{GroupID: group.ID, UserID: user.ID, GroupRoleID: &groupRole.ID}).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	appData, err := GetAppData(user.ID, nil)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	visible := appData.GroupCategories[group.ID]
+	if len(visible) != 1 || visible[0].ID != grantedCategory.ID {
+		utils.PrintTestError(t, visible, []uint{grantedCategory.ID})
+	}
+
+	// A non-admin gets no flat global list.
+	if len(appData.Categories) != 0 {
+		utils.PrintTestError(t, len(appData.Categories), 0)
+	}
+}
+
+// GetAppData gives an admin (app.categories.read) the flat global list, and an
+// unrestricted group's catalog contains every category.
+func TestGetAppData_AdminGetsFlatCategoriesUnrestrictedGroup(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	ClearRolePermissionCacheForTests()
+	ClearGroupRoleGrantCacheForTests()
+
+	db := repositories.GetDB()
+	roleRepository := repositories.NewRoleRepository(nil)
+
+	db.Create(&models.Category{Name: "Groceries"})
+	db.Create(&models.Category{Name: "Salary"})
+
+	appRole, err := roleRepository.CreateAppRole("AppData Admin Role", "", []string{permissions.AppCategoriesRead, permissions.AppTagsRead})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	user := models.User{Username: "appdata-admin-user", Password: "password", AppRoleID: &appRole.ID}
+	if err := db.Create(&user).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	groupRole, err := roleRepository.CreateGroupRole("AppData Open Role", "", []string{permissions.GroupReceiptsRead}, nil, nil)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	group := models.Group{Name: "appdata-admin-group"}
+	if err := db.Create(&group).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	if err := db.Create(&models.GroupMember{GroupID: group.ID, UserID: user.ID, GroupRoleID: &groupRole.ID}).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	appData, err := GetAppData(user.ID, nil)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+
+	if len(appData.Categories) != 2 {
+		utils.PrintTestError(t, len(appData.Categories), 2)
+	}
+	if len(appData.GroupCategories[group.ID]) != 2 {
+		utils.PrintTestError(t, len(appData.GroupCategories[group.ID]), 2)
+	}
+}
+
 // GetAppData returns an empty (non-nil) permission set for a user with no
 // assigned app role.
 func TestGetAppData_NoRolePermissionsEmpty(t *testing.T) {

--- a/api/internal/services/auth_test.go
+++ b/api/internal/services/auth_test.go
@@ -498,7 +498,7 @@ func TestGetAppData_PopulatesPermissions(t *testing.T) {
 	}
 
 	groupPerms := []string{permissions.GroupReceiptsRead, permissions.GroupReceiptsUpdate}
-	groupRole, err := roleRepository.CreateGroupRole("AppData Group Role", "", groupPerms)
+	groupRole, err := roleRepository.CreateGroupRole("AppData Group Role", "", groupPerms, nil, nil)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 	}

--- a/api/internal/services/grant.go
+++ b/api/internal/services/grant.go
@@ -1,0 +1,137 @@
+package services
+
+import (
+	"errors"
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/repositories"
+
+	"gorm.io/gorm"
+)
+
+// GetGroupCategoryIdsForUser returns the set of category ids a user may use in a
+// group, plus an "unrestricted" flag. When unrestricted is true the returned set
+// is nil and the caller must treat every category as allowed (the empty-grants =
+// see-all rule). A non-member, or a member whose group role has no category
+// grants, is unrestricted — grants only NARROW access within an already-permitted
+// group; they never grant access (the handler permission gate is the access
+// control). The returned map is read-only shared cache state.
+func (service PermissionService) GetGroupCategoryIdsForUser(userId uint, groupId uint) (map[uint]struct{}, bool, error) {
+	entry, err := service.resolveGroupRoleGrants(userId, groupId)
+	if err != nil {
+		return nil, false, err
+	}
+	if entry == nil || len(entry.categoryIds) == 0 {
+		return nil, true, nil
+	}
+	return entry.categoryIds, false, nil
+}
+
+// GetGroupTagIdsForUser is the tag counterpart of GetGroupCategoryIdsForUser.
+func (service PermissionService) GetGroupTagIdsForUser(userId uint, groupId uint) (map[uint]struct{}, bool, error) {
+	entry, err := service.resolveGroupRoleGrants(userId, groupId)
+	if err != nil {
+		return nil, false, err
+	}
+	if entry == nil || len(entry.tagIds) == 0 {
+		return nil, true, nil
+	}
+	return entry.tagIds, false, nil
+}
+
+// GetVisibleCategoriesForUser filters allCategories down to the ones a user may
+// see in a group. Unrestricted users get allCategories unchanged. Used by
+// GetAppData to build the per-group category catalog.
+func (service PermissionService) GetVisibleCategoriesForUser(userId uint, groupId uint, allCategories []models.Category) ([]models.Category, error) {
+	allowed, unrestricted, err := service.GetGroupCategoryIdsForUser(userId, groupId)
+	if err != nil {
+		return nil, err
+	}
+	if unrestricted {
+		return allCategories, nil
+	}
+
+	visible := make([]models.Category, 0, len(allowed))
+	for _, category := range allCategories {
+		if _, ok := allowed[category.ID]; ok {
+			visible = append(visible, category)
+		}
+	}
+	return visible, nil
+}
+
+// GetVisibleTagsForUser is the tag counterpart of GetVisibleCategoriesForUser.
+func (service PermissionService) GetVisibleTagsForUser(userId uint, groupId uint, allTags []models.Tag) ([]models.Tag, error) {
+	allowed, unrestricted, err := service.GetGroupTagIdsForUser(userId, groupId)
+	if err != nil {
+		return nil, err
+	}
+	if unrestricted {
+		return allTags, nil
+	}
+
+	visible := make([]models.Tag, 0, len(allowed))
+	for _, tag := range allTags {
+		if _, ok := allowed[tag.ID]; ok {
+			visible = append(visible, tag)
+		}
+	}
+	return visible, nil
+}
+
+// resolveGroupRoleGrants returns the cached grant entry for a user's role in a
+// group, or nil when the user is not a member or the membership has no group role
+// (both mean "unrestricted").
+func (service PermissionService) resolveGroupRoleGrants(userId uint, groupId uint) (*grantEntry, error) {
+	roleRepository := repositories.NewRoleRepository(service.TX)
+
+	groupRoleId, err := roleRepository.GetGroupMemberRoleId(userId, groupId)
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if groupRoleId == nil {
+		return nil, nil
+	}
+
+	return loadGroupRoleGrants(roleRepository, *groupRoleId)
+}
+
+// loadGroupRoleGrants returns a group role's grant sets, consulting the cache
+// first and populating it on a miss (mirroring loadRolePermissions).
+func loadGroupRoleGrants(roleRepository repositories.RoleRepository, roleId uint) (*grantEntry, error) {
+	if cached, ok := getCachedGroupRoleGrants(roleId); ok {
+		return cached, nil
+	}
+
+	// Capture the eviction generation before reading so a concurrent grant
+	// update/delete invalidates this write instead of being undone by it.
+	observedGen := groupRoleGrantCacheGen()
+
+	categoryIds, err := roleRepository.GetGroupRoleCategoryIds(roleId)
+	if err != nil {
+		return nil, err
+	}
+	tagIds, err := roleRepository.GetGroupRoleTagIds(roleId)
+	if err != nil {
+		return nil, err
+	}
+
+	entry := &grantEntry{
+		categoryIds: uintSliceToSet(categoryIds),
+		tagIds:      uintSliceToSet(tagIds),
+	}
+
+	setCachedGroupRoleGrants(roleId, entry, observedGen)
+	return entry, nil
+}
+
+// uintSliceToSet converts a slice of ids to a set for O(1) membership tests.
+func uintSliceToSet(ids []uint) map[uint]struct{} {
+	set := make(map[uint]struct{}, len(ids))
+	for _, id := range ids {
+		set[id] = struct{}{}
+	}
+	return set
+}

--- a/api/internal/services/grant_cache.go
+++ b/api/internal/services/grant_cache.go
@@ -1,0 +1,91 @@
+package services
+
+import "sync"
+
+// grantEntry holds the category/tag ids a group role grants its members, as sets
+// for O(1) membership tests. An EMPTY set means that resource is unrestricted
+// (the role grants every category/tag) — so categories and tags are independent:
+// a role may restrict categories while leaving tags unrestricted, or vice versa.
+// Callers must treat the maps as read-only (they are shared cache state).
+type grantEntry struct {
+	categoryIds map[uint]struct{}
+	tagIds      map[uint]struct{}
+}
+
+// groupRoleGrantCache memoizes a group role's category/tag grant id sets, keyed
+// by group-role id (grants only exist on group roles). Like the permission
+// cache, only a role's grant *lists* are cached — a user's role *assignment* is
+// resolved fresh on every check, so re-assigning a user takes effect
+// immediately. Invalidated whenever a group role is updated or deleted.
+//
+// groupRoleGrantCacheGeneration is bumped on every eviction; a cache write
+// carries the generation observed before its DB read and is dropped if the
+// generation has since advanced, preventing an in-flight miss from resurrecting
+// stale grants after a concurrent eviction (which would otherwise leave a
+// just-removed restriction — or a just-added one — applied incorrectly).
+var (
+	groupRoleGrantCacheMutex      sync.RWMutex
+	groupRoleGrantCache           = map[uint]*grantEntry{}
+	groupRoleGrantCacheGeneration uint64
+)
+
+func getCachedGroupRoleGrants(roleId uint) (*grantEntry, bool) {
+	groupRoleGrantCacheMutex.RLock()
+	defer groupRoleGrantCacheMutex.RUnlock()
+
+	entry, ok := groupRoleGrantCache[roleId]
+	return entry, ok
+}
+
+// groupRoleGrantCacheGen returns the current eviction generation. Capture it
+// before reading grants from the database and pass it to setCachedGroupRoleGrants
+// so a concurrent eviction invalidates the write.
+func groupRoleGrantCacheGen() uint64 {
+	groupRoleGrantCacheMutex.RLock()
+	defer groupRoleGrantCacheMutex.RUnlock()
+
+	return groupRoleGrantCacheGeneration
+}
+
+// setCachedGroupRoleGrants stores entry only if no eviction has happened since
+// observedGen was captured; otherwise the value is considered potentially stale
+// and discarded (the next check re-reads from the database).
+func setCachedGroupRoleGrants(roleId uint, entry *grantEntry, observedGen uint64) {
+	groupRoleGrantCacheMutex.Lock()
+	defer groupRoleGrantCacheMutex.Unlock()
+
+	if groupRoleGrantCacheGeneration != observedGen {
+		return
+	}
+
+	groupRoleGrantCache[roleId] = entry
+}
+
+// clearGroupRoleGrantCache evicts a single group role's cached grants and bumps
+// the generation. Call this after a group role's grants change or the role is
+// deleted.
+func clearGroupRoleGrantCache(roleId uint) {
+	groupRoleGrantCacheMutex.Lock()
+	defer groupRoleGrantCacheMutex.Unlock()
+
+	groupRoleGrantCacheGeneration++
+	delete(groupRoleGrantCache, roleId)
+}
+
+// clearGroupRoleGrantCacheAll empties the cache entirely and bumps the
+// generation. Used by tests to keep cases independent.
+func clearGroupRoleGrantCacheAll() {
+	groupRoleGrantCacheMutex.Lock()
+	defer groupRoleGrantCacheMutex.Unlock()
+
+	groupRoleGrantCacheGeneration++
+	groupRoleGrantCache = map[uint]*grantEntry{}
+}
+
+// ClearGroupRoleGrantCacheForTests empties the entire grant cache. Exported so
+// tests in other packages can keep cases independent: a truncated test database
+// reuses role ids across cases, which would otherwise return another case's
+// cached grants.
+func ClearGroupRoleGrantCacheForTests() {
+	clearGroupRoleGrantCacheAll()
+}

--- a/api/internal/services/grant_filter.go
+++ b/api/internal/services/grant_filter.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"receipt-wrangler/api/internal/commands"
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/permissions"
 )
@@ -114,6 +115,154 @@ func (service PermissionService) selectionWithinGrants(
 	return true, nil
 }
 
+// MergeHiddenReceiptCategoriesTags appends to an update command the
+// receipt-level categories/tags that exist on the current receipt but are
+// outside the user's grants (and so were hidden from them on read). Without this
+// a restricted user's full-replace update would silently delete categories/tags
+// they could not see. No-op when the user is unrestricted or bypasses grants.
+//
+// NOTE: this only merges RECEIPT-level associations. Receipt items have no stable
+// id across an update (UpdateReceipt recreates them), so hidden item-level
+// categories/tags cannot be matched back and are not preserved.
+func (service PermissionService) MergeHiddenReceiptCategoriesTags(
+	userId uint,
+	groupId uint,
+	currentCategories []models.Category,
+	currentTags []models.Tag,
+	command *commands.UpsertReceiptCommand,
+) error {
+	bypassCategories, err := service.userBypassesGrants(userId, permissions.AppCategoriesRead)
+	if err != nil {
+		return err
+	}
+	if !bypassCategories {
+		allowed, unrestricted, err := service.GetGroupCategoryIdsForUser(userId, groupId)
+		if err != nil {
+			return err
+		}
+		if !unrestricted {
+			for i := range currentCategories {
+				category := currentCategories[i]
+				if _, ok := allowed[category.ID]; !ok {
+					categoryId := category.ID
+					command.Categories = append(command.Categories, commands.UpsertCategoryCommand{
+						Id:          &categoryId,
+						Name:        category.Name,
+						Description: category.Description,
+					})
+				}
+			}
+		}
+	}
+
+	bypassTags, err := service.userBypassesGrants(userId, permissions.AppTagsRead)
+	if err != nil {
+		return err
+	}
+	if !bypassTags {
+		allowed, unrestricted, err := service.GetGroupTagIdsForUser(userId, groupId)
+		if err != nil {
+			return err
+		}
+		if !unrestricted {
+			for i := range currentTags {
+				tag := currentTags[i]
+				if _, ok := allowed[tag.ID]; !ok {
+					tagId := tag.ID
+					command.Tags = append(command.Tags, commands.UpsertTagCommand{
+						Id:          &tagId,
+						Name:        tag.Name,
+						Description: tag.Description,
+					})
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// IntersectReceiptFilterWithGrants narrows a paged-request category/tag filter to
+// the ids the user may see, so a restricted user cannot probe receipt existence
+// by filtering on a category/tag they have no access to. When a filter is made
+// up entirely of disallowed ids it is forced to a no-match sentinel rather than
+// dropped (dropping would widen the result set). No-op for unrestricted/bypass.
+func (service PermissionService) IntersectReceiptFilterWithGrants(userId uint, groupId uint, filter *commands.ReceiptPagedRequestFilter) error {
+	bypassCategories, err := service.userBypassesGrants(userId, permissions.AppCategoriesRead)
+	if err != nil {
+		return err
+	}
+	if !bypassCategories {
+		allowed, unrestricted, err := service.GetGroupCategoryIdsForUser(userId, groupId)
+		if err != nil {
+			return err
+		}
+		if !unrestricted {
+			intersectFilterFieldWithGrants(&filter.Categories, allowed)
+		}
+	}
+
+	bypassTags, err := service.userBypassesGrants(userId, permissions.AppTagsRead)
+	if err != nil {
+		return err
+	}
+	if !bypassTags {
+		allowed, unrestricted, err := service.GetGroupTagIdsForUser(userId, groupId)
+		if err != nil {
+			return err
+		}
+		if !unrestricted {
+			intersectFilterFieldWithGrants(&filter.Tags, allowed)
+		}
+	}
+
+	return nil
+}
+
+func intersectFilterFieldWithGrants(field *commands.PagedRequestField, allowed map[uint]struct{}) {
+	if field.Value == nil {
+		return
+	}
+	values, ok := field.Value.([]interface{})
+	if !ok || len(values) == 0 {
+		return
+	}
+
+	filtered := make([]interface{}, 0, len(values))
+	for _, value := range values {
+		id, ok := filterValueToUint(value)
+		if !ok {
+			continue
+		}
+		if _, allowedOk := allowed[id]; allowedOk {
+			filtered = append(filtered, value)
+		}
+	}
+
+	if len(filtered) == 0 {
+		// The user filtered entirely by ids they cannot see; force a no-match so
+		// receipt existence is not revealed. Category/tag ids start at 1, so 0
+		// matches nothing.
+		filtered = []interface{}{float64(0)}
+	}
+
+	field.Value = filtered
+}
+
+// filterValueToUint coerces a JSON-decoded filter id (typically float64) to uint.
+func filterValueToUint(value interface{}) (uint, bool) {
+	switch typed := value.(type) {
+	case float64:
+		return uint(typed), true
+	case int:
+		return uint(typed), true
+	case uint:
+		return typed, true
+	default:
+		return 0, false
+	}
+}
+
 // receiptGrantFilter caches a user's bypass flags and per-group allowed sets for
 // the lifetime of one filter pass, so a batch of receipts resolves each group's
 // grants at most once.
@@ -162,13 +311,30 @@ func (filter *receiptGrantFilter) apply(receipt *models.Receipt) error {
 		return err
 	}
 
-	if !filter.bypassCategories && !grants.categoryUnrestricted {
-		receipt.Categories = filterCategoriesBySet(receipt.Categories, grants.categoryAllowed)
-	}
-	if !filter.bypassTags && !grants.tagUnrestricted {
-		receipt.Tags = filterTagsBySet(receipt.Tags, grants.tagAllowed)
+	filter.stripCategoriesTags(&receipt.Categories, &receipt.Tags, grants)
+
+	// Receipt items (and their linked items) carry their own categories/tags —
+	// strip them with the same rule so item-level associations don't leak.
+	for i := range receipt.ReceiptItems {
+		item := &receipt.ReceiptItems[i]
+		filter.stripCategoriesTags(&item.Categories, &item.Tags, grants)
+		for j := range item.LinkedItems {
+			linkedItem := &item.LinkedItems[j]
+			filter.stripCategoriesTags(&linkedItem.Categories, &linkedItem.Tags, grants)
+		}
 	}
 	return nil
+}
+
+// stripCategoriesTags rewrites a categories/tags pair in place to the allowed
+// subset, honoring the per-resource bypass and unrestricted flags.
+func (filter *receiptGrantFilter) stripCategoriesTags(categories *[]models.Category, tags *[]models.Tag, grants receiptGroupGrants) {
+	if !filter.bypassCategories && !grants.categoryUnrestricted {
+		*categories = filterCategoriesBySet(*categories, grants.categoryAllowed)
+	}
+	if !filter.bypassTags && !grants.tagUnrestricted {
+		*tags = filterTagsBySet(*tags, grants.tagAllowed)
+	}
 }
 
 func (filter *receiptGrantFilter) grantsForGroup(groupId uint) (receiptGroupGrants, error) {

--- a/api/internal/services/grant_filter.go
+++ b/api/internal/services/grant_filter.go
@@ -1,0 +1,217 @@
+package services
+
+import (
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/permissions"
+)
+
+// This file holds the shared category/tag grant enforcement used by every read
+// surface (list/search, single receipt, widgets, export, duplicate) and the
+// write surface (receipt create/update), so the rules live in exactly one place.
+
+// userBypassesGrants reports whether a user holds the app-level read permission
+// for a resource (app.categories.read / app.tags.read). Such users (admins,
+// category/tag managers) can already see the entire global pool, so grant
+// restrictions are not applied to them — keeping their view consistent with the
+// global lists they are entitled to.
+func (service PermissionService) userBypassesGrants(userId uint, appReadPermission string) (bool, error) {
+	return service.HasAppPermissions(userId, appReadPermission)
+}
+
+// FilterReceiptCategoriesTags strips every receipt's Categories/Tags down to the
+// set the user may see, in place. The allowed sets are resolved once per group
+// (cache-backed), so a page of receipts spanning N groups does at most N
+// resolutions. Receipts whose group is unrestricted (or where the user bypasses
+// grants) are left untouched.
+func (service PermissionService) FilterReceiptCategoriesTags(userId uint, receipts []models.Receipt) error {
+	if len(receipts) == 0 {
+		return nil
+	}
+
+	filter, err := service.newReceiptGrantFilter(userId)
+	if err != nil {
+		return err
+	}
+
+	for i := range receipts {
+		if err := filter.apply(&receipts[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// FilterReceiptCategoriesTagsForReceipt is the single-receipt variant of
+// FilterReceiptCategoriesTags (single GetReceipt, duplicate source, etc.).
+func (service PermissionService) FilterReceiptCategoriesTagsForReceipt(userId uint, receipt *models.Receipt) error {
+	if receipt == nil {
+		return nil
+	}
+
+	filter, err := service.newReceiptGrantFilter(userId)
+	if err != nil {
+		return err
+	}
+
+	return filter.apply(receipt)
+}
+
+// ValidateCategoryTagSelection reports whether every category/tag id is within
+// the user's allowed set for the group. Unrestricted resources, and users who
+// bypass grants, always pass. Used on receipt create/update for ids that
+// reference EXISTING categories/tags; new-by-name selections are not id-checked
+// here — they are gated by the create permission at the call site.
+func (service PermissionService) ValidateCategoryTagSelection(userId uint, groupId uint, categoryIds []uint, tagIds []uint) (bool, error) {
+	if len(categoryIds) > 0 {
+		ok, err := service.selectionWithinGrants(userId, groupId, permissions.AppCategoriesRead, categoryIds, service.GetGroupCategoryIdsForUser)
+		if err != nil || !ok {
+			return false, err
+		}
+	}
+
+	if len(tagIds) > 0 {
+		ok, err := service.selectionWithinGrants(userId, groupId, permissions.AppTagsRead, tagIds, service.GetGroupTagIdsForUser)
+		if err != nil || !ok {
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+// selectionWithinGrants checks that every id is allowed for the user in the
+// group, short-circuiting when the user bypasses grants or the resource is
+// unrestricted. resolve is the per-resource id resolver
+// (GetGroupCategoryIdsForUser / GetGroupTagIdsForUser).
+func (service PermissionService) selectionWithinGrants(
+	userId uint,
+	groupId uint,
+	appReadPermission string,
+	ids []uint,
+	resolve func(uint, uint) (map[uint]struct{}, bool, error),
+) (bool, error) {
+	bypass, err := service.userBypassesGrants(userId, appReadPermission)
+	if err != nil {
+		return false, err
+	}
+	if bypass {
+		return true, nil
+	}
+
+	allowed, unrestricted, err := resolve(userId, groupId)
+	if err != nil {
+		return false, err
+	}
+	if unrestricted {
+		return true, nil
+	}
+
+	for _, id := range ids {
+		if _, ok := allowed[id]; !ok {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// receiptGrantFilter caches a user's bypass flags and per-group allowed sets for
+// the lifetime of one filter pass, so a batch of receipts resolves each group's
+// grants at most once.
+type receiptGrantFilter struct {
+	service          PermissionService
+	userId           uint
+	bypassCategories bool
+	bypassTags       bool
+	groupCache       map[uint]receiptGroupGrants
+}
+
+type receiptGroupGrants struct {
+	categoryAllowed      map[uint]struct{}
+	categoryUnrestricted bool
+	tagAllowed           map[uint]struct{}
+	tagUnrestricted      bool
+}
+
+func (service PermissionService) newReceiptGrantFilter(userId uint) (*receiptGrantFilter, error) {
+	bypassCategories, err := service.userBypassesGrants(userId, permissions.AppCategoriesRead)
+	if err != nil {
+		return nil, err
+	}
+
+	bypassTags, err := service.userBypassesGrants(userId, permissions.AppTagsRead)
+	if err != nil {
+		return nil, err
+	}
+
+	return &receiptGrantFilter{
+		service:          service,
+		userId:           userId,
+		bypassCategories: bypassCategories,
+		bypassTags:       bypassTags,
+		groupCache:       map[uint]receiptGroupGrants{},
+	}, nil
+}
+
+func (filter *receiptGrantFilter) apply(receipt *models.Receipt) error {
+	if filter.bypassCategories && filter.bypassTags {
+		return nil
+	}
+
+	grants, err := filter.grantsForGroup(receipt.GroupId)
+	if err != nil {
+		return err
+	}
+
+	if !filter.bypassCategories && !grants.categoryUnrestricted {
+		receipt.Categories = filterCategoriesBySet(receipt.Categories, grants.categoryAllowed)
+	}
+	if !filter.bypassTags && !grants.tagUnrestricted {
+		receipt.Tags = filterTagsBySet(receipt.Tags, grants.tagAllowed)
+	}
+	return nil
+}
+
+func (filter *receiptGrantFilter) grantsForGroup(groupId uint) (receiptGroupGrants, error) {
+	if cached, ok := filter.groupCache[groupId]; ok {
+		return cached, nil
+	}
+
+	categoryAllowed, categoryUnrestricted, err := filter.service.GetGroupCategoryIdsForUser(filter.userId, groupId)
+	if err != nil {
+		return receiptGroupGrants{}, err
+	}
+
+	tagAllowed, tagUnrestricted, err := filter.service.GetGroupTagIdsForUser(filter.userId, groupId)
+	if err != nil {
+		return receiptGroupGrants{}, err
+	}
+
+	grants := receiptGroupGrants{
+		categoryAllowed:      categoryAllowed,
+		categoryUnrestricted: categoryUnrestricted,
+		tagAllowed:           tagAllowed,
+		tagUnrestricted:      tagUnrestricted,
+	}
+	filter.groupCache[groupId] = grants
+	return grants, nil
+}
+
+func filterCategoriesBySet(categories []models.Category, allowed map[uint]struct{}) []models.Category {
+	filtered := make([]models.Category, 0, len(categories))
+	for _, category := range categories {
+		if _, ok := allowed[category.ID]; ok {
+			filtered = append(filtered, category)
+		}
+	}
+	return filtered
+}
+
+func filterTagsBySet(tags []models.Tag, allowed map[uint]struct{}) []models.Tag {
+	filtered := make([]models.Tag, 0, len(tags))
+	for _, tag := range tags {
+		if _, ok := allowed[tag.ID]; ok {
+			filtered = append(filtered, tag)
+		}
+	}
+	return filtered
+}

--- a/api/internal/services/grant_filter_test.go
+++ b/api/internal/services/grant_filter_test.go
@@ -1,0 +1,242 @@
+package services
+
+import (
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/permissions"
+	"receipt-wrangler/api/internal/repositories"
+	"testing"
+)
+
+// categoryWithId / tagWithId build an in-memory association row referencing an
+// existing category/tag id (the grant filter only inspects ids).
+func categoryWithId(id uint) models.Category {
+	return models.Category{BaseModel: models.BaseModel{ID: id}}
+}
+
+func tagWithId(id uint) models.Tag {
+	return models.Tag{BaseModel: models.BaseModel{ID: id}}
+}
+
+func categoryIdSet(categories []models.Category) map[uint]struct{} {
+	set := make(map[uint]struct{}, len(categories))
+	for _, category := range categories {
+		set[category.ID] = struct{}{}
+	}
+	return set
+}
+
+// grantUserAppPermissions assigns userId an app role granting perms, so the
+// user bypasses grant filtering for those resources.
+func grantUserAppPermissions(t *testing.T, userId uint, perms []string) {
+	t.Helper()
+	role, err := repositories.NewRoleRepository(nil).CreateAppRole("Bypass Role", "", perms)
+	if err != nil {
+		t.Fatalf("create app role: %v", err)
+	}
+	if err := repositories.GetDB().Model(&models.User{}).Where("id = ?", userId).Update("app_role_id", role.ID).Error; err != nil {
+		t.Fatalf("assign app role: %v", err)
+	}
+	clearRolePermissionCacheAll()
+}
+
+func TestFilterReceiptStripsDisallowedCategories(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	cat2 := makeCategory(t, "Utilities")
+	tag1 := makeTag(t, "Reimbursable")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-strip", []uint{cat1}, nil)
+
+	receipts := []models.Receipt{{
+		GroupId:    groupId,
+		Categories: []models.Category{categoryWithId(cat1), categoryWithId(cat2)},
+		Tags:       []models.Tag{tagWithId(tag1)},
+	}}
+
+	service := NewPermissionService(nil)
+	if err := service.FilterReceiptCategoriesTags(userId, receipts); err != nil {
+		t.Fatalf("FilterReceiptCategoriesTags: %v", err)
+	}
+
+	if len(receipts[0].Categories) != 1 || receipts[0].Categories[0].ID != cat1 {
+		t.Errorf("expected only cat1 to survive, got %v", receipts[0].Categories)
+	}
+	// The role grants no tags, so tags are unrestricted and left untouched.
+	if len(receipts[0].Tags) != 1 || receipts[0].Tags[0].ID != tag1 {
+		t.Errorf("expected tags untouched (unrestricted), got %v", receipts[0].Tags)
+	}
+}
+
+func TestFilterReceiptUnrestrictedNoOp(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	cat2 := makeCategory(t, "Utilities")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-open", nil, nil)
+
+	receipts := []models.Receipt{{
+		GroupId:    groupId,
+		Categories: []models.Category{categoryWithId(cat1), categoryWithId(cat2)},
+	}}
+
+	service := NewPermissionService(nil)
+	if err := service.FilterReceiptCategoriesTags(userId, receipts); err != nil {
+		t.Fatalf("FilterReceiptCategoriesTags: %v", err)
+	}
+
+	if len(receipts[0].Categories) != 2 {
+		t.Errorf("expected unrestricted receipt untouched, got %v", receipts[0].Categories)
+	}
+}
+
+func TestFilterReceiptAdminBypass(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	cat2 := makeCategory(t, "Utilities")
+	// Restricted group role (only cat1) ...
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-admin", []uint{cat1}, nil)
+	// ... but the user holds app.categories.read, so grants do not apply.
+	grantUserAppPermissions(t, userId, []string{permissions.AppCategoriesRead})
+
+	receipts := []models.Receipt{{
+		GroupId:    groupId,
+		Categories: []models.Category{categoryWithId(cat1), categoryWithId(cat2)},
+	}}
+
+	service := NewPermissionService(nil)
+	if err := service.FilterReceiptCategoriesTags(userId, receipts); err != nil {
+		t.Fatalf("FilterReceiptCategoriesTags: %v", err)
+	}
+
+	if len(receipts[0].Categories) != 2 {
+		t.Errorf("expected admin (app.categories.read) to bypass stripping, got %v", receipts[0].Categories)
+	}
+}
+
+func TestFilterReceiptBatchPerGroup(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	catA := makeCategory(t, "A")
+	catB := makeCategory(t, "B")
+
+	// Same user restricted differently in two groups.
+	userId, groupA, _ := seedMemberWithGroupRoleGrants(t, "u-batch", []uint{catA}, nil)
+
+	db := repositories.GetDB()
+	groupB := models.Group{Name: "group-b"}
+	db.Create(&groupB)
+	roleB, err := repositories.NewRoleRepository(nil).CreateGroupRole("Role B", "", []string{permissions.GroupReceiptsRead}, []uint{catB}, nil)
+	if err != nil {
+		t.Fatalf("create role B: %v", err)
+	}
+	memberB := models.GroupMember{GroupID: groupB.ID, UserID: userId, GroupRoleID: &roleB.ID}
+	db.Create(&memberB)
+
+	receipts := []models.Receipt{
+		{GroupId: groupA, Categories: []models.Category{categoryWithId(catA), categoryWithId(catB)}},
+		{GroupId: groupB.ID, Categories: []models.Category{categoryWithId(catA), categoryWithId(catB)}},
+	}
+
+	service := NewPermissionService(nil)
+	if err := service.FilterReceiptCategoriesTags(userId, receipts); err != nil {
+		t.Fatalf("FilterReceiptCategoriesTags: %v", err)
+	}
+
+	if _, ok := categoryIdSet(receipts[0].Categories)[catA]; !ok || len(receipts[0].Categories) != 1 {
+		t.Errorf("group A receipt should keep only catA, got %v", receipts[0].Categories)
+	}
+	if _, ok := categoryIdSet(receipts[1].Categories)[catB]; !ok || len(receipts[1].Categories) != 1 {
+		t.Errorf("group B receipt should keep only catB, got %v", receipts[1].Categories)
+	}
+}
+
+func TestFilterReceiptForReceiptSingle(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	cat2 := makeCategory(t, "Utilities")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-single", []uint{cat1}, nil)
+
+	receipt := models.Receipt{
+		GroupId:    groupId,
+		Categories: []models.Category{categoryWithId(cat1), categoryWithId(cat2)},
+	}
+
+	service := NewPermissionService(nil)
+	if err := service.FilterReceiptCategoriesTagsForReceipt(userId, &receipt); err != nil {
+		t.Fatalf("FilterReceiptCategoriesTagsForReceipt: %v", err)
+	}
+
+	if len(receipt.Categories) != 1 || receipt.Categories[0].ID != cat1 {
+		t.Errorf("expected only cat1 to survive, got %v", receipt.Categories)
+	}
+}
+
+func TestValidateCategoryTagSelection(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	cat2 := makeCategory(t, "Utilities")
+	tag1 := makeTag(t, "Reimbursable")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-validate", []uint{cat1}, nil)
+
+	service := NewPermissionService(nil)
+
+	// In-set category passes.
+	ok, err := service.ValidateCategoryTagSelection(userId, groupId, []uint{cat1}, nil)
+	if err != nil {
+		t.Fatalf("validate in-set: %v", err)
+	}
+	if !ok {
+		t.Error("expected in-set category selection to be allowed")
+	}
+
+	// Out-of-set category fails.
+	ok, err = service.ValidateCategoryTagSelection(userId, groupId, []uint{cat2}, nil)
+	if err != nil {
+		t.Fatalf("validate out-of-set: %v", err)
+	}
+	if ok {
+		t.Error("expected out-of-set category selection to be rejected")
+	}
+
+	// Tags are unrestricted for this role, so any tag passes.
+	ok, err = service.ValidateCategoryTagSelection(userId, groupId, []uint{cat1}, []uint{tag1})
+	if err != nil {
+		t.Fatalf("validate tag: %v", err)
+	}
+	if !ok {
+		t.Error("expected tag selection allowed when tags unrestricted")
+	}
+}
+
+func TestValidateCategoryTagSelectionUnrestricted(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-validate-open", nil, nil)
+
+	service := NewPermissionService(nil)
+	// Unrestricted role: any id passes (here an id that does not even exist).
+	ok, err := service.ValidateCategoryTagSelection(userId, groupId, []uint{424242}, nil)
+	if err != nil {
+		t.Fatalf("validate unrestricted: %v", err)
+	}
+	if !ok {
+		t.Error("expected unrestricted role to allow any category selection")
+	}
+}

--- a/api/internal/services/grant_filter_test.go
+++ b/api/internal/services/grant_filter_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"receipt-wrangler/api/internal/commands"
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/permissions"
 	"receipt-wrangler/api/internal/repositories"
@@ -220,6 +221,143 @@ func TestValidateCategoryTagSelection(t *testing.T) {
 	}
 	if !ok {
 		t.Error("expected tag selection allowed when tags unrestricted")
+	}
+}
+
+func TestFilterReceiptStripsItemCategories(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	cat2 := makeCategory(t, "Utilities")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-item-strip", []uint{cat1}, nil)
+
+	receipts := []models.Receipt{{
+		GroupId: groupId,
+		ReceiptItems: []models.Item{{
+			Categories: []models.Category{categoryWithId(cat1), categoryWithId(cat2)},
+			LinkedItems: []models.Item{{
+				Categories: []models.Category{categoryWithId(cat1), categoryWithId(cat2)},
+			}},
+		}},
+	}}
+
+	service := NewPermissionService(nil)
+	if err := service.FilterReceiptCategoriesTags(userId, receipts); err != nil {
+		t.Fatalf("FilterReceiptCategoriesTags: %v", err)
+	}
+
+	item := receipts[0].ReceiptItems[0]
+	if len(item.Categories) != 1 || item.Categories[0].ID != cat1 {
+		t.Errorf("expected item categories stripped to cat1, got %v", item.Categories)
+	}
+	if len(item.LinkedItems[0].Categories) != 1 || item.LinkedItems[0].Categories[0].ID != cat1 {
+		t.Errorf("expected linked-item categories stripped to cat1, got %v", item.LinkedItems[0].Categories)
+	}
+}
+
+func TestMergeHiddenReceiptCategoriesTags(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	allowedCat := makeCategory(t, "Groceries")
+	hiddenCat := makeCategory(t, "Salary")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-merge", []uint{allowedCat}, nil)
+
+	// The current receipt has both an allowed and a hidden category; the user's
+	// submitted command only carries the allowed one (they couldn't see hidden).
+	currentCategories := []models.Category{
+		{BaseModel: models.BaseModel{ID: allowedCat}, Name: "Groceries"},
+		{BaseModel: models.BaseModel{ID: hiddenCat}, Name: "Salary"},
+	}
+	command := commands.UpsertReceiptCommand{
+		GroupId:    groupId,
+		Categories: []commands.UpsertCategoryCommand{{Id: &allowedCat, Name: "Groceries"}},
+	}
+
+	service := NewPermissionService(nil)
+	if err := service.MergeHiddenReceiptCategoriesTags(userId, groupId, currentCategories, nil, &command); err != nil {
+		t.Fatalf("MergeHiddenReceiptCategoriesTags: %v", err)
+	}
+
+	// The hidden category must be re-added so the update does not drop it.
+	foundHidden := false
+	for _, category := range command.Categories {
+		if category.Id != nil && *category.Id == hiddenCat {
+			foundHidden = true
+		}
+	}
+	if !foundHidden {
+		t.Errorf("expected hidden category to be merged back, got %v", command.Categories)
+	}
+	if len(command.Categories) != 2 {
+		t.Errorf("expected 2 categories after merge, got %d", len(command.Categories))
+	}
+}
+
+func TestMergeHiddenReceiptCategoriesTagsUnrestrictedNoOp(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-merge-open", nil, nil)
+
+	currentCategories := []models.Category{{BaseModel: models.BaseModel{ID: cat1}, Name: "Groceries"}}
+	command := commands.UpsertReceiptCommand{GroupId: groupId}
+
+	service := NewPermissionService(nil)
+	if err := service.MergeHiddenReceiptCategoriesTags(userId, groupId, currentCategories, nil, &command); err != nil {
+		t.Fatalf("MergeHiddenReceiptCategoriesTags: %v", err)
+	}
+
+	// Unrestricted users hide nothing, so nothing is merged back.
+	if len(command.Categories) != 0 {
+		t.Errorf("expected no merge for unrestricted user, got %v", command.Categories)
+	}
+}
+
+func TestIntersectReceiptFilterWithGrants(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	allowedCat := makeCategory(t, "Groceries")
+	hiddenCat := makeCategory(t, "Salary")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-filter", []uint{allowedCat}, nil)
+
+	service := NewPermissionService(nil)
+
+	// Mixed filter -> only the allowed id remains.
+	filter := commands.ReceiptPagedRequestFilter{
+		Categories: commands.PagedRequestField{
+			Operation: commands.CONTAINS,
+			Value:     []interface{}{float64(allowedCat), float64(hiddenCat)},
+		},
+	}
+	if err := service.IntersectReceiptFilterWithGrants(userId, groupId, &filter); err != nil {
+		t.Fatalf("IntersectReceiptFilterWithGrants: %v", err)
+	}
+	values := filter.Categories.Value.([]interface{})
+	if len(values) != 1 || uint(values[0].(float64)) != allowedCat {
+		t.Errorf("expected filter narrowed to allowed category, got %v", values)
+	}
+
+	// Filter made entirely of disallowed ids -> no-match sentinel (0).
+	filter = commands.ReceiptPagedRequestFilter{
+		Categories: commands.PagedRequestField{
+			Operation: commands.CONTAINS,
+			Value:     []interface{}{float64(hiddenCat)},
+		},
+	}
+	if err := service.IntersectReceiptFilterWithGrants(userId, groupId, &filter); err != nil {
+		t.Fatalf("IntersectReceiptFilterWithGrants: %v", err)
+	}
+	values = filter.Categories.Value.([]interface{})
+	if len(values) != 1 || uint(values[0].(float64)) != 0 {
+		t.Errorf("expected no-match sentinel [0], got %v", values)
 	}
 }
 

--- a/api/internal/services/grant_test.go
+++ b/api/internal/services/grant_test.go
@@ -1,0 +1,312 @@
+package services
+
+import (
+	"receipt-wrangler/api/internal/commands"
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/permissions"
+	"receipt-wrangler/api/internal/repositories"
+	"slices"
+	"testing"
+)
+
+// seedMemberWithGroupRoleGrants creates a group, a group role granting
+// receipts.read plus the given category/tag grants, and a member assigned to it.
+// Returns the user id, group id, and role id.
+func seedMemberWithGroupRoleGrants(t *testing.T, username string, categoryGrantIds []uint, tagGrantIds []uint) (uint, uint, uint) {
+	t.Helper()
+	db := repositories.GetDB()
+
+	group := models.Group{Name: "grant-group-" + username}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("seed group: %v", err)
+	}
+
+	roleRepository := repositories.NewRoleRepository(nil)
+	role, err := roleRepository.CreateGroupRole("Grant Role "+username, "", []string{permissions.GroupReceiptsRead}, categoryGrantIds, tagGrantIds)
+	if err != nil {
+		t.Fatalf("seed group role: %v", err)
+	}
+
+	user := models.User{Username: username, Password: "password"}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	member := models.GroupMember{GroupID: group.ID, UserID: user.ID, GroupRoleID: &role.ID}
+	if err := db.Create(&member).Error; err != nil {
+		t.Fatalf("seed group member: %v", err)
+	}
+
+	return user.ID, group.ID, role.ID
+}
+
+func makeCategory(t *testing.T, name string) uint {
+	t.Helper()
+	category := models.Category{Name: name}
+	if err := repositories.GetDB().Create(&category).Error; err != nil {
+		t.Fatalf("seed category: %v", err)
+	}
+	return category.ID
+}
+
+func makeTag(t *testing.T, name string) uint {
+	t.Helper()
+	tag := models.Tag{Name: name}
+	if err := repositories.GetDB().Create(&tag).Error; err != nil {
+		t.Fatalf("seed tag: %v", err)
+	}
+	return tag.ID
+}
+
+func TestGetGroupCategoryIdsUnrestrictedWhenNoGrants(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-open", nil, nil)
+	service := NewPermissionService(nil)
+
+	allowed, unrestricted, err := service.GetGroupCategoryIdsForUser(userId, groupId)
+	if err != nil {
+		t.Fatalf("GetGroupCategoryIdsForUser: %v", err)
+	}
+	if !unrestricted {
+		t.Error("expected unrestricted when role has no category grants")
+	}
+	if allowed != nil {
+		t.Errorf("expected nil allowed set when unrestricted, got %v", allowed)
+	}
+}
+
+func TestGetGroupCategoryIdsRestricted(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	cat2 := makeCategory(t, "Utilities")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-restricted", []uint{cat1, cat2}, nil)
+	service := NewPermissionService(nil)
+
+	allowed, unrestricted, err := service.GetGroupCategoryIdsForUser(userId, groupId)
+	if err != nil {
+		t.Fatalf("GetGroupCategoryIdsForUser: %v", err)
+	}
+	if unrestricted {
+		t.Error("expected restricted when role has category grants")
+	}
+	if len(allowed) != 2 {
+		t.Fatalf("expected 2 allowed categories, got %d", len(allowed))
+	}
+	if _, ok := allowed[cat1]; !ok {
+		t.Error("expected cat1 in allowed set")
+	}
+	if _, ok := allowed[cat2]; !ok {
+		t.Error("expected cat2 in allowed set")
+	}
+}
+
+func TestGetGroupCategoryIdsNonMemberUnrestricted(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	_, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-member", []uint{cat1}, nil)
+
+	// A user who is NOT a member of the group resolves to unrestricted: grants
+	// only narrow access within an already-permitted group, never grant it.
+	outsider := models.User{Username: "outsider", Password: "password"}
+	if err := repositories.GetDB().Create(&outsider).Error; err != nil {
+		t.Fatalf("seed outsider: %v", err)
+	}
+
+	service := NewPermissionService(nil)
+	_, unrestricted, err := service.GetGroupCategoryIdsForUser(outsider.ID, groupId)
+	if err != nil {
+		t.Fatalf("GetGroupCategoryIdsForUser: %v", err)
+	}
+	if !unrestricted {
+		t.Error("expected a non-member to resolve as unrestricted")
+	}
+}
+
+func TestCategoryRestrictedLeavesTagsUnrestricted(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-cat-only", []uint{cat1}, nil)
+	service := NewPermissionService(nil)
+
+	_, catUnrestricted, err := service.GetGroupCategoryIdsForUser(userId, groupId)
+	if err != nil {
+		t.Fatalf("category resolve: %v", err)
+	}
+	if catUnrestricted {
+		t.Error("expected categories restricted")
+	}
+
+	_, tagUnrestricted, err := service.GetGroupTagIdsForUser(userId, groupId)
+	if err != nil {
+		t.Fatalf("tag resolve: %v", err)
+	}
+	if !tagUnrestricted {
+		t.Error("expected tags unrestricted when role grants no tags")
+	}
+}
+
+func TestGetVisibleCategoriesForUserFilters(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	makeCategory(t, "Utilities")
+	cat3 := makeCategory(t, "Travel")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-vis", []uint{cat1, cat3}, nil)
+	service := NewPermissionService(nil)
+
+	allCategories, err := repositories.NewCategoryRepository(nil).GetAllCategories("*")
+	if err != nil {
+		t.Fatalf("get all categories: %v", err)
+	}
+
+	visible, err := service.GetVisibleCategoriesForUser(userId, groupId, allCategories)
+	if err != nil {
+		t.Fatalf("GetVisibleCategoriesForUser: %v", err)
+	}
+	if len(visible) != 2 {
+		t.Fatalf("expected 2 visible categories, got %d", len(visible))
+	}
+
+	gotIds := []uint{visible[0].ID, visible[1].ID}
+	slices.Sort(gotIds)
+	want := []uint{cat1, cat3}
+	slices.Sort(want)
+	if !slices.Equal(gotIds, want) {
+		t.Errorf("visible ids = %v, want %v", gotIds, want)
+	}
+}
+
+func TestGetVisibleCategoriesUnrestrictedPassThrough(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	makeCategory(t, "Groceries")
+	makeCategory(t, "Utilities")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-open2", nil, nil)
+	service := NewPermissionService(nil)
+
+	allCategories, err := repositories.NewCategoryRepository(nil).GetAllCategories("*")
+	if err != nil {
+		t.Fatalf("get all categories: %v", err)
+	}
+
+	visible, err := service.GetVisibleCategoriesForUser(userId, groupId, allCategories)
+	if err != nil {
+		t.Fatalf("GetVisibleCategoriesForUser: %v", err)
+	}
+	if len(visible) != len(allCategories) {
+		t.Errorf("expected pass-through of all %d categories, got %d", len(allCategories), len(visible))
+	}
+}
+
+func TestGetVisibleTagsForUserFilters(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	tag1 := makeTag(t, "Reimbursable")
+	makeTag(t, "Personal")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-tagvis", nil, []uint{tag1})
+	service := NewPermissionService(nil)
+
+	allTags, err := repositories.NewTagsRepository(nil).GetAllTags("*")
+	if err != nil {
+		t.Fatalf("get all tags: %v", err)
+	}
+
+	visible, err := service.GetVisibleTagsForUser(userId, groupId, allTags)
+	if err != nil {
+		t.Fatalf("GetVisibleTagsForUser: %v", err)
+	}
+	if len(visible) != 1 || visible[0].ID != tag1 {
+		t.Errorf("expected only tag1 visible, got %v", visible)
+	}
+}
+
+func TestGrantCacheInvalidatedOnRoleUpdate(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	cat2 := makeCategory(t, "Utilities")
+	userId, groupId, roleId := seedMemberWithGroupRoleGrants(t, "u-cache", []uint{cat1}, nil)
+
+	permissionService := NewPermissionService(nil)
+
+	// Populate the cache with the initial grant set.
+	allowed, _, err := permissionService.GetGroupCategoryIdsForUser(userId, groupId)
+	if err != nil {
+		t.Fatalf("initial resolve: %v", err)
+	}
+	if _, ok := allowed[cat1]; !ok || len(allowed) != 1 {
+		t.Fatalf("expected initial allowed {cat1}, got %v", allowed)
+	}
+
+	// Replace the grants via the service — should evict the grant cache.
+	roleService := NewRoleService(nil)
+	_, err = roleService.UpdateRole(roleId, commands.UpsertRoleCommand{
+		Name:           "Grant Role u-cache",
+		Scope:          permissions.ScopeGroup,
+		Permissions:    []string{permissions.GroupReceiptsRead},
+		CategoryGrants: []uint{cat2},
+	})
+	if err != nil {
+		t.Fatalf("update role: %v", err)
+	}
+
+	allowed, _, err = permissionService.GetGroupCategoryIdsForUser(userId, groupId)
+	if err != nil {
+		t.Fatalf("re-resolve: %v", err)
+	}
+	if _, ok := allowed[cat2]; !ok || len(allowed) != 1 {
+		t.Errorf("expected allowed {cat2} after update, got %v", allowed)
+	}
+}
+
+func TestGrantCacheReturnsCachedUntilCleared(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	cat2 := makeCategory(t, "Utilities")
+	userId, groupId, roleId := seedMemberWithGroupRoleGrants(t, "u-cachehit", []uint{cat1}, nil)
+	service := NewPermissionService(nil)
+
+	// Populate the cache.
+	if _, _, err := service.GetGroupCategoryIdsForUser(userId, groupId); err != nil {
+		t.Fatalf("populate: %v", err)
+	}
+
+	// Mutate grant rows directly, bypassing the service so the cache is NOT
+	// invalidated.
+	db := repositories.GetDB()
+	db.Where("group_role_id = ?", roleId).Delete(&models.GroupRoleCategoryGrant{})
+	db.Omit("Category").Create(&models.GroupRoleCategoryGrant{GroupRoleID: roleId, CategoryID: cat2})
+
+	allowed, _, err := service.GetGroupCategoryIdsForUser(userId, groupId)
+	if err != nil {
+		t.Fatalf("cached resolve: %v", err)
+	}
+	if _, ok := allowed[cat1]; !ok || len(allowed) != 1 {
+		t.Errorf("expected cached {cat1}, got %v", allowed)
+	}
+
+	// After an explicit eviction, the fresh DB value {cat2} is read.
+	clearGroupRoleGrantCache(roleId)
+	allowed, _, err = service.GetGroupCategoryIdsForUser(userId, groupId)
+	if err != nil {
+		t.Fatalf("fresh resolve: %v", err)
+	}
+	if _, ok := allowed[cat2]; !ok || len(allowed) != 1 {
+		t.Errorf("expected fresh {cat2}, got %v", allowed)
+	}
+}

--- a/api/internal/services/permission_test.go
+++ b/api/internal/services/permission_test.go
@@ -42,7 +42,7 @@ func seedMemberWithGroupRole(t *testing.T, username string, perms []string) (uin
 	}
 
 	roleRepository := repositories.NewRoleRepository(nil)
-	role, err := roleRepository.CreateGroupRole("Group Role", "", perms)
+	role, err := roleRepository.CreateGroupRole("Group Role", "", perms, nil, nil)
 	if err != nil {
 		t.Fatalf("seed group role: %v", err)
 	}

--- a/api/internal/services/pie_chart.go
+++ b/api/internal/services/pie_chart.go
@@ -6,6 +6,7 @@ import (
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/repositories"
 	"receipt-wrangler/api/internal/structs"
+	"receipt-wrangler/api/internal/utils"
 
 	"github.com/shopspring/decimal"
 )
@@ -28,6 +29,12 @@ func (service PieChartService) GetPieChartData(
 	command commands.PieChartDataCommand,
 ) (structs.PieChartData, error) {
 	receiptRepository := repositories.NewReceiptRepository(service.TX)
+	permissionService := NewPermissionService(service.TX)
+
+	uintGroupId, err := utils.StringToUint(groupId)
+	if err != nil {
+		return structs.PieChartData{}, err
+	}
 
 	pagedRequest := commands.ReceiptPagedRequestCommand{
 		PagedRequestCommand: commands.PagedRequestCommand{
@@ -39,12 +46,25 @@ func (service PieChartService) GetPieChartData(
 		Filter: command.Filter,
 	}
 
+	// Restrict any category/tag filter to what the caller may see (anti-probing).
+	err = permissionService.IntersectReceiptFilterWithGrants(userId, uintGroupId, &pagedRequest.Filter)
+	if err != nil {
+		return structs.PieChartData{}, err
+	}
+
 	receipts, _, err := receiptRepository.GetPagedReceiptsByGroupId(
 		userId,
 		groupId,
 		pagedRequest,
 		[]string{"Categories", "Tags"},
 	)
+	if err != nil {
+		return structs.PieChartData{}, err
+	}
+
+	// Strip categories/tags the caller cannot see so they are not aggregated into
+	// the chart (a disallowed category collapses to Uncategorized/Untagged).
+	err = permissionService.FilterReceiptCategoriesTags(userId, receipts)
 	if err != nil {
 		return structs.PieChartData{}, err
 	}

--- a/api/internal/services/receipt_image.go
+++ b/api/internal/services/receipt_image.go
@@ -104,12 +104,15 @@ func ReadReceiptFromTextOnly(bodyText string, groupId string) (commands.UpsertRe
 	return receiptProcessingService.ReadReceiptText(bodyText)
 }
 
-func MagicFillFromImage(command commands.MagicFillCommand, groupId string) (commands.UpsertReceiptCommand, commands.ReceiptProcessingMetadata, error) {
+func MagicFillFromImage(command commands.MagicFillCommand, groupId string, userId uint) (commands.UpsertReceiptCommand, commands.ReceiptProcessingMetadata, error) {
 	fileRepository := repositories.NewFileRepository(nil)
 	receiptProcessingService, err := NewSystemReceiptProcessingService(nil, groupId)
 	if err != nil {
 		return commands.UpsertReceiptCommand{}, commands.ReceiptProcessingMetadata{}, err
 	}
+	// Restrict the AI prompt's candidate categories/tags to this user's grants
+	// (0 when there is no triggering user, e.g. system processing).
+	receiptProcessingService.UserId = userId
 
 	bytes, err := fileRepository.GetBytesFromImageBytes(command.ImageData)
 	if err != nil {

--- a/api/internal/services/receipt_image_test.go
+++ b/api/internal/services/receipt_image_test.go
@@ -292,7 +292,7 @@ func TestMagicFillFromImage_HappyPath(t *testing.T) {
 	}
 
 	cmd := commands.MagicFillCommand{ImageData: jpg}
-	receipt, _, err := MagicFillFromImage(cmd, utils.UintToString(group.ID))
+	receipt, _, err := MagicFillFromImage(cmd, utils.UintToString(group.ID), 0)
 	if err != nil {
 		t.Fatalf("MagicFillFromImage: %v", err)
 	}
@@ -308,7 +308,7 @@ func TestMagicFillFromImage_InvalidImageData(t *testing.T) {
 	_, group, _ := seedReceiptImagePipeline(t, server.URL)
 
 	cmd := commands.MagicFillCommand{ImageData: []byte("not an image")}
-	_, _, err := MagicFillFromImage(cmd, utils.UintToString(group.ID))
+	_, _, err := MagicFillFromImage(cmd, utils.UintToString(group.ID), 0)
 	if err == nil {
 		t.Fatal("expected invalid file type error")
 	}

--- a/api/internal/services/receipt_processing.go
+++ b/api/internal/services/receipt_processing.go
@@ -20,6 +20,12 @@ type ReceiptProcessingService struct {
 	ReceiptProcessingSettings         models.ReceiptProcessingSettings
 	FallbackReceiptProcessingSettings models.ReceiptProcessingSettings
 	Group                             models.Group
+	// UserId is the user who triggered processing, when there is one (e.g. a
+	// quick scan). 0 means system-initiated (e.g. email polling) with no user
+	// context. When set together with a Group, the candidate categories/tags fed
+	// to the AI prompt are restricted to that user's grants so the model cannot
+	// suggest a category/tag the user is not allowed to see.
+	UserId uint
 }
 
 func NewSystemReceiptProcessingService(tx *gorm.DB, groupId string) (ReceiptProcessingService, error) {
@@ -464,6 +470,16 @@ func (service ReceiptProcessingService) getCategoriesString() (string, error) {
 		return "", err
 	}
 
+	// Restrict the candidate categories to the triggering user's grants (no-op
+	// for system-initiated processing or an unrestricted user).
+	if service.UserId > 0 && service.Group.ID > 0 {
+		permissionService := NewPermissionService(service.TX)
+		categories, err = permissionService.GetVisibleCategoriesForUser(service.UserId, service.Group.ID, categories)
+		if err != nil {
+			return "", err
+		}
+	}
+
 	categoriesBytes, err := json.Marshal(categories)
 	if err != nil {
 		return "", err
@@ -477,6 +493,14 @@ func (service ReceiptProcessingService) getTagsString() (string, error) {
 	tags, err := tagsRepository.GetAllTags("id, name")
 	if err != nil {
 		return "", err
+	}
+
+	if service.UserId > 0 && service.Group.ID > 0 {
+		permissionService := NewPermissionService(service.TX)
+		tags, err = permissionService.GetVisibleTagsForUser(service.UserId, service.Group.ID, tags)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	tagsBytes, err := json.Marshal(tags)

--- a/api/internal/services/receipt_processing_grant_test.go
+++ b/api/internal/services/receipt_processing_grant_test.go
@@ -1,0 +1,89 @@
+package services
+
+import (
+	"encoding/json"
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/repositories"
+	"testing"
+)
+
+func TestGetCategoriesStringRestrictedToUserGrants(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	grantedCategory := makeCategory(t, "Groceries")
+	makeCategory(t, "Salary")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-ai-cat", []uint{grantedCategory}, nil)
+
+	service := ReceiptProcessingService{
+		Group:  models.Group{BaseModel: models.BaseModel{ID: groupId}},
+		UserId: userId,
+	}
+
+	result, err := service.getCategoriesString()
+	if err != nil {
+		t.Fatalf("getCategoriesString: %v", err)
+	}
+
+	var categories []models.Category
+	if err := json.Unmarshal([]byte(result), &categories); err != nil {
+		t.Fatalf("unmarshal categories: %v", err)
+	}
+	if len(categories) != 1 || categories[0].ID != grantedCategory {
+		t.Errorf("expected the AI prompt to see only the granted category, got %v", categories)
+	}
+}
+
+func TestGetCategoriesStringUnrestrictedForSystemProcessing(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	makeCategory(t, "Groceries")
+	makeCategory(t, "Salary")
+
+	// UserId 0 = system-initiated (e.g. email polling): no restriction.
+	service := ReceiptProcessingService{}
+
+	result, err := service.getCategoriesString()
+	if err != nil {
+		t.Fatalf("getCategoriesString: %v", err)
+	}
+
+	var categories []models.Category
+	if err := json.Unmarshal([]byte(result), &categories); err != nil {
+		t.Fatalf("unmarshal categories: %v", err)
+	}
+	if len(categories) != 2 {
+		t.Errorf("expected all categories for system processing, got %d", len(categories))
+	}
+}
+
+func TestGetTagsStringRestrictedToUserGrants(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	grantedTag := makeTag(t, "Reimbursable")
+	makeTag(t, "Personal")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-ai-tag", nil, []uint{grantedTag})
+
+	service := ReceiptProcessingService{
+		Group:  models.Group{BaseModel: models.BaseModel{ID: groupId}},
+		UserId: userId,
+	}
+
+	result, err := service.getTagsString()
+	if err != nil {
+		t.Fatalf("getTagsString: %v", err)
+	}
+
+	var tags []models.Tag
+	if err := json.Unmarshal([]byte(result), &tags); err != nil {
+		t.Fatalf("unmarshal tags: %v", err)
+	}
+	if len(tags) != 1 || tags[0].ID != grantedTag {
+		t.Errorf("expected the AI prompt to see only the granted tag, got %v", tags)
+	}
+}

--- a/api/internal/services/receipts.go
+++ b/api/internal/services/receipts.go
@@ -141,7 +141,7 @@ func (service ReceiptService) QuickScan(
 	groupIdString := utils.UintToString(groupId)
 
 	now := time.Now()
-	receiptCommand, receiptProcessingMetadata, magicFillErr := MagicFillFromImage(magicFillCommand, groupIdString)
+	receiptCommand, receiptProcessingMetadata, magicFillErr := MagicFillFromImage(magicFillCommand, groupIdString, token.UserId)
 	finishedAt := time.Now()
 
 	quickScanSystemTasks, taskErr := systemTaskService.CreateSystemTasksFromMetadata(

--- a/api/internal/services/receipts.go
+++ b/api/internal/services/receipts.go
@@ -255,6 +255,14 @@ func (service ReceiptService) DuplicateReceipt(
 
 	systemTaskCommand.GroupId = &receipt.GroupId
 
+	// Strip categories/tags the duplicating user cannot see so they are not
+	// copied onto the new receipt.
+	permissionService := NewPermissionService(nil)
+	err = permissionService.FilterReceiptCategoriesTagsForReceipt(userId, &receipt)
+	if err != nil {
+		return models.Receipt{}, err
+	}
+
 	copier.Copy(&newReceipt, receipt)
 
 	newReceipt.ID = 0

--- a/api/internal/services/roles.go
+++ b/api/internal/services/roles.go
@@ -18,6 +18,7 @@ var (
 	ErrSystemRoleUndeletable = errors.New("system roles cannot be deleted")
 	ErrRoleAssigned          = errors.New("role is assigned and cannot be deleted")
 	ErrRoleIsDefault         = errors.New("the default role cannot be deleted")
+	ErrInvalidGrant          = errors.New("a category or tag grant references a non-existent category or tag")
 )
 
 type RoleService struct {
@@ -39,6 +40,8 @@ func (service RoleService) CreateRole(command commands.UpsertRoleCommand) (struc
 	if perms == nil {
 		perms = []string{}
 	}
+	categoryGrants := normalizeUintSlice(command.CategoryGrants)
+	tagGrants := normalizeUintSlice(command.TagGrants)
 
 	err := repositories.GetDB().Transaction(func(tx *gorm.DB) error {
 		roleRepository := repositories.NewRoleRepository(tx)
@@ -50,29 +53,37 @@ func (service RoleService) CreateRole(command commands.UpsertRoleCommand) (struc
 			}
 
 			roleView = structs.RoleView{
-				Id:          role.ID,
-				Name:        role.Name,
-				Description: role.Description,
-				Scope:       permissions.ScopeApp,
-				IsSystem:    role.IsSystem,
-				Permissions: perms,
+				Id:             role.ID,
+				Name:           role.Name,
+				Description:    role.Description,
+				Scope:          permissions.ScopeApp,
+				IsSystem:       role.IsSystem,
+				Permissions:    perms,
+				CategoryGrants: []uint{},
+				TagGrants:      []uint{},
 			}
 
 			return nil
 		}
 
-		role, txErr := roleRepository.CreateGroupRole(command.Name, command.Description, perms)
+		if txErr := validateGrantsExist(tx, categoryGrants, tagGrants); txErr != nil {
+			return txErr
+		}
+
+		role, txErr := roleRepository.CreateGroupRole(command.Name, command.Description, perms, categoryGrants, tagGrants)
 		if txErr != nil {
 			return txErr
 		}
 
 		roleView = structs.RoleView{
-			Id:          role.ID,
-			Name:        role.Name,
-			Description: role.Description,
-			Scope:       permissions.ScopeGroup,
-			IsSystem:    role.IsSystem,
-			Permissions: perms,
+			Id:             role.ID,
+			Name:           role.Name,
+			Description:    role.Description,
+			Scope:          permissions.ScopeGroup,
+			IsSystem:       role.IsSystem,
+			Permissions:    perms,
+			CategoryGrants: categoryGrants,
+			TagGrants:      tagGrants,
 		}
 
 		return nil
@@ -91,6 +102,8 @@ func (service RoleService) UpdateRole(id uint, command commands.UpsertRoleComman
 	if perms == nil {
 		perms = []string{}
 	}
+	categoryGrants := normalizeUintSlice(command.CategoryGrants)
+	tagGrants := normalizeUintSlice(command.TagGrants)
 
 	err := repositories.GetDB().Transaction(func(tx *gorm.DB) error {
 		roleRepository := repositories.NewRoleRepository(tx)
@@ -113,13 +126,15 @@ func (service RoleService) UpdateRole(id uint, command commands.UpsertRoleComman
 			}
 
 			roleView = structs.RoleView{
-				Id:          role.ID,
-				Name:        role.Name,
-				Description: role.Description,
-				Scope:       permissions.ScopeApp,
-				IsDefault:   role.IsDefault,
-				IsSystem:    role.IsSystem,
-				Permissions: perms,
+				Id:             role.ID,
+				Name:           role.Name,
+				Description:    role.Description,
+				Scope:          permissions.ScopeApp,
+				IsDefault:      role.IsDefault,
+				IsSystem:       role.IsSystem,
+				Permissions:    perms,
+				CategoryGrants: []uint{},
+				TagGrants:      []uint{},
 			}
 
 			return nil
@@ -136,19 +151,25 @@ func (service RoleService) UpdateRole(id uint, command commands.UpsertRoleComman
 			return ErrSystemRoleImmutable
 		}
 
-		role, txErr := roleRepository.UpdateGroupRole(id, command.Name, command.Description, perms)
+		if txErr := validateGrantsExist(tx, categoryGrants, tagGrants); txErr != nil {
+			return txErr
+		}
+
+		role, txErr := roleRepository.UpdateGroupRole(id, command.Name, command.Description, perms, categoryGrants, tagGrants)
 		if txErr != nil {
 			return txErr
 		}
 
 		roleView = structs.RoleView{
-			Id:          role.ID,
-			Name:        role.Name,
-			Description: role.Description,
-			Scope:       permissions.ScopeGroup,
-			IsDefault:   role.IsDefault,
-			IsSystem:    role.IsSystem,
-			Permissions: perms,
+			Id:             role.ID,
+			Name:           role.Name,
+			Description:    role.Description,
+			Scope:          permissions.ScopeGroup,
+			IsDefault:      role.IsDefault,
+			IsSystem:       role.IsSystem,
+			Permissions:    perms,
+			CategoryGrants: categoryGrants,
+			TagGrants:      tagGrants,
 		}
 
 		return nil
@@ -162,6 +183,44 @@ func (service RoleService) UpdateRole(id uint, command commands.UpsertRoleComman
 	clearRolePermissionCache(command.Scope, id)
 
 	return roleView, nil
+}
+
+// normalizeUintSlice returns a non-nil slice so empty grant sets serialize as
+// [] rather than null and never alias the caller's nil.
+func normalizeUintSlice(ids []uint) []uint {
+	if ids == nil {
+		return []uint{}
+	}
+	return ids
+}
+
+// validateGrantsExist confirms every category/tag grant id references a real
+// row. Because UpsertRoleCommand.Validate already rejects duplicate grant ids, a
+// matching count means all ids exist. Returns ErrInvalidGrant otherwise.
+func validateGrantsExist(tx *gorm.DB, categoryGrants []uint, tagGrants []uint) error {
+	if len(categoryGrants) > 0 {
+		categoryRepository := repositories.NewCategoryRepository(tx)
+		count, err := categoryRepository.CountByIds(categoryGrants)
+		if err != nil {
+			return err
+		}
+		if int(count) != len(categoryGrants) {
+			return ErrInvalidGrant
+		}
+	}
+
+	if len(tagGrants) > 0 {
+		tagsRepository := repositories.NewTagsRepository(tx)
+		count, err := tagsRepository.CountByIds(tagGrants)
+		if err != nil {
+			return err
+		}
+		if int(count) != len(tagGrants) {
+			return ErrInvalidGrant
+		}
+	}
+
+	return nil
 }
 
 // resolveMissingRoleError distinguishes a genuine not-found from a forbidden
@@ -320,31 +379,46 @@ func appRoleToView(role models.AppRole, isDefault bool) structs.RoleView {
 	}
 
 	return structs.RoleView{
-		Id:          role.ID,
-		Name:        role.Name,
-		Description: role.Description,
-		Scope:       permissions.ScopeApp,
-		IsDefault:   isDefault,
-		IsSystem:    role.IsSystem,
-		Permissions: perms,
+		Id:             role.ID,
+		Name:           role.Name,
+		Description:    role.Description,
+		Scope:          permissions.ScopeApp,
+		IsDefault:      isDefault,
+		IsSystem:       role.IsSystem,
+		Permissions:    perms,
+		CategoryGrants: []uint{},
+		TagGrants:      []uint{},
 	}
 }
 
 // groupRoleToView builds the read model for a group role, overriding IsDefault
-// with the post-update value.
+// with the post-update value. Grant ids are read from the role's preloaded
+// CategoryGrants/TagGrants (GetGroupRoleById preloads them).
 func groupRoleToView(role models.GroupRoleDefinition, isDefault bool) structs.RoleView {
 	perms := make([]string, 0, len(role.Permissions))
 	for _, permission := range role.Permissions {
 		perms = append(perms, permission.Permission)
 	}
 
+	categoryGrants := make([]uint, 0, len(role.CategoryGrants))
+	for _, grant := range role.CategoryGrants {
+		categoryGrants = append(categoryGrants, grant.CategoryID)
+	}
+
+	tagGrants := make([]uint, 0, len(role.TagGrants))
+	for _, grant := range role.TagGrants {
+		tagGrants = append(tagGrants, grant.TagID)
+	}
+
 	return structs.RoleView{
-		Id:          role.ID,
-		Name:        role.Name,
-		Description: role.Description,
-		Scope:       permissions.ScopeGroup,
-		IsDefault:   isDefault,
-		IsSystem:    role.IsSystem,
-		Permissions: perms,
+		Id:             role.ID,
+		Name:           role.Name,
+		Description:    role.Description,
+		Scope:          permissions.ScopeGroup,
+		IsDefault:      isDefault,
+		IsSystem:       role.IsSystem,
+		Permissions:    perms,
+		CategoryGrants: categoryGrants,
+		TagGrants:      tagGrants,
 	}
 }

--- a/api/internal/services/roles.go
+++ b/api/internal/services/roles.go
@@ -182,6 +182,12 @@ func (service RoleService) UpdateRole(id uint, command commands.UpsertRoleComman
 	// next permission check resolves the new set.
 	clearRolePermissionCache(command.Scope, id)
 
+	// Group roles also carry category/tag grants, which the update just
+	// replaced — evict the cached grant sets so enforcement uses the new grants.
+	if command.Scope == permissions.ScopeGroup {
+		clearGroupRoleGrantCache(id)
+	}
+
 	return roleView, nil
 }
 
@@ -315,6 +321,11 @@ func (service RoleService) DeleteRole(id uint, scope permissions.Scope) error {
 
 	// The role is gone; evict any cached permissions for it.
 	clearRolePermissionCache(scope, id)
+
+	// And its cached category/tag grants (group roles only).
+	if scope == permissions.ScopeGroup {
+		clearGroupRoleGrantCache(id)
+	}
 
 	return nil
 }

--- a/api/internal/services/roles_test.go
+++ b/api/internal/services/roles_test.go
@@ -10,6 +10,88 @@ import (
 	"testing"
 )
 
+func TestCreateGroupRoleWithGrantsExposesGrantIds(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	category := models.Category{Name: "Groceries"}
+	repositories.GetDB().Create(&category)
+	tag := models.Tag{Name: "Reimbursable"}
+	repositories.GetDB().Create(&tag)
+
+	service := NewRoleService(nil)
+	command := commands.UpsertRoleCommand{
+		Name:           "Restricted Group Role",
+		Scope:          permissions.ScopeGroup,
+		Permissions:    []string{permissions.GroupReceiptsRead},
+		CategoryGrants: []uint{category.ID},
+		TagGrants:      []uint{tag.ID},
+	}
+
+	roleView, err := service.CreateRole(command)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if len(roleView.CategoryGrants) != 1 || roleView.CategoryGrants[0] != category.ID {
+		utils.PrintTestError(t, roleView.CategoryGrants, []uint{category.ID})
+	}
+	if len(roleView.TagGrants) != 1 || roleView.TagGrants[0] != tag.ID {
+		utils.PrintTestError(t, roleView.TagGrants, []uint{tag.ID})
+	}
+}
+
+func TestCreateGroupRoleRejectsNonExistentGrant(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	service := NewRoleService(nil)
+	command := commands.UpsertRoleCommand{
+		Name:           "Bad Grant Role",
+		Scope:          permissions.ScopeGroup,
+		Permissions:    []string{permissions.GroupReceiptsRead},
+		CategoryGrants: []uint{999999},
+	}
+
+	_, err := service.CreateRole(command)
+	if !errors.Is(err, ErrInvalidGrant) {
+		utils.PrintTestError(t, err, ErrInvalidGrant)
+	}
+}
+
+func TestUpdateGroupRoleServiceReplacesGrants(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	roleRepository := repositories.NewRoleRepository(nil)
+
+	catA := models.Category{Name: "A"}
+	repositories.GetDB().Create(&catA)
+	catB := models.Category{Name: "B"}
+	repositories.GetDB().Create(&catB)
+
+	created, err := roleRepository.CreateGroupRole("Role", "", []string{permissions.GroupReceiptsRead}, []uint{catA.ID}, nil)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	service := NewRoleService(nil)
+	command := commands.UpsertRoleCommand{
+		Name:           "Role",
+		Scope:          permissions.ScopeGroup,
+		Permissions:    []string{permissions.GroupReceiptsRead},
+		CategoryGrants: []uint{catB.ID},
+	}
+
+	roleView, err := service.UpdateRole(created.ID, command)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if len(roleView.CategoryGrants) != 1 || roleView.CategoryGrants[0] != catB.ID {
+		utils.PrintTestError(t, roleView.CategoryGrants, []uint{catB.ID})
+	}
+}
+
 func TestUpdateRolePersistsChanges(t *testing.T) {
 	defer repositories.TruncateTestDb()
 	roleRepository := repositories.NewRoleRepository(nil)

--- a/api/internal/structs/app_data.go
+++ b/api/internal/structs/app_data.go
@@ -14,6 +14,8 @@ type AppData struct {
 	CurrencyHideDecimalPlaces    bool                          `json:"currencyHideDecimalPlaces"`
 	Categories                   []models.Category             `json:"categories"`
 	Tags                         []models.Tag                  `json:"tags"`
+	GroupCategories              map[uint][]models.Category     `json:"groupCategories"`
+	GroupTags                    map[uint][]models.Tag          `json:"groupTags"`
 	UserPreferences              models.UserPrefernces         `json:"userPreferences"`
 	Users                        []UserView                    `json:"users"`
 	FeatureConfig                FeatureConfig                 `json:"featureConfig"`

--- a/api/internal/structs/role_view.go
+++ b/api/internal/structs/role_view.go
@@ -11,4 +11,9 @@ type RoleView struct {
 	IsSystem      bool              `json:"isSystem"`
 	Permissions   []string          `json:"permissions"`
 	AssignedCount int               `json:"assignedCount"`
+	// CategoryGrants / TagGrants are the category/tag ids a group role restricts
+	// its members to. Empty means unrestricted (see all). Always group-scoped;
+	// app roles serialize empty slices.
+	CategoryGrants []uint `json:"categoryGrants"`
+	TagGrants      []uint `json:"tagGrants"`
 }

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -3068,6 +3068,23 @@ components:
         assignedCount:
           type: integer
           description: Number of users or group members currently assigned this role
+        categoryGrants:
+          type: array
+          description: >-
+            Category ids a GROUP role restricts its members to. Empty means
+            unrestricted (members may use every category). Always empty for app
+            roles.
+          items:
+            type: integer
+            format: uint64
+        tagGrants:
+          type: array
+          description: >-
+            Tag ids a GROUP role restricts its members to. Empty means
+            unrestricted (members may use every tag). Always empty for app roles.
+          items:
+            type: integer
+            format: uint64
     UpsertRoleCommand:
       type: object
       required:
@@ -3085,6 +3102,22 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Permission"
+        categoryGrants:
+          type: array
+          description: >-
+            Category ids to restrict a GROUP role's members to. Only valid on
+            group roles; omit or leave empty for unrestricted access.
+          items:
+            type: integer
+            format: uint64
+        tagGrants:
+          type: array
+          description: >-
+            Tag ids to restrict a GROUP role's members to. Only valid on group
+            roles; omit or leave empty for unrestricted access.
+          items:
+            type: integer
+            format: uint64
     SortDirection:
       type: string
       enum:

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -4627,6 +4627,26 @@ components:
             type: array
             items:
               $ref: "#/components/schemas/Permission"
+        groupCategories:
+          type: object
+          description: >-
+            The categories the calling user may use in each group, keyed by group
+            id. Filtered to the user's group-role grants (the full pool when
+            unrestricted). Non-admins receive categories only through this map.
+          additionalProperties:
+            type: array
+            items:
+              $ref: "#/components/schemas/Category"
+        groupTags:
+          type: object
+          description: >-
+            The tags the calling user may use in each group, keyed by group id.
+            Filtered to the user's group-role grants (the full pool when
+            unrestricted). Non-admins receive tags only through this map.
+          additionalProperties:
+            type: array
+            items:
+              $ref: "#/components/schemas/Tag"
     TokenPair:
       type: object
       required:

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -125,6 +125,14 @@ gated by `appPermissionGuard` requiring `app.roles.read` (see **Permission-based
   `src/open-api/` — regenerate it from `swagger.yml` instead.
 - Built on existing shared patterns: `app-breadcrumb` and the segmented `app-filter-bar` (see "Use
   Established Patterns" above).
+- **Category/tag grants (group roles only):** the role editor shows a "Category & tag access" section
+  (gated on `showGrants()` = group scope) with `app-category-autocomplete` / `app-tag-autocomplete`
+  (both fed the full pool via `CategoryService.getAllCategories()` / `TagService.getAllTags()` — the
+  editor is admin-only). Selecting grants restricts members to those categories/tags; **empty = all**.
+  The selections drive `FormArray`s loaded from `role.categoryGrants` / `role.tagGrants` (resolved to
+  pool objects by an effect once the pool arrives) and serialized back as id arrays on
+  `UpsertRoleCommand` for group scope only. The grant pickers pass `[creatable]="false"` (pick from
+  existing, never create). See `api/CLAUDE.md` → "Data model".
 - **Default roles:** the role-list page shows two `app-select` controls above the filter bar —
   "Default application role" and "Default group role". Each is pre-selected from the role flagged
   `isDefault` for its scope and, on change, calls `RoleService.setDefaultRole(scope, roleId)` then
@@ -156,6 +164,13 @@ gated by `appPermissionGuard` requiring `app.roles.read` (see **Permission-based
   `TokenRefreshService` (whose claims-only `SetAuthState` must not wipe permissions). They refresh on
   login + app-init; the server re-checks real permissions on every request, so the stored set is a UI
   hint (a stale button at worst 403s, handled by the interceptor).
+  - **Category/tag catalogs:** AppData also carries `groupCategories` / `groupTags` (keyed by group
+    id, filtered to the user's grants), stored via `SetGroupCatalog` and read with the
+    `AuthState.groupCategories(groupId)` / `groupTags(groupId)` selectors. The **receipt form** and
+    **receipts-table filters** source their category/tag options from these per-group catalogs (not
+    the global `GET /category` / `GET /tag`, which are now admin-only — the receipt routes no longer
+    use the category/tag resolvers). The receipt form's pickers gate `[creatable]` on
+    `app.categories.create` / `app.tags.create` so restricted users can only pick from the granted set.
   - **Matcher:** `src/utils/permission.utils.ts` — `matches`/`hasAll`/`hasAny`, a faithful port of the Go
     matcher (`api/internal/permissions/matcher.go`) including wildcard semantics, so UI gating === backend.
   - **Selectors** (`AuthState`): `hasAppPermission(perm)`, `hasAnyAppPermission(perms)`,

--- a/desktop/src/category-autocomplete/category-autocomplete.component.html
+++ b/desktop/src/category-autocomplete/category-autocomplete.component.html
@@ -8,7 +8,7 @@
   [optionTemplate]="categoryOptionTemplate"
   [optionChipTemplate]="categoryOptionTemplate"
   [multiple]="true"
-  [creatable]="true"
+  [creatable]="creatable()"
   [readonly]="readonly()"
 ></app-autocomlete>
 

--- a/desktop/src/category-autocomplete/category-autocomplete.component.ts
+++ b/desktop/src/category-autocomplete/category-autocomplete.component.ts
@@ -20,4 +20,9 @@ export class CategoryAutocompleteComponent {
   public readonly inputFormControl = input.required<FormControl>();
 
   public readonly readonly = input(false);
+
+  // Whether the user may create a brand-new category inline. Defaults to true to
+  // preserve existing call sites; gated callers (e.g. the receipt form) bind it
+  // to the app.categories.create permission.
+  public readonly creatable = input(true);
 }

--- a/desktop/src/open-api/model/appData.ts
+++ b/desktop/src/open-api/model/appData.ts
@@ -73,6 +73,14 @@ export interface AppData {
      * The calling user\'s effective group-level permissions, keyed by group id.
      */
     groupPermissions: { [key: string]: Array<Permission>; };
+    /**
+     * The categories the calling user may use in each group, keyed by group id. Filtered to the user\'s group-role grants (the full pool when unrestricted). Non-admins receive categories only through this map.
+     */
+    groupCategories?: { [key: string]: Array<Category>; };
+    /**
+     * The tags the calling user may use in each group, keyed by group id. Filtered to the user\'s group-role grants (the full pool when unrestricted). Non-admins receive tags only through this map.
+     */
+    groupTags?: { [key: string]: Array<Tag>; };
 }
 export namespace AppData {
 }

--- a/desktop/src/open-api/model/role.ts
+++ b/desktop/src/open-api/model/role.ts
@@ -26,6 +26,14 @@ export interface Role {
      * Number of users or group members currently assigned this role
      */
     assignedCount?: number;
+    /**
+     * Category ids a GROUP role restricts its members to. Empty means unrestricted (members may use every category). Always empty for app roles.
+     */
+    categoryGrants?: Array<number>;
+    /**
+     * Tag ids a GROUP role restricts its members to. Empty means unrestricted (members may use every tag). Always empty for app roles.
+     */
+    tagGrants?: Array<number>;
 }
 export namespace Role {
 }

--- a/desktop/src/open-api/model/upsertRoleCommand.ts
+++ b/desktop/src/open-api/model/upsertRoleCommand.ts
@@ -16,6 +16,14 @@ export interface UpsertRoleCommand {
     description?: string;
     scope: PermissionScope;
     permissions: Array<Permission>;
+    /**
+     * Category ids to restrict a GROUP role\'s members to. Only valid on group roles; omit or leave empty for unrestricted access.
+     */
+    categoryGrants?: Array<number>;
+    /**
+     * Tag ids to restrict a GROUP role\'s members to. Only valid on group roles; omit or leave empty for unrestricted access.
+     */
+    tagGrants?: Array<number>;
 }
 export namespace UpsertRoleCommand {
 }

--- a/desktop/src/receipts/receipt-form/receipt-form.component.html
+++ b/desktop/src/receipts/receipt-form/receipt-form.component.html
@@ -56,6 +56,7 @@
                 class="w-100"
                 [inputFormControl]="form | formGet : 'categories'"
                 [categories]="categories"
+                [creatable]="canCreateCategories()"
                 [readonly]="mode | inputReadonly"
               ></app-category-autocomplete>
             }
@@ -64,6 +65,7 @@
                 class="w-100"
                 [inputFormControl]="form | formGet : 'tags'"
                 [tags]="tags"
+                [creatable]="canCreateTags()"
                 [readonly]="mode | inputReadonly"
               ></app-tag-autocomplete>
             }

--- a/desktop/src/receipts/receipt-form/receipt-form.component.ts
+++ b/desktop/src/receipts/receipt-form/receipt-form.component.ts
@@ -86,6 +86,15 @@ export class ReceiptFormComponent implements OnInit {
 
   public tags: Tag[] = [];
 
+  // Inline category/tag creation is allowed only with the matching app create
+  // permission (the receipt form otherwise restricts users to the granted set).
+  public canCreateCategories = this.store.selectSignal(
+    AuthState.hasAppPermission(Permission.AppCategoriesCreate)
+  );
+  public canCreateTags = this.store.selectSignal(
+    AuthState.hasAppPermission(Permission.AppTagsCreate)
+  );
+
   public customFields: CustomField[] = [];
 
   public customFieldsStatefulMenuItems: StatefulMenuItem[] = [];
@@ -197,8 +206,8 @@ export class ReceiptFormComponent implements OnInit {
       .pipe(untilDestroyed(this))
       .subscribe((data) => {
         this.duplicatedSnackbarRef?.dismiss();
-        this.categories = data["categories"] ?? [];
-        this.tags = data["tags"] ?? [];
+        // categories/tags are sourced per-group from AppData (see
+        // setCategoryTagPoolsForGroup), driven by the group-change listener.
         this.customFields = data["customFields"] ?? [];
         this.originalReceipt = data["receipt"];
         this.editLink = `/receipts/${this.originalReceipt?.id}/edit`;
@@ -406,6 +415,19 @@ export class ReceiptFormComponent implements OnInit {
     this.listenForSyncWithItemsChanges();
   }
 
+  // Source the category/tag pickers from the selected group's AppData catalog
+  // (filtered to the user's grants by the backend). No group selected -> empty.
+  private setCategoryTagPoolsForGroup(groupId: number | string | null | undefined): void {
+    const numericGroupId = Number(groupId);
+    if (!groupId || Number.isNaN(numericGroupId)) {
+      this.categories = [];
+      this.tags = [];
+      return;
+    }
+    this.categories = this.store.selectSnapshot(AuthState.groupCategories(numericGroupId));
+    this.tags = this.store.selectSnapshot(AuthState.groupTags(numericGroupId));
+  }
+
   private listenForSyncWithItemsChanges(): void {
     this.form
       .get("syncAmountWithItems")?.valueChanges.pipe(untilDestroyed(this), tap((sync) => this.toggleAmountSync(sync))).subscribe();
@@ -430,6 +452,7 @@ export class ReceiptFormComponent implements OnInit {
       untilDestroyed(this),
       startWith(this.form.get("groupId")?.value),
       tap((groupId) => {
+        this.setCategoryTagPoolsForGroup(groupId);
         const paidBy = this.form.get("paidByUserId");
         const users = this.store.selectSnapshot(UserState.users);
         if (!groupId) {

--- a/desktop/src/receipts/receipts-routing.module.ts
+++ b/desktop/src/receipts/receipts-routing.module.ts
@@ -5,10 +5,8 @@ import { groupPermissionGuard } from "src/guards/group-permission.guard";
 import { GroupGuard } from "src/guards/group.guard";
 import { receiptGuardGuard } from "src/guards/receipt-guard.guard";
 import { Permission } from "../open-api";
-import { categoryResolverFn } from "../resolvers/categories.resolver";
 import { customFieldResolverFn } from "../resolvers/custom-field.resolver";
 import { receiptResolverFn } from "../resolvers/receipt.resolver";
-import { tagResolverFn } from "../resolvers/tags.resolver";
 import { ReceiptFormComponent } from "./receipt-form/receipt-form.component";
 import { ReceiptsTableComponent } from "./receipts-table/receipts-table.component";
 
@@ -17,10 +15,6 @@ const routes: Routes = [
     path: "group/:groupId",
     component: ReceiptsTableComponent,
     canActivate: [GroupGuard],
-    resolve: {
-      tags: tagResolverFn,
-      categories: categoryResolverFn,
-    },
     data: {
       groupGuardBasePath: `/receipts/group`,
     },
@@ -29,8 +23,6 @@ const routes: Routes = [
     path: "add",
     component: ReceiptFormComponent,
     resolve: {
-      tags: tagResolverFn,
-      categories: categoryResolverFn,
       customFields: customFieldResolverFn,
     },
     data: {
@@ -43,8 +35,6 @@ const routes: Routes = [
     path: ":id/view",
     component: ReceiptFormComponent,
     resolve: {
-      tags: tagResolverFn,
-      categories: categoryResolverFn,
       receipt: receiptResolverFn,
       customFields: customFieldResolverFn,
     },
@@ -58,8 +48,6 @@ const routes: Routes = [
     path: ":id/edit",
     component: ReceiptFormComponent,
     resolve: {
-      tags: tagResolverFn,
-      categories: categoryResolverFn,
       receipt: receiptResolverFn,
       customFields: customFieldResolverFn,
     },

--- a/desktop/src/receipts/receipts-table/receipts-table.component.ts
+++ b/desktop/src/receipts/receipts-table/receipts-table.component.ts
@@ -132,9 +132,15 @@ export class ReceiptsTableComponent implements OnInit, AfterViewInit {
 
     this.setHeaderText();
 
-    const data = this.activatedRoute.snapshot.data;
-    this.categories = data["categories"];
-    this.tags = data["tags"];
+    // Filter options come from the selected group's AppData catalog (filtered to
+    // the user's grants), so a restricted user can't filter by a hidden one.
+    const numericGroupId = Number(this.groupId);
+    this.categories = Number.isNaN(numericGroupId)
+      ? []
+      : this.store.selectSnapshot(AuthState.groupCategories(numericGroupId));
+    this.tags = Number.isNaN(numericGroupId)
+      ? []
+      : this.store.selectSnapshot(AuthState.groupTags(numericGroupId));
     this.getInitialData();
   }
 

--- a/desktop/src/roles/role-form/role-form.component.html
+++ b/desktop/src/roles/role-form/role-form.component.html
@@ -190,6 +190,37 @@
             </div>
           }
         </div>
+
+        <!-- Category & tag grants (group roles only) -->
+        @if (showGrants()) {
+          <div class="rw-card rw-form-section">
+            <div class="rw-perm-header">
+              <div>
+                <h2>Category &amp; tag access</h2>
+                <div class="hint hint-inline">
+                  Limit members to specific categories and tags. Leave empty for
+                  unrestricted access to all of them.
+                </div>
+              </div>
+            </div>
+
+            <app-category-autocomplete
+              class="w-100"
+              [inputFormControl]="$any(grantedCategories)"
+              [categories]="categoryPool()"
+              [creatable]="false"
+              [readonly]="isViewMode()"
+            ></app-category-autocomplete>
+
+            <app-tag-autocomplete
+              class="w-100"
+              [inputFormControl]="$any(grantedTags)"
+              [tags]="tagPool()"
+              [creatable]="false"
+              [readonly]="isViewMode()"
+            ></app-tag-autocomplete>
+          </div>
+        }
       </div>
 
       <!-- Summary side panel -->

--- a/desktop/src/roles/role-form/role-form.component.spec.ts
+++ b/desktop/src/roles/role-form/role-form.component.spec.ts
@@ -7,7 +7,7 @@ import {
   provideZonelessChangeDetection,
 } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
-import { ReactiveFormsModule } from "@angular/forms";
+import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import {
   ActivatedRoute,
   convertToParamMap,
@@ -302,6 +302,51 @@ describe("RoleFormComponent", () => {
 
     expect(component.lastPayload?.scope).toBe("GROUP");
     expect(component.lastPayload?.permissions).toEqual(["group.view"]);
+  });
+
+  it("shows the grant section only for group roles", async () => {
+    const { component } = await setup();
+    expect(component.showGrants()).toBe(false);
+    component.pickType("group");
+    expect(component.showGrants()).toBe(true);
+  });
+
+  it("includes category and tag grants in a GROUP payload", async () => {
+    const { component } = await setup();
+    component.pickType("group");
+    component.form.controls.name.setValue("Restricted Role");
+    component.toggle("group.receipts.read");
+
+    // The autocomplete drives these FormArrays; push selected grants directly.
+    component.grantedCategories.push(new FormControl({ id: 10, name: "Groceries" } as any));
+    component.grantedTags.push(new FormControl({ id: 20, name: "Reimbursable" } as any));
+
+    component.submit();
+
+    expect(component.lastPayload?.scope).toBe("GROUP");
+    expect(component.lastPayload?.categoryGrants).toEqual([10]);
+    expect(component.lastPayload?.tagGrants).toEqual([20]);
+  });
+
+  it("omits grants from an APP payload", async () => {
+    const { component } = await setup();
+    component.form.controls.name.setValue("App Role");
+    component.toggle("app.users.read");
+
+    component.submit();
+
+    expect(component.lastPayload?.categoryGrants).toBeUndefined();
+    expect(component.lastPayload?.tagGrants).toBeUndefined();
+  });
+
+  it("resets grants when switching role type", async () => {
+    const { component } = await setup();
+    component.pickType("group");
+    component.grantedCategories.push(new FormControl({ id: 10, name: "Groceries" } as any));
+    expect(component.grantedCategories.length).toBe(1);
+
+    component.pickType("app");
+    expect(component.grantedCategories.length).toBe(0);
   });
 
   it("calls createRole, notifies, and navigates back to the list on submit", async () => {

--- a/desktop/src/roles/role-form/role-form.component.ts
+++ b/desktop/src/roles/role-form/role-form.component.ts
@@ -1,17 +1,21 @@
 import { Component, DestroyRef, computed, effect, signal } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
-import { FormControl, FormGroup, Validators } from "@angular/forms";
+import { FormArray, FormControl, FormGroup, Validators } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
 import { catchError, EMPTY, take, tap } from "rxjs";
 import { FormMode } from "../../enums/form-mode.enum";
 import { SnackbarService } from "../../services/snackbar.service";
 import { BreadcrumbItem } from "../../shared-ui/breadcrumb/breadcrumb-item.interface";
 import {
+  Category,
+  CategoryService,
   Permission,
   PermissionDescriptor,
   PermissionScope,
   PermissionService,
   RoleService,
+  Tag,
+  TagService,
   UpsertRoleCommand,
 } from "../../open-api";
 import {
@@ -64,6 +68,22 @@ export class RoleFormComponent {
   public readonly granted = signal<Set<string>>(new Set<string>());
   public readonly selectedPreset = signal<string>(CUSTOM_PRESET_ID);
   public readonly openPanels = signal<Record<string, boolean>>({});
+
+  // ----- Category/tag grants (group roles only) -----
+  // The full pool an admin picks grants from, and the selected grants. The
+  // autocomplete drives these as FormArrays of the selected category/tag objects.
+  public readonly categoryPool = signal<Category[]>([]);
+  public readonly tagPool = signal<Tag[]>([]);
+  public readonly grantedCategories = new FormArray<FormControl<Category>>([]);
+  public readonly grantedTags = new FormArray<FormControl<Tag>>([]);
+
+  // Grant ids loaded for an existing role, resolved to pool objects by an effect
+  // once the pool arrives (pool and role load independently/asynchronously).
+  private readonly pendingCategoryGrantIds = signal<number[]>([]);
+  private readonly pendingTagGrantIds = signal<number[]>([]);
+
+  /** Grants are a group-role concept; hidden for app roles. */
+  public readonly showGrants = computed<boolean>(() => this.type() === "group");
 
   // ----- Mode-derived state -----
   public readonly isEditMode = computed<boolean>(() => this.mode() === FormMode.edit);
@@ -156,6 +176,8 @@ export class RoleFormComponent {
   constructor(
     private readonly permissionService: PermissionService,
     private readonly roleService: RoleService,
+    private readonly categoryService: CategoryService,
+    private readonly tagService: TagService,
     private readonly router: Router,
     private readonly route: ActivatedRoute,
     private readonly snackbar: SnackbarService,
@@ -170,6 +192,17 @@ export class RoleFormComponent {
       )
       .subscribe((descriptors) => this.registry.set(descriptors));
 
+    // The role editor is admin-only (app.roles.*), so it may read the full
+    // category/tag pool to choose grants from.
+    this.categoryService
+      .getAllCategories()
+      .pipe(take(1), catchError(() => EMPTY), takeUntilDestroyed())
+      .subscribe((categories) => this.categoryPool.set(categories));
+    this.tagService
+      .getAllTags()
+      .pipe(take(1), catchError(() => EMPTY), takeUntilDestroyed())
+      .subscribe((tags) => this.tagPool.set(tags));
+
     // A view-mode role is read-only; keep the reactive form in sync with that.
     effect(() => {
       if (this.isViewMode()) {
@@ -177,6 +210,20 @@ export class RoleFormComponent {
       } else {
         this.form.enable({ emitEvent: false });
       }
+    });
+
+    // Resolve a loaded role's grant ids to pool objects once the pool is
+    // available. Pool and grant ids are stable after load, so this does not
+    // clobber subsequent manual edits.
+    effect(() => {
+      const pool = this.categoryPool();
+      const ids = this.pendingCategoryGrantIds();
+      this.setGrantArray(this.grantedCategories, pool.filter((category) => category.id !== undefined && ids.includes(category.id)));
+    });
+    effect(() => {
+      const pool = this.tagPool();
+      const ids = this.pendingTagGrantIds();
+      this.setGrantArray(this.grantedTags, pool.filter((tag) => tag.id !== undefined && ids.includes(tag.id)));
     });
 
     const id = this.route.snapshot.paramMap.get("id");
@@ -224,7 +271,18 @@ export class RoleFormComponent {
         this.form.patchValue({ name: role.name, description: role.description ?? "" });
         this.type.set(role.scope === PermissionScope.Group ? "group" : "app");
         this.granted.set(new Set(role.permissions));
+        this.pendingCategoryGrantIds.set(role.categoryGrants ?? []);
+        this.pendingTagGrantIds.set(role.tagGrants ?? []);
       });
+  }
+
+  // Replace a grant FormArray's contents with the given option objects, without
+  // emitting (the autocomplete reads the value, not change events, on load).
+  private setGrantArray<T>(array: FormArray, values: T[]): void {
+    array.clear({ emitEvent: false });
+    for (const value of values) {
+      array.push(new FormControl(value), { emitEvent: false });
+    }
   }
 
   private scopeMatches(scope: PermissionScope, scopeParam: string | null): boolean {
@@ -263,6 +321,11 @@ export class RoleFormComponent {
     this.selectedPreset.set(CUSTOM_PRESET_ID);
     this.granted.set(new Set<string>());
     this.openPanels.set({});
+    // Grants only apply to group roles — reset them on a type switch.
+    this.pendingCategoryGrantIds.set([]);
+    this.pendingTagGrantIds.set([]);
+    this.setGrantArray(this.grantedCategories, []);
+    this.setGrantArray(this.grantedTags, []);
   }
 
   public pickPreset(preset: RolePreset): void {
@@ -326,6 +389,16 @@ export class RoleFormComponent {
       scope: this.typeMeta().scope,
       permissions: [...this.granted()] as Permission[],
     };
+
+    // Category/tag grants are only valid on group roles.
+    if (this.showGrants()) {
+      payload.categoryGrants = (this.grantedCategories.value as Category[])
+        .map((category) => category.id)
+        .filter((id): id is number => id !== undefined);
+      payload.tagGrants = (this.grantedTags.value as Tag[])
+        .map((tag) => tag.id)
+        .filter((id): id is number => id !== undefined);
+    }
 
     this.lastPayload = payload;
 

--- a/desktop/src/roles/roles.module.ts
+++ b/desktop/src/roles/roles.module.ts
@@ -6,7 +6,9 @@ import { MatTooltipModule } from "@angular/material/tooltip";
 import { RouterModule } from "@angular/router";
 import { PipesModule } from "src/pipes/pipes.module";
 import { ButtonModule } from "../button";
+import { CategoryAutocompleteComponent } from "../category-autocomplete/category-autocomplete.component";
 import { InputModule } from "../input";
+import { TagAutocompleteComponent } from "../tag-autocomplete/tag-autocomplete.component";
 import { SelectModule } from "../select/select.module";
 import { SharedUiModule } from "../shared-ui/shared-ui.module";
 import { TableModule } from "../table/table.module";
@@ -31,6 +33,8 @@ import { RolesRoutingModule } from "./roles-routing.module";
     TableModule,
     TextareaModule,
     RolesRoutingModule,
+    CategoryAutocompleteComponent,
+    TagAutocompleteComponent,
   ],
 })
 export class RolesModule {}

--- a/desktop/src/store/auth-state.interface.ts
+++ b/desktop/src/store/auth-state.interface.ts
@@ -1,4 +1,4 @@
-import { Icon } from "../open-api";
+import { Category, Icon, Tag } from "../open-api";
 import { UserPreferences } from "../open-api/model/userPreferences";
 
 export interface AuthStateInterface {
@@ -11,4 +11,9 @@ export interface AuthStateInterface {
   icons?: Icon[];
   appPermissions?: string[];
   groupPermissions?: { [groupId: number]: string[] };
+  // The categories/tags the user may use in each group (keyed by group id),
+  // filtered to their group-role grants. Non-admins receive categories/tags
+  // only through these maps.
+  groupCategories?: { [groupId: number]: Category[] };
+  groupTags?: { [groupId: number]: Tag[] };
 }

--- a/desktop/src/store/auth.state.actions.ts
+++ b/desktop/src/store/auth.state.actions.ts
@@ -1,4 +1,4 @@
-import { Claims, Icon } from "../open-api";
+import { Category, Claims, Icon, Tag } from "../open-api";
 import { UserPreferences } from "../open-api/model/userPreferences";
 
 export class SetAuthState {
@@ -25,6 +25,15 @@ export class SetPermissions {
   constructor(
     public appPermissions: string[],
     public groupPermissions: { [groupId: number]: string[] }
+  ) {}
+}
+
+export class SetGroupCatalog {
+  static readonly type = "[Auth] Set Group Catalog";
+
+  constructor(
+    public groupCategories: { [groupId: number]: Category[] },
+    public groupTags: { [groupId: number]: Tag[] }
   ) {}
 }
 

--- a/desktop/src/store/auth.state.spec.ts
+++ b/desktop/src/store/auth.state.spec.ts
@@ -2,13 +2,15 @@ import { TestBed } from "@angular/core/testing";
 import { NgxsModule, Store } from "@ngxs/store";
 import { Claims } from "../open-api";
 import { AuthState } from "./auth.state";
-import { Logout, SetAuthState, SetPermissions } from "./auth.state.actions";
+import { Logout, SetAuthState, SetGroupCatalog, SetPermissions } from "./auth.state.actions";
 
 describe("AuthState", () => {
   let store: Store;
 
   const APP_PERMISSIONS = ["app.users.read", "app.roles.read"];
   const GROUP_PERMISSIONS = { 1: ["group.view", "group.receipts.read"] };
+  const GROUP_CATEGORIES = { 1: [{ id: 10, name: "Groceries" }] };
+  const GROUP_TAGS = { 1: [{ id: 20, name: "Reimbursable" }] };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -33,6 +35,23 @@ describe("AuthState", () => {
     expect(store.selectSnapshot(AuthState.appPermissions)).toEqual([]);
     expect(store.selectSnapshot(AuthState.hasAppPermission("app.users.read"))).toBe(false);
     expect(store.selectSnapshot(AuthState.hasGroupPermission(1, "group.view"))).toBe(false);
+  });
+
+  it("SetGroupCatalog stores per-group categories and tags", () => {
+    store.dispatch(new SetGroupCatalog(GROUP_CATEGORIES as any, GROUP_TAGS as any));
+
+    expect(store.selectSnapshot(AuthState.groupCategories(1))).toEqual(GROUP_CATEGORIES[1]);
+    expect(store.selectSnapshot(AuthState.groupTags(1))).toEqual(GROUP_TAGS[1]);
+    // A group with no catalog resolves to an empty list.
+    expect(store.selectSnapshot(AuthState.groupCategories(999))).toEqual([]);
+  });
+
+  it("Logout clears the group catalog", () => {
+    store.dispatch(new SetGroupCatalog(GROUP_CATEGORIES as any, GROUP_TAGS as any));
+    store.dispatch(new Logout());
+
+    expect(store.selectSnapshot(AuthState.groupCategories(1))).toEqual([]);
+    expect(store.selectSnapshot(AuthState.groupTags(1))).toEqual([]);
   });
 
   it("SetAuthState (claims only) does NOT wipe permissions", () => {

--- a/desktop/src/store/auth.state.ts
+++ b/desktop/src/store/auth.state.ts
@@ -2,10 +2,10 @@ import { Injectable } from "@angular/core";
 import { Action, createSelector, Selector, State, StateContext } from "@ngxs/store";
 
 import { hasAll, hasAny } from "../utils/permission.utils";
-import { Icon, UserPreferences } from "../open-api";
+import { Category, Icon, Tag, UserPreferences } from "../open-api";
 import { User } from "../open-api/model/user";
 import { AuthStateInterface } from "./auth-state.interface";
-import { Logout, SetAuthState, SetIcons, SetPermissions, SetUserPreferences } from "./auth.state.actions";
+import { Logout, SetAuthState, SetGroupCatalog, SetIcons, SetPermissions, SetUserPreferences } from "./auth.state.actions";
 
 @State<AuthStateInterface>({
   name: "auth",
@@ -67,6 +67,18 @@ export class AuthState {
     return state.groupPermissions ?? {};
   }
 
+  static groupCategories(groupId: number) {
+    return createSelector([AuthState], (state: AuthStateInterface): Category[] => {
+      return state.groupCategories?.[groupId] ?? [];
+    });
+  }
+
+  static groupTags(groupId: number) {
+    return createSelector([AuthState], (state: AuthStateInterface): Tag[] => {
+      return state.groupTags?.[groupId] ?? [];
+    });
+  }
+
   static hasAppPermission(permission: string) {
     return createSelector([AuthState], (state: AuthStateInterface) => {
       return hasAll(state.appPermissions ?? [], permission);
@@ -122,6 +134,17 @@ export class AuthState {
     });
   }
 
+  @Action(SetGroupCatalog)
+  setGroupCatalog(
+    { patchState }: StateContext<AuthStateInterface>,
+    { groupCategories, groupTags }: SetGroupCatalog
+  ) {
+    patchState({
+      groupCategories,
+      groupTags,
+    });
+  }
+
   @Action(Logout)
   logout({ getState, patchState }: StateContext<AuthStateInterface>) {
     patchState({
@@ -133,6 +156,8 @@ export class AuthState {
       userPreferences: undefined,
       appPermissions: undefined,
       groupPermissions: undefined,
+      groupCategories: undefined,
+      groupTags: undefined,
     });
   }
 

--- a/desktop/src/tag-autocomplete/tag-autocomplete.component.html
+++ b/desktop/src/tag-autocomplete/tag-autocomplete.component.html
@@ -8,7 +8,7 @@
   [optionTemplate]="tagOptionTemplate"
   [optionChipTemplate]="tagOptionTemplate"
   [multiple]="true"
-  [creatable]="true"
+  [creatable]="creatable()"
   [readonly]="readonly()"
 ></app-autocomlete>
 

--- a/desktop/src/tag-autocomplete/tag-autocomplete.component.ts
+++ b/desktop/src/tag-autocomplete/tag-autocomplete.component.ts
@@ -20,4 +20,8 @@ export class TagAutocompleteComponent {
   public readonly inputFormControl = input.required<FormControl>();
 
   public readonly readonly = input(false);
+
+  // Whether the user may create a brand-new tag inline. Defaults to true to
+  // preserve existing call sites; gated callers bind it to app.tags.create.
+  public readonly creatable = input(true);
 }

--- a/desktop/src/utils/app-data.utill.ts
+++ b/desktop/src/utils/app-data.utill.ts
@@ -5,6 +5,7 @@ import {
   GroupState,
   SetAuthState,
   SetFeatureConfig,
+  SetGroupCatalog,
   SetGroups,
   SetIcons,
   SetPermissions,
@@ -26,6 +27,7 @@ export function setAppData(store: Store, appData: AppData): Observable<any[]> {
   return forkJoin([
     store.dispatch(new SetAuthState(appData.claims)),
     store.dispatch(new SetPermissions(appData.appPermissions ?? [], appData.groupPermissions ?? {})),
+    store.dispatch(new SetGroupCatalog(appData.groupCategories ?? {}, appData.groupTags ?? {})),
     store.dispatch(new SetFeatureConfig(appData.featureConfig)),
     store.dispatch(new SetGroups(appData.groups)),
     store.dispatch(new SetUserPreferences(appData.userPreferences)),


### PR DESCRIPTION
## What

Adds the ability to **restrict which categories and tags a user can read and use, scoped per group role** — closing a data-leakage gap (every user previously received the entire global category/tag pool). Admins assign a subset of the global pool to a group role; members are limited to that subset *in that group*. **Empty grants = unrestricted (opt-in lock-down)**, so existing installs/roles are unaffected and **no data migration is needed**.

Full stack: backend enforcement + desktop UI. Mobile intentionally out of scope (its client carries the new fields after regen; no UI work).

> Consolidated from what were 5 stacked PRs (#593–#597, now closed) into this single branch. The 7 commits below map to the original phases.

## Design decisions (confirmed with the requester)

- **Empty grants = see all.** A group role with no grants is unrestricted; a non-empty set restricts to exactly those ids. Categories and tags are independent.
- **Full enforcement** across reads, writes, AI prompt, reports, export, duplicate.
- **Inline create** in the receipt form requires `app.categories.create` / `app.tags.create`.
- **AI prompt** restricted to the triggering user (quick scan / magic fill); system/email processing stays unrestricted and is covered by read-stripping.
- **Update merge** preserves hidden receipt-level associations (response still stripped). **Known limitation:** item-level merge isn't possible (receipt items have no stable id across an update); item-level read-stripping + write-validation are in place.

## Backend (`api/`)

1. **Grant CRUD** — wire the previously-dead `GroupRoleCategoryGrant`/`GroupRoleTagGrant` tables through role CRUD (`UpsertRoleCommand`/`RoleView` carry `categoryGrants`/`tagGrants`; delete-then-insert sync; existence validation → 400).
2. **Resolution + cache** — `PermissionService.GetGroup{Category,Tag}IdsForUser` (`nil` = unrestricted), `GetVisible{Categories,Tags}ForUser`, a group-role-id-keyed grant cache invalidated on role update/delete.
3. **Shared helpers** (`grant_filter.go`) — strip receipts (receipt/item/linked-item), validate selections, intersect filters, admin-bypass for `app.categories.read`/`app.tags.read` holders.
4. **Enforcement** — `GetReceipt`, paged list ×2, pie chart, both CSV exports, duplicate strip; create/update validate + merge-preserve; list/pie/export filters intersected (anti-probing); AI prompt restricted to the triggering user.
5. **AppData + lock-down** — AppData carries per-group `groupCategories`/`groupTags`; flat `categories`/`tags` (and `GET /category`/`GET /tag`) become admin-only; Legacy User loses `app.categories.read`/`app.tags.read` (keeps create).

## Desktop (`desktop/`)

6. Role editor gains a group-scope "Category & tag access" picker (loads/saves grant ids). AppData catalogs stored via `SetGroupCatalog` with `AuthState.groupCategories/groupTags(groupId)` selectors. Receipt form + receipts-table filters source categories/tags from the per-group catalogs (resolvers removed); pickers gate `creatable` on the create permission.

## Verification

- **Backend:** `go test ./internal/{permissions,repositories,services,handlers,commands}/` all green; new tests for grant CRUD, resolution + cache invalidation, the shared helpers, every enforcement surface, AI-prompt restriction, AppData filtering, and the Legacy-User key change.
- **Desktop:** `npm run build` green; **928 unit tests pass** (incl. new AuthState catalog + role-form grant-payload specs).
- swagger updated; desktop client regenerated (no hand edits).

## Suggested manual/e2e check (against the dev stack)

Create a group role granting only "Groceries"; assign a user; as that user confirm the receipt picker shows only Groceries, create/update rejects other category ids (403), list/pie/export never surface non-granted categories, and quick-scan only offers Groceries — while an admin still sees everything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added group-level category and tag access restrictions for roles, allowing group members to be limited to specific categories and tags.
  * Receipt operations—including creation, updates, filtering, export, and AI magic fill—now enforce category and tag restrictions based on user permissions.
  * Receipt forms now display only permitted categories and tags per user's role.
  * Inline category and tag creation is now gated by user permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->