### PR TITLE
Gate notifications bell on app.notifications.read

### DIFF
--- a/desktop/src/layout/header/header.component.html
+++ b/desktop/src/layout/header/header.component.html
@@ -50,6 +50,7 @@
     <div class="col-auto d-flex align-items-center justify-content-end">
       <app-searchbar class="receipt-searchbar w-100 me-2"></app-searchbar>
       <app-button
+        *hasAppPermission="Permission.AppNotificationsRead"
         class="ms-4"
         #notificationsPopover="ngbPopover"
         matButtonType="iconButton"

--- a/desktop/src/layout/header/header.component.spec.ts
+++ b/desktop/src/layout/header/header.component.spec.ts
@@ -1,32 +1,59 @@
+import { provideHttpClient, withInterceptorsFromDi } from "@angular/common/http";
 import { provideHttpClientTesting } from "@angular/common/http/testing";
+import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { MatDialogModule } from "@angular/material/dialog";
 import { MatSnackBarModule } from "@angular/material/snack-bar";
-import { NgxsModule, Store } from "@ngxs/store";
+import { Store } from "@ngxs/store";
+import { NgbPopoverModule } from "@ng-bootstrap/ng-bootstrap";
+import { of } from "rxjs";
 import { ToggleIsSidebarOpen } from "src/store/layout.state.actions";
-import { ApiModule } from "../../open-api";
+import { DirectivesModule } from "../../directives/directives.module";
+import { ApiModule, NotificationsService } from "../../open-api";
+import { SetAuthState, SetPermissions } from "../../store/auth.state.actions";
 import { StoreModule } from "../../store/store.module";
 import { HeaderComponent } from "./header.component";
-import { provideHttpClient, withInterceptorsFromDi } from "@angular/common/http";
 
 describe("HeaderComponent", () => {
   let component: HeaderComponent;
   let fixture: ComponentFixture<HeaderComponent>;
+  let store: Store;
+  let notificationsService: NotificationsService;
+
+  const logIn = () =>
+    store.dispatch(
+      new SetAuthState({ exp: Math.floor(Date.now() / 1000) + 3600 } as any)
+    );
+
+  const grantNotificationsRead = () =>
+    store.dispatch(new SetPermissions(["app.notifications.read"], {}));
+
+  const bellRendered = (): boolean =>
+    !!fixture.nativeElement.querySelector('app-button[icon="notifications"]');
 
   beforeEach(async () => {
+    // StoreModule persists auth (incl. permissions) to localStorage; clear it so
+    // granted permissions don't leak across tests in this file.
+    localStorage.clear();
+
     await TestBed.configureTestingModule({
     declarations: [HeaderComponent],
     imports: [ApiModule,
+        DirectivesModule,
         MatDialogModule,
         MatSnackBarModule,
+        NgbPopoverModule,
         StoreModule,
     ],
-    providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
+    providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()],
+    schemas: [NO_ERRORS_SCHEMA],
 }).compileComponents();
 
+    store = TestBed.inject(Store);
+    notificationsService = TestBed.inject(NotificationsService);
     fixture = TestBed.createComponent(HeaderComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    fixture.autoDetectChanges();
   });
 
   it("should create", () => {
@@ -38,5 +65,44 @@ describe("HeaderComponent", () => {
     component.toggleSidebar();
 
     expect(store).toHaveBeenCalledWith(new ToggleIsSidebarOpen());
+  });
+
+  it("should hide the notifications bell without app.notifications.read", async () => {
+    logIn();
+    await fixture.whenStable();
+
+    expect(bellRendered()).toBe(false);
+  });
+
+  it("should show the notifications bell with app.notifications.read", async () => {
+    logIn();
+    grantNotificationsRead();
+    await fixture.whenStable();
+
+    expect(bellRendered()).toBe(true);
+  });
+
+  it("should not fetch the notification count without app.notifications.read", async () => {
+    const countSpy = jest
+      .spyOn(notificationsService, "getNotificationCount")
+      .mockReturnValue(of(0));
+
+    logIn();
+    await fixture.whenStable();
+
+    expect(countSpy).not.toHaveBeenCalled();
+  });
+
+  it("should fetch the notification count once permission is present", async () => {
+    const countSpy = jest
+      .spyOn(notificationsService, "getNotificationCount")
+      .mockReturnValue(of(3));
+
+    logIn();
+    grantNotificationsRead();
+    await fixture.whenStable();
+
+    expect(countSpy).toHaveBeenCalledTimes(1);
+    expect(component.notificationCount()).toBe(3);
   });
 });

--- a/desktop/src/layout/header/header.component.ts
+++ b/desktop/src/layout/header/header.component.ts
@@ -4,7 +4,7 @@ import { Store } from "@ngxs/store";
 import { take, tap } from "rxjs";
 import { LayoutState } from "src/store/layout.state";
 import { ToggleIsSidebarOpen } from "src/store/layout.state.actions";
-import { AuthService, NotificationsService } from "../../open-api";
+import { AuthService, NotificationsService, Permission } from "../../open-api";
 import { AuthState, GroupState } from "../../store";
 
 @Component({
@@ -47,6 +47,12 @@ export class HeaderComponent {
 
   public notificationCount = signal<number | undefined>(undefined);
 
+  protected readonly Permission = Permission;
+
+  private readonly canReadNotifications = this.store.selectSignal(
+    AuthState.hasAppPermission(Permission.AppNotificationsRead)
+  );
+
   constructor(
     private authService: AuthService,
     private notificationsService: NotificationsService,
@@ -57,11 +63,16 @@ export class HeaderComponent {
   }
 
   private listenForLoggedInUser(): void {
-    let wasLoggedIn = false;
+    let fetched = false;
     effect(() => {
       const loggedIn = this.isLoggedIn();
-      if (loggedIn && !wasLoggedIn) {
-        wasLoggedIn = true;
+      const canRead = this.canReadNotifications();
+      if (!loggedIn) {
+        fetched = false;
+        return;
+      }
+      if (canRead && !fetched) {
+        fetched = true;
         untracked(() => {
           this.notificationsService.getNotificationCount().pipe(
             take(1),
@@ -70,8 +81,6 @@ export class HeaderComponent {
             })
           ).subscribe();
         });
-      } else if (!loggedIn) {
-        wasLoggedIn = false;
       }
     });
   }


### PR DESCRIPTION
## Problem

The header rendered the notifications bell for **every** logged-in user, and the header eagerly called `GET /api/notifications/notificationCount` on login regardless of permissions. Users without `app.notifications.read` triggered a guaranteed **403** on that call (the backend handler enforces the permission).

## Change (desktop-only)

- Gate the bell with `*hasAppPermission="Permission.AppNotificationsRead"` in `header.component.html` — reusing the existing shared directive (`DirectivesModule` is already imported by `LayoutModule`).
- Only fetch the notification count once the user is **both** logged in **and** holds `app.notifications.read`. The check is signal-driven via the existing `AuthState.hasAppPermission` selector, so a permission that lands after login (AppData → `SetPermissions`) still triggers a single fetch, and the once-flag resets on logout.
- Add header unit tests: bell hidden/shown by permission, and the count call fires only with the permission.

No backend or swagger changes — the API already enforces `app.notifications.read`.

## Testing

- `npm run build` — clean.
- `npm test` — 205 suites / 932 tests pass, including 4 new header specs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notifications button is now conditionally displayed based on user permissions.
  * Notification count is only fetched for users with the required permission.

* **Tests**
  * Added test coverage for permission-gated notification UI and notification count fetching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->