### PR TITLE
Gate mobile search/dashboards by permission + e2e negative coverage (mobile & desktop)

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -454,6 +454,33 @@ In CI the same spec files run against the demo URL. GitHub secrets populate the 
 - Submit buttons use `<app-button>` rendering `<button>` with visible text — `page.getByRole('button', { name: '...' })` works directly.
 - Error feedback is often a Material snackbar (not inline `<mat-error>`). When asserting errors, locate the snackbar container or its text, not the form.
 
+### Permission-gating specs (provisioned roles/users/groups)
+
+Negative-permission coverage needs an account/role that *lacks* the permission under test, which no
+seeded account provides — so an admin context **provisions a custom role (and user/group) through the
+real UI** in `beforeAll` and **tears it down through the admin API** in `afterAll`. Shared flows live
+in `e2e/helpers/provisioning.ts`: `createRole` (role form — type, preset, category toggles, individual
+toggle-offs), `createUserWithRole`, `createGroupWithMember`, `uniqueName`, and the API-teardown
+helpers `withAdminApi` + `apiDeleteUserByName` / `apiDeleteGroupById` / `apiDeleteRoleByName`.
+
+- An admin `BrowserContext` (`storageState: 'e2e/.auth/admin.json'`) provisions in `beforeAll`. Tests
+  then run **either** as the default e2e-user — for a *group-scoped* member added to a fixture group
+  (Angular re-fetches AppData on every navigation, so a membership added after the saved session still
+  drives the route guards without re-login) — **or** as a freshly-provisioned *custom user* whose
+  session is captured to a git-ignored `e2e/.auth/<name>.json` (wait for the held permission in
+  `localStorage.auth` before saving) and `rmSync`-ed in `afterAll`.
+- **Teardown is API-based, not UI.** The role-list delete button is disabled while a role is assigned,
+  and the UI's *bulk* user-delete dummy-converts a group-owning user (so the role stays assigned and
+  never deletable) — UI teardown leaks roles. `withAdminApi` logs in via `request.newContext` (through
+  the dev-server `/api` proxy) and `DELETE /api/user/{id}` **hard-deletes** (freeing the app-role) /
+  `DELETE /api/group/{id}` frees the group-role assignment, so the role then deletes. **Order:** delete
+  the user/group first, then the role; best-effort `try/catch` so a cleanup error doesn't mask the result.
+- Reference specs: `system-settings-tab-gating.spec.ts` (custom app role + user + storageState — note:
+  its UI teardown leaks roles, the reason the new specs use API teardown), `group-viewer-visibility.spec.ts`
+  (group member with a group role), `search-bar-visibility.spec.ts` (no `app.receipts.search` → header
+  search bar never renders), `dashboard-read-redirect.spec.ts` (no `group.dashboards.read` →
+  `/dashboard/group/:id` redirects to `/receipts/group/:id`; an owner contrast still sees the dashboard).
+
 ## Testing Requirements
 
 **All new code must have accompanying unit tests.**

--- a/desktop/e2e/dashboard-read-redirect.spec.ts
+++ b/desktop/e2e/dashboard-read-redirect.spec.ts
@@ -1,0 +1,100 @@
+import { BrowserContext, expect, Page, test } from '@playwright/test';
+import { stubTokenRefresh } from './helpers/auth';
+import {
+  apiDeleteGroupById,
+  apiDeleteRoleByName,
+  createGroupWithMember,
+  createRole,
+  uniqueName,
+  withAdminApi,
+} from './helpers/provisioning';
+
+// The group dashboard route is gated by groupDashboardReadGuard
+// (group-dashboard-read.guard.ts): a member without group.dashboards.read who
+// hits /dashboard/group/:id is redirected to /receipts/group/:id (a page they can
+// use) instead of letting the dashboard fetch 403. The suite had no coverage of
+// this guard; this spec adds the deny (redirect) path and an allow contrast.
+//
+// No seeded group role lacks group.dashboards.read, so an admin context
+// provisions a custom group role — the "Viewer" preset minus "Read Dashboards"
+// (keeping group.receipts.read so the redirect target loads) — and adds e2e-user
+// to a fixture group with it. The admin who creates the group is its Owner
+// (full perms incl. group.dashboards.read), giving the allow contrast for free.
+
+test.describe('Group dashboard read gating', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let adminContext: BrowserContext;
+  let adminPage: Page;
+  let roleName: string;
+  let groupName: string;
+  let groupId: string;
+
+  test.beforeAll(async ({ browser }) => {
+    roleName = uniqueName('no-dash-role');
+    groupName = uniqueName('no-dash-grp');
+
+    adminContext = await browser.newContext({
+      storageState: 'e2e/.auth/admin.json',
+    });
+    adminPage = await adminContext.newPage();
+    await stubTokenRefresh(adminPage);
+
+    await createRole(adminPage, {
+      name: roleName,
+      type: 'Group role',
+      preset: 'Viewer',
+      // Viewer grants group.dashboards.read + group.receipts.read; drop only the
+      // dashboards read so the member keeps a loadable receipts list after the
+      // redirect.
+      disablePermissions: [
+        { panelKey: 'group.dashboards', label: 'Read Dashboards' },
+      ],
+    });
+
+    groupId = await createGroupWithMember(adminPage, {
+      groupName,
+      memberDisplayName: 'E2E User',
+      roleName,
+    });
+  });
+
+  test.afterAll(async () => {
+    await adminContext?.close();
+    try {
+      await withAdminApi(async (api) => {
+        // Delete the group first (frees the members' group-role assignment),
+        // then the now-unassigned role.
+        await apiDeleteGroupById(api, groupId);
+        await apiDeleteRoleByName(api, roleName, 'GROUP');
+      });
+    } catch {
+      // Best-effort cleanup — don't mask a test failure with a cleanup error.
+    }
+  });
+
+  // Runs as the default project user (e2e-user = the no-dashboards member).
+  test('a member without group.dashboards.read is redirected to receipts', async ({
+    page,
+  }) => {
+    await stubTokenRefresh(page);
+    await page.goto(`/dashboard/group/${groupId}`);
+    // The guard redirects to the group's receipt list.
+    await expect(page).toHaveURL(new RegExp(`/receipts/group/${groupId}`));
+    await expect(page.getByTestId('configure-columns')).toBeVisible();
+  });
+
+  test.describe('owner with group.dashboards.read', () => {
+    // The admin created the group, so they are its Owner and hold the permission.
+    test.use({ storageState: 'e2e/.auth/admin.json' });
+
+    test('sees the dashboard (no redirect)', async ({ page }) => {
+      await stubTokenRefresh(page);
+      await page.goto(`/dashboard/group/${groupId}`);
+      await expect(page).toHaveURL(new RegExp(`/dashboard/group/${groupId}`));
+      await expect(
+        page.getByRole('heading', { name: /Dashboards$/ }),
+      ).toBeVisible();
+    });
+  });
+});

