### PR TITLE
Apply receiptItems on Magic Fill so line items reach the form

### DIFF
--- a/desktop/src/receipts/receipt-form/receipt-form.component.spec.ts
+++ b/desktop/src/receipts/receipt-form/receipt-form.component.spec.ts
@@ -236,6 +236,98 @@ describe("ReceiptFormComponent", () => {
     );
   });
 
+  it("should patch magic-filled receiptItems and list them in the success snackbar", () => {
+    // Mock timezone offset to be EST
+    Date.prototype.getTimezoneOffset = () => 240;
+    component.images.set([{ id: 1 } as any]);
+    component.ngOnInit();
+    component.mode = FormMode.edit;
+    Object.defineProperty(component, 'carouselComponent', {
+      value: () => ({
+        currentlyShownImageIndex: 0,
+      }),
+      configurable: true,
+    });
+
+    const magicReceipt = {
+      name: "magic",
+      amount: "54.5",
+      date: "2023-08-05T00:00:00.000Z",
+      receiptItems: [
+        { name: "Macchiato", amount: "4.5", status: "DRAFT" },
+        { name: "Schnitzel", amount: "22", status: "DRAFT" },
+      ],
+    } as any;
+
+    jest.spyOn(
+      TestBed.inject(ReceiptImageService),
+      "magicFillReceipt"
+    ).mockReturnValue(of(magicReceipt));
+
+    const snackbarSpy = jest.spyOn(
+      TestBed.inject(SnackbarService),
+      "success"
+    ).mockReturnValue(undefined);
+
+    component.magicFill();
+
+    const receiptValue = component.form.getRawValue();
+
+    expect(receiptValue.receiptItems.length).toEqual(2);
+    expect(receiptValue.receiptItems[0].name).toEqual("Macchiato");
+    expect(receiptValue.receiptItems[1].name).toEqual("Schnitzel");
+    expect(snackbarSpy).toHaveBeenCalledWith(
+      "Magic fill successfully filled name, amount, date, receiptItems from selected image!",
+      { duration: 10000 }
+    );
+  });
+
+  it("should keep good receiptItems and pop an error snackbar listing the corrupted ones", () => {
+    Date.prototype.getTimezoneOffset = () => 240;
+    component.images.set([{ id: 1 } as any]);
+    component.ngOnInit();
+    component.mode = FormMode.edit;
+    Object.defineProperty(component, 'carouselComponent', {
+      value: () => ({
+        currentlyShownImageIndex: 0,
+      }),
+      configurable: true,
+    });
+
+    const magicReceipt = {
+      name: "magic",
+      amount: "4.5",
+      date: "2023-08-05T00:00:00.000Z",
+      receiptItems: [
+        { name: "Macchiato", amount: "4.5", status: "DRAFT" },
+        null,
+        // non-string name + bad categories shape: buildItemForm throws,
+        // and the catch path must coerce safely instead of calling .trim() on a number
+        { name: 42, amount: 5, categories: "not-an-array", status: "DRAFT" },
+      ],
+    } as any;
+
+    jest.spyOn(
+      TestBed.inject(ReceiptImageService),
+      "magicFillReceipt"
+    ).mockReturnValue(of(magicReceipt));
+
+    const errorSpy = jest.spyOn(
+      TestBed.inject(SnackbarService),
+      "error"
+    ).mockReturnValue(undefined);
+
+    component.magicFill();
+
+    const receiptValue = component.form.getRawValue();
+
+    expect(receiptValue.receiptItems.length).toEqual(1);
+    expect(receiptValue.receiptItems[0].name).toEqual("Macchiato");
+    expect(errorSpy).toHaveBeenCalledWith(
+      "The following receipt items were corrupted: 5; 1 unnamed item"
+    );
+  });
+
   it("should set queue data when there is no data", () => {
     component.ngOnInit();
 

--- a/desktop/src/receipts/receipt-form/receipt-form.component.ts
+++ b/desktop/src/receipts/receipt-form/receipt-form.component.ts
@@ -544,6 +544,49 @@ export class ReceiptFormComponent implements OnInit {
       }
     });
 
+    const magicReceiptItems = Array.isArray(magicReceipt?.receiptItems)
+      ? magicReceipt.receiptItems
+      : [];
+    let pushedItemCount = 0;
+    const failedItemLabels: string[] = [];
+    let unlabeledFailedCount = 0;
+    magicReceiptItems.forEach((item) => {
+      if (!item) {
+        unlabeledFailedCount += 1;
+        return;
+      }
+      try {
+        this.receiptItemsFormArray.push(
+          buildItemForm(item, this.originalReceipt?.id?.toString(), !!item.chargedToUserId, this.syncAmountWithItems)
+        );
+        pushedItemCount += 1;
+      } catch {
+        const safeName = typeof item.name === "string" ? item.name.trim() : "";
+        const safeAmount = item.amount != null ? String(item.amount) : "";
+        const label = safeName || safeAmount;
+        if (label) {
+          failedItemLabels.push(label);
+        } else {
+          unlabeledFailedCount += 1;
+        }
+      }
+    });
+    if (pushedItemCount > 0) {
+      validKeys.push("receiptItems");
+    }
+    if (pushedItemCount > 0 && (failedItemLabels.length > 0 || unlabeledFailedCount > 0)) {
+      const parts: string[] = [];
+      if (failedItemLabels.length > 0) {
+        parts.push(failedItemLabels.join(", "));
+      }
+      if (unlabeledFailedCount > 0) {
+        parts.push(`${unlabeledFailedCount} unnamed item${unlabeledFailedCount === 1 ? "" : "s"}`);
+      }
+      this.snackbarService.error(
+        `The following receipt items were corrupted: ${parts.join("; ")}`
+      );
+    }
+
     if (validKeys.length > 0) {
       const successString = `Magic fill successfully filled ${validKeys.join(
         ", "


### PR DESCRIPTION
Magic Fill on the receipt form drops line items in the UI even though
the backend already returns them. patchMagicValues only iterates name,
amount, date, categories, tags, so receiptItems from the response never
reach the items FormArray. Quick Scan isn't affected because it builds
the receipt server-side.

This pushes each returned item via the existing buildItemForm helper
(already imported) and the existing receiptItemsFormArray getter, using
the same call shape as the form-builder seeding path. Each item is
wrapped in a try/catch so one malformed item from the AI doesn't drop
the rest, and partial items still get added so the form's own required
validators show the user which fields to finish. If any items couldn't
be added, a second snackbar lists them by name (or by amount, or as
"N unnamed items" when neither is available). chargedToUserId is left
unset so the user can assign each unit afterwards, and isShare is
passed as !!item.chargedToUserId so the required-user validator only
kicks in when the AI actually filled one (it doesn't, today).

Closes #515. Same diagnosis and diff are on that issue if anyone wants
the longer write-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced auto-fill to additionally detect and populate receipt items from magic-filled results
  * Improved robustness when receipt items contain corrupted entries, keeping valid items while reporting failures
  * Updated feedback messaging: success now reflects when receipt items were filled, and errors summarize corrupted items (by name when available, otherwise by count)
* **Tests**
  * Added unit tests covering successful and corrupted `receiptItems` auto-fill scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->