--- a/desktop/e2e/helpers/provisioning.ts
+++ b/desktop/e2e/helpers/provisioning.ts
@@ -1,0 +1,201 @@
+import {
+  type APIRequestContext,
+  expect,
+  type Page,
+  request as pwRequest,
+} from '@playwright/test';
+import { creds } from './auth';
+
+// Shared provisioning for permission e2e specs. Roles/users/groups are CREATED
+// through the real app UI (the realistic flow under test); TEARDOWN goes through
+// the admin API. UI teardown can't reliably remove a custom role: the role-list
+// delete button is disabled while the role is assigned, and the UI's *bulk*
+// user-delete dummy-converts a group-owning user (keeping the role assigned), so
+// the role is never freed. `DELETE /api/user/{id}` hard-deletes, and deleting a
+// group frees its members' group-role assignment — so the API tears down cleanly.
+
+export function uniqueName(tag: string): string {
+  return `e2e-${tag}-${Date.now()}`;
+}
+
+export interface CreateRoleOptions {
+  name: string;
+  /** Role-type card to pick, e.g. 'Application role' | 'Group role'. */
+  type: 'Application role' | 'Group role';
+  /** Starting template button, matched by (sub)string, e.g. 'Start from scratch' | 'Viewer'. */
+  preset: string;
+  /** Resource categories to flip fully on, e.g. ['Account', 'Notifications', 'Groups']. */
+  enableCategories?: string[];
+  /**
+   * Individual permissions to switch OFF after applying the preset. Identify the
+   * accordion by its resource key (key minus last segment, e.g. 'group.dashboards')
+   * and the row by its label (e.g. 'Read Dashboards').
+   */
+  disablePermissions?: { panelKey: string; label: string }[];
+}
+
+/**
+ * Creates a role via the role form: pick type → name it → apply a preset →
+ * optionally flip whole resource groups on → optionally switch individual
+ * permissions off. Leaves the browser on `/roles`.
+ */
+export async function createRole(page: Page, opts: CreateRoleOptions): Promise<void> {
+  await page.goto('/roles');
+  await page.getByRole('button', { name: 'Add Role' }).first().click();
+  await expect(page).toHaveURL(/\/roles\/new$/);
+  await expect(page.getByLabel('Role Name')).toBeVisible();
+
+  // Pick the scope first — it swaps the available presets.
+  await page.getByRole('button', { name: new RegExp(opts.type) }).click();
+  await page.getByLabel('Role Name').fill(opts.name);
+  await page.getByRole('button', { name: opts.preset }).click();
+
+  for (const category of opts.enableCategories ?? []) {
+    await page
+      .getByRole('button', { name: `Toggle all ${category} permissions` })
+      .click();
+  }
+
+  for (const { panelKey, label } of opts.disablePermissions ?? []) {
+    // Expand the accordion by clicking its sub-text (the resource key is unique
+    // on the page, so this won't collide with e.g. a sidebar "Dashboards" link),
+    // then switch the individual permission off.
+    const subText = new RegExp(`${panelKey.replace(/\./g, '\\.')} \\u00b7`);
+    await page.getByText(subText).click();
+    await page.getByRole('button', { name: `Toggle ${label}` }).click();
+  }
+
+  await page.getByRole('button', { name: 'Save Role' }).click();
+  await expect(page).toHaveURL(/\/roles$/);
+}
+
+/** Creates a user assigned [opts.role] via the Create User dialog. */
+export async function createUserWithRole(
+  page: Page,
+  opts: { username: string; password: string; role: string },
+): Promise<void> {
+  await page.goto('/users');
+  await page.getByRole('button', { name: 'Create User' }).click();
+  const dialog = page.getByRole('dialog').filter({ hasText: 'Create User' });
+  await expect(dialog).toBeVisible();
+  await dialog.getByLabel('Username').fill(opts.username);
+  await dialog.getByLabel('Displayname').fill(opts.username);
+  await dialog.getByLabel('Password').fill(opts.password);
+  await dialog.getByRole('combobox', { name: 'App Role' }).click();
+  // The option panel is a floating overlay rendered on the page, not the dialog.
+  await page.getByRole('option', { name: opts.role, exact: true }).click();
+  await dialog.locator('app-submit-button button').click();
+  await expect(dialog).toBeHidden();
+}
+
+/**
+ * Creates a group with [opts.memberDisplayName] added as [opts.roleName], and
+ * returns the new group's id. Mirrors the group-member form flow.
+ */
+export async function createGroupWithMember(
+  page: Page,
+  opts: { groupName: string; memberDisplayName: string; roleName: string },
+): Promise<string> {
+  await page.goto('/groups/create');
+  await expect(page.getByLabel('Group Name')).toBeVisible();
+  await page.getByLabel('Group Name').fill(opts.groupName);
+
+  await page.getByTestId('add-group-member').click();
+  const memberDialog = page
+    .getByRole('dialog')
+    .filter({ hasText: 'Add Group Member' });
+  await expect(memberDialog).toBeVisible();
+
+  // The user autocomplete filters/displays by display name; while the option
+  // panel is open the listbox shares the field's aria label, so target the combobox.
+  const userField = memberDialog.getByRole('combobox', { name: 'User' });
+  await userField.fill(opts.memberDisplayName);
+  await page
+    .getByRole('option', { name: opts.memberDisplayName, exact: true })
+    .click();
+
+  // Role defaults to "Legacy Owner" — switch it to the chosen role.
+  const roleSelect = memberDialog.getByRole('combobox', { name: 'Role' });
+  await roleSelect.click();
+  await page.getByRole('option', { name: opts.roleName, exact: true }).click();
+
+  await memberDialog.getByTestId('dialog-submit-button').click();
+  await expect(memberDialog).toBeHidden();
+
+  // The page-level save is icon-only; the app-form submits on Enter from a field.
+  await page.getByLabel('Group Name').press('Enter');
+  await page.waitForURL(/\/groups\/\d+\/details\/view/);
+  return page.url().match(/\/groups\/(\d+)\//)![1];
+}
+
+// --- API teardown -----------------------------------------------------------
+//
+// Cleanup runs over the admin API (see the file header for why the UI can't do
+// it). `request.newContext` against E2E_BASE_URL reuses the dev-server proxy to
+// `/api`; the admin login cookie is stored on the context for later DELETEs.
+
+const apiBaseUrl = (): string =>
+  process.env.E2E_BASE_URL ?? 'http://localhost:4200';
+
+/**
+ * Opens an admin-authenticated `APIRequestContext`, runs [fn], and disposes it.
+ * Use in `afterAll` for best-effort teardown of provisioned roles/users/groups.
+ */
+export async function withAdminApi<T>(
+  fn: (api: APIRequestContext) => Promise<T>,
+): Promise<T> {
+  const api = await pwRequest.newContext({ baseURL: apiBaseUrl() });
+  try {
+    const { username, password } = creds('admin');
+    const res = await api.post('/api/login', { data: { username, password } });
+    if (!res.ok()) {
+      throw new Error(`admin API login failed: HTTP ${res.status()}`);
+    }
+    return await fn(api);
+  } finally {
+    await api.dispose();
+  }
+}
+
+/** Hard-deletes the user with [username] (frees any app-role assignment). */
+export async function apiDeleteUserByName(
+  api: APIRequestContext,
+  username: string,
+): Promise<void> {
+  const users = (await (await api.get('/api/user/')).json()) as {
+    id: number;
+    username: string;
+  }[];
+  const user = users.find((u) => u.username === username);
+  if (user) {
+    await api.delete(`/api/user/${user.id}`);
+  }
+}
+
+/** Deletes the group [groupId] (frees its members' group-role assignment). */
+export async function apiDeleteGroupById(
+  api: APIRequestContext,
+  groupId: string,
+): Promise<void> {
+  await api.delete(`/api/group/${groupId}`);
+}
+
+/**
+ * Deletes the [scope] role named [name]. Only succeeds once it's unassigned, so
+ * call after the user/group that referenced it is gone.
+ */
+export async function apiDeleteRoleByName(
+  api: APIRequestContext,
+  name: string,
+  scope: 'APP' | 'GROUP',
+): Promise<void> {
+  const roles = (await (await api.get('/api/role')).json()) as {
+    id: number;
+    name: string;
+    scope: string;
+  }[];
+  const role = roles.find((r) => r.name === name && r.scope === scope);
+  if (role) {
+    await api.delete(`/api/role/${role.id}?scope=${scope}`);
+  }
+}

--- a/desktop/e2e/search-bar-visibility.spec.ts
+++ b/desktop/e2e/search-bar-visibility.spec.ts
@@ -21,7 +21,10 @@ import {
 // permission is app.receipts.search) and assigns it to a fresh user. The role
 // still grants Account/Notifications/Groups so the user can load the app.
 
-const NEW_USER_PASSWORD = 'a-really-secure-password';
+// Generated at runtime (no static secret in the repo). uniqueName gives a
+// per-run value; the -Aa1! suffix guarantees upper/lower/digit/symbol in case a
+// password policy is ever added.
+const NEW_USER_PASSWORD = `${uniqueName('pw')}-Aa1!`;
 
 // Session for the provisioned no-search user, written in beforeAll under the
 // git-ignored .auth/ dir and removed in afterAll.

--- a/desktop/e2e/search-bar-visibility.spec.ts
+++ b/desktop/e2e/search-bar-visibility.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test } from '@playwright/test';
+import { rmSync } from 'node:fs';
+import { stubTokenRefresh } from './helpers/auth';
+import {
+  apiDeleteRoleByName,
+  apiDeleteUserByName,
+  createRole,
+  createUserWithRole,
+  uniqueName,
+  withAdminApi,
+} from './helpers/provisioning';
+
+// The header search bar is gated on app.receipts.search
+// (`*hasAppPermission="Permission.AppReceiptsSearch"` in header.component.html).
+// legacy-user-visibility.spec.ts covers the POSITIVE side (Legacy User holds the
+// permission -> the bar renders). This is the negative side: a user WITHOUT it
+// never sees the bar.
+//
+// No seeded account lacks app.receipts.search, so an admin context provisions a
+// custom app role omitting the Receipts resource entirely (its only app
+// permission is app.receipts.search) and assigns it to a fresh user. The role
+// still grants Account/Notifications/Groups so the user can load the app.
+
+const NEW_USER_PASSWORD = 'a-really-secure-password';
+
+// Session for the provisioned no-search user, written in beforeAll under the
+// git-ignored .auth/ dir and removed in afterAll.
+const PARTIAL_AUTH_FILE = 'e2e/.auth/no-search-user.json';
+
+test.describe('Header search bar gating (no app.receipts.search)', () => {
+  test.use({ storageState: PARTIAL_AUTH_FILE });
+  test.describe.configure({ mode: 'serial' });
+
+  let roleName: string;
+  let username: string;
+
+  test.beforeAll(async ({ browser }) => {
+    roleName = uniqueName('no-search-role');
+    username = uniqueName('no-search-user');
+
+    const admin = await browser.newContext({
+      storageState: 'e2e/.auth/admin.json',
+    });
+    const adminPage = await admin.newPage();
+    await stubTokenRefresh(adminPage);
+    await createRole(adminPage, {
+      name: roleName,
+      type: 'Application role',
+      preset: 'Start from scratch',
+      // Baseline to load the app; deliberately no Receipts -> no app.receipts.search.
+      enableCategories: ['Account', 'Notifications', 'Groups'],
+    });
+    await createUserWithRole(adminPage, {
+      username,
+      password: NEW_USER_PASSWORD,
+      role: roleName,
+    });
+    await admin.close();
+
+    // Log in once as that user and persist the session for the test below.
+    // storageState: undefined opts out of the describe's (not-yet-created) file.
+    const userContext = await browser.newContext({ storageState: undefined });
+    const userPage = await userContext.newPage();
+    await userPage.goto('/auth/login');
+    await userPage.getByLabel('Username').fill(username);
+    await userPage.getByLabel('Password').fill(NEW_USER_PASSWORD);
+    await userPage.getByRole('button', { name: 'Login' }).click();
+    await expect(userPage).toHaveURL(/\/dashboard\/group\/\d+/, {
+      timeout: 15_000,
+    });
+    // Wait until permissions are persisted to the "auth" localStorage slice so
+    // the saved session hydrates them synchronously on the next load.
+    await userPage.waitForFunction(() =>
+      (localStorage.getItem('auth') ?? '').includes('app.account.read'),
+    );
+    await userContext.storageState({ path: PARTIAL_AUTH_FILE });
+    await userContext.close();
+  });
+
+  test.afterAll(async () => {
+    try {
+      await withAdminApi(async (api) => {
+        // Delete the user first (hard delete frees the role assignment), then
+        // the now-unassigned role.
+        await apiDeleteUserByName(api, username);
+        await apiDeleteRoleByName(api, roleName, 'APP');
+      });
+    } catch {
+      // Best-effort cleanup — don't mask a test failure.
+    }
+    rmSync(PARTIAL_AUTH_FILE, { force: true });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await stubTokenRefresh(page);
+  });
+
+  test('the search bar never renders without app.receipts.search', async ({
+    page,
+  }) => {
+    // Same page the positive test uses (the user holds app.groups.create).
+    await page.goto('/groups/create');
+    await expect(page.getByLabel('Group Name')).toBeVisible();
+    await expect(page.getByPlaceholder('Search receipts')).toHaveCount(0);
+  });
+});

--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -371,11 +371,13 @@ All three runners source `api/dev/switch-to-sqlite.sh` for the four `E2E_*` cred
 
 - `integration_test/smoke_login_test.dart` — canonical smoke test.
 - `integration_test/permission_add_menu_test.dart` / `permission_receipt_edit_test.dart` — permission-gating coverage (add-menu gate, edit-popup gate, swipe-to-edit gate) using per-spec provisioned users/groups.
+- `integration_test/permission_search_test.dart` — search bottom-nav destination gated on `app.receipts.search` (deny via a custom app role minus that permission; allow via a Legacy User).
+- `integration_test/permission_dashboard_redirect_test.dart` — group dashboards route gated on `group.dashboards.read` (deny → redirected to the receipts list via a custom group role minus that permission; allow via a Legacy Viewer). Landing is told apart by `GroupReceiptsList` vs `GroupDashboardWrapper`.
 - `integration_test/helpers/env.dart` — dart-define consumption + guards.
 - `integration_test/helpers/pump.dart` — `pumpUntilFound` polling helper.
 - `integration_test/helpers/platform_mocks.dart` — Linux-desktop platform-channel stubs for `permission_handler`, `gal`, `flutter_secure_storage`.
 - `integration_test/helpers/login.dart` / `api.dart` — UI + API login as admin, the shared e2e-user, or arbitrary credentials (`loginAs` / `apiLoginAs`).
-- `integration_test/helpers/permission_fixtures.dart` — admin-API provisioning for permission specs: fresh user + group with a chosen system group role ("Legacy Viewer"/"Legacy Editor"), optional seeded receipt, `addTearDown` cleanup.
+- `integration_test/helpers/permission_fixtures.dart` — admin-API provisioning for permission specs: fresh user + group with a chosen system group role ("Legacy Viewer"/"Legacy Editor"), optional seeded receipt, `addTearDown` cleanup. Also mints **custom roles** for negative specs: `createRole`/`deleteRole`, `rolePermissionsByName`, and the convenience `provisionUserWithoutAppPermission` / `provisionGroupMemberWithoutPermission` (build a role = a Legacy role **minus one permission**). The backend won't delete an assigned role, so the role-delete teardown is registered **before** the user/group ones — LIFO makes it run last, after the assignments are gone.
 - `integration_test/helpers/feature_flags.dart` — `enableAiPoweredReceiptsForTest()`: toggles the Quick Scan flag by pointing systemSettings at a junk receiptProcessingSettings record, restoring on teardown.
 - `integration_test/helpers/receipt_test_helpers.dart` — `addManualReceiptViaUI` (group-selectable), URL/id extraction, receipt cleanup.
 - `integration_test/helpers/nav.dart` — group-entry and group-receipt navigation helpers.

--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -103,10 +103,12 @@ re-checks real permissions on every request, so a stale action at worst returns 
   first (the backend `OrAppPermissions` admin-not-a-member pattern) — and
   `hasGroupPermissionInAnyGroup(p)` for screens with no single current group.
 - **Gating pattern:** read `Provider.of<PermissionsModel>(context, listen: false)` and conditionally
-  render, referencing the generated `Permission` constants. Gating is **widget-level only** — mobile
-  has no permission-scoped routes/screens (admin features live on desktop), so there are no
-  permission route guards.
-- **Current gates:**
+  render, referencing the generated `Permission` constants. Most gating is **widget-level**, but a
+  couple of permission-scoped routes also have **go_router redirects** (see "Route redirects" below) —
+  a `redirect:` callback reads the same `PermissionsModel` from the provider tree (the router is built
+  under the app's `MultiProvider`, exactly like the existing `/receipts/add` redirect), so the check
+  is identical to the widget-level one.
+- **Current widget gates:**
   - `canEditReceipt(permissionsModel, groupId)` (`lib/shared/functions/permissions.dart`) →
     `group.receipts.update`, used by the receipt-edit popup (`receipt_edit_popup_menu.dart`) and the
     receipt swipe-to-edit (`receipt_list_item.dart`).
@@ -114,6 +116,19 @@ re-checks real permissions on every request, so a stale action at worst returns 
   - The add menu (`show_add_menu.dart`) shows "Add Manual Receipt" on `group.receipts.create` and
     "Quick Scan" on `group.receipts.quick-scan` — per-group when inside a group, or "held in any
     group" on the group-select / all-groups view, where there is no single current group.
+  - The **Search** bottom-nav destination (`group_bottom_nav.dart`, `group_select_bottom_nav.dart`) is
+    shown only on `app.receipts.search`. It is the **trailing** destination in both navs, so gating it
+    out doesn't shift the other indices and the `switch`/`setIndexSelected` logic is unchanged.
+- **Route redirects** (`lib/guards/permission-guard.dart`, mirroring the desktop route guards; wired
+  in `main.dart`'s `_buildAppRouter`):
+  - `groupDashboardReadRedirect` on `/groups/:groupId/dashboards` → redirects to that group's
+    `/receipts` when the caller lacks `group.dashboards.read` for the route's group (mirrors desktop's
+    `groupDashboardReadGuard`). Group selection always lands on the dashboards route, so this covers
+    both group entry and the Dashboards tab tap; the Dashboards tab itself stays visible (redirect-only,
+    matching desktop).
+  - `receiptsSearchRedirect` on `/search` → bounces deep links to the originating group's `/receipts`
+    (or `/groups`) when the caller lacks `app.receipts.search`. Defense-in-depth behind the hidden
+    search buttons; it also runs before the search shell's `state.extra as Map` cast.
 
 ## Development Notes
 

--- a/mobile/integration_test/helpers/permission_fixtures.dart
+++ b/mobile/integration_test/helpers/permission_fixtures.dart
@@ -61,9 +61,9 @@ Map<String, String> _auth(String jwt) => {'Cookie': 'jwt=$jwt'};
 
 String _unique() => DateTime.now().microsecondsSinceEpoch.toString();
 
-/// Resolves the id of a system role by [name] within [scope] (`APP` or `GROUP`)
-/// via `GET /role`.
-Future<int> _roleIdByName(
+/// Fetches the full `RoleView` map for the system role [name] within [scope]
+/// (`APP` or `GROUP`) via `GET /role`.
+Future<Map<String, dynamic>> _findRole(
   String name,
   String scope, {
   required String jwt,
@@ -75,15 +75,31 @@ Future<int> _roleIdByName(
     throw StateError('GET /role failed: HTTP ${res.statusCode}: ${res.body}');
   }
   final roles = (jsonDecode(res.body) as List).cast<Map<String, dynamic>>();
-  final match = roles.firstWhere(
+  return roles.firstWhere(
     (r) => r['name'] == name && r['scope'] == scope,
     orElse: () => throw StateError(
       'No $scope role named "$name". Available: '
       '${roles.where((r) => r['scope'] == scope).map((r) => r['name']).toList()}',
     ),
   );
-  return match['id'] as int;
 }
+
+/// Resolves the id of a system role by [name] within [scope] (`APP` or `GROUP`)
+/// via `GET /role`.
+Future<int> _roleIdByName(String name, String scope, {required String jwt}) async =>
+    (await _findRole(name, scope, jwt: jwt))['id'] as int;
+
+/// Returns the permission strings held by the system role [name] within [scope].
+/// Used by the negative-permission specs to derive a "Legacy role minus one
+/// permission" set — the custom role is then identical to the Legacy baseline
+/// except the single permission under test (robust against registry drift).
+Future<List<String>> rolePermissionsByName(
+  String name,
+  String scope, {
+  required String jwt,
+}) async =>
+    ((await _findRole(name, scope, jwt: jwt))['permissions'] as List)
+        .cast<String>();
 
 /// Resolves the id of a system group role by name (e.g. "Legacy Viewer",
 /// "Legacy Editor", "Legacy Owner") via `GET /role`.
@@ -112,17 +128,20 @@ Future<int> userIdByUsername(String username, {required String jwt}) async {
   return match['id'] as int;
 }
 
-/// Creates a regular account assigned the Legacy User app role and returns its
-/// id. Legacy User carries no group permissions, so the user only gets the
-/// group permissions a fixture grants it. The admin create endpoint requires an
-/// `appRoleId`, so we resolve Legacy User (the default app role) by name.
+/// Creates a regular account and returns its id. The admin create endpoint
+/// requires an `appRoleId`; [appRoleId] assigns a specific app role (e.g. a
+/// custom one minus a permission), defaulting to Legacy User (the default app
+/// role, which carries no group permissions — the user only gets the group
+/// permissions a fixture grants it).
 Future<int> createUser({
   required String username,
   required String password,
   required String displayName,
   required String jwt,
+  int? appRoleId,
 }) async {
-  final appRoleId = await appRoleIdByName('Legacy User', jwt: jwt);
+  final resolvedAppRoleId =
+      appRoleId ?? await appRoleIdByName('Legacy User', jwt: jwt);
   final res = await http
       .post(
         Uri.parse('${E2eEnv.baseUrl}/user/'),
@@ -131,7 +150,7 @@ Future<int> createUser({
           'username': username,
           'password': password,
           'displayName': displayName,
-          'appRoleId': appRoleId,
+          'appRoleId': resolvedAppRoleId,
           'isDummyUser': false,
         }),
       )
@@ -141,6 +160,57 @@ Future<int> createUser({
         'HTTP ${res.statusCode}: ${res.body}');
   }
   return (jsonDecode(res.body) as Map<String, dynamic>)['id'] as int;
+}
+
+/// Creates a custom role via `POST /role/` and returns its id. [scope] is `APP`
+/// or `GROUP`; every entry in [permissions] must belong to that scope (validated
+/// server-side against the registry). Used by the negative-permission specs to
+/// mint a role mirroring a Legacy role minus the single permission under test.
+Future<int> createRole({
+  required String name,
+  required String scope,
+  required List<String> permissions,
+  required String jwt,
+  String description = 'e2e custom role',
+}) async {
+  final res = await http
+      .post(
+        Uri.parse('${E2eEnv.baseUrl}/role/'),
+        headers: _jsonAuth(jwt),
+        body: jsonEncode({
+          'name': name,
+          'description': description,
+          'scope': scope,
+          'permissions': permissions,
+        }),
+      )
+      .timeout(const Duration(seconds: 10));
+  if (res.statusCode != 200) {
+    throw StateError('createRole($name) failed: '
+        'HTTP ${res.statusCode}: ${res.body}');
+  }
+  return (jsonDecode(res.body) as Map<String, dynamic>)['id'] as int;
+}
+
+/// Best-effort `DELETE /role/{roleId}?scope=…`. The backend refuses to delete an
+/// *assigned* role, so this must run only after the user/group that reference it
+/// are gone — see the teardown ordering in [provisionUserWithoutAppPermission] /
+/// [provisionGroupMemberWithoutPermission]. Swallows errors like [deleteUser].
+Future<void> deleteRole(
+  int roleId, {
+  required String scope,
+  required String jwt,
+}) async {
+  try {
+    await http
+        .delete(
+          Uri.parse('${E2eEnv.baseUrl}/role/$roleId?scope=$scope'),
+          headers: _auth(jwt),
+        )
+        .timeout(const Duration(seconds: 5));
+  } catch (_) {
+    // best-effort
+  }
 }
 
 /// Best-effort `DELETE /user/{id}`. Swallows errors so a cleanup failure (e.g.
@@ -231,16 +301,21 @@ Future<int> createReceipt({
 /// Provisions a fresh user and (optionally) a fixture group it belongs to,
 /// registering `addTearDown` to delete the group and user afterwards.
 ///
-/// - [roleName] null → user belongs to no group (the add-menu "no permission"
-///   negative case). Non-null → a group is created with the user holding that
-///   system role ("Legacy Viewer" / "Legacy Editor" / "Legacy Owner").
+/// - [groupRoleId] (wins over [roleName]) / [roleName] → a group is created with
+///   the user holding that group role. [groupRoleId] takes an explicit role id
+///   (e.g. a custom role from [createRole]); [roleName] resolves a system role
+///   ("Legacy Viewer" / "Legacy Editor" / "Legacy Owner") by name. Both null →
+///   the user belongs to no group (the add-menu "no permission" negative case).
+/// - [appRoleId] assigns a specific app role (default: Legacy User).
 /// - [withReceipt] seeds one receipt into the group (for the receipt-edit /
-///   swipe gates). Ignored when [roleName] is null.
+///   swipe gates). Ignored when the user belongs to no group.
 ///
 /// Provision BEFORE `loginAs` so the user's permissions hydrate from AppData at
 /// login. The returned [PermFixture] carries the login credentials.
 Future<PermFixture> provisionPermUser({
   String? roleName,
+  int? groupRoleId,
+  int? appRoleId,
   bool withReceipt = false,
 }) async {
   final jwt = await apiLogin(); // admin
@@ -253,21 +328,27 @@ Future<PermFixture> provisionPermUser({
     password: _password,
     displayName: 'Perm $suffix',
     jwt: jwt,
+    appRoleId: appRoleId,
   );
   addTearDown(() async => deleteUser(userId, jwt: await apiLogin()));
+
+  // An explicit group role id wins; otherwise resolve a system role by name.
+  int? resolvedGroupRoleId = groupRoleId;
+  if (resolvedGroupRoleId == null && roleName != null) {
+    resolvedGroupRoleId = await groupRoleIdByName(roleName, jwt: jwt);
+  }
 
   int? groupId;
   String? groupName;
   int? receiptId;
   String? receiptName;
 
-  if (roleName != null) {
-    final roleId = await groupRoleIdByName(roleName, jwt: jwt);
+  if (resolvedGroupRoleId != null) {
     groupName = 'e2e-perm-$suffix';
     groupId = await createGroupWithMember(
       name: groupName,
       memberUserId: userId,
-      groupRoleId: roleId,
+      groupRoleId: resolvedGroupRoleId,
       jwt: jwt,
     );
     addTearDown(() async => deleteGroup(groupId!, jwt: await apiLogin()));
@@ -292,4 +373,58 @@ Future<PermFixture> provisionPermUser({
     receiptId: receiptId,
     receiptName: receiptName,
   );
+}
+
+/// Provisions a user whose APP role is "Legacy User" **minus** [permission],
+/// registering teardown for both the user and the custom role. Use for negative
+/// app-permission specs (e.g. `app.receipts.search`). The user belongs to no
+/// fixture group — the custom app role is the only thing under test.
+///
+/// The custom role is the Legacy User permission set with exactly [permission]
+/// removed, so the only behavioral difference from a Legacy User is that single
+/// missing permission. The backend refuses to delete an assigned role, so the
+/// role-delete teardown is registered **before** [provisionPermUser] — with
+/// LIFO teardown that makes it run **after** the user delete, when the role is
+/// unassigned and deletable.
+Future<PermFixture> provisionUserWithoutAppPermission(String permission) async {
+  final jwt = await apiLogin(); // admin
+  final perms = (await rolePermissionsByName('Legacy User', 'APP', jwt: jwt))
+      .where((p) => p != permission)
+      .toList();
+  final roleId = await createRole(
+    name: 'e2e-app-${_unique()}',
+    scope: 'APP',
+    permissions: perms,
+    jwt: jwt,
+  );
+  addTearDown(() async => deleteRole(roleId, scope: 'APP', jwt: await apiLogin()));
+
+  return provisionPermUser(appRoleId: roleId);
+}
+
+/// Provisions a user in a fixture group whose GROUP role is "Legacy Viewer"
+/// **minus** [permission], registering teardown for the user, group and custom
+/// role. Use for negative group-permission specs (e.g. `group.dashboards.read`).
+///
+/// Same minus-one rationale and LIFO teardown ordering as
+/// [provisionUserWithoutAppPermission]: the role-delete is registered first so
+/// it runs after the group (and its membership) and the user are gone.
+Future<PermFixture> provisionGroupMemberWithoutPermission(
+  String permission, {
+  bool withReceipt = false,
+}) async {
+  final jwt = await apiLogin(); // admin
+  final perms = (await rolePermissionsByName('Legacy Viewer', 'GROUP', jwt: jwt))
+      .where((p) => p != permission)
+      .toList();
+  final roleId = await createRole(
+    name: 'e2e-group-${_unique()}',
+    scope: 'GROUP',
+    permissions: perms,
+    jwt: jwt,
+  );
+  addTearDown(
+      () async => deleteRole(roleId, scope: 'GROUP', jwt: await apiLogin()));
+
+  return provisionPermUser(groupRoleId: roleId, withReceipt: withReceipt);
 }

--- a/mobile/integration_test/permission_dashboard_redirect_test.dart
+++ b/mobile/integration_test/permission_dashboard_redirect_test.dart
@@ -1,0 +1,74 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:receipt_wrangler_mobile/groups/widgets/group_dashboard_wrapper.dart';
+import 'package:receipt_wrangler_mobile/groups/widgets/group_receipts_list.dart';
+
+import 'helpers/login.dart';
+import 'helpers/nav.dart';
+import 'helpers/permission_fixtures.dart';
+import 'helpers/platform_mocks.dart';
+import 'helpers/pump.dart';
+
+/// Permission-gating coverage for the group dashboards route, gated on
+/// `group.dashboards.read` by `groupDashboardReadRedirect` (wired on
+/// `/groups/:groupId/dashboards` in `main.dart`). Selecting a group always lands
+/// on that route; a member without the permission is redirected to the group's
+/// receipt list instead, mirroring the desktop `groupDashboardReadGuard`.
+///
+/// Landing is told apart by screen-unique widgets: `GroupReceiptsList` (receipts
+/// screen) vs `GroupDashboardWrapper` (dashboards screen) — `GroupReceiptsList`
+/// is used nowhere else. The deny case needs a custom group role (every seeded
+/// group role holds `group.dashboards.read`), provisioned + torn down by
+/// `provisionGroupMemberWithoutPermission`.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    if (Platform.isLinux) {
+      installLinuxDesktopMocks();
+    }
+  });
+
+  testWidgets(
+    'dashboards: a member without group.dashboards.read is redirected to receipts',
+    (tester) async {
+      final fixture =
+          await provisionGroupMemberWithoutPermission('group.dashboards.read');
+      await loginAs(
+        tester,
+        username: fixture.username,
+        password: fixture.password,
+      );
+
+      // Selecting the group routes to /groups/:id/dashboards, which the redirect
+      // bounces to /groups/:id/receipts (the role keeps group.receipts.read, so
+      // the receipts list loads; the dashboards screen never builds).
+      await enterGroup(tester, fixture.groupName!);
+      await pumpUntilFound(tester, find.byType(GroupReceiptsList));
+
+      expect(find.byType(GroupReceiptsList), findsOneWidget);
+      expect(find.byType(GroupDashboardWrapper), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'dashboards: a Legacy Viewer (holds group.dashboards.read) sees the dashboard',
+    (tester) async {
+      final fixture = await provisionPermUser(roleName: 'Legacy Viewer');
+      await loginAs(
+        tester,
+        username: fixture.username,
+        password: fixture.password,
+      );
+
+      // Legacy Viewer holds group.dashboards.read, so no redirect fires.
+      await enterGroup(tester, fixture.groupName!);
+      await pumpUntilFound(tester, find.byType(GroupDashboardWrapper));
+
+      expect(find.byType(GroupDashboardWrapper), findsOneWidget);
+      expect(find.byType(GroupReceiptsList), findsNothing);
+    },
+  );
+}

--- a/mobile/integration_test/permission_search_test.dart
+++ b/mobile/integration_test/permission_search_test.dart
@@ -1,0 +1,62 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'helpers/login.dart';
+import 'helpers/permission_fixtures.dart';
+import 'helpers/platform_mocks.dart';
+import 'helpers/pump.dart';
+
+/// Permission-gating coverage for the Search bottom-nav destination, gated on the
+/// app-scoped `app.receipts.search` (`group_bottom_nav.dart` /
+/// `group_select_bottom_nav.dart`). A caller without it sees no Search
+/// destination at all (and the `/search` route is additionally redirected by
+/// `receiptsSearchRedirect`, but the nav destination is the user-facing surface).
+///
+/// We assert on the group-select bottom nav, which mounts immediately on the
+/// post-login `GroupSelect` landing — no group needed, and "Search" text appears
+/// only in the bottom nav on mobile. The deny case needs a custom app role
+/// (every seeded role holds `app.receipts.search`), provisioned and torn down by
+/// `provisionUserWithoutAppPermission`.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    if (Platform.isLinux) {
+      installLinuxDesktopMocks();
+    }
+  });
+
+  testWidgets(
+    'search nav: hidden for a user without app.receipts.search',
+    (tester) async {
+      final fixture =
+          await provisionUserWithoutAppPermission('app.receipts.search');
+      await loginAs(
+        tester,
+        username: fixture.username,
+        password: fixture.password,
+      );
+
+      // The group-select bottom nav is up, but the Search destination is gated
+      // out for a caller missing app.receipts.search.
+      await pumpUntilFound(tester, find.byType(NavigationBar));
+      expect(find.text('Search'), findsNothing);
+      expect(find.byIcon(Icons.search), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'search nav: visible for a Legacy User (holds app.receipts.search)',
+    (tester) async {
+      // The default e2e-user is a Legacy User, which holds app.receipts.search.
+      await loginAsUser(tester);
+
+      await pumpUntilFound(tester, find.byType(NavigationBar));
+      expect(find.text('Search'), findsOneWidget);
+      expect(find.byIcon(Icons.search), findsOneWidget);
+    },
+  );
+}

--- a/mobile/lib/groups/nav/group/group_bottom_nav.dart
+++ b/mobile/lib/groups/nav/group/group_bottom_nav.dart
@@ -2,7 +2,10 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:openapi/openapi.dart' show Permission;
+import 'package:provider/provider.dart';
 import 'package:receipt_wrangler_mobile/constants/search.dart';
+import 'package:receipt_wrangler_mobile/models/permissions_model.dart';
 import 'package:receipt_wrangler_mobile/shared/widgets/bottom_nav.dart';
 import 'package:receipt_wrangler_mobile/utils/group.dart';
 
@@ -21,6 +24,11 @@ class _GroupBottomNav extends State<GroupBottomNav> {
 
   @override
   Widget build(BuildContext context) {
+    final permissionsModel =
+        Provider.of<PermissionsModel>(context, listen: false);
+    final canSearch = permissionsModel
+        .hasAppPermission(Permission.appPeriodReceiptsPeriodSearch);
+
     onDestinationSelected(int indexSelected) {
       var groupId = getGroupId(context);
 
@@ -77,10 +85,14 @@ class _GroupBottomNav extends State<GroupBottomNav> {
         icon: Icon(Icons.receipt),
         label: "Receipts",
       ),
-      const NavigationDestination(
-        icon: Icon(Icons.search),
-        label: "Search",
-      ),
+      // Search is the trailing destination; gating it on app.receipts.search
+      // keeps the earlier indices stable, so the switch/setIndexSelected logic
+      // needs no remap.
+      if (canSearch)
+        const NavigationDestination(
+          icon: Icon(Icons.search),
+          label: "Search",
+        ),
     ];
 
     return BottomNav(

--- a/mobile/lib/groups/nav/group_select/group_select_bottom_nav.dart
+++ b/mobile/lib/groups/nav/group_select/group_select_bottom_nav.dart
@@ -2,6 +2,9 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:openapi/openapi.dart' show Permission;
+import 'package:provider/provider.dart';
+import 'package:receipt_wrangler_mobile/models/permissions_model.dart';
 import 'package:receipt_wrangler_mobile/shared/widgets/bottom_nav.dart';
 
 import '../../../constants/search.dart';
@@ -20,6 +23,11 @@ class _GroupSelectBottomNav extends State<GroupSelectBottomNav> {
 
   @override
   Widget build(BuildContext context) {
+    final permissionsModel =
+        Provider.of<PermissionsModel>(context, listen: false);
+    final canSearch = permissionsModel
+        .hasAppPermission(Permission.appPeriodReceiptsPeriodSearch);
+
     onDestinationSelected(int indexSelected) {
       switch (indexSelected) {
         case 0:
@@ -64,10 +72,14 @@ class _GroupSelectBottomNav extends State<GroupSelectBottomNav> {
         icon: Icon(Icons.add),
         label: "Add",
       ),
-      const NavigationDestination(
-        icon: Icon(Icons.search),
-        label: "Search",
-      ),
+      // Search is the trailing destination; gating it on app.receipts.search
+      // keeps the earlier indices stable, so the switch/setIndexSelected logic
+      // needs no remap.
+      if (canSearch)
+        const NavigationDestination(
+          icon: Icon(Icons.search),
+          label: "Search",
+        ),
     ];
 
     return BottomNav(

--- a/mobile/lib/guards/permission-guard.dart
+++ b/mobile/lib/guards/permission-guard.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openapi/openapi.dart' show Permission;
+import 'package:provider/provider.dart';
+
+import '../constants/search.dart';
+import '../models/permissions_model.dart';
+
+/// go_router route-level redirects that gate permission-scoped screens, mirroring
+/// the desktop route guards (`desktop/src/dashboard/guards/group-dashboard-read.guard.ts`).
+/// The server re-checks permissions on every request, so these are UI hints that
+/// keep users off pages they can't use (which would otherwise 403); they read
+/// [PermissionsModel] from the provider tree the router is built under.
+
+/// Allows the group dashboards route only when the caller holds
+/// `group.dashboards.read` for the route's group. On deny, redirects to that
+/// group's receipt list so the user lands on a page they can use, instead of
+/// letting the dashboard fetch 403. The group id (for both the check and the
+/// redirect) comes from the route's `:groupId` param, mirroring the desktop guard.
+String? groupDashboardReadRedirect(BuildContext context, GoRouterState state) {
+  final permissionsModel =
+      Provider.of<PermissionsModel>(context, listen: false);
+  final groupId = state.pathParameters["groupId"];
+  final parsedGroupId = int.tryParse(groupId ?? "");
+
+  if (parsedGroupId != null &&
+      permissionsModel.hasGroupPermission(
+          parsedGroupId, Permission.groupPeriodDashboardsPeriodRead)) {
+    return null;
+  }
+
+  return "/groups/$groupId/receipts";
+}
+
+/// Allows the search route only when the caller holds `app.receipts.search`.
+/// The search entry points are hidden for users without it (see the bottom
+/// navs), so this is defense-in-depth against a deep link. On deny, lands on the
+/// originating group's receipts when known (the group bottom nav passes a
+/// `groupId` in `extra`), else the group-select screen. Reads `extra`
+/// defensively so a no-`extra` deep link can't reach the search shell builder's
+/// `state.extra as Map` cast.
+String? receiptsSearchRedirect(BuildContext context, GoRouterState state) {
+  final permissionsModel =
+      Provider.of<PermissionsModel>(context, listen: false);
+
+  if (permissionsModel
+      .hasAppPermission(Permission.appPeriodReceiptsPeriodSearch)) {
+    return null;
+  }
+
+  final extra = state.extra;
+  if (extra is Map &&
+      extra["from"] == fromGroupBottomNav &&
+      extra["groupId"] != null) {
+    return "/groups/${extra["groupId"]}/receipts";
+  }
+  return "/groups";
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -13,6 +13,7 @@ import 'package:receipt_wrangler_mobile/groups/screens/group_dashboards.dart';
 import 'package:receipt_wrangler_mobile/groups/screens/group_receipts_screen.dart';
 import 'package:receipt_wrangler_mobile/groups/screens/group_select.dart';
 import 'package:receipt_wrangler_mobile/guards/auth-guard.dart';
+import 'package:receipt_wrangler_mobile/guards/permission-guard.dart';
 import 'package:receipt_wrangler_mobile/home/screens/home.dart';
 import 'package:receipt_wrangler_mobile/models/auth_model.dart';
 import 'package:receipt_wrangler_mobile/models/category_model.dart';
@@ -124,6 +125,7 @@ GoRouter _buildAppRouter() {
           routes: [
             GoRoute(
               path: '/groups/:groupId/dashboards',
+              redirect: groupDashboardReadRedirect,
               builder: (context, state) => const GroupDashboards(),
             ),
             GoRoute(
@@ -185,6 +187,7 @@ GoRouter _buildAppRouter() {
         routes: [
           GoRoute(
             path: '/search',
+            redirect: receiptsSearchRedirect,
             builder: (context, state) => const SearchScreen(),
           ),
         ],

--- a/mobile/test/guards/permission_guard_test.dart
+++ b/mobile/test/guards/permission_guard_test.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openapi/openapi.dart' show Permission;
+import 'package:provider/provider.dart';
+import 'package:receipt_wrangler_mobile/constants/search.dart';
+import 'package:receipt_wrangler_mobile/guards/permission-guard.dart';
+import 'package:receipt_wrangler_mobile/models/permissions_model.dart';
+
+import '../helpers/permission_test_helpers.dart';
+
+/// Unit coverage for the go_router permission redirects. Each test mounts a
+/// minimal router (provider-backed) at a neutral start route, then navigates so
+/// the redirect runs with the navigator mounted — exactly as it does in the app.
+void main() {
+  Widget harness(PermissionsModel permissions, GoRouter router) {
+    return ChangeNotifierProvider<PermissionsModel>.value(
+      value: permissions,
+      child: MaterialApp.router(routerConfig: router),
+    );
+  }
+
+  GoRouter dashboardRouter() => GoRouter(
+        initialLocation: '/start',
+        routes: [
+          GoRoute(path: '/start', builder: (c, s) => const Text('START')),
+          GoRoute(
+            path: '/groups/:groupId/dashboards',
+            redirect: groupDashboardReadRedirect,
+            builder: (c, s) => const Text('DASHBOARDS'),
+          ),
+          GoRoute(
+            path: '/groups/:groupId/receipts',
+            builder: (c, s) => const Text('RECEIPTS'),
+          ),
+        ],
+      );
+
+  GoRouter searchRouter() => GoRouter(
+        initialLocation: '/start',
+        routes: [
+          GoRoute(path: '/start', builder: (c, s) => const Text('START')),
+          GoRoute(
+            path: '/search',
+            redirect: receiptsSearchRedirect,
+            builder: (c, s) => const Text('SEARCH'),
+          ),
+          GoRoute(path: '/groups', builder: (c, s) => const Text('GROUPS')),
+          GoRoute(
+            path: '/groups/:groupId/receipts',
+            builder: (c, s) => const Text('RECEIPTS'),
+          ),
+        ],
+      );
+
+  group('groupDashboardReadRedirect', () {
+    testWidgets('redirects to receipts without group.dashboards.read',
+        (tester) async {
+      final router = dashboardRouter();
+      await tester.pumpWidget(harness(seededPermissions(), router));
+      await tester.pumpAndSettle();
+
+      router.go('/groups/5/dashboards');
+      await tester.pumpAndSettle();
+
+      expect(find.text('RECEIPTS'), findsOneWidget);
+      expect(find.text('DASHBOARDS'), findsNothing);
+    });
+
+    testWidgets('allows dashboards with group.dashboards.read',
+        (tester) async {
+      final router = dashboardRouter();
+      await tester.pumpWidget(harness(
+        seededPermissions(
+          group: {
+            5: [Permission.groupPeriodDashboardsPeriodRead]
+          },
+        ),
+        router,
+      ));
+      await tester.pumpAndSettle();
+
+      router.go('/groups/5/dashboards');
+      await tester.pumpAndSettle();
+
+      expect(find.text('DASHBOARDS'), findsOneWidget);
+      expect(find.text('RECEIPTS'), findsNothing);
+    });
+
+    testWidgets('redirect is group-scoped — read in another group does not allow',
+        (tester) async {
+      final router = dashboardRouter();
+      await tester.pumpWidget(harness(
+        seededPermissions(
+          group: {
+            9: [Permission.groupPeriodDashboardsPeriodRead]
+          },
+        ),
+        router,
+      ));
+      await tester.pumpAndSettle();
+
+      router.go('/groups/5/dashboards');
+      await tester.pumpAndSettle();
+
+      expect(find.text('RECEIPTS'), findsOneWidget);
+      expect(find.text('DASHBOARDS'), findsNothing);
+    });
+  });
+
+  group('receiptsSearchRedirect', () {
+    testWidgets('redirects to /groups without app.receipts.search',
+        (tester) async {
+      final router = searchRouter();
+      await tester.pumpWidget(harness(seededPermissions(), router));
+      await tester.pumpAndSettle();
+
+      router.go('/search');
+      await tester.pumpAndSettle();
+
+      expect(find.text('GROUPS'), findsOneWidget);
+      expect(find.text('SEARCH'), findsNothing);
+    });
+
+    testWidgets('redirects to the group receipts when extra carries a groupId',
+        (tester) async {
+      final router = searchRouter();
+      await tester.pumpWidget(harness(seededPermissions(), router));
+      await tester.pumpAndSettle();
+
+      router.go('/search',
+          extra: {'from': fromGroupBottomNav, 'groupId': '3'});
+      await tester.pumpAndSettle();
+
+      expect(find.text('RECEIPTS'), findsOneWidget);
+      expect(find.text('SEARCH'), findsNothing);
+    });
+
+    testWidgets('allows search with app.receipts.search', (tester) async {
+      final router = searchRouter();
+      await tester.pumpWidget(harness(
+        seededPermissions(app: [Permission.appPeriodReceiptsPeriodSearch]),
+        router,
+      ));
+      await tester.pumpAndSettle();
+
+      router.go('/search');
+      await tester.pumpAndSettle();
+
+      expect(find.text('SEARCH'), findsOneWidget);
+      expect(find.text('GROUPS'), findsNothing);
+    });
+  });
+}

--- a/mobile/test/helpers/permission_test_helpers.dart
+++ b/mobile/test/helpers/permission_test_helpers.dart
@@ -1,0 +1,22 @@
+import 'package:built_collection/built_collection.dart';
+import 'package:openapi/openapi.dart';
+import 'package:receipt_wrangler_mobile/models/permissions_model.dart';
+
+/// Builds a [PermissionsModel] seeded with the given app- and group-scoped
+/// permissions, mirroring how `setPermissions` hydrates from `AppData` (group
+/// keys arrive as the string group ids). Use in widget/guard tests that need a
+/// caller with a specific permission set without standing up the backend.
+PermissionsModel seededPermissions({
+  List<Permission> app = const [],
+  Map<int, List<Permission>> group = const {},
+}) {
+  final model = PermissionsModel();
+  model.setPermissions(
+    BuiltList<Permission>(app),
+    BuiltMap<String, BuiltList<Permission>>({
+      for (final entry in group.entries)
+        entry.key.toString(): BuiltList<Permission>(entry.value),
+    }),
+  );
+  return model;
+}

--- a/mobile/test/widgets/group_bottom_nav_test.dart
+++ b/mobile/test/widgets/group_bottom_nav_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openapi/openapi.dart' show Permission;
+import 'package:provider/provider.dart';
+import 'package:receipt_wrangler_mobile/groups/nav/group/group_bottom_nav.dart';
+import 'package:receipt_wrangler_mobile/models/permissions_model.dart';
+
+import '../helpers/permission_test_helpers.dart';
+
+/// The group-context bottom nav hides its trailing Search destination when the
+/// caller lacks `app.receipts.search`. A real `GoRouter` ancestor is required
+/// because `setIndexSelected` reads `GoRouter.of(context)` during build.
+void main() {
+  Widget harness(PermissionsModel permissions) {
+    final router = GoRouter(
+      initialLocation: '/groups/1/receipts',
+      routes: [
+        GoRoute(
+          path: '/groups/:groupId/receipts',
+          builder: (context, state) =>
+              const Scaffold(bottomNavigationBar: GroupBottomNav()),
+        ),
+      ],
+    );
+    return ChangeNotifierProvider<PermissionsModel>.value(
+      value: permissions,
+      child: MaterialApp.router(routerConfig: router),
+    );
+  }
+
+  testWidgets('hides the Search destination without app.receipts.search',
+      (tester) async {
+    await tester.pumpWidget(harness(seededPermissions()));
+    await tester.pump();
+
+    expect(find.byIcon(Icons.search), findsNothing);
+    expect(find.text('Search'), findsNothing);
+    // The other destinations remain.
+    expect(find.byIcon(Icons.dashboard), findsOneWidget);
+    expect(find.byIcon(Icons.add), findsOneWidget);
+    expect(find.byIcon(Icons.receipt), findsOneWidget);
+  });
+
+  testWidgets('shows the Search destination with app.receipts.search',
+      (tester) async {
+    await tester.pumpWidget(harness(
+      seededPermissions(app: [Permission.appPeriodReceiptsPeriodSearch]),
+    ));
+    await tester.pump();
+
+    expect(find.byIcon(Icons.search), findsOneWidget);
+    expect(find.text('Search'), findsOneWidget);
+  });
+}

--- a/mobile/test/widgets/group_select_bottom_nav_test.dart
+++ b/mobile/test/widgets/group_select_bottom_nav_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openapi/openapi.dart' show Permission;
+import 'package:provider/provider.dart';
+import 'package:receipt_wrangler_mobile/groups/nav/group_select/group_select_bottom_nav.dart';
+import 'package:receipt_wrangler_mobile/models/permissions_model.dart';
+
+import '../helpers/permission_test_helpers.dart';
+
+/// The group-select bottom nav hides its trailing Search destination when the
+/// caller lacks `app.receipts.search`. A real `GoRouter` ancestor is required
+/// because `setIndexSelected` reads `GoRouter.of(context)` during build.
+void main() {
+  Widget harness(PermissionsModel permissions) {
+    final router = GoRouter(
+      initialLocation: '/groups',
+      routes: [
+        GoRoute(
+          path: '/groups',
+          builder: (context, state) =>
+              const Scaffold(bottomNavigationBar: GroupSelectBottomNav()),
+        ),
+      ],
+    );
+    return ChangeNotifierProvider<PermissionsModel>.value(
+      value: permissions,
+      child: MaterialApp.router(routerConfig: router),
+    );
+  }
+
+  testWidgets('hides the Search destination without app.receipts.search',
+      (tester) async {
+    await tester.pumpWidget(harness(seededPermissions()));
+    await tester.pump();
+
+    expect(find.byIcon(Icons.search), findsNothing);
+    expect(find.text('Search'), findsNothing);
+    // The other destinations remain.
+    expect(find.byIcon(Icons.group), findsOneWidget);
+    expect(find.byIcon(Icons.add), findsOneWidget);
+  });
+
+  testWidgets('shows the Search destination with app.receipts.search',
+      (tester) async {
+    await tester.pumpWidget(harness(
+      seededPermissions(app: [Permission.appPeriodReceiptsPeriodSearch]),
+    ));
+    await tester.pump();
+
+    expect(find.byIcon(Icons.search), findsOneWidget);
+    expect(find.text('Search'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## What & why

Extends the role-rework permission gating to the **mobile** app and closes the **negative e2e coverage** gap on both mobile and desktop, mirroring the existing desktop guards/specs.

### 1. Mobile permission gating (`f482593e`)
- **Search:** the Search bottom-nav destination (group and group-select navs) is hidden when the caller lacks `app.receipts.search`. It's the trailing destination in both navs, so dropping it leaves the index/switch logic untouched. A `/search` route redirect (`receiptsSearchRedirect`) also bounces deep links.
- **Dashboards:** a route redirect (`groupDashboardReadRedirect`) on `/groups/:groupId/dashboards` sends users lacking `group.dashboards.read` to that group's receipts list — mirroring the desktop `groupDashboardReadGuard`. Redirect-only (the Dashboards tab stays visible), matching desktop. The per-user all-group is owned by its creator, so its dashboard is never wrongly bounced.
- Both redirects live in `mobile/lib/guards/permission-guard.dart` and read the same `PermissionsModel` as the widget gates.
- Covered by widget tests (both navs) and router-level tests (both redirects).

### 2. Mobile e2e negative coverage (`ae29d003`)
- Extends `integration_test/helpers/permission_fixtures.dart` with custom-role provisioning (`createRole`/`deleteRole`/`rolePermissionsByName` + `provisionUserWithoutAppPermission` / `provisionGroupMemberWithoutPermission`) that build a role identical to a Legacy role **minus the single permission under test**.
- `permission_search_test.dart` (no `app.receipts.search` → no Search destination; Legacy User → present) and `permission_dashboard_redirect_test.dart` (no `group.dashboards.read` → redirected to receipts; Legacy Viewer → dashboard shown).
- Teardown is registered so the role-delete runs **after** the user/group are removed (the backend won't delete an assigned role).

### 3. Desktop e2e negative coverage (`09bd34e9`)
- `helpers/provisioning.ts`: shared UI provisioning (`createRole` driving the role form, `createUserWithRole`, `createGroupWithMember`) + **API teardown** (`withAdminApi` + `apiDelete*`).
- `search-bar-visibility.spec.ts` (custom app role with no Receipts category → header search bar never renders) and `dashboard-read-redirect.spec.ts` (custom group role = Viewer minus "Read Dashboards" → member redirected `/dashboard/group/:id → /receipts/group/:id`; owner still sees the dashboard).
- **Teardown is API-based, not UI:** the role-list delete button is disabled while a role is assigned, and the UI's bulk user-delete dummy-converts a group-owning user (keeping the role assigned), so UI cleanup leaks roles. `DELETE /api/user/{id}` hard-deletes (freeing the app role); deleting a group frees its group-role assignment.

## Testing
- **Mobile:** `flutter analyze` clean; full unit/widget suite green (135 tests); both new integration specs pass on the Android emulator (search 2/2, dashboard 2/2) with verified clean teardown (no orphan roles/users/groups).
- **Desktop:** both new specs pass against a live API (5/5 incl. setup) with verified clean teardown (no orphan roles/users; storageState file removed).
- CLAUDE.md updated for all three components.

## Notes
- Base is `feature/role-rework` (this branches off the epic, like the other role-rework sub-features).
- Surfaced (out of scope here): the existing `system-settings-tab-gating.spec.ts` / `role-assignment.spec.ts` leak orphan roles/users via UI teardown — they should switch to the same API teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added permission-based routing and navigation for mobile group dashboards and receipts search, including redirects when access is unavailable.
  * The Search destination in group navigation now appears only when the user has the required receipts search permission.

* **Tests**
  * Added desktop end-to-end coverage for group dashboard read redirect behavior and receipts search visibility.
  * Added mobile widget/integration tests validating redirect and navigation behavior for missing vs. present permissions.

* **Documentation**
  * Updated permission-gating guidance and reference specs for negative permission coverage (including teardown/provisioning patterns).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->