### PR TITLE
Add per-group-role paid-by receipt visibility filter

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -403,7 +403,9 @@ Because paid-by hides the **whole** receipt (not just fields), enforcement diffe
   blocks also select `paid_by_user_id`; `enforcePaidByVisibility` denies **403** when any resolved
   receipt is outside the caller's allowed set. This one place covers `GetReceipt`, image
   get/download/remove, comments, duplicate-source, update/delete, and the multi-id export (deny if
-  **any** id is hidden).
+  **any** id is hidden). The `HasAccess` probe (the desktop receipt-route guard's check) does its own
+  in-handler check, so it **also** calls `ReceiptPaidByVisible` after its group-permission check —
+  otherwise the guard would admit the member to a hidden receipt that then 403s on fetch.
 - **Unpaginated surfaces** (`GetReceiptsForGroupIds`, `Search`): `FilterReceiptsByPaidBy` post-filters
   the returned slice (no `totalCount` to keep consistent). Search returns `paidByUserId`, so it must
   be filtered. **Pie chart** and **CSV export** pass the resolver through `GetPagedReceiptsByGroupId`.

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -199,6 +199,17 @@ them.
   `GroupId`); a grant is a per-group-role slice of the global pool. CRUD persists/returns the grants
   and `PermissionService` resolves them (see "Category/tag grant resolution" below); wiring the
   resolved sets into AppData delivery and request enforcement is rolled out in later slices.
+  - **Paid-by visibility** is a third, **row-level** grant type: `GroupRolePaidByUserGrant`
+    (composite-PK `{GroupRoleID, UserID}`) plus an `IncludeOwnPaidReceipts` bool column on
+    `GroupRoleDefinition`. It restricts **which receipts** a member sees by the receipt's
+    `paid_by_user_id` (vs. category/tag grants, which strip fields off a still-visible receipt). Same
+    opt-in rule: no grant rows **and** `IncludeOwnPaidReceipts == false` ⇒ unrestricted (see every
+    payer). The bool is the relative "their own receipts" token — the member's own id is unioned in at
+    **resolution** time (never stored/cached, since the cache is role-keyed and shared across members),
+    so a role granting only specific users (bool false) is a "pure reviewer" that can't see its
+    holder's own receipts. `UpsertRoleCommand`/`RoleView`/swagger carry `paidByUserGrants` +
+    `includeOwnPaidReceipts`; the granted user ids are existence-validated like category/tag grants
+    (`ErrInvalidGrant`). See "Paid-by visibility enforcement" below.
 - **Assignment:** nullable FKs `User.AppRoleID` and `GroupMember.GroupRoleID` (one app role per
   user; one group role per group membership). Nullable because per-create assignment is best-effort
   (the FK is left `nil` rather than failing creation when no role can be resolved, e.g. an unseeded
@@ -370,6 +381,42 @@ them.
   can't surface or auto-assign a category/tag the user isn't allowed to see. `MagicFillFromImage`
   takes the triggering `userId` and sets it on the service; system/email processing passes 0 and
   stays unrestricted (the resulting receipts are covered by read-stripping when any user views them).
+
+### Paid-by visibility enforcement (`PermissionService`, `services/paid_by_filter.go`)
+
+Row-level visibility by the receipt's `paid_by_user_id`, layered on top of the existing
+group-membership scoping. `GetGroupPaidByUserIdsForUser(userId, groupId)` returns `(allowedSet,
+unrestricted, err)` with the same empty-grants = see-all rule as the category/tag resolvers, but it
+returns a **freshly allocated** set (the requesting user's own id is unioned in when the role sets
+`IncludeOwnPaidReceipts`) so it never mutates the role-keyed grant cache. There is **no app-level
+bypass** — every receipt read gates on `group.receipts.read` (the very permission a restricted member
+holds), and an admin who isn't a group member has no group role there so resolves to unrestricted.
+
+Because paid-by hides the **whole** receipt (not just fields), enforcement differs by surface:
+
+- **Paged list** (`GetPagedReceiptsByGroupId`): a `PaidByAllowedResolver` is passed in from the
+  handler/service (the repo can't import the service). The WHERE is added **before** the count, so
+  `totalCount` stays correct — single-group adds `paid_by_user_id IN (allowed)` (empty restricted set
+  ⇒ `IN (0)` no-match sentinel); the all-group view builds a per-group **disjunction**
+  `(group_id=G AND paid_by_user_id IN s_G) OR (group_id=G2) …` so each group applies its own role.
+- **Single receipt + dependent reads** (`HandleRequest` chokepoint): the `ReceiptId`/`ReceiptIds`
+  blocks also select `paid_by_user_id`; `enforcePaidByVisibility` denies **403** when any resolved
+  receipt is outside the caller's allowed set. This one place covers `GetReceipt`, image
+  get/download/remove, comments, duplicate-source, update/delete, and the multi-id export (deny if
+  **any** id is hidden).
+- **Unpaginated surfaces** (`GetReceiptsForGroupIds`, `Search`): `FilterReceiptsByPaidBy` post-filters
+  the returned slice (no `totalCount` to keep consistent). Search returns `paidByUserId`, so it must
+  be filtered. **Pie chart** and **CSV export** pass the resolver through `GetPagedReceiptsByGroupId`.
+- **No request-filter intersection needed** (unlike category/tag grants): the paged query already
+  row-filters on the allowed set, so a caller filtering by a payer they can't see intersects to
+  nothing and can't probe receipt existence.
+- **Scope boundary (intentional):** group totals / splitting / settlement aggregates stay unfiltered
+  (paid-by restricts *browsing*, not the group's accounting — the per-viewer pie chart *is* filtered);
+  write-side (which payer a member may *set*) is unchanged — this is read-visibility only.
+- Tests: `services/paid_by_filter_test.go`, `repositories/receipts_test.go` (single + all-group
+  disjunction count correctness), `handlers/receipt_paid_by_enforcement_test.go` (single-GET 403),
+  plus the round-trip/validation cases in `repositories/roles_grants_test.go`,
+  `services/roles_test.go`, and `commands/upsert_role_command_test.go`.
 
 ### Enforcement status
 

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -427,7 +427,11 @@ Because paid-by hides the **whole** receipt (not just fields), enforcement diffe
   nothing and can't probe receipt existence.
 - **Scope boundary (intentional):** group totals / splitting / settlement aggregates stay unfiltered
   (paid-by restricts *browsing*, not the group's accounting — the per-viewer pie chart *is* filtered);
-  write-side (which payer a member may *set*) is unchanged — this is read-visibility only.
+  write-side (which payer a member may *set*) is unchanged — this is read-visibility only. The
+  settlement endpoint `GetAmountOwedForUser` sets `ReceiptIds` (for the permission gate) but marks the
+  handler `SkipPaidByVisibilityCheck: true`, so the amount-owed total is identical for every member
+  regardless of their paid-by filter — `HandleRequest` honors that flag to skip `enforcePaidByVisibility`
+  while still enforcing `group.receipts.read`. Any future accounting endpoint should set the same flag.
 - Tests: `services/paid_by_filter_test.go`, `repositories/receipts_test.go` (single + all-group
   disjunction count correctness), `handlers/receipt_paid_by_enforcement_test.go` (single-GET 403),
   plus the round-trip/validation cases in `repositories/roles_grants_test.go`,

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -386,11 +386,20 @@ them.
 
 Row-level visibility by the receipt's `paid_by_user_id`, layered on top of the existing
 group-membership scoping. `GetGroupPaidByUserIdsForUser(userId, groupId)` returns `(allowedSet,
-unrestricted, err)` with the same empty-grants = see-all rule as the category/tag resolvers, but it
-returns a **freshly allocated** set (the requesting user's own id is unioned in when the role sets
-`IncludeOwnPaidReceipts`) so it never mutates the role-keyed grant cache. There is **no app-level
-bypass** — every receipt read gates on `group.receipts.read` (the very permission a restricted member
-holds), and an admin who isn't a group member has no group role there so resolves to unrestricted.
+unrestricted, err)` and returns a **freshly allocated** set (the requesting user's own id is unioned
+in when the role sets `IncludeOwnPaidReceipts`) so it never mutates the role-keyed grant cache. There
+is **no app-level bypass** — every receipt read gates on `group.receipts.read` (the very permission a
+restricted member holds), and an admin who isn't a group member has no group role there so resolves to
+unrestricted.
+
+**Fail closed (`PaidByVisibilityRestricted`).** "Unrestricted" is keyed off a persisted
+`GroupRoleDefinition.PaidByVisibilityRestricted` flag — set on save to `includeOwn || len(paidByUserGrants) > 0`
+— **not** the live grant count. This matters because the `user_id` FK is `ON DELETE CASCADE`: a role
+restricted to only `[X]` (include-own false) would otherwise become *unrestricted* (see-all) once X is
+deleted and its grant row cascades away — a silent privacy widening. With the flag, a configured role
+stays restricted and resolves to an **empty** allowed set → the `IN (0)` sentinel → "see nothing".
+(A user delete does not evict the role grant cache, but that is benign: the deleted user's receipts are
+gone too, and the cached flag stays true.) The flag is internal/derived — not on the API contract.
 
 Because paid-by hides the **whole** receipt (not just fields), enforcement differs by surface:
 
@@ -406,9 +415,13 @@ Because paid-by hides the **whole** receipt (not just fields), enforcement diffe
   **any** id is hidden). The `HasAccess` probe (the desktop receipt-route guard's check) does its own
   in-handler check, so it **also** calls `ReceiptPaidByVisible` after its group-permission check —
   otherwise the guard would admit the member to a hidden receipt that then 403s on fetch.
-- **Unpaginated surfaces** (`GetReceiptsForGroupIds`, `Search`): `FilterReceiptsByPaidBy` post-filters
-  the returned slice (no `totalCount` to keep consistent). Search returns `paidByUserId`, so it must
-  be filtered. **Pie chart** and **CSV export** pass the resolver through `GetPagedReceiptsByGroupId`.
+- **Search** (`handlers/search.go`): applies the predicate in SQL **before** `Limit(100)` via the
+  shared `ReceiptRepository.ApplyPaidByDisjunction(query, memberGroupIds, resolver)` (the same per-group
+  disjunction the all-group paged read uses). A post-fetch filter would be wrong here: hidden receipts
+  filling the first 100 by date would drop a restricted user's visible matches.
+- **`GetReceiptsForGroupIds`**: `FilterReceiptsByPaidBy` post-filters the returned slice — fine because
+  it has no `LIMIT` (it returns all receipts for the groups). **Pie chart** and **CSV export** pass the
+  resolver through `GetPagedReceiptsByGroupId`.
 - **No request-filter intersection needed** (unlike category/tag grants): the paged query already
   row-filters on the allowed set, so a caller filtering by a payer they can't see intersects to
   nothing and can't probe receipt existence.

--- a/api/internal/commands/upsert_role_command.go
+++ b/api/internal/commands/upsert_role_command.go
@@ -21,6 +21,15 @@ type UpsertRoleCommand struct {
 	// against the database in the role service.
 	CategoryGrants []uint `json:"categoryGrants"`
 	TagGrants      []uint `json:"tagGrants"`
+	// PaidByUserGrants / IncludeOwnPaidReceipts restrict which receipts members of
+	// a group role may see, by the receipt's "paid by" user. Group-scoped only and
+	// opt-in: an empty set with IncludeOwnPaidReceipts == false means unrestricted
+	// (see every payer's receipts). PaidByUserGrants are user ids (validated to
+	// exist in the role service); IncludeOwnPaidReceipts adds the current member's
+	// own receipts. Selecting only specific users (IncludeOwnPaidReceipts false)
+	// therefore hides the member's own receipts too.
+	PaidByUserGrants       []uint `json:"paidByUserGrants"`
+	IncludeOwnPaidReceipts bool   `json:"includeOwnPaidReceipts"`
 }
 
 func (command *UpsertRoleCommand) LoadDataFromRequest(w http.ResponseWriter, r *http.Request) error {
@@ -69,10 +78,12 @@ func (command *UpsertRoleCommand) Validate() structs.ValidatorError {
 		}
 	}
 
-	// Category/tag grants are a group-role concept (they slice the global pool
-	// per group role); they make no sense on an app role.
-	if command.Scope == permissions.ScopeApp && (len(command.CategoryGrants) > 0 || len(command.TagGrants) > 0) {
-		errors["grants"] = "Category and tag grants are only valid on group roles"
+	// Category/tag/paid-by grants are a group-role concept (they slice the global
+	// pool / narrow visibility per group role); they make no sense on an app role.
+	if command.Scope == permissions.ScopeApp &&
+		(len(command.CategoryGrants) > 0 || len(command.TagGrants) > 0 ||
+			len(command.PaidByUserGrants) > 0 || command.IncludeOwnPaidReceipts) {
+		errors["grants"] = "Category, tag, and paid-by grants are only valid on group roles"
 	}
 
 	if hasDuplicateUint(command.CategoryGrants) {
@@ -81,6 +92,10 @@ func (command *UpsertRoleCommand) Validate() structs.ValidatorError {
 
 	if hasDuplicateUint(command.TagGrants) {
 		errors["tagGrants"] = "Duplicate tag grant"
+	}
+
+	if hasDuplicateUint(command.PaidByUserGrants) {
+		errors["paidByUserGrants"] = "Duplicate paid-by user grant"
 	}
 
 	vErr.Errors = errors

--- a/api/internal/commands/upsert_role_command_test.go
+++ b/api/internal/commands/upsert_role_command_test.go
@@ -153,3 +153,60 @@ func TestUpsertRoleCommandDuplicateTagGrant(t *testing.T) {
 		t.Errorf("expected tagGrants error, got %+v", vErr.Errors)
 	}
 }
+
+func TestUpsertRoleCommandPaidByGrantsValidOnGroupScope(t *testing.T) {
+	command := UpsertRoleCommand{
+		Name:                   "Paid-By Group Role",
+		Scope:                  permissions.ScopeGroup,
+		Permissions:            []string{permissions.GroupReceiptsRead},
+		PaidByUserGrants:       []uint{1, 2},
+		IncludeOwnPaidReceipts: true,
+	}
+
+	vErr := command.Validate()
+	if len(vErr.Errors) > 0 {
+		t.Errorf("expected no errors, got %+v", vErr.Errors)
+	}
+}
+
+func TestUpsertRoleCommandPaidByGrantsRejectedOnAppScope(t *testing.T) {
+	command := UpsertRoleCommand{
+		Name:             "App Role With Paid-By",
+		Scope:            permissions.ScopeApp,
+		Permissions:      []string{permissions.AppUsersRead},
+		PaidByUserGrants: []uint{1},
+	}
+
+	vErr := command.Validate()
+	if _, ok := vErr.Errors["grants"]; !ok {
+		t.Errorf("expected grants error, got %+v", vErr.Errors)
+	}
+}
+
+func TestUpsertRoleCommandIncludeOwnRejectedOnAppScope(t *testing.T) {
+	command := UpsertRoleCommand{
+		Name:                   "App Role With Include Own",
+		Scope:                  permissions.ScopeApp,
+		Permissions:            []string{permissions.AppUsersRead},
+		IncludeOwnPaidReceipts: true,
+	}
+
+	vErr := command.Validate()
+	if _, ok := vErr.Errors["grants"]; !ok {
+		t.Errorf("expected grants error, got %+v", vErr.Errors)
+	}
+}
+
+func TestUpsertRoleCommandDuplicatePaidByGrant(t *testing.T) {
+	command := UpsertRoleCommand{
+		Name:             "Dup Paid-By Grant",
+		Scope:            permissions.ScopeGroup,
+		Permissions:      []string{permissions.GroupReceiptsRead},
+		PaidByUserGrants: []uint{7, 7},
+	}
+
+	vErr := command.Validate()
+	if _, ok := vErr.Errors["paidByUserGrants"]; !ok {
+		t.Errorf("expected paidByUserGrants error, got %+v", vErr.Errors)
+	}
+}

--- a/api/internal/handlers/auth_test_helpers_test.go
+++ b/api/internal/handlers/auth_test_helpers_test.go
@@ -51,6 +51,11 @@ func grantAppPerms(t *testing.T, userId uint, perms ...string) {
 func grantGroupPerms(t *testing.T, userId uint, groupId uint, perms ...string) {
 	t.Helper()
 	services.ClearRolePermissionCacheForTests()
+	// Also drop the group-role grant cache: a truncated test DB reuses role ids,
+	// so a fresh (grant-less) role here could otherwise resolve to another case's
+	// cached grants — and paid-by visibility now consults that cache on every
+	// receipt read (e.g. the pie chart), wrongly restricting this role's members.
+	services.ClearGroupRoleGrantCacheForTests()
 	db := repositories.GetDB()
 
 	roleRepository := repositories.NewRoleRepository(nil)

--- a/api/internal/handlers/auth_test_helpers_test.go
+++ b/api/internal/handlers/auth_test_helpers_test.go
@@ -54,7 +54,7 @@ func grantGroupPerms(t *testing.T, userId uint, groupId uint, perms ...string) {
 	db := repositories.GetDB()
 
 	roleRepository := repositories.NewRoleRepository(nil)
-	role, err := roleRepository.CreateGroupRole(fmt.Sprintf("Test Group Role %d-%d", userId, groupId), "", perms, nil, nil)
+	role, err := roleRepository.CreateGroupRole(fmt.Sprintf("Test Group Role %d-%d", userId, groupId), "", perms, nil, nil, nil, false)
 	if err != nil {
 		t.Fatalf("create group role: %v", err)
 	}

--- a/api/internal/handlers/export.go
+++ b/api/internal/handlers/export.go
@@ -54,6 +54,7 @@ func ExportAllReceiptsFromGroup(w http.ResponseWriter, r *http.Request) {
 					groupId,
 					pagedRequest,
 					getExportReceiptAssociations(),
+					permissionService.PaidByListResolver(token.UserId),
 				)
 			if err != nil {
 				return http.StatusInternalServerError, err

--- a/api/internal/handlers/generic_handler.go
+++ b/api/internal/handlers/generic_handler.go
@@ -15,10 +15,15 @@ func HandleRequest(handler structs.Handler) {
 		handler.Writer.Header().Set("Content-Type", handler.ResponseType)
 	}
 
+	// Receipts resolved by id here also have their paid-by visibility checked once
+	// permissions pass, so a member cannot reach (read, edit, comment on, export, or
+	// download) a receipt hidden from them by their group role's paid-by filter.
+	var receiptsToCheck []models.Receipt
+
 	if len(handler.ReceiptId) > 0 {
 		var receipt models.Receipt
 		db := repositories.GetDB()
-		err := db.Model(models.Receipt{}).Where("id = ?", handler.ReceiptId).Select("group_id").First(&receipt).Error
+		err := db.Model(models.Receipt{}).Where("id = ?", handler.ReceiptId).Select("group_id", "paid_by_user_id").First(&receipt).Error
 		if err != nil {
 			logging.LogStd(logging.LOG_LEVEL_ERROR, err.Error())
 			utils.WriteCustomErrorResponse(handler.Writer, "User is unauthorized to access entity", http.StatusForbidden)
@@ -26,12 +31,13 @@ func HandleRequest(handler structs.Handler) {
 		}
 
 		handler.GroupId = utils.UintToString(receipt.GroupId)
+		receiptsToCheck = append(receiptsToCheck, receipt)
 	}
 
 	if len(handler.ReceiptIds) > 0 {
 		var receipts []models.Receipt
 		db := repositories.GetDB()
-		err := db.Model(models.Receipt{}).Where("id IN (?)", handler.ReceiptIds).Select("group_id").Find(&receipts).Error
+		err := db.Model(models.Receipt{}).Where("id IN (?)", handler.ReceiptIds).Select("group_id", "paid_by_user_id").Find(&receipts).Error
 		if err != nil {
 			logging.LogStd(logging.LOG_LEVEL_ERROR, err.Error())
 			utils.WriteCustomErrorResponse(handler.Writer, "User is unauthorized to access entity", http.StatusForbidden)
@@ -41,9 +47,14 @@ func HandleRequest(handler structs.Handler) {
 		for _, receipt := range receipts {
 			handler.GroupIds = append(handler.GroupIds, utils.UintToString(receipt.GroupId))
 		}
+		receiptsToCheck = append(receiptsToCheck, receipts...)
 	}
 
 	if !enforcePermissions(handler) {
+		return
+	}
+
+	if !enforcePaidByVisibility(handler, receiptsToCheck) {
 		return
 	}
 
@@ -110,6 +121,29 @@ func enforcePermissions(handler structs.Handler) bool {
 			if err != nil || !hasPermissions {
 				return denyUnauthorized(handler, err)
 			}
+		}
+	}
+
+	return true
+}
+
+// enforcePaidByVisibility denies (with 403) when any of the resolved receipts is
+// hidden from the caller by their group role's paid-by visibility filter. An
+// unrestricted caller, or a non-member (no group role), passes. This is the
+// single chokepoint for every receipt-by-id surface, since they all flow through
+// HandleRequest with ReceiptId/ReceiptIds set.
+func enforcePaidByVisibility(handler structs.Handler, receipts []models.Receipt) bool {
+	if len(receipts) == 0 {
+		return true
+	}
+
+	token := structs.GetClaims(handler.Request)
+	permissionService := services.NewPermissionService(nil)
+
+	for _, receipt := range receipts {
+		visible, err := permissionService.ReceiptPaidByVisible(token.UserId, receipt.GroupId, receipt.PaidByUserID)
+		if err != nil || !visible {
+			return denyUnauthorized(handler, err)
 		}
 	}
 

--- a/api/internal/handlers/generic_handler.go
+++ b/api/internal/handlers/generic_handler.go
@@ -54,7 +54,7 @@ func HandleRequest(handler structs.Handler) {
 		return
 	}
 
-	if !enforcePaidByVisibility(handler, receiptsToCheck) {
+	if !handler.SkipPaidByVisibilityCheck && !enforcePaidByVisibility(handler, receiptsToCheck) {
 		return
 	}
 
@@ -131,7 +131,9 @@ func enforcePermissions(handler structs.Handler) bool {
 // hidden from the caller by their group role's paid-by visibility filter. An
 // unrestricted caller, or a non-member (no group role), passes. This is the
 // single chokepoint for every receipt-by-id surface, since they all flow through
-// HandleRequest with ReceiptId/ReceiptIds set.
+// HandleRequest with ReceiptId/ReceiptIds set. FilterReceiptsByPaidBy resolves
+// each group's allowed set at most once, so a multi-id request costs O(distinct
+// groups) lookups rather than O(receipts); "any hidden" => fewer survive => deny.
 func enforcePaidByVisibility(handler structs.Handler, receipts []models.Receipt) bool {
 	if len(receipts) == 0 {
 		return true
@@ -140,11 +142,12 @@ func enforcePaidByVisibility(handler structs.Handler, receipts []models.Receipt)
 	token := structs.GetClaims(handler.Request)
 	permissionService := services.NewPermissionService(nil)
 
-	for _, receipt := range receipts {
-		visible, err := permissionService.ReceiptPaidByVisible(token.UserId, receipt.GroupId, receipt.PaidByUserID)
-		if err != nil || !visible {
-			return denyUnauthorized(handler, err)
-		}
+	visible, err := permissionService.FilterReceiptsByPaidBy(token.UserId, receipts)
+	if err != nil {
+		return denyUnauthorized(handler, err)
+	}
+	if len(visible) != len(receipts) {
+		return denyUnauthorized(handler, nil)
 	}
 
 	return true

--- a/api/internal/handlers/receipt_grant_enforcement_test.go
+++ b/api/internal/handlers/receipt_grant_enforcement_test.go
@@ -46,6 +46,8 @@ func seedRestrictedReceiptCreator(t *testing.T, categoryGrantIds []uint) (uint, 
 		[]string{permissions.GroupReceiptsCreate, permissions.GroupReceiptsRead, permissions.GroupReceiptsUpdate},
 		categoryGrantIds,
 		nil,
+		nil,
+		false,
 	)
 	if err != nil {
 		t.Fatalf("seed group role: %v", err)

--- a/api/internal/handlers/receipt_paid_by_enforcement_test.go
+++ b/api/internal/handlers/receipt_paid_by_enforcement_test.go
@@ -1,0 +1,124 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/permissions"
+	"receipt-wrangler/api/internal/repositories"
+	"receipt-wrangler/api/internal/services"
+	"receipt-wrangler/api/internal/utils"
+	"testing"
+
+	jwtmiddleware "github.com/auth0/go-jwt-middleware/v2"
+	"github.com/go-chi/chi/v5"
+)
+
+// seedPaidByRestrictedMember creates a group plus a member whose group role
+// grants receipts.read with the given paid-by visibility config. Returns the
+// member user id and group id.
+func seedPaidByRestrictedMember(t *testing.T, paidByUserGrantIds []uint, includeOwn bool) (uint, uint) {
+	t.Helper()
+	services.ClearRolePermissionCacheForTests()
+	services.ClearGroupRoleGrantCacheForTests()
+	db := repositories.GetDB()
+
+	group := models.Group{Name: "paidby-handler-group"}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("seed group: %v", err)
+	}
+
+	role, err := repositories.NewRoleRepository(nil).CreateGroupRole(
+		"PaidBy Restricted Reader",
+		"",
+		[]string{permissions.GroupReceiptsRead},
+		nil,
+		nil,
+		paidByUserGrantIds,
+		includeOwn,
+	)
+	if err != nil {
+		t.Fatalf("seed group role: %v", err)
+	}
+
+	user := models.User{Username: "paidby-reader", Password: "password"}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	member := models.GroupMember{GroupID: group.ID, UserID: user.ID, GroupRoleID: &role.ID}
+	if err := db.Create(&member).Error; err != nil {
+		t.Fatalf("seed member: %v", err)
+	}
+
+	return user.ID, group.ID
+}
+
+func getReceiptByIdRequest(receiptId uint, userId uint) (*httptest.ResponseRecorder, *http.Request) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/api", nil)
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", utils.UintToString(receiptId))
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+	r = r.WithContext(context.WithValue(r.Context(), jwtmiddleware.ContextKey{}, claimsForUser(userId)))
+
+	return w, r
+}
+
+func TestGetReceiptDeniedWhenPaidByHidden(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	payer := models.User{Username: "allowed-payer", Password: "x"}
+	repositories.GetDB().Create(&payer)
+	hidden := models.User{Username: "hidden-payer", Password: "x"}
+	repositories.GetDB().Create(&hidden)
+
+	// The member may see only payer's receipts (no own); a receipt paid by a
+	// different user is hidden and accessing it by id must be denied.
+	userId, groupId := seedPaidByRestrictedMember(t, []uint{payer.ID}, false)
+	receiptId := seedReceipt(t, groupId, hidden.ID, 0)
+
+	w, r := getReceiptByIdRequest(receiptId, userId)
+	GetReceipt(w, r)
+
+	if w.Result().StatusCode != 403 {
+		utils.PrintTestError(t, w.Result().StatusCode, 403)
+	}
+}
+
+func TestGetReceiptAllowedWhenPaidByVisible(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	payer := models.User{Username: "allowed-payer-2", Password: "x"}
+	repositories.GetDB().Create(&payer)
+
+	userId, groupId := seedPaidByRestrictedMember(t, []uint{payer.ID}, false)
+	receiptId := seedReceipt(t, groupId, payer.ID, 0)
+
+	w, r := getReceiptByIdRequest(receiptId, userId)
+	GetReceipt(w, r)
+
+	if w.Result().StatusCode != 200 {
+		utils.PrintTestError(t, w.Result().StatusCode, 200)
+	}
+}
+
+func TestGetReceiptAllowedWhenPaidByUnrestricted(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	anyPayer := models.User{Username: "any-payer", Password: "x"}
+	repositories.GetDB().Create(&anyPayer)
+
+	// No paid-by config => unrestricted => visible regardless of payer.
+	userId, groupId := seedPaidByRestrictedMember(t, nil, false)
+	receiptId := seedReceipt(t, groupId, anyPayer.ID, 0)
+
+	w, r := getReceiptByIdRequest(receiptId, userId)
+	GetReceipt(w, r)
+
+	if w.Result().StatusCode != 200 {
+		utils.PrintTestError(t, w.Result().StatusCode, 200)
+	}
+}

--- a/api/internal/handlers/receipt_paid_by_enforcement_test.go
+++ b/api/internal/handlers/receipt_paid_by_enforcement_test.go
@@ -170,3 +170,54 @@ func TestHasAccessAllowedWhenPaidByVisible(t *testing.T) {
 		utils.PrintTestError(t, w.Result().StatusCode, 200)
 	}
 }
+
+func TestGetAmountOwedNotBlockedByPaidByVisibility(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	payer := models.User{Username: "owed-payer", Password: "x"}
+	repositories.GetDB().Create(&payer)
+	hidden := models.User{Username: "owed-hidden", Password: "x"}
+	repositories.GetDB().Create(&hidden)
+
+	// The member is restricted to payer's receipts; amount-owed references a receipt
+	// paid by a hidden user. Accounting must stay reachable (settlement totals are
+	// the same for every member), so it is exempt from the paid-by check — only
+	// group.receipts.read is required, which the member holds.
+	userId, groupId := seedPaidByRestrictedMember(t, []uint{payer.ID}, false)
+	receiptId := seedReceipt(t, groupId, hidden.ID, 0)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/?receiptIds="+utils.UintToString(receiptId), nil)
+	r = r.WithContext(context.WithValue(r.Context(), jwtmiddleware.ContextKey{}, claimsForUser(userId)))
+
+	GetAmountOwedForUser(w, r)
+
+	if w.Result().StatusCode != 200 {
+		utils.PrintTestError(t, w.Result().StatusCode, 200)
+	}
+}
+
+func TestExportByIdDeniedWhenAnyPaidByHidden(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	payer := models.User{Username: "exp-payer", Password: "x"}
+	repositories.GetDB().Create(&payer)
+	hidden := models.User{Username: "exp-hidden", Password: "x"}
+	repositories.GetDB().Create(&hidden)
+
+	// A multi-id surface (export by id) must deny the whole request when ANY id is
+	// hidden by the caller's paid-by filter.
+	userId, groupId := seedPaidByRestrictedMember(t, []uint{payer.ID}, false)
+	visibleReceipt := seedReceipt(t, groupId, payer.ID, 0)
+	hiddenReceipt := seedReceipt(t, groupId, hidden.ID, 0)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/?receiptIds="+utils.UintToString(visibleReceipt)+"&receiptIds="+utils.UintToString(hiddenReceipt), nil)
+	r = r.WithContext(context.WithValue(r.Context(), jwtmiddleware.ContextKey{}, claimsForUser(userId)))
+
+	ExportReceiptsById(w, r)
+
+	if w.Result().StatusCode != 403 {
+		utils.PrintTestError(t, w.Result().StatusCode, 403)
+	}
+}

--- a/api/internal/handlers/receipt_paid_by_enforcement_test.go
+++ b/api/internal/handlers/receipt_paid_by_enforcement_test.go
@@ -122,3 +122,51 @@ func TestGetReceiptAllowedWhenPaidByUnrestricted(t *testing.T) {
 		utils.PrintTestError(t, w.Result().StatusCode, 200)
 	}
 }
+
+// hasAccessRequest builds a GET /hasAccess request (the receipt-route guard's
+// probe) for receiptId + permission, acting as userId.
+func hasAccessRequest(receiptId uint, permission string, userId uint) (*httptest.ResponseRecorder, *http.Request) {
+	w := httptest.NewRecorder()
+	url := "/hasAccess?receiptId=" + utils.UintToString(receiptId) + "&permission=" + permission
+	r := httptest.NewRequest("GET", url, nil)
+	r = r.WithContext(context.WithValue(r.Context(), jwtmiddleware.ContextKey{}, claimsForUser(userId)))
+	return w, r
+}
+
+func TestHasAccessDeniedWhenPaidByHidden(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	payer := models.User{Username: "ha-payer", Password: "x"}
+	repositories.GetDB().Create(&payer)
+	hidden := models.User{Username: "ha-hidden", Password: "x"}
+	repositories.GetDB().Create(&hidden)
+
+	// The member holds group.receipts.read but is paid-by-restricted to payer, so
+	// the guard probe for a hidden-payer receipt must be denied (clean redirect).
+	userId, groupId := seedPaidByRestrictedMember(t, []uint{payer.ID}, false)
+	receiptId := seedReceipt(t, groupId, hidden.ID, 0)
+
+	w, r := hasAccessRequest(receiptId, permissions.GroupReceiptsRead, userId)
+	HasAccess(w, r)
+
+	if w.Result().StatusCode != 403 {
+		utils.PrintTestError(t, w.Result().StatusCode, 403)
+	}
+}
+
+func TestHasAccessAllowedWhenPaidByVisible(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	payer := models.User{Username: "ha-payer-2", Password: "x"}
+	repositories.GetDB().Create(&payer)
+
+	userId, groupId := seedPaidByRestrictedMember(t, []uint{payer.ID}, false)
+	receiptId := seedReceipt(t, groupId, payer.ID, 0)
+
+	w, r := hasAccessRequest(receiptId, permissions.GroupReceiptsRead, userId)
+	HasAccess(w, r)
+
+	if w.Result().StatusCode != 200 {
+		utils.PrintTestError(t, w.Result().StatusCode, 200)
+	}
+}

--- a/api/internal/handlers/receipts.go
+++ b/api/internal/handlers/receipts.go
@@ -64,6 +64,7 @@ func GetPagedReceiptsForGroup(w http.ResponseWriter, r *http.Request) {
 				groupId,
 				pagedRequest,
 				associations,
+				permissionService.PaidByListResolver(token.UserId),
 			)
 			if err != nil {
 				return http.StatusInternalServerError, err
@@ -111,13 +112,22 @@ func GetReceiptsForGroupIds(w http.ResponseWriter, r *http.Request) {
 		ResponseType:     constants.ApplicationJson,
 		HandlerFunction: func(w http.ResponseWriter, r *http.Request) (int, error) {
 			token := structs.GetClaims(r)
+			permissionService := services.NewPermissionService(nil)
 			receiptRepository := repositories.NewReceiptRepository(nil)
 			receipts, err := receiptRepository.GetReceiptsByGroupIds(groupIds, "*", clause.Associations)
 			if err != nil {
 				return http.StatusInternalServerError, err
 			}
 
-			err = services.NewPermissionService(nil).FilterReceiptCategoriesTags(token.UserId, receipts)
+			// Drop receipts hidden by the caller's paid-by visibility filter (this
+			// surface is unpaginated, so removing rows is safe), then strip the
+			// categories/tags they may not see from what remains.
+			receipts, err = permissionService.FilterReceiptsByPaidBy(token.UserId, receipts)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			err = permissionService.FilterReceiptCategoriesTags(token.UserId, receipts)
 			if err != nil {
 				return http.StatusInternalServerError, err
 			}

--- a/api/internal/handlers/receipts.go
+++ b/api/internal/handlers/receipts.go
@@ -572,6 +572,17 @@ func HasAccess(w http.ResponseWriter, r *http.Request) {
 				return http.StatusForbidden, errors.New("user is unauthorized to access entity")
 			}
 
+			// Paid-by visibility narrows access within a permitted group, so the
+			// route guard redirects cleanly instead of admitting the user to a
+			// receipt their group role hides (which would then 403 on fetch).
+			paidByVisible, err := permissionService.ReceiptPaidByVisible(token.UserId, receipt.GroupId, receipt.PaidByUserID)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+			if !paidByVisible {
+				return http.StatusForbidden, errors.New("user is unauthorized to access entity")
+			}
+
 			w.WriteHeader(200)
 
 			return 0, nil

--- a/api/internal/handlers/roles.go
+++ b/api/internal/handlers/roles.go
@@ -67,7 +67,7 @@ func CreateRole(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				if errors.Is(err, services.ErrInvalidGrant) {
 					structs.WriteValidatorErrorResponse(w, structs.ValidatorError{
-						Errors: map[string]string{"grants": "One or more category or tag grants do not exist"},
+						Errors: map[string]string{"grants": "One or more category, tag, or paid-by user grants do not exist"},
 					}, http.StatusBadRequest)
 					return 0, nil
 				}
@@ -138,7 +138,7 @@ func UpdateRole(w http.ResponseWriter, r *http.Request) {
 				}
 				if errors.Is(err, services.ErrInvalidGrant) {
 					structs.WriteValidatorErrorResponse(w, structs.ValidatorError{
-						Errors: map[string]string{"grants": "One or more category or tag grants do not exist"},
+						Errors: map[string]string{"grants": "One or more category, tag, or paid-by user grants do not exist"},
 					}, http.StatusBadRequest)
 					return 0, nil
 				}

--- a/api/internal/handlers/roles_test.go
+++ b/api/internal/handlers/roles_test.go
@@ -592,7 +592,7 @@ func TestShouldNotDeleteAssignedAppRole(t *testing.T) {
 func TestShouldNotDeleteAssignedGroupRole(t *testing.T) {
 	defer repositories.TruncateTestDb()
 	roleRepository := repositories.NewRoleRepository(nil)
-	created, err := roleRepository.CreateGroupRole("Group Role", "desc", []string{permissions.GroupReceiptsCreate}, nil, nil)
+	created, err := roleRepository.CreateGroupRole("Group Role", "desc", []string{permissions.GroupReceiptsCreate}, nil, nil, nil, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return

--- a/api/internal/handlers/search.go
+++ b/api/internal/handlers/search.go
@@ -36,15 +36,22 @@ func Search(w http.ResponseWriter, r *http.Request) {
 					return http.StatusInternalServerError, err
 				}
 
-				err = db.Table("receipts").Where("group_id IN ? AND name LIKE ?", groupIds, searchTerm).Limit(100).Order("date desc").Find(&receipts).Error
+				query := db.Table("receipts").Where("group_id IN ? AND name LIKE ?", groupIds, searchTerm)
+
+				// Apply the caller's paid-by visibility in SQL BEFORE the limit —
+				// SearchResult exposes paidByUserId, and a post-fetch filter would drop
+				// visible matches whenever hidden receipts fill the first 100 rows.
+				receiptRepository := repositories.NewReceiptRepository(nil)
+				query, err = receiptRepository.ApplyPaidByDisjunction(
+					query,
+					groupIds,
+					services.NewPermissionService(nil).PaidByListResolver(token.UserId),
+				)
 				if err != nil {
 					return http.StatusInternalServerError, err
 				}
 
-				// Drop receipts hidden by the caller's paid-by visibility filter —
-				// SearchResult exposes paidByUserId, so unfiltered results would leak
-				// hidden payers' receipts.
-				receipts, err = services.NewPermissionService(nil).FilterReceiptsByPaidBy(token.UserId, receipts)
+				err = query.Limit(100).Order("date desc").Find(&receipts).Error
 				if err != nil {
 					return http.StatusInternalServerError, err
 				}

--- a/api/internal/handlers/search.go
+++ b/api/internal/handlers/search.go
@@ -6,6 +6,7 @@ import (
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/permissions"
 	"receipt-wrangler/api/internal/repositories"
+	"receipt-wrangler/api/internal/services"
 	"receipt-wrangler/api/internal/structs"
 	"receipt-wrangler/api/internal/utils"
 )
@@ -36,6 +37,14 @@ func Search(w http.ResponseWriter, r *http.Request) {
 				}
 
 				err = db.Table("receipts").Where("group_id IN ? AND name LIKE ?", groupIds, searchTerm).Limit(100).Order("date desc").Find(&receipts).Error
+				if err != nil {
+					return http.StatusInternalServerError, err
+				}
+
+				// Drop receipts hidden by the caller's paid-by visibility filter —
+				// SearchResult exposes paidByUserId, so unfiltered results would leak
+				// hidden payers' receipts.
+				receipts, err = services.NewPermissionService(nil).FilterReceiptsByPaidBy(token.UserId, receipts)
 				if err != nil {
 					return http.StatusInternalServerError, err
 				}

--- a/api/internal/handlers/users.go
+++ b/api/internal/handlers/users.go
@@ -130,6 +130,10 @@ func GetAmountOwedForUser(w http.ResponseWriter, r *http.Request) {
 		ReceiptIds:       receiptIds,
 		GroupId:          groupId,
 		GroupPermissions: []string{permissions.GroupReceiptsRead},
+		// Amount-owed is settlement accounting: the totals must be identical for
+		// every member, so it is exempt from the paid-by visibility filter (it
+		// still requires group.receipts.read in each receipt's group).
+		SkipPaidByVisibilityCheck: true,
 		HandlerFunction: func(w http.ResponseWriter, r *http.Request) (int, error) {
 			if err != nil {
 				return http.StatusInternalServerError, err

--- a/api/internal/models/group_role_definition.go
+++ b/api/internal/models/group_role_definition.go
@@ -14,7 +14,14 @@ type GroupRoleDefinition struct {
 	IsDefault   bool   `gorm:"not null;default:false" json:"isDefault"`
 	IsSystem    bool   `gorm:"not null;default:false" json:"isSystem"`
 
-	Permissions    []GroupRolePermission    `gorm:"foreignKey:GroupRoleID;constraint:OnDelete:CASCADE" json:"permissions"`
-	CategoryGrants []GroupRoleCategoryGrant `gorm:"foreignKey:GroupRoleID;constraint:OnDelete:CASCADE" json:"categoryGrants"`
-	TagGrants      []GroupRoleTagGrant      `gorm:"foreignKey:GroupRoleID;constraint:OnDelete:CASCADE" json:"tagGrants"`
+	// IncludeOwnPaidReceipts is the relative "their own receipts" token of the
+	// paid-by visibility filter: when true the role lets each member see receipts
+	// they paid for. It is stored separately from PaidByUserGrants because it
+	// resolves to the current member at query time rather than a fixed user id.
+	IncludeOwnPaidReceipts bool `gorm:"not null;default:false" json:"includeOwnPaidReceipts"`
+
+	Permissions      []GroupRolePermission      `gorm:"foreignKey:GroupRoleID;constraint:OnDelete:CASCADE" json:"permissions"`
+	CategoryGrants   []GroupRoleCategoryGrant   `gorm:"foreignKey:GroupRoleID;constraint:OnDelete:CASCADE" json:"categoryGrants"`
+	TagGrants        []GroupRoleTagGrant        `gorm:"foreignKey:GroupRoleID;constraint:OnDelete:CASCADE" json:"tagGrants"`
+	PaidByUserGrants []GroupRolePaidByUserGrant `gorm:"foreignKey:GroupRoleID;constraint:OnDelete:CASCADE" json:"paidByUserGrants"`
 }

--- a/api/internal/models/group_role_definition.go
+++ b/api/internal/models/group_role_definition.go
@@ -20,6 +20,15 @@ type GroupRoleDefinition struct {
 	// resolves to the current member at query time rather than a fixed user id.
 	IncludeOwnPaidReceipts bool `gorm:"not null;default:false" json:"includeOwnPaidReceipts"`
 
+	// PaidByVisibilityRestricted records whether the admin opted into paid-by
+	// filtering at all (any specific user grant OR include-own). It is what keeps a
+	// configured role restricted even after its grant rows are removed — e.g. when a
+	// granted user is deleted and the FK cascade empties PaidByUserGrants. Without
+	// it, "no grants + include-own false" is indistinguishable from "never
+	// configured", which would silently widen a restricted role to see-all. Derived
+	// and set on save; internal only (not exposed on the API).
+	PaidByVisibilityRestricted bool `gorm:"not null;default:false" json:"-"`
+
 	Permissions      []GroupRolePermission      `gorm:"foreignKey:GroupRoleID;constraint:OnDelete:CASCADE" json:"permissions"`
 	CategoryGrants   []GroupRoleCategoryGrant   `gorm:"foreignKey:GroupRoleID;constraint:OnDelete:CASCADE" json:"categoryGrants"`
 	TagGrants        []GroupRoleTagGrant        `gorm:"foreignKey:GroupRoleID;constraint:OnDelete:CASCADE" json:"tagGrants"`

--- a/api/internal/models/group_role_paid_by_user_grant.go
+++ b/api/internal/models/group_role_paid_by_user_grant.go
@@ -1,0 +1,15 @@
+package models
+
+// GroupRolePaidByUserGrant restricts a group role's members to receipts paid by
+// specific users. It is the row-level "paid by" counterpart of
+// GroupRoleCategoryGrant/GroupRoleTagGrant: a group role with NO paid-by grant
+// rows and IncludeOwnPaidReceipts == false is unrestricted (sees every payer's
+// receipts); a non-empty set restricts members to receipts paid by exactly those
+// users. The relative "their own receipts" token is carried separately by
+// GroupRoleDefinition.IncludeOwnPaidReceipts (it resolves to the current member
+// at query time and so cannot be a stored user id).
+type GroupRolePaidByUserGrant struct {
+	GroupRoleID uint `gorm:"primaryKey;autoIncrement:false" json:"groupRoleId"`
+	UserID      uint `gorm:"primaryKey;autoIncrement:false;index" json:"userId"`
+	User        User `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
+}

--- a/api/internal/repositories/data_migrations_test.go
+++ b/api/internal/repositories/data_migrations_test.go
@@ -268,7 +268,7 @@ func TestRunDataMigrationsDoesNotClobberExistingAssignment(t *testing.T) {
 		utils.PrintTestError(t, err, nil)
 		return
 	}
-	customGroupRole, err := roleRepository.CreateGroupRole("Custom Group Role", "", []string{permissions.GroupReceiptsRead}, nil, nil)
+	customGroupRole, err := roleRepository.CreateGroupRole("Custom Group Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return

--- a/api/internal/repositories/db.go
+++ b/api/internal/repositories/db.go
@@ -101,6 +101,7 @@ func MakeMigrations() error {
 		&models.GroupRolePermission{},
 		&models.GroupRoleCategoryGrant{},
 		&models.GroupRoleTagGrant{},
+		&models.GroupRolePaidByUserGrant{},
 		&models.GroupMember{},
 		&models.Comment{},
 		&models.Notification{},

--- a/api/internal/repositories/receipts.go
+++ b/api/internal/repositories/receipts.go
@@ -634,6 +634,13 @@ func (repository ReceiptRepository) ApplyPaidByDisjunction(
 	memberGroupIds []uint,
 	resolver PaidByAllowedResolver,
 ) (*gorm.DB, error) {
+	// memberGroupIds is the caller's member groups. With none, there is nothing to
+	// see — fail closed explicitly rather than leave the (empty) disjunction as a
+	// silent no-op that adds no predicate, mirroring the single-group IN (0) guard.
+	if len(memberGroupIds) == 0 {
+		return query.Where("1 = 0"), nil
+	}
+
 	disjunction := repository.GetDB().Session(&gorm.Session{NewDB: true})
 	for _, groupId := range memberGroupIds {
 		allowed, unrestricted, err := resolver(groupId)

--- a/api/internal/repositories/receipts.go
+++ b/api/internal/repositories/receipts.go
@@ -620,8 +620,20 @@ func (repository ReceiptRepository) applyPaidByVisibility(
 		return query.Where("paid_by_user_id IN ?", paidByInValues(allowed)), nil
 	}
 
-	// All-group: OR each member group's own visibility condition together, then
-	// AND the group as a whole onto the running query.
+	return repository.ApplyPaidByDisjunction(query, memberGroupIds, resolver)
+}
+
+// ApplyPaidByDisjunction AND-s a per-group "paid by" visibility disjunction onto
+// query across memberGroupIds: each group contributes either `group_id = G`
+// (unrestricted) or `(group_id = G AND paid_by_user_id IN (allowed))`, OR-ed
+// together. It is shared by the all-group paged read and by search — both scope
+// receipts to a member's groups and must apply each group's own paid-by role in
+// SQL, BEFORE any LIMIT, so visible rows are not lost to a pre-filter row cap.
+func (repository ReceiptRepository) ApplyPaidByDisjunction(
+	query *gorm.DB,
+	memberGroupIds []uint,
+	resolver PaidByAllowedResolver,
+) (*gorm.DB, error) {
 	disjunction := repository.GetDB().Session(&gorm.Session{NewDB: true})
 	for _, groupId := range memberGroupIds {
 		allowed, unrestricted, err := resolver(groupId)

--- a/api/internal/repositories/receipts.go
+++ b/api/internal/repositories/receipts.go
@@ -500,11 +500,20 @@ func (repository ReceiptRepository) GetReceiptById(receiptId string) (models.Rec
 	return receipt, nil
 }
 
+// PaidByAllowedResolver returns the paid_by_user_id values a user may see in a
+// group, and whether they are unrestricted (see every payer). It lets the receipt
+// repository apply the role-based "paid by" visibility filter without importing
+// the service layer that resolves grants. Pass a nil resolver to
+// GetPagedReceiptsByGroupId to skip paid-by filtering entirely (internal/system
+// callers).
+type PaidByAllowedResolver func(groupId uint) (allowedUserIds []uint, unrestricted bool, err error)
+
 func (repository ReceiptRepository) GetPagedReceiptsByGroupId(
 	userId uint,
 	groupId string,
 	pagedRequest commands.ReceiptPagedRequestCommand,
 	associations []string,
+	paidByResolver PaidByAllowedResolver,
 ) ([]models.Receipt, int64, error) {
 	var receipts []models.Receipt
 	var count int64
@@ -526,15 +535,26 @@ func (repository ReceiptRepository) GetPagedReceiptsByGroupId(
 	}
 
 	// Filter receipts by group
+	var memberGroupIds []uint
 	if isAllGroup {
 		groupMemberRepository := NewGroupMemberRepository(nil)
-		groupIds, err := groupMemberRepository.GetGroupIdsByUserId(utils.UintToString(userId))
+		memberGroupIds, err = groupMemberRepository.GetGroupIdsByUserId(utils.UintToString(userId))
 		if err != nil {
 			return nil, 0, err
 		}
-		query = query.Where("group_id IN ?", groupIds)
+		query = query.Where("group_id IN ?", memberGroupIds)
 	} else {
 		query = query.Where("group_id = ?", groupId)
+	}
+
+	// Apply role-based "paid by" visibility, AND-ed with the group scope above and
+	// BEFORE the count below so totalCount matches the rows actually returned (a
+	// post-fetch filter would corrupt pagination).
+	if paidByResolver != nil {
+		query, err = repository.applyPaidByVisibility(query, uintGroupId, isAllGroup, memberGroupIds, paidByResolver)
+		if err != nil {
+			return nil, 0, err
+		}
 	}
 
 	// Set order by
@@ -573,6 +593,64 @@ func (repository ReceiptRepository) GetPagedReceiptsByGroupId(
 	}
 
 	return receipts, count, nil
+}
+
+// applyPaidByVisibility narrows query to the receipts a user may see by the
+// "paid by" user, using resolver to look up each group's allowed set. For a
+// single group it adds a simple paid_by_user_id IN (...) constraint; for the
+// all-group view it builds a per-group disjunction so each group applies its own
+// allowed set (a member may hold a different group role per group). The whole
+// disjunction is AND-ed onto query, preserving the existing group scope and
+// keeping the row count correct.
+func (repository ReceiptRepository) applyPaidByVisibility(
+	query *gorm.DB,
+	uintGroupId uint,
+	isAllGroup bool,
+	memberGroupIds []uint,
+	resolver PaidByAllowedResolver,
+) (*gorm.DB, error) {
+	if !isAllGroup {
+		allowed, unrestricted, err := resolver(uintGroupId)
+		if err != nil {
+			return nil, err
+		}
+		if unrestricted {
+			return query, nil
+		}
+		return query.Where("paid_by_user_id IN ?", paidByInValues(allowed)), nil
+	}
+
+	// All-group: OR each member group's own visibility condition together, then
+	// AND the group as a whole onto the running query.
+	disjunction := repository.GetDB().Session(&gorm.Session{NewDB: true})
+	for _, groupId := range memberGroupIds {
+		allowed, unrestricted, err := resolver(groupId)
+		if err != nil {
+			return nil, err
+		}
+		if unrestricted {
+			disjunction = disjunction.Or("group_id = ?", groupId)
+		} else {
+			groupCondition := repository.GetDB().Session(&gorm.Session{NewDB: true}).
+				Where("group_id = ?", groupId).
+				Where("paid_by_user_id IN ?", paidByInValues(allowed))
+			disjunction = disjunction.Or(groupCondition)
+		}
+	}
+
+	return query.Where(disjunction), nil
+}
+
+// paidByInValues guards the IN clause against an empty restricted set: paid-by
+// user ids start at 1, so 0 matches no receipt, yielding "see nothing" rather
+// than a malformed IN (). A restricted role normally always has at least one id
+// (a grant or the resolved self id), but a role whose only granted user was
+// deleted lands here.
+func paidByInValues(allowedUserIds []uint) []uint {
+	if len(allowedUserIds) == 0 {
+		return []uint{0}
+	}
+	return allowedUserIds
 }
 
 func (repository ReceiptRepository) BuildGormFilterQuery(pagedRequest commands.ReceiptPagedRequestCommand) (*gorm.DB, error) {

--- a/api/internal/repositories/receipts_test.go
+++ b/api/internal/repositories/receipts_test.go
@@ -487,6 +487,44 @@ func TestApplyPaidByDisjunctionFiltersBeforeLimit(t *testing.T) {
 	}
 }
 
+func TestApplyPaidByDisjunctionEmptyGroupsFailsClosed(t *testing.T) {
+	defer TruncateTestDb()
+	db := GetDB()
+
+	group := models.Group{Name: "pb-empty-grp"}
+	payer := models.User{Username: "pb-empty-payer", Password: "x"}
+	db.Create(&group)
+	db.Create(&payer)
+	db.Create(&models.Receipt{
+		Name:         "r",
+		Amount:       decimal.NewFromInt(1),
+		Date:         time.Now(),
+		PaidByUserID: payer.ID,
+		GroupId:      group.ID,
+		Status:       models.OPEN,
+	})
+
+	resolver := func(groupId uint) ([]uint, bool, error) { return nil, true, nil }
+
+	repository := NewReceiptRepository(nil)
+	// No member groups => the helper must fail closed (return zero rows), not leave
+	// the query unfiltered.
+	query, err := repository.ApplyPaidByDisjunction(db.Table("receipts"), []uint{}, resolver)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	var receipts []models.Receipt
+	if err := query.Find(&receipts).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if len(receipts) != 0 {
+		utils.PrintTestError(t, len(receipts), 0)
+	}
+}
+
 func TestShouldBuildGormFilterQuery(t *testing.T) {
 	defer teardownReceiptTest()
 	setupReceiptTest()

--- a/api/internal/repositories/receipts_test.go
+++ b/api/internal/repositories/receipts_test.go
@@ -285,7 +285,7 @@ func TestShouldGetPagedReceiptsByGroupId(t *testing.T) {
 		},
 	}
 
-	receipts, count, err := repository.GetPagedReceiptsByGroupId(1, "1", pagedRequest, nil)
+	receipts, count, err := repository.GetPagedReceiptsByGroupId(1, "1", pagedRequest, nil, nil)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -297,6 +297,133 @@ func TestShouldGetPagedReceiptsByGroupId(t *testing.T) {
 
 	if len(receipts) != 2 {
 		utils.PrintTestError(t, len(receipts), 2)
+	}
+}
+
+func pagedRequestAllReceipts() commands.ReceiptPagedRequestCommand {
+	return commands.ReceiptPagedRequestCommand{
+		PagedRequestCommand: commands.PagedRequestCommand{
+			Page:          1,
+			PageSize:      50,
+			OrderBy:       "created_at",
+			SortDirection: commands.DESCENDING,
+		},
+	}
+}
+
+func TestGetPagedReceiptsAppliesPaidByVisibilitySingleGroup(t *testing.T) {
+	defer teardownReceiptTest()
+	setupReceiptTest()
+	createTestReceipts() // group 1: one receipt paid by user 1, one by user 2
+
+	repository := NewReceiptRepository(nil)
+
+	// Restrict visibility to receipts paid by user 1 only.
+	restrictedToUser1 := func(groupId uint) ([]uint, bool, error) {
+		return []uint{1}, false, nil
+	}
+	receipts, count, err := repository.GetPagedReceiptsByGroupId(1, "1", pagedRequestAllReceipts(), nil, restrictedToUser1)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if count != 1 {
+		utils.PrintTestError(t, count, 1)
+	}
+	if len(receipts) != 1 || receipts[0].PaidByUserID != 1 {
+		utils.PrintTestError(t, receipts, "only the receipt paid by user 1")
+	}
+
+	// Unrestricted resolver returns everything (count must match).
+	unrestricted := func(groupId uint) ([]uint, bool, error) {
+		return nil, true, nil
+	}
+	_, count, err = repository.GetPagedReceiptsByGroupId(1, "1", pagedRequestAllReceipts(), nil, unrestricted)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if count != 2 {
+		utils.PrintTestError(t, count, 2)
+	}
+
+	// An empty-but-restricted set sees nothing (the 0 sentinel matches no rows).
+	seeNothing := func(groupId uint) ([]uint, bool, error) {
+		return []uint{}, false, nil
+	}
+	receipts, count, err = repository.GetPagedReceiptsByGroupId(1, "1", pagedRequestAllReceipts(), nil, seeNothing)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if count != 0 || len(receipts) != 0 {
+		utils.PrintTestError(t, count, 0)
+	}
+}
+
+func TestGetPagedReceiptsAppliesPaidByVisibilityAllGroup(t *testing.T) {
+	defer TruncateTestDb()
+	db := GetDB()
+
+	group1 := models.Group{Name: "pb-all-g1"}
+	group2 := models.Group{Name: "pb-all-g2"}
+	allGroup := models.Group{Name: "pb-all", IsAllGroup: true}
+	db.Create(&group1)
+	db.Create(&group2)
+	db.Create(&allGroup)
+
+	member := models.User{Username: "pb-all-member", Password: "x"}
+	payer1 := models.User{Username: "pb-all-payer1", Password: "x"}
+	payer2 := models.User{Username: "pb-all-payer2", Password: "x"}
+	db.Create(&member)
+	db.Create(&payer1)
+	db.Create(&payer2)
+
+	db.Create(&models.GroupMember{GroupID: group1.ID, UserID: member.ID})
+	db.Create(&models.GroupMember{GroupID: group2.ID, UserID: member.ID})
+
+	makeReceipt := func(groupId uint, payerId uint, name string) {
+		db.Create(&models.Receipt{
+			Name:         name,
+			Amount:       decimal.NewFromInt(1),
+			Date:         time.Now(),
+			PaidByUserID: payerId,
+			GroupId:      groupId,
+			Status:       models.OPEN,
+		})
+	}
+	makeReceipt(group1.ID, payer1.ID, "g1-p1")
+	makeReceipt(group1.ID, payer2.ID, "g1-p2")
+	makeReceipt(group2.ID, payer1.ID, "g2-p1")
+	makeReceipt(group2.ID, payer2.ID, "g2-p2")
+
+	// Different roles per group: group 1 restricted to payer1; group 2 unrestricted.
+	resolver := func(groupId uint) ([]uint, bool, error) {
+		if groupId == group1.ID {
+			return []uint{payer1.ID}, false, nil
+		}
+		return nil, true, nil
+	}
+
+	repository := NewReceiptRepository(nil)
+	receipts, count, err := repository.GetPagedReceiptsByGroupId(member.ID, utils.UintToString(allGroup.ID), pagedRequestAllReceipts(), nil, resolver)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	// Visible: g1-p1 (group1 restricted to payer1), g2-p1 + g2-p2 (group2 open).
+	// Hidden: g1-p2. totalCount must match the rows actually returned.
+	if count != 3 {
+		utils.PrintTestError(t, count, 3)
+	}
+	if len(receipts) != 3 {
+		utils.PrintTestError(t, len(receipts), 3)
+	}
+	for _, receipt := range receipts {
+		if receipt.GroupId == group1.ID && receipt.PaidByUserID != payer1.ID {
+			utils.PrintTestError(t, receipt.Name, "group 1 should only show payer1's receipt")
+		}
 	}
 }
 

--- a/api/internal/repositories/receipts_test.go
+++ b/api/internal/repositories/receipts_test.go
@@ -427,6 +427,66 @@ func TestGetPagedReceiptsAppliesPaidByVisibilityAllGroup(t *testing.T) {
 	}
 }
 
+func TestApplyPaidByDisjunctionFiltersBeforeLimit(t *testing.T) {
+	defer TruncateTestDb()
+	db := GetDB()
+
+	group := models.Group{Name: "pb-search-grp"}
+	visiblePayer := models.User{Username: "pb-search-visible", Password: "x"}
+	hiddenPayer := models.User{Username: "pb-search-hidden", Password: "x"}
+	db.Create(&group)
+	db.Create(&visiblePayer)
+	db.Create(&hiddenPayer)
+
+	// Hidden receipts are NEWER (sort first by date desc); the visible one is the
+	// oldest, so a limit applied before filtering would drop it.
+	for i := 0; i < 5; i++ {
+		db.Create(&models.Receipt{
+			Name:         "hidden-" + utils.UintToString(uint(i)),
+			Amount:       decimal.NewFromInt(1),
+			Date:         time.Now().Add(time.Duration(i+1) * time.Hour),
+			PaidByUserID: hiddenPayer.ID,
+			GroupId:      group.ID,
+			Status:       models.OPEN,
+		})
+	}
+	db.Create(&models.Receipt{
+		Name:         "visible",
+		Amount:       decimal.NewFromInt(1),
+		Date:         time.Now(),
+		PaidByUserID: visiblePayer.ID,
+		GroupId:      group.ID,
+		Status:       models.OPEN,
+	})
+
+	// The role restricts the group to the visible payer only.
+	resolver := func(groupId uint) ([]uint, bool, error) {
+		return []uint{visiblePayer.ID}, false, nil
+	}
+
+	repository := NewReceiptRepository(nil)
+	query := db.Table("receipts").Where("group_id = ?", group.ID)
+	query, err := repository.ApplyPaidByDisjunction(query, []uint{group.ID}, resolver)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	// Limit smaller than the hidden count: the visible receipt must still come back
+	// because the paid-by predicate is applied in SQL BEFORE the limit. (If it were
+	// post-filtered, the limit would return 3 hidden rows -> 0 visible.)
+	var receipts []models.Receipt
+	err = query.Limit(3).Order("date desc").Find(&receipts).Error
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if len(receipts) != 1 || receipts[0].PaidByUserID != visiblePayer.ID {
+		utils.PrintTestError(t, receipts, "only the visible-payer receipt")
+	}
+}
+
 func TestShouldBuildGormFilterQuery(t *testing.T) {
 	defer teardownReceiptTest()
 	setupReceiptTest()

--- a/api/internal/repositories/roles.go
+++ b/api/internal/repositories/roles.go
@@ -43,7 +43,7 @@ func (repository RoleRepository) CreateAppRole(name string, description string, 
 	return role, nil
 }
 
-func (repository RoleRepository) CreateGroupRole(name string, description string, perms []string, categoryGrantIds []uint, tagGrantIds []uint) (models.GroupRoleDefinition, error) {
+func (repository RoleRepository) CreateGroupRole(name string, description string, perms []string, categoryGrantIds []uint, tagGrantIds []uint, paidByUserGrantIds []uint, includeOwnPaidReceipts bool) (models.GroupRoleDefinition, error) {
 	db := repository.GetDB()
 
 	rolePermissions := make([]models.GroupRolePermission, 0, len(perms))
@@ -52,9 +52,10 @@ func (repository RoleRepository) CreateGroupRole(name string, description string
 	}
 
 	role := models.GroupRoleDefinition{
-		Name:        name,
-		Description: description,
-		Permissions: rolePermissions,
+		Name:                   name,
+		Description:            description,
+		IncludeOwnPaidReceipts: includeOwnPaidReceipts,
+		Permissions:            rolePermissions,
 	}
 
 	err := db.Create(&role).Error
@@ -62,7 +63,7 @@ func (repository RoleRepository) CreateGroupRole(name string, description string
 		return models.GroupRoleDefinition{}, err
 	}
 
-	err = repository.replaceGroupRoleGrants(role.ID, categoryGrantIds, tagGrantIds)
+	err = repository.replaceGroupRoleGrants(role.ID, categoryGrantIds, tagGrantIds, paidByUserGrantIds)
 	if err != nil {
 		return models.GroupRoleDefinition{}, err
 	}
@@ -89,6 +90,7 @@ func (repository RoleRepository) GetGroupRoleById(id uint) (models.GroupRoleDefi
 	err := db.Preload("Permissions").
 		Preload("CategoryGrants").
 		Preload("TagGrants").
+		Preload("PaidByUserGrants").
 		First(&role, id).Error
 	if err != nil {
 		return models.GroupRoleDefinition{}, err
@@ -128,7 +130,7 @@ func (repository RoleRepository) UpdateAppRole(id uint, name string, description
 	return repository.GetAppRoleById(id)
 }
 
-func (repository RoleRepository) UpdateGroupRole(id uint, name string, description string, perms []string, categoryGrantIds []uint, tagGrantIds []uint) (models.GroupRoleDefinition, error) {
+func (repository RoleRepository) UpdateGroupRole(id uint, name string, description string, perms []string, categoryGrantIds []uint, tagGrantIds []uint, paidByUserGrantIds []uint, includeOwnPaidReceipts bool) (models.GroupRoleDefinition, error) {
 	db := repository.GetDB()
 
 	err := db.Where("group_role_id = ?", id).Delete(&models.GroupRolePermission{}).Error
@@ -136,9 +138,12 @@ func (repository RoleRepository) UpdateGroupRole(id uint, name string, descripti
 		return models.GroupRoleDefinition{}, err
 	}
 
+	// Use the map form so a false includeOwnPaidReceipts persists (GORM's struct
+	// Updates skips zero-value bools, which would leave a toggled-off flag set).
 	err = db.Model(&models.GroupRoleDefinition{}).Where("id = ?", id).Updates(map[string]interface{}{
-		"name":        name,
-		"description": description,
+		"name":                      name,
+		"description":               description,
+		"include_own_paid_receipts": includeOwnPaidReceipts,
 	}).Error
 	if err != nil {
 		return models.GroupRoleDefinition{}, err
@@ -156,7 +161,7 @@ func (repository RoleRepository) UpdateGroupRole(id uint, name string, descripti
 		}
 	}
 
-	err = repository.replaceGroupRoleGrants(id, categoryGrantIds, tagGrantIds)
+	err = repository.replaceGroupRoleGrants(id, categoryGrantIds, tagGrantIds, paidByUserGrantIds)
 	if err != nil {
 		return models.GroupRoleDefinition{}, err
 	}
@@ -164,12 +169,12 @@ func (repository RoleRepository) UpdateGroupRole(id uint, name string, descripti
 	return repository.GetGroupRoleById(id)
 }
 
-// replaceGroupRoleGrants resets a group role's category and tag grants to exactly
-// the given id sets (delete-all-then-insert, mirroring the permission sync). The
-// nested Category/Tag belongs-to associations are Omit-ted so GORM never tries to
-// upsert a zero-valued category/tag from the grant rows — only the join rows are
-// written.
-func (repository RoleRepository) replaceGroupRoleGrants(groupRoleId uint, categoryGrantIds []uint, tagGrantIds []uint) error {
+// replaceGroupRoleGrants resets a group role's category, tag, and paid-by user
+// grants to exactly the given id sets (delete-all-then-insert, mirroring the
+// permission sync). The nested Category/Tag/User belongs-to associations are
+// Omit-ted so GORM never tries to upsert a zero-valued row from the grant rows —
+// only the join rows are written.
+func (repository RoleRepository) replaceGroupRoleGrants(groupRoleId uint, categoryGrantIds []uint, tagGrantIds []uint, paidByUserGrantIds []uint) error {
 	db := repository.GetDB()
 
 	err := db.Where("group_role_id = ?", groupRoleId).Delete(&models.GroupRoleCategoryGrant{}).Error
@@ -178,6 +183,11 @@ func (repository RoleRepository) replaceGroupRoleGrants(groupRoleId uint, catego
 	}
 
 	err = db.Where("group_role_id = ?", groupRoleId).Delete(&models.GroupRoleTagGrant{}).Error
+	if err != nil {
+		return err
+	}
+
+	err = db.Where("group_role_id = ?", groupRoleId).Delete(&models.GroupRolePaidByUserGrant{}).Error
 	if err != nil {
 		return err
 	}
@@ -206,6 +216,18 @@ func (repository RoleRepository) replaceGroupRoleGrants(groupRoleId uint, catego
 		}
 	}
 
+	if len(paidByUserGrantIds) > 0 {
+		paidByUserGrants := make([]models.GroupRolePaidByUserGrant, 0, len(paidByUserGrantIds))
+		for _, userId := range paidByUserGrantIds {
+			paidByUserGrants = append(paidByUserGrants, models.GroupRolePaidByUserGrant{GroupRoleID: groupRoleId, UserID: userId})
+		}
+
+		err = db.Omit("User").Create(&paidByUserGrants).Error
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -222,6 +244,7 @@ func (repository RoleRepository) GetAllRoles() ([]structs.RoleView, error) {
 	err = db.Preload("Permissions").
 		Preload("CategoryGrants").
 		Preload("TagGrants").
+		Preload("PaidByUserGrants").
 		Find(&groupRoles).Error
 	if err != nil {
 		return nil, err
@@ -246,16 +269,17 @@ func (repository RoleRepository) GetAllRoles() ([]structs.RoleView, error) {
 		}
 
 		roles = append(roles, structs.RoleView{
-			Id:             role.ID,
-			Name:           role.Name,
-			Description:    role.Description,
-			Scope:          permissions.ScopeApp,
-			IsDefault:      role.IsDefault,
-			IsSystem:       role.IsSystem,
-			Permissions:    perms,
-			AssignedCount:  appRoleCounts[role.ID],
-			CategoryGrants: []uint{},
-			TagGrants:      []uint{},
+			Id:               role.ID,
+			Name:             role.Name,
+			Description:      role.Description,
+			Scope:            permissions.ScopeApp,
+			IsDefault:        role.IsDefault,
+			IsSystem:         role.IsSystem,
+			Permissions:      perms,
+			AssignedCount:    appRoleCounts[role.ID],
+			CategoryGrants:   []uint{},
+			TagGrants:        []uint{},
+			PaidByUserGrants: []uint{},
 		})
 	}
 
@@ -266,16 +290,18 @@ func (repository RoleRepository) GetAllRoles() ([]structs.RoleView, error) {
 		}
 
 		roles = append(roles, structs.RoleView{
-			Id:             role.ID,
-			Name:           role.Name,
-			Description:    role.Description,
-			Scope:          permissions.ScopeGroup,
-			IsDefault:      role.IsDefault,
-			IsSystem:       role.IsSystem,
-			Permissions:    perms,
-			AssignedCount:  groupRoleCounts[role.ID],
-			CategoryGrants: categoryGrantIdsFromRole(role),
-			TagGrants:      tagGrantIdsFromRole(role),
+			Id:                     role.ID,
+			Name:                   role.Name,
+			Description:            role.Description,
+			Scope:                  permissions.ScopeGroup,
+			IsDefault:              role.IsDefault,
+			IsSystem:               role.IsSystem,
+			Permissions:            perms,
+			AssignedCount:          groupRoleCounts[role.ID],
+			CategoryGrants:         categoryGrantIdsFromRole(role),
+			TagGrants:              tagGrantIdsFromRole(role),
+			PaidByUserGrants:       paidByUserGrantIdsFromRole(role),
+			IncludeOwnPaidReceipts: role.IncludeOwnPaidReceipts,
 		})
 	}
 
@@ -298,6 +324,16 @@ func tagGrantIdsFromRole(role models.GroupRoleDefinition) []uint {
 	ids := make([]uint, 0, len(role.TagGrants))
 	for _, grant := range role.TagGrants {
 		ids = append(ids, grant.TagID)
+	}
+	return ids
+}
+
+// paidByUserGrantIdsFromRole extracts the paid-by user-grant ids from a loaded
+// group role's preloaded PaidByUserGrants, normalized to a non-nil slice.
+func paidByUserGrantIdsFromRole(role models.GroupRoleDefinition) []uint {
+	ids := make([]uint, 0, len(role.PaidByUserGrants))
+	for _, grant := range role.PaidByUserGrants {
+		ids = append(ids, grant.UserID)
 	}
 	return ids
 }
@@ -497,6 +533,40 @@ func (repository RoleRepository) GetGroupRoleTagIds(groupRoleId uint) ([]uint, e
 	}
 
 	return ids, nil
+}
+
+// GetGroupRolePaidByUserIds returns the user ids whose receipts a group role
+// lets its members see (the absolute paid-by grants only — the relative "their
+// own" token is GetGroupRoleIncludeOwnPaidReceipts). An empty result with
+// include-own false means the role is unrestricted (members see every payer).
+func (repository RoleRepository) GetGroupRolePaidByUserIds(groupRoleId uint) ([]uint, error) {
+	db := repository.GetDB()
+
+	ids := make([]uint, 0)
+	err := db.Model(&models.GroupRolePaidByUserGrant{}).
+		Where("group_role_id = ?", groupRoleId).
+		Pluck("user_id", &ids).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return ids, nil
+}
+
+// GetGroupRoleIncludeOwnPaidReceipts returns whether a group role lets each
+// member see receipts they paid for (the relative "their own" paid-by token).
+func (repository RoleRepository) GetGroupRoleIncludeOwnPaidReceipts(groupRoleId uint) (bool, error) {
+	db := repository.GetDB()
+
+	var includeOwn bool
+	err := db.Model(&models.GroupRoleDefinition{}).
+		Where("id = ?", groupRoleId).
+		Pluck("include_own_paid_receipts", &includeOwn).Error
+	if err != nil {
+		return false, err
+	}
+
+	return includeOwn, nil
 }
 
 // GetUserAppRoleId returns the app role id assigned to a user, or nil when the

--- a/api/internal/repositories/roles.go
+++ b/api/internal/repositories/roles.go
@@ -52,10 +52,11 @@ func (repository RoleRepository) CreateGroupRole(name string, description string
 	}
 
 	role := models.GroupRoleDefinition{
-		Name:                   name,
-		Description:            description,
-		IncludeOwnPaidReceipts: includeOwnPaidReceipts,
-		Permissions:            rolePermissions,
+		Name:                       name,
+		Description:                description,
+		IncludeOwnPaidReceipts:     includeOwnPaidReceipts,
+		PaidByVisibilityRestricted: includeOwnPaidReceipts || len(paidByUserGrantIds) > 0,
+		Permissions:                rolePermissions,
 	}
 
 	err := db.Create(&role).Error
@@ -138,12 +139,13 @@ func (repository RoleRepository) UpdateGroupRole(id uint, name string, descripti
 		return models.GroupRoleDefinition{}, err
 	}
 
-	// Use the map form so a false includeOwnPaidReceipts persists (GORM's struct
-	// Updates skips zero-value bools, which would leave a toggled-off flag set).
+	// Use the map form so false bools persist (GORM's struct Updates skips
+	// zero-value bools, which would leave a toggled-off flag set).
 	err = db.Model(&models.GroupRoleDefinition{}).Where("id = ?", id).Updates(map[string]interface{}{
-		"name":                      name,
-		"description":               description,
-		"include_own_paid_receipts": includeOwnPaidReceipts,
+		"name":                          name,
+		"description":                   description,
+		"include_own_paid_receipts":     includeOwnPaidReceipts,
+		"paid_by_visibility_restricted": includeOwnPaidReceipts || len(paidByUserGrantIds) > 0,
 	}).Error
 	if err != nil {
 		return models.GroupRoleDefinition{}, err
@@ -567,6 +569,24 @@ func (repository RoleRepository) GetGroupRoleIncludeOwnPaidReceipts(groupRoleId 
 	}
 
 	return includeOwn, nil
+}
+
+// GetGroupRolePaidByVisibilityRestricted returns whether the role opted into
+// paid-by filtering at all. It stays true after a granted user is deleted and the
+// grant rows cascade away, so a configured role keeps failing closed (sees
+// nothing) instead of widening to see-all.
+func (repository RoleRepository) GetGroupRolePaidByVisibilityRestricted(groupRoleId uint) (bool, error) {
+	db := repository.GetDB()
+
+	var restricted bool
+	err := db.Model(&models.GroupRoleDefinition{}).
+		Where("id = ?", groupRoleId).
+		Pluck("paid_by_visibility_restricted", &restricted).Error
+	if err != nil {
+		return false, err
+	}
+
+	return restricted, nil
 }
 
 // GetUserAppRoleId returns the app role id assigned to a user, or nil when the

--- a/api/internal/repositories/roles.go
+++ b/api/internal/repositories/roles.go
@@ -539,8 +539,8 @@ func (repository RoleRepository) GetGroupRoleTagIds(groupRoleId uint) ([]uint, e
 
 // GetGroupRolePaidByUserIds returns the user ids whose receipts a group role
 // lets its members see (the absolute paid-by grants only — the relative "their
-// own" token is GetGroupRoleIncludeOwnPaidReceipts). An empty result with
-// include-own false means the role is unrestricted (members see every payer).
+// own" token is on GetGroupRolePaidByConfig). An empty result with include-own
+// false means the role is unrestricted (members see every payer).
 func (repository RoleRepository) GetGroupRolePaidByUserIds(groupRoleId uint) ([]uint, error) {
 	db := repository.GetDB()
 
@@ -555,38 +555,23 @@ func (repository RoleRepository) GetGroupRolePaidByUserIds(groupRoleId uint) ([]
 	return ids, nil
 }
 
-// GetGroupRoleIncludeOwnPaidReceipts returns whether a group role lets each
-// member see receipts they paid for (the relative "their own" paid-by token).
-func (repository RoleRepository) GetGroupRoleIncludeOwnPaidReceipts(groupRoleId uint) (bool, error) {
+// GetGroupRolePaidByConfig returns a group role's two scalar paid-by flags in a
+// single row read: includeOwn (the relative "their own receipts" token) and
+// restricted (whether the role opted into paid-by filtering at all — it stays
+// true after a granted user is deleted and the grant rows cascade away, so a
+// configured role keeps failing closed instead of widening to see-all).
+func (repository RoleRepository) GetGroupRolePaidByConfig(groupRoleId uint) (includeOwn bool, restricted bool, err error) {
 	db := repository.GetDB()
 
-	var includeOwn bool
-	err := db.Model(&models.GroupRoleDefinition{}).
+	var role models.GroupRoleDefinition
+	err = db.Select("include_own_paid_receipts", "paid_by_visibility_restricted").
 		Where("id = ?", groupRoleId).
-		Pluck("include_own_paid_receipts", &includeOwn).Error
+		First(&role).Error
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 
-	return includeOwn, nil
-}
-
-// GetGroupRolePaidByVisibilityRestricted returns whether the role opted into
-// paid-by filtering at all. It stays true after a granted user is deleted and the
-// grant rows cascade away, so a configured role keeps failing closed (sees
-// nothing) instead of widening to see-all.
-func (repository RoleRepository) GetGroupRolePaidByVisibilityRestricted(groupRoleId uint) (bool, error) {
-	db := repository.GetDB()
-
-	var restricted bool
-	err := db.Model(&models.GroupRoleDefinition{}).
-		Where("id = ?", groupRoleId).
-		Pluck("paid_by_visibility_restricted", &restricted).Error
-	if err != nil {
-		return false, err
-	}
-
-	return restricted, nil
+	return role.IncludeOwnPaidReceipts, role.PaidByVisibilityRestricted, nil
 }
 
 // GetUserAppRoleId returns the app role id assigned to a user, or nil when the

--- a/api/internal/repositories/roles_grants_test.go
+++ b/api/internal/repositories/roles_grants_test.go
@@ -40,6 +40,8 @@ func TestCreateGroupRolePersistsCategoryAndTagGrants(t *testing.T) {
 		[]string{permissions.GroupReceiptsRead},
 		[]uint{cat1, cat2},
 		[]uint{tag1},
+		nil,
+		false,
 	)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
@@ -79,7 +81,7 @@ func TestCreateGroupRoleWithNoGrantsIsUnrestricted(t *testing.T) {
 	defer TruncateTestDb()
 	repository := NewRoleRepository(nil)
 
-	role, err := repository.CreateGroupRole("Open Role", "", []string{permissions.GroupReceiptsRead}, nil, nil)
+	role, err := repository.CreateGroupRole("Open Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -104,14 +106,14 @@ func TestUpdateGroupRoleReplacesGrants(t *testing.T) {
 	cat3 := makeTestCategory(t, "Travel")
 	tag1 := makeTestTag(t, "Reimbursable")
 
-	created, err := repository.CreateGroupRole("Role", "", []string{permissions.GroupReceiptsRead}, []uint{cat1, cat2}, []uint{tag1})
+	created, err := repository.CreateGroupRole("Role", "", []string{permissions.GroupReceiptsRead}, []uint{cat1, cat2}, []uint{tag1}, nil, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
 	}
 
 	// Replace the grant sets entirely with cat3 and no tags.
-	updated, err := repository.UpdateGroupRole(created.ID, "Role", "", []string{permissions.GroupReceiptsRead}, []uint{cat3}, nil)
+	updated, err := repository.UpdateGroupRole(created.ID, "Role", "", []string{permissions.GroupReceiptsRead}, []uint{cat3}, nil, nil, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -141,7 +143,7 @@ func TestDeleteGroupRoleCascadesGrants(t *testing.T) {
 	cat1 := makeTestCategory(t, "Groceries")
 	tag1 := makeTestTag(t, "Reimbursable")
 
-	created, err := repository.CreateGroupRole("Role", "", []string{permissions.GroupReceiptsRead}, []uint{cat1}, []uint{tag1})
+	created, err := repository.CreateGroupRole("Role", "", []string{permissions.GroupReceiptsRead}, []uint{cat1}, []uint{tag1}, nil, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -198,5 +200,150 @@ func TestCategoryAndTagCountByIds(t *testing.T) {
 	}
 	if tagCount != 1 {
 		utils.PrintTestError(t, tagCount, 1)
+	}
+}
+
+// makeTestUser inserts a user and returns its id.
+func makeTestUser(t *testing.T, username string) uint {
+	user := models.User{Username: username, Password: "x"}
+	if err := GetDB().Create(&user).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+	}
+	return user.ID
+}
+
+func TestCreateGroupRolePersistsPaidByGrants(t *testing.T) {
+	defer TruncateTestDb()
+	repository := NewRoleRepository(nil)
+
+	payer1 := makeTestUser(t, "payer1")
+	payer2 := makeTestUser(t, "payer2")
+
+	role, err := repository.CreateGroupRole(
+		"Paid-By Role",
+		"",
+		[]string{permissions.GroupReceiptsRead},
+		nil,
+		nil,
+		[]uint{payer1, payer2},
+		true,
+	)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if len(role.PaidByUserGrants) != 2 {
+		utils.PrintTestError(t, len(role.PaidByUserGrants), 2)
+	}
+	if !role.IncludeOwnPaidReceipts {
+		utils.PrintTestError(t, role.IncludeOwnPaidReceipts, true)
+	}
+
+	userIds, err := repository.GetGroupRolePaidByUserIds(role.ID)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	slices.Sort(userIds)
+	expected := []uint{payer1, payer2}
+	slices.Sort(expected)
+	if !slices.Equal(userIds, expected) {
+		utils.PrintTestError(t, userIds, expected)
+	}
+
+	includeOwn, err := repository.GetGroupRoleIncludeOwnPaidReceipts(role.ID)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if !includeOwn {
+		utils.PrintTestError(t, includeOwn, true)
+	}
+}
+
+func TestUpdateGroupRolePersistsIncludeOwnToggleOff(t *testing.T) {
+	defer TruncateTestDb()
+	repository := NewRoleRepository(nil)
+
+	payer := makeTestUser(t, "toggle-payer")
+
+	created, err := repository.CreateGroupRole("Toggle Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, []uint{payer}, true)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	// Toggle include-own OFF and drop the user grant. The map-based update must
+	// persist the false value (a struct update would skip the zero-value bool).
+	updated, err := repository.UpdateGroupRole(created.ID, "Toggle Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if updated.IncludeOwnPaidReceipts {
+		utils.PrintTestError(t, updated.IncludeOwnPaidReceipts, false)
+	}
+	if len(updated.PaidByUserGrants) != 0 {
+		utils.PrintTestError(t, len(updated.PaidByUserGrants), 0)
+	}
+
+	includeOwn, err := repository.GetGroupRoleIncludeOwnPaidReceipts(created.ID)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if includeOwn {
+		utils.PrintTestError(t, includeOwn, false)
+	}
+}
+
+func TestDeleteGroupRoleCascadesPaidByGrants(t *testing.T) {
+	defer TruncateTestDb()
+	repository := NewRoleRepository(nil)
+
+	payer := makeTestUser(t, "cascade-payer")
+
+	created, err := repository.CreateGroupRole("Cascade Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, []uint{payer}, false)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if err := repository.DeleteGroupRole(created.ID); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	var paidByGrantCount int64
+	GetDB().Model(&models.GroupRolePaidByUserGrant{}).Where("group_role_id = ?", created.ID).Count(&paidByGrantCount)
+	if paidByGrantCount != 0 {
+		utils.PrintTestError(t, paidByGrantCount, 0)
+	}
+}
+
+func TestUserCountByIds(t *testing.T) {
+	defer TruncateTestDb()
+
+	user1 := makeTestUser(t, "count-user1")
+	user2 := makeTestUser(t, "count-user2")
+
+	count, err := NewUserRepository(nil).CountByIds([]uint{user1, user2})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if count != 2 {
+		utils.PrintTestError(t, count, 2)
+	}
+
+	count, err = NewUserRepository(nil).CountByIds([]uint{user1, 999999})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if count != 1 {
+		utils.PrintTestError(t, count, 1)
 	}
 }

--- a/api/internal/repositories/roles_grants_test.go
+++ b/api/internal/repositories/roles_grants_test.go
@@ -323,6 +323,56 @@ func TestDeleteGroupRoleCascadesPaidByGrants(t *testing.T) {
 	}
 }
 
+func TestGroupRolePaidByVisibilityRestrictedPersists(t *testing.T) {
+	defer TruncateTestDb()
+	repository := NewRoleRepository(nil)
+	payer := makeTestUser(t, "restricted-flag-payer")
+
+	assertRestricted := func(roleId uint, want bool, desc string) {
+		got, err := repository.GetGroupRolePaidByVisibilityRestricted(roleId)
+		if err != nil {
+			utils.PrintTestError(t, err, nil)
+			return
+		}
+		if got != want {
+			utils.PrintTestError(t, got, desc)
+		}
+	}
+
+	// Specific-user grant (no include-own) is restricted.
+	usersOnly, err := repository.CreateGroupRole("Users Only", "", []string{permissions.GroupReceiptsRead}, nil, nil, []uint{payer}, false)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	assertRestricted(usersOnly.ID, true, "users-only role should be restricted")
+
+	// Include-own only is restricted.
+	ownOnly, err := repository.CreateGroupRole("Own Only", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, true)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	assertRestricted(ownOnly.ID, true, "include-own role should be restricted")
+
+	// Empty paid-by config is NOT restricted (unrestricted = see everyone).
+	open, err := repository.CreateGroupRole("Open", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	assertRestricted(open.ID, false, "empty paid-by config should not be restricted")
+
+	// Updating a restricted role to an empty config clears the flag (map update
+	// persists the false value).
+	_, err = repository.UpdateGroupRole(usersOnly.ID, "Users Only", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	assertRestricted(usersOnly.ID, false, "clearing the paid-by config should clear restricted")
+}
+
 func TestUserCountByIds(t *testing.T) {
 	defer TruncateTestDb()
 

--- a/api/internal/repositories/roles_grants_test.go
+++ b/api/internal/repositories/roles_grants_test.go
@@ -252,7 +252,7 @@ func TestCreateGroupRolePersistsPaidByGrants(t *testing.T) {
 		utils.PrintTestError(t, userIds, expected)
 	}
 
-	includeOwn, err := repository.GetGroupRoleIncludeOwnPaidReceipts(role.ID)
+	includeOwn, _, err := repository.GetGroupRolePaidByConfig(role.ID)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -289,7 +289,7 @@ func TestUpdateGroupRolePersistsIncludeOwnToggleOff(t *testing.T) {
 		utils.PrintTestError(t, len(updated.PaidByUserGrants), 0)
 	}
 
-	includeOwn, err := repository.GetGroupRoleIncludeOwnPaidReceipts(created.ID)
+	includeOwn, _, err := repository.GetGroupRolePaidByConfig(created.ID)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -329,7 +329,7 @@ func TestGroupRolePaidByVisibilityRestrictedPersists(t *testing.T) {
 	payer := makeTestUser(t, "restricted-flag-payer")
 
 	assertRestricted := func(roleId uint, want bool, desc string) {
-		got, err := repository.GetGroupRolePaidByVisibilityRestricted(roleId)
+		_, got, err := repository.GetGroupRolePaidByConfig(roleId)
 		if err != nil {
 			utils.PrintTestError(t, err, nil)
 			return

--- a/api/internal/repositories/roles_test.go
+++ b/api/internal/repositories/roles_test.go
@@ -49,7 +49,7 @@ func TestCreateGroupRolePersistsPermissions(t *testing.T) {
 	repository := NewRoleRepository(nil)
 
 	perms := []string{permissions.GroupReceiptsCreate}
-	role, err := repository.CreateGroupRole("Group Role", "Description", perms, nil, nil)
+	role, err := repository.CreateGroupRole("Group Role", "Description", perms, nil, nil, nil, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -93,13 +93,13 @@ func TestUpdateGroupRolePersistsChanges(t *testing.T) {
 	defer TruncateTestDb()
 	repository := NewRoleRepository(nil)
 
-	created, err := repository.CreateGroupRole("Group Role", "Description", []string{permissions.GroupReceiptsCreate}, nil, nil)
+	created, err := repository.CreateGroupRole("Group Role", "Description", []string{permissions.GroupReceiptsCreate}, nil, nil, nil, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
 	}
 
-	updated, err := repository.UpdateGroupRole(created.ID, "Renamed Group Role", "New description", []string{permissions.GroupReceiptsRead}, nil, nil)
+	updated, err := repository.UpdateGroupRole(created.ID, "Renamed Group Role", "New description", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -228,7 +228,7 @@ func TestGetGroupRolePermissions(t *testing.T) {
 	repository := NewRoleRepository(nil)
 
 	perms := []string{permissions.GroupReceiptsRead}
-	role, err := repository.CreateGroupRole("Group Role", "", perms, nil, nil)
+	role, err := repository.CreateGroupRole("Group Role", "", perms, nil, nil, nil, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -298,7 +298,7 @@ func TestGetGroupMemberRoleId(t *testing.T) {
 		utils.PrintTestError(t, err, nil)
 		return
 	}
-	role, err := repository.CreateGroupRole("Group Role", "", []string{permissions.GroupReceiptsRead}, nil, nil)
+	role, err := repository.CreateGroupRole("Group Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -378,12 +378,12 @@ func TestSetDefaultGroupRoleClearsOthers(t *testing.T) {
 	defer TruncateTestDb()
 	repository := NewRoleRepository(nil)
 
-	first, err := repository.CreateGroupRole("First", "", []string{permissions.GroupReceiptsRead}, nil, nil)
+	first, err := repository.CreateGroupRole("First", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
 	}
-	second, err := repository.CreateGroupRole("Second", "", []string{permissions.GroupReceiptsRead}, nil, nil)
+	second, err := repository.CreateGroupRole("Second", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return

--- a/api/internal/repositories/users.go
+++ b/api/internal/repositories/users.go
@@ -23,6 +23,21 @@ func NewUserRepository(tx *gorm.DB) UserRepository {
 	return repository
 }
 
+// CountByIds returns how many of the given user ids exist. Used to validate that
+// a group role's paid-by user grants reference real users. Duplicate ids in the
+// input are de-duplicated by the IN clause, so callers should pass a unique set.
+func (repository UserRepository) CountByIds(ids []uint) (int64, error) {
+	db := repository.GetDB()
+
+	var count int64
+	err := db.Model(&models.User{}).Where("id IN ?", ids).Count(&count).Error
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
 func (repository UserRepository) CreateUser(userData commands.SignUpCommand) (models.User, error) {
 	db := repository.GetDB()
 	user := models.User{

--- a/api/internal/services/auth_test.go
+++ b/api/internal/services/auth_test.go
@@ -498,7 +498,7 @@ func TestGetAppData_PopulatesPermissions(t *testing.T) {
 	}
 
 	groupPerms := []string{permissions.GroupReceiptsRead, permissions.GroupReceiptsUpdate}
-	groupRole, err := roleRepository.CreateGroupRole("AppData Group Role", "", groupPerms, nil, nil)
+	groupRole, err := roleRepository.CreateGroupRole("AppData Group Role", "", groupPerms, nil, nil, nil, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 	}
@@ -554,7 +554,7 @@ func TestGetAppData_GroupCategoriesFilteredByGrants(t *testing.T) {
 		utils.PrintTestError(t, err, nil)
 	}
 
-	groupRole, err := roleRepository.CreateGroupRole("AppData Restricted Role", "", []string{permissions.GroupReceiptsRead}, []uint{grantedCategory.ID}, nil)
+	groupRole, err := roleRepository.CreateGroupRole("AppData Restricted Role", "", []string{permissions.GroupReceiptsRead}, []uint{grantedCategory.ID}, nil, nil, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 	}
@@ -604,7 +604,7 @@ func TestGetAppData_AdminGetsFlatCategoriesUnrestrictedGroup(t *testing.T) {
 		utils.PrintTestError(t, err, nil)
 	}
 
-	groupRole, err := roleRepository.CreateGroupRole("AppData Open Role", "", []string{permissions.GroupReceiptsRead}, nil, nil)
+	groupRole, err := roleRepository.CreateGroupRole("AppData Open Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 	}

--- a/api/internal/services/grant.go
+++ b/api/internal/services/grant.go
@@ -57,7 +57,12 @@ func (service PermissionService) GetGroupPaidByUserIdsForUser(userId uint, group
 	if err != nil {
 		return nil, false, err
 	}
-	if entry == nil || !entry.paidByVisibilityRestricted {
+	// Unrestricted only when the role did NOT opt into paid-by filtering. The
+	// persisted PaidByVisibilityRestricted flag is the primary signal (it survives
+	// grant rows being cascade-deleted when a granted user is deleted), but we also
+	// honor the live grants/include-own so a role whose flag somehow desynced from
+	// its rows still fails closed rather than widening to see-all.
+	if entry == nil || (!entry.paidByVisibilityRestricted && len(entry.paidByUserIds) == 0 && !entry.includeOwnPaidReceipts) {
 		return nil, true, nil
 	}
 
@@ -159,11 +164,7 @@ func loadGroupRoleGrants(roleRepository repositories.RoleRepository, roleId uint
 	if err != nil {
 		return nil, err
 	}
-	includeOwnPaidReceipts, err := roleRepository.GetGroupRoleIncludeOwnPaidReceipts(roleId)
-	if err != nil {
-		return nil, err
-	}
-	paidByVisibilityRestricted, err := roleRepository.GetGroupRolePaidByVisibilityRestricted(roleId)
+	includeOwnPaidReceipts, paidByVisibilityRestricted, err := roleRepository.GetGroupRolePaidByConfig(roleId)
 	if err != nil {
 		return nil, err
 	}

--- a/api/internal/services/grant.go
+++ b/api/internal/services/grant.go
@@ -41,26 +41,30 @@ func (service PermissionService) GetGroupTagIdsForUser(userId uint, groupId uint
 // GetGroupPaidByUserIdsForUser returns the set of "paid by" user ids whose
 // receipts a user may see in a group, plus an "unrestricted" flag. When
 // unrestricted is true the returned set is nil and the caller must treat every
-// payer as allowed (the empty-grants = see-all rule). The role's absolute
-// paid-by grants are combined with the relative "their own receipts" token: when
-// the role sets includeOwnPaidReceipts, the requesting user's own id is unioned
-// into the result. Selecting only specific users (includeOwnPaidReceipts false)
-// therefore excludes the member's own receipts. A non-member, or a member whose
-// group role has no paid-by grants and no include-own, is unrestricted — grants
-// only NARROW visibility within an already-permitted group (the handler
-// permission gate is the access control). The returned map is freshly allocated
-// per call (the requesting user's id may be unioned in), so callers may keep it.
+// payer as allowed. "Unrestricted" is keyed off whether the role opted into
+// paid-by filtering at all (paidByVisibilityRestricted), NOT the current grant
+// count: a role that the admin configured stays restricted even if its grant rows
+// were since removed (e.g. a granted user was deleted and the FK cascade emptied
+// PaidByUserGrants) — it then resolves to an EMPTY allowed set ("see nothing"),
+// failing closed rather than silently widening to see-all. A non-member, or a
+// member whose role never opted in, is unrestricted — grants only NARROW
+// visibility within an already-permitted group (the handler permission gate is
+// the access control). When restricted, the role's absolute grants are combined
+// with the relative "their own receipts" token (the requester's own id is unioned
+// in when includeOwnPaidReceipts). The returned map is freshly allocated per call.
 func (service PermissionService) GetGroupPaidByUserIdsForUser(userId uint, groupId uint) (map[uint]struct{}, bool, error) {
 	entry, err := service.resolveGroupRoleGrants(userId, groupId)
 	if err != nil {
 		return nil, false, err
 	}
-	if entry == nil || (len(entry.paidByUserIds) == 0 && !entry.includeOwnPaidReceipts) {
+	if entry == nil || !entry.paidByVisibilityRestricted {
 		return nil, true, nil
 	}
 
 	// Copy the cached absolute grants (shared, read-only) before unioning in the
-	// per-user "their own" id, so we never mutate cache state.
+	// per-user "their own" id, so we never mutate cache state. The result may be
+	// empty (a configured role whose only granted users were deleted) — that is
+	// the intended "see nothing", enforced by the IN (0) sentinel downstream.
 	allowed := make(map[uint]struct{}, len(entry.paidByUserIds)+1)
 	for id := range entry.paidByUserIds {
 		allowed[id] = struct{}{}
@@ -159,12 +163,17 @@ func loadGroupRoleGrants(roleRepository repositories.RoleRepository, roleId uint
 	if err != nil {
 		return nil, err
 	}
+	paidByVisibilityRestricted, err := roleRepository.GetGroupRolePaidByVisibilityRestricted(roleId)
+	if err != nil {
+		return nil, err
+	}
 
 	entry := &grantEntry{
-		categoryIds:            uintSliceToSet(categoryIds),
-		tagIds:                 uintSliceToSet(tagIds),
-		paidByUserIds:          uintSliceToSet(paidByUserIds),
-		includeOwnPaidReceipts: includeOwnPaidReceipts,
+		categoryIds:                uintSliceToSet(categoryIds),
+		tagIds:                     uintSliceToSet(tagIds),
+		paidByUserIds:              uintSliceToSet(paidByUserIds),
+		includeOwnPaidReceipts:     includeOwnPaidReceipts,
+		paidByVisibilityRestricted: paidByVisibilityRestricted,
 	}
 
 	setCachedGroupRoleGrants(roleId, entry, observedGen)

--- a/api/internal/services/grant.go
+++ b/api/internal/services/grant.go
@@ -38,6 +38,40 @@ func (service PermissionService) GetGroupTagIdsForUser(userId uint, groupId uint
 	return entry.tagIds, false, nil
 }
 
+// GetGroupPaidByUserIdsForUser returns the set of "paid by" user ids whose
+// receipts a user may see in a group, plus an "unrestricted" flag. When
+// unrestricted is true the returned set is nil and the caller must treat every
+// payer as allowed (the empty-grants = see-all rule). The role's absolute
+// paid-by grants are combined with the relative "their own receipts" token: when
+// the role sets includeOwnPaidReceipts, the requesting user's own id is unioned
+// into the result. Selecting only specific users (includeOwnPaidReceipts false)
+// therefore excludes the member's own receipts. A non-member, or a member whose
+// group role has no paid-by grants and no include-own, is unrestricted — grants
+// only NARROW visibility within an already-permitted group (the handler
+// permission gate is the access control). The returned map is freshly allocated
+// per call (the requesting user's id may be unioned in), so callers may keep it.
+func (service PermissionService) GetGroupPaidByUserIdsForUser(userId uint, groupId uint) (map[uint]struct{}, bool, error) {
+	entry, err := service.resolveGroupRoleGrants(userId, groupId)
+	if err != nil {
+		return nil, false, err
+	}
+	if entry == nil || (len(entry.paidByUserIds) == 0 && !entry.includeOwnPaidReceipts) {
+		return nil, true, nil
+	}
+
+	// Copy the cached absolute grants (shared, read-only) before unioning in the
+	// per-user "their own" id, so we never mutate cache state.
+	allowed := make(map[uint]struct{}, len(entry.paidByUserIds)+1)
+	for id := range entry.paidByUserIds {
+		allowed[id] = struct{}{}
+	}
+	if entry.includeOwnPaidReceipts {
+		allowed[userId] = struct{}{}
+	}
+
+	return allowed, false, nil
+}
+
 // GetVisibleCategoriesForUser filters allCategories down to the ones a user may
 // see in a group. Unrestricted users get allCategories unchanged. Used by
 // GetAppData to build the per-group category catalog.
@@ -117,10 +151,20 @@ func loadGroupRoleGrants(roleRepository repositories.RoleRepository, roleId uint
 	if err != nil {
 		return nil, err
 	}
+	paidByUserIds, err := roleRepository.GetGroupRolePaidByUserIds(roleId)
+	if err != nil {
+		return nil, err
+	}
+	includeOwnPaidReceipts, err := roleRepository.GetGroupRoleIncludeOwnPaidReceipts(roleId)
+	if err != nil {
+		return nil, err
+	}
 
 	entry := &grantEntry{
-		categoryIds: uintSliceToSet(categoryIds),
-		tagIds:      uintSliceToSet(tagIds),
+		categoryIds:            uintSliceToSet(categoryIds),
+		tagIds:                 uintSliceToSet(tagIds),
+		paidByUserIds:          uintSliceToSet(paidByUserIds),
+		includeOwnPaidReceipts: includeOwnPaidReceipts,
 	}
 
 	setCachedGroupRoleGrants(roleId, entry, observedGen)

--- a/api/internal/services/grant_cache.go
+++ b/api/internal/services/grant_cache.go
@@ -18,6 +18,12 @@ type grantEntry struct {
 	tagIds                 map[uint]struct{}
 	paidByUserIds          map[uint]struct{}
 	includeOwnPaidReceipts bool
+	// paidByVisibilityRestricted records whether the role opted into paid-by
+	// filtering. It is the source of truth for "restricted vs unrestricted" — NOT
+	// the paidByUserIds count — so a configured role whose grant rows were removed
+	// (e.g. a granted user was deleted) stays restricted (and resolves to "see
+	// nothing") rather than widening to see-all.
+	paidByVisibilityRestricted bool
 }
 
 // groupRoleGrantCache memoizes a group role's category/tag grant id sets, keyed

--- a/api/internal/services/grant_cache.go
+++ b/api/internal/services/grant_cache.go
@@ -7,9 +7,17 @@ import "sync"
 // (the role grants every category/tag) — so categories and tags are independent:
 // a role may restrict categories while leaving tags unrestricted, or vice versa.
 // Callers must treat the maps as read-only (they are shared cache state).
+//
+// paidByUserIds / includeOwnPaidReceipts carry the row-level "paid by" visibility
+// filter. paidByUserIds holds ONLY the absolute granted user ids — the relative
+// "their own receipts" token (includeOwnPaidReceipts) is unioned with the
+// requesting user's id at resolution time, never stored here, because this cache
+// is keyed by role id and shared across every member holding that role.
 type grantEntry struct {
-	categoryIds map[uint]struct{}
-	tagIds      map[uint]struct{}
+	categoryIds            map[uint]struct{}
+	tagIds                 map[uint]struct{}
+	paidByUserIds          map[uint]struct{}
+	includeOwnPaidReceipts bool
 }
 
 // groupRoleGrantCache memoizes a group role's category/tag grant id sets, keyed

--- a/api/internal/services/grant_filter_test.go
+++ b/api/internal/services/grant_filter_test.go
@@ -135,7 +135,7 @@ func TestFilterReceiptBatchPerGroup(t *testing.T) {
 	db := repositories.GetDB()
 	groupB := models.Group{Name: "group-b"}
 	db.Create(&groupB)
-	roleB, err := repositories.NewRoleRepository(nil).CreateGroupRole("Role B", "", []string{permissions.GroupReceiptsRead}, []uint{catB}, nil)
+	roleB, err := repositories.NewRoleRepository(nil).CreateGroupRole("Role B", "", []string{permissions.GroupReceiptsRead}, []uint{catB}, nil, nil, false)
 	if err != nil {
 		t.Fatalf("create role B: %v", err)
 	}

--- a/api/internal/services/grant_test.go
+++ b/api/internal/services/grant_test.go
@@ -22,7 +22,7 @@ func seedMemberWithGroupRoleGrants(t *testing.T, username string, categoryGrantI
 	}
 
 	roleRepository := repositories.NewRoleRepository(nil)
-	role, err := roleRepository.CreateGroupRole("Grant Role "+username, "", []string{permissions.GroupReceiptsRead}, categoryGrantIds, tagGrantIds)
+	role, err := roleRepository.CreateGroupRole("Grant Role "+username, "", []string{permissions.GroupReceiptsRead}, categoryGrantIds, tagGrantIds, nil, false)
 	if err != nil {
 		t.Fatalf("seed group role: %v", err)
 	}

--- a/api/internal/services/paid_by_filter.go
+++ b/api/internal/services/paid_by_filter.go
@@ -1,0 +1,97 @@
+package services
+
+import (
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/repositories"
+)
+
+// This file holds the row-level "paid by" visibility enforcement: which receipts
+// a group role lets its members see, keyed on the receipt's paid_by_user_id.
+// Unlike the category/tag grants (which strip fields off a still-visible receipt
+// in grant_filter.go), paid-by hides the WHOLE receipt — so enforcement adds a
+// WHERE to the paged query (PaidByListResolver), denies single-receipt access
+// (ReceiptPaidByVisible), and post-filters the unpaginated read surfaces
+// (FilterReceiptsByPaidBy). No request-filter intersection is needed: because the
+// paged query already row-filters on the allowed set, a caller filtering by a
+// payer they cannot see is neutralized by that AND (a hidden id intersects to
+// nothing), so it cannot probe receipt existence.
+
+// PaidByListResolver adapts GetGroupPaidByUserIdsForUser to the per-group
+// resolver the receipt repository uses to build its paged WHERE clause. The
+// returned closure reports the allowed paid_by_user_id values for userId in a
+// group, or unrestricted == true (see every payer). Pass the result to
+// GetPagedReceiptsByGroupId; pass nil there to skip paid-by filtering.
+func (service PermissionService) PaidByListResolver(userId uint) repositories.PaidByAllowedResolver {
+	return func(groupId uint) ([]uint, bool, error) {
+		allowed, unrestricted, err := service.GetGroupPaidByUserIdsForUser(userId, groupId)
+		if err != nil || unrestricted {
+			return nil, unrestricted, err
+		}
+		return uintSetToSlice(allowed), false, nil
+	}
+}
+
+// ReceiptPaidByVisible reports whether a user may see a receipt given its group
+// and paid_by user. Unrestricted users (and non-members, who have no group role)
+// always pass. Used to deny single-receipt and dependent reads (image, comments,
+// duplicate source, update/delete) for a receipt hidden by the paid-by filter.
+func (service PermissionService) ReceiptPaidByVisible(userId uint, groupId uint, paidByUserId uint) (bool, error) {
+	allowed, unrestricted, err := service.GetGroupPaidByUserIdsForUser(userId, groupId)
+	if err != nil {
+		return false, err
+	}
+	if unrestricted {
+		return true, nil
+	}
+	_, ok := allowed[paidByUserId]
+	return ok, nil
+}
+
+// FilterReceiptsByPaidBy drops the receipts a user may not see by the paid-by
+// filter, resolving each group's allowed set at most once. Used by the
+// unpaginated read surfaces (search, group-ids list) where there is no
+// totalCount to keep consistent, so removing rows is safe.
+func (service PermissionService) FilterReceiptsByPaidBy(userId uint, receipts []models.Receipt) ([]models.Receipt, error) {
+	if len(receipts) == 0 {
+		return receipts, nil
+	}
+
+	type groupVisibility struct {
+		allowed      map[uint]struct{}
+		unrestricted bool
+	}
+	cache := map[uint]groupVisibility{}
+
+	filtered := make([]models.Receipt, 0, len(receipts))
+	for i := range receipts {
+		groupId := receipts[i].GroupId
+		visibility, ok := cache[groupId]
+		if !ok {
+			allowed, unrestricted, err := service.GetGroupPaidByUserIdsForUser(userId, groupId)
+			if err != nil {
+				return nil, err
+			}
+			visibility = groupVisibility{allowed: allowed, unrestricted: unrestricted}
+			cache[groupId] = visibility
+		}
+
+		if visibility.unrestricted {
+			filtered = append(filtered, receipts[i])
+			continue
+		}
+		if _, allowedOk := visibility.allowed[receipts[i].PaidByUserID]; allowedOk {
+			filtered = append(filtered, receipts[i])
+		}
+	}
+
+	return filtered, nil
+}
+
+// uintSetToSlice flattens a set to a slice (order is irrelevant for an IN clause).
+func uintSetToSlice(set map[uint]struct{}) []uint {
+	ids := make([]uint, 0, len(set))
+	for id := range set {
+		ids = append(ids, id)
+	}
+	return ids
+}

--- a/api/internal/services/paid_by_filter_test.go
+++ b/api/internal/services/paid_by_filter_test.go
@@ -1,0 +1,340 @@
+package services
+
+import (
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/permissions"
+	"receipt-wrangler/api/internal/repositories"
+	"testing"
+)
+
+// makeUser inserts a user and returns its id (used as a "paid by" payer).
+func makeUser(t *testing.T, username string) uint {
+	t.Helper()
+	user := models.User{Username: username, Password: "password"}
+	if err := repositories.GetDB().Create(&user).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	return user.ID
+}
+
+// seedMemberWithPaidByRole creates a group, a group role granting receipts.read
+// with the given paid-by config, and a member assigned to it. Returns the member
+// user id, group id, and role id.
+func seedMemberWithPaidByRole(t *testing.T, username string, paidByUserGrantIds []uint, includeOwn bool) (uint, uint, uint) {
+	t.Helper()
+	db := repositories.GetDB()
+
+	group := models.Group{Name: "pb-group-" + username}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("seed group: %v", err)
+	}
+
+	roleRepository := repositories.NewRoleRepository(nil)
+	role, err := roleRepository.CreateGroupRole("PaidBy Role "+username, "", []string{permissions.GroupReceiptsRead}, nil, nil, paidByUserGrantIds, includeOwn)
+	if err != nil {
+		t.Fatalf("seed group role: %v", err)
+	}
+
+	user := models.User{Username: username, Password: "password"}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("seed member user: %v", err)
+	}
+
+	member := models.GroupMember{GroupID: group.ID, UserID: user.ID, GroupRoleID: &role.ID}
+	if err := db.Create(&member).Error; err != nil {
+		t.Fatalf("seed group member: %v", err)
+	}
+
+	return user.ID, group.ID, role.ID
+}
+
+func TestGetGroupPaidByUserIdsUnrestrictedWhenNoConfig(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	userId, groupId, _ := seedMemberWithPaidByRole(t, "pb-open", nil, false)
+	service := NewPermissionService(nil)
+
+	allowed, unrestricted, err := service.GetGroupPaidByUserIdsForUser(userId, groupId)
+	if err != nil {
+		t.Fatalf("GetGroupPaidByUserIdsForUser: %v", err)
+	}
+	if !unrestricted {
+		t.Error("expected unrestricted when role has no paid-by grants and no include-own")
+	}
+	if allowed != nil {
+		t.Errorf("expected nil allowed set when unrestricted, got %v", allowed)
+	}
+}
+
+func TestGetGroupPaidByUserIdsSelfOnly(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	userId, groupId, _ := seedMemberWithPaidByRole(t, "pb-self", nil, true)
+	service := NewPermissionService(nil)
+
+	allowed, unrestricted, err := service.GetGroupPaidByUserIdsForUser(userId, groupId)
+	if err != nil {
+		t.Fatalf("GetGroupPaidByUserIdsForUser: %v", err)
+	}
+	if unrestricted {
+		t.Error("expected restricted when include-own is set")
+	}
+	if len(allowed) != 1 {
+		t.Fatalf("expected exactly the member's own id, got %v", allowed)
+	}
+	if _, ok := allowed[userId]; !ok {
+		t.Errorf("expected own id %d in allowed set %v", userId, allowed)
+	}
+}
+
+func TestGetGroupPaidByUserIdsUsersOnlyExcludesSelf(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	payer := makeUser(t, "pb-payer")
+	userId, groupId, _ := seedMemberWithPaidByRole(t, "pb-reviewer", []uint{payer}, false)
+	service := NewPermissionService(nil)
+
+	allowed, unrestricted, err := service.GetGroupPaidByUserIdsForUser(userId, groupId)
+	if err != nil {
+		t.Fatalf("GetGroupPaidByUserIdsForUser: %v", err)
+	}
+	if unrestricted {
+		t.Error("expected restricted when a specific paid-by user is granted")
+	}
+	if _, ok := allowed[payer]; !ok {
+		t.Errorf("expected granted payer %d in allowed set %v", payer, allowed)
+	}
+	// include-own is false, so the member's OWN receipts must NOT be visible — this
+	// is the "pure reviewer" case.
+	if _, ok := allowed[userId]; ok {
+		t.Errorf("expected own id %d NOT in allowed set %v when include-own is false", userId, allowed)
+	}
+	if len(allowed) != 1 {
+		t.Fatalf("expected only the granted payer, got %v", allowed)
+	}
+}
+
+func TestGetGroupPaidByUserIdsSelfPlusUser(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	payer := makeUser(t, "pb-payer2")
+	userId, groupId, _ := seedMemberWithPaidByRole(t, "pb-self-plus", []uint{payer}, true)
+	service := NewPermissionService(nil)
+
+	allowed, _, err := service.GetGroupPaidByUserIdsForUser(userId, groupId)
+	if err != nil {
+		t.Fatalf("GetGroupPaidByUserIdsForUser: %v", err)
+	}
+	if len(allowed) != 2 {
+		t.Fatalf("expected own id + granted payer, got %v", allowed)
+	}
+	if _, ok := allowed[userId]; !ok {
+		t.Errorf("expected own id %d in allowed set %v", userId, allowed)
+	}
+	if _, ok := allowed[payer]; !ok {
+		t.Errorf("expected granted payer %d in allowed set %v", payer, allowed)
+	}
+}
+
+func TestGetGroupPaidByUserIdsNonMemberUnrestricted(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	payer := makeUser(t, "pb-payer3")
+	_, groupId, _ := seedMemberWithPaidByRole(t, "pb-member", []uint{payer}, false)
+
+	outsider := makeUser(t, "pb-outsider")
+	service := NewPermissionService(nil)
+
+	_, unrestricted, err := service.GetGroupPaidByUserIdsForUser(outsider, groupId)
+	if err != nil {
+		t.Fatalf("GetGroupPaidByUserIdsForUser: %v", err)
+	}
+	if !unrestricted {
+		t.Error("expected a non-member to resolve as unrestricted")
+	}
+}
+
+// TestGetGroupPaidByUserIdsDoesNotMutateCacheAcrossUsers guards the relative
+// "their own" union: two members share one role-keyed cache entry, so resolving
+// for one member must not leak that member's id into the shared cache or the
+// other member's result.
+func TestGetGroupPaidByUserIdsDoesNotMutateCacheAcrossUsers(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	db := repositories.GetDB()
+	payer := makeUser(t, "pb-shared-payer")
+
+	group := models.Group{Name: "pb-shared-group"}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("seed group: %v", err)
+	}
+
+	roleRepository := repositories.NewRoleRepository(nil)
+	role, err := roleRepository.CreateGroupRole("PaidBy Shared Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, []uint{payer}, true)
+	if err != nil {
+		t.Fatalf("seed role: %v", err)
+	}
+
+	memberA := makeUser(t, "pb-member-a")
+	memberB := makeUser(t, "pb-member-b")
+	if err := db.Create(&models.GroupMember{GroupID: group.ID, UserID: memberA, GroupRoleID: &role.ID}).Error; err != nil {
+		t.Fatalf("seed member A: %v", err)
+	}
+	if err := db.Create(&models.GroupMember{GroupID: group.ID, UserID: memberB, GroupRoleID: &role.ID}).Error; err != nil {
+		t.Fatalf("seed member B: %v", err)
+	}
+
+	service := NewPermissionService(nil)
+
+	allowedA, _, err := service.GetGroupPaidByUserIdsForUser(memberA, group.ID)
+	if err != nil {
+		t.Fatalf("resolve A: %v", err)
+	}
+	allowedB, _, err := service.GetGroupPaidByUserIdsForUser(memberB, group.ID)
+	if err != nil {
+		t.Fatalf("resolve B: %v", err)
+	}
+
+	// Each member sees the granted payer plus only their OWN id.
+	if _, ok := allowedA[memberA]; !ok {
+		t.Errorf("member A should see own id; got %v", allowedA)
+	}
+	if _, ok := allowedA[memberB]; ok {
+		t.Errorf("member A must NOT see member B's id; got %v", allowedA)
+	}
+	if _, ok := allowedB[memberB]; !ok {
+		t.Errorf("member B should see own id; got %v", allowedB)
+	}
+	if _, ok := allowedB[memberA]; ok {
+		t.Errorf("member B must NOT see member A's id (cache leak); got %v", allowedB)
+	}
+}
+
+func TestReceiptPaidByVisible(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	payer := makeUser(t, "pb-vis-payer")
+	other := makeUser(t, "pb-vis-other")
+	userId, groupId, _ := seedMemberWithPaidByRole(t, "pb-vis-member", []uint{payer}, false)
+	service := NewPermissionService(nil)
+
+	visible, err := service.ReceiptPaidByVisible(userId, groupId, payer)
+	if err != nil {
+		t.Fatalf("visible(payer): %v", err)
+	}
+	if !visible {
+		t.Error("expected a receipt paid by the granted payer to be visible")
+	}
+
+	visible, err = service.ReceiptPaidByVisible(userId, groupId, other)
+	if err != nil {
+		t.Fatalf("visible(other): %v", err)
+	}
+	if visible {
+		t.Error("expected a receipt paid by a non-granted user to be hidden")
+	}
+}
+
+func TestFilterReceiptsByPaidBy(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	payer := makeUser(t, "pb-filter-payer")
+	other := makeUser(t, "pb-filter-other")
+	userId, groupId, _ := seedMemberWithPaidByRole(t, "pb-filter-member", []uint{payer}, false)
+	service := NewPermissionService(nil)
+
+	receipts := []models.Receipt{
+		{GroupId: groupId, PaidByUserID: payer},
+		{GroupId: groupId, PaidByUserID: other},
+		{GroupId: groupId, PaidByUserID: payer},
+	}
+
+	filtered, err := service.FilterReceiptsByPaidBy(userId, receipts)
+	if err != nil {
+		t.Fatalf("FilterReceiptsByPaidBy: %v", err)
+	}
+	if len(filtered) != 2 {
+		t.Fatalf("expected 2 receipts (the payer's), got %d", len(filtered))
+	}
+	for _, receipt := range filtered {
+		if receipt.PaidByUserID != payer {
+			t.Errorf("unexpected hidden payer leaked: %d", receipt.PaidByUserID)
+		}
+	}
+}
+
+func TestPaidByListResolver(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	payer := makeUser(t, "pb-resolver-payer")
+	userId, groupId, _ := seedMemberWithPaidByRole(t, "pb-resolver-member", []uint{payer}, true)
+	service := NewPermissionService(nil)
+
+	resolver := service.PaidByListResolver(userId)
+
+	allowed, unrestricted, err := resolver(groupId)
+	if err != nil {
+		t.Fatalf("resolver(restricted group): %v", err)
+	}
+	if unrestricted {
+		t.Error("expected restricted for a configured group role")
+	}
+	got := make(map[uint]struct{}, len(allowed))
+	for _, id := range allowed {
+		got[id] = struct{}{}
+	}
+	if _, ok := got[payer]; !ok {
+		t.Errorf("expected granted payer %d in resolver result %v", payer, allowed)
+	}
+	if _, ok := got[userId]; !ok {
+		t.Errorf("expected own id %d in resolver result %v", userId, allowed)
+	}
+	if len(allowed) != 2 {
+		t.Fatalf("expected own id + payer, got %v", allowed)
+	}
+
+	// A group the user is not a member of has no role, so the resolver is
+	// unrestricted (no paid-by constraint added to the query for that group).
+	otherGroup := models.Group{Name: "pb-resolver-other"}
+	if err := repositories.GetDB().Create(&otherGroup).Error; err != nil {
+		t.Fatalf("seed other group: %v", err)
+	}
+	_, unrestricted, err = resolver(otherGroup.ID)
+	if err != nil {
+		t.Fatalf("resolver(non-member group): %v", err)
+	}
+	if !unrestricted {
+		t.Error("expected unrestricted for a group the user is not a member of")
+	}
+}
+
+func TestFilterReceiptsByPaidByUnrestrictedPassThrough(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	other := makeUser(t, "pb-pass-other")
+	userId, groupId, _ := seedMemberWithPaidByRole(t, "pb-pass-member", nil, false)
+	service := NewPermissionService(nil)
+
+	receipts := []models.Receipt{
+		{GroupId: groupId, PaidByUserID: userId},
+		{GroupId: groupId, PaidByUserID: other},
+	}
+
+	filtered, err := service.FilterReceiptsByPaidBy(userId, receipts)
+	if err != nil {
+		t.Fatalf("FilterReceiptsByPaidBy: %v", err)
+	}
+	if len(filtered) != 2 {
+		t.Errorf("expected pass-through of all receipts when unrestricted, got %d", len(filtered))
+	}
+}

--- a/api/internal/services/paid_by_filter_test.go
+++ b/api/internal/services/paid_by_filter_test.go
@@ -216,6 +216,49 @@ func TestGetGroupPaidByUserIdsDoesNotMutateCacheAcrossUsers(t *testing.T) {
 	}
 }
 
+// TestGetGroupPaidByUserIdsFailsClosedAfterGrantedUserDeleted guards the
+// privacy-widening fix: a role configured to see only a specific payer must STAY
+// restricted (and resolve to "see nothing") after that payer is deleted and the
+// FK cascade empties the grant rows — it must NOT silently widen to see-all.
+func TestGetGroupPaidByUserIdsFailsClosedAfterGrantedUserDeleted(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	payer := makeUser(t, "pb-cascade-payer")
+	userId, groupId, roleId := seedMemberWithPaidByRole(t, "pb-cascade-member", []uint{payer}, false)
+	service := NewPermissionService(nil)
+
+	// Initially restricted to the granted payer.
+	allowed, unrestricted, err := service.GetGroupPaidByUserIdsForUser(userId, groupId)
+	if err != nil {
+		t.Fatalf("initial resolve: %v", err)
+	}
+	if unrestricted {
+		t.Fatal("expected restricted before the payer is deleted")
+	}
+	if _, ok := allowed[payer]; !ok || len(allowed) != 1 {
+		t.Fatalf("expected allowed {payer}, got %v", allowed)
+	}
+
+	// Delete the granted user; the FK cascade removes the role's paid-by grant row.
+	if err := repositories.GetDB().Delete(&models.User{}, payer).Error; err != nil {
+		t.Fatalf("delete payer: %v", err)
+	}
+	// A user delete does not evict the role's grant cache, so force a fresh load.
+	clearGroupRoleGrantCache(roleId)
+
+	allowed, unrestricted, err = service.GetGroupPaidByUserIdsForUser(userId, groupId)
+	if err != nil {
+		t.Fatalf("re-resolve: %v", err)
+	}
+	if unrestricted {
+		t.Error("a configured role whose only payer was deleted must stay restricted (fail closed), not widen to see-all")
+	}
+	if len(allowed) != 0 {
+		t.Errorf("expected an empty allowed set (see nothing), got %v", allowed)
+	}
+}
+
 func TestReceiptPaidByVisible(t *testing.T) {
 	defer repositories.TruncateTestDb()
 	clearGroupRoleGrantCacheAll()

--- a/api/internal/services/paid_by_filter_test.go
+++ b/api/internal/services/paid_by_filter_test.go
@@ -259,6 +259,41 @@ func TestGetGroupPaidByUserIdsFailsClosedAfterGrantedUserDeleted(t *testing.T) {
 	}
 }
 
+// TestGetGroupPaidByUserIdsFailsClosedWhenFlagDesynced guards the hardening: even
+// if the persisted PaidByVisibilityRestricted flag is out of sync (false) while
+// grant rows exist, the resolver still treats the role as restricted (fail closed)
+// rather than widening to see-all.
+func TestGetGroupPaidByUserIdsFailsClosedWhenFlagDesynced(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+
+	payer := makeUser(t, "pb-desync-payer")
+	userId, groupId, roleId := seedMemberWithPaidByRole(t, "pb-desync-member", nil, false)
+
+	// Simulate a desync: a grant row exists but the restricted flag was left false
+	// (e.g. a future write path that inserted grants without recomputing the flag).
+	db := repositories.GetDB()
+	if err := db.Create(&models.GroupRolePaidByUserGrant{GroupRoleID: roleId, UserID: payer}).Error; err != nil {
+		t.Fatalf("insert grant row: %v", err)
+	}
+	if err := db.Model(&models.GroupRoleDefinition{}).Where("id = ?", roleId).
+		Update("paid_by_visibility_restricted", false).Error; err != nil {
+		t.Fatalf("force flag false: %v", err)
+	}
+	clearGroupRoleGrantCache(roleId)
+
+	allowed, unrestricted, err := NewPermissionService(nil).GetGroupPaidByUserIdsForUser(userId, groupId)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if unrestricted {
+		t.Error("a role with live grant rows must resolve restricted even if the persisted flag is false")
+	}
+	if _, ok := allowed[payer]; !ok || len(allowed) != 1 {
+		t.Errorf("expected allowed {payer}, got %v", allowed)
+	}
+}
+
 func TestReceiptPaidByVisible(t *testing.T) {
 	defer repositories.TruncateTestDb()
 	clearGroupRoleGrantCacheAll()

--- a/api/internal/services/permission_test.go
+++ b/api/internal/services/permission_test.go
@@ -42,7 +42,7 @@ func seedMemberWithGroupRole(t *testing.T, username string, perms []string) (uin
 	}
 
 	roleRepository := repositories.NewRoleRepository(nil)
-	role, err := roleRepository.CreateGroupRole("Group Role", "", perms, nil, nil)
+	role, err := roleRepository.CreateGroupRole("Group Role", "", perms, nil, nil, nil, false)
 	if err != nil {
 		t.Fatalf("seed group role: %v", err)
 	}

--- a/api/internal/services/pie_chart.go
+++ b/api/internal/services/pie_chart.go
@@ -57,6 +57,7 @@ func (service PieChartService) GetPieChartData(
 		groupId,
 		pagedRequest,
 		[]string{"Categories", "Tags"},
+		permissionService.PaidByListResolver(userId),
 	)
 	if err != nil {
 		return structs.PieChartData{}, err

--- a/api/internal/services/roles.go
+++ b/api/internal/services/roles.go
@@ -18,7 +18,7 @@ var (
 	ErrSystemRoleUndeletable = errors.New("system roles cannot be deleted")
 	ErrRoleAssigned          = errors.New("role is assigned and cannot be deleted")
 	ErrRoleIsDefault         = errors.New("the default role cannot be deleted")
-	ErrInvalidGrant          = errors.New("a category or tag grant references a non-existent category or tag")
+	ErrInvalidGrant          = errors.New("a category, tag, or paid-by grant references a non-existent category, tag, or user")
 )
 
 type RoleService struct {
@@ -42,6 +42,7 @@ func (service RoleService) CreateRole(command commands.UpsertRoleCommand) (struc
 	}
 	categoryGrants := normalizeUintSlice(command.CategoryGrants)
 	tagGrants := normalizeUintSlice(command.TagGrants)
+	paidByUserGrants := normalizeUintSlice(command.PaidByUserGrants)
 
 	err := repositories.GetDB().Transaction(func(tx *gorm.DB) error {
 		roleRepository := repositories.NewRoleRepository(tx)
@@ -53,37 +54,40 @@ func (service RoleService) CreateRole(command commands.UpsertRoleCommand) (struc
 			}
 
 			roleView = structs.RoleView{
-				Id:             role.ID,
-				Name:           role.Name,
-				Description:    role.Description,
-				Scope:          permissions.ScopeApp,
-				IsSystem:       role.IsSystem,
-				Permissions:    perms,
-				CategoryGrants: []uint{},
-				TagGrants:      []uint{},
+				Id:               role.ID,
+				Name:             role.Name,
+				Description:      role.Description,
+				Scope:            permissions.ScopeApp,
+				IsSystem:         role.IsSystem,
+				Permissions:      perms,
+				CategoryGrants:   []uint{},
+				TagGrants:        []uint{},
+				PaidByUserGrants: []uint{},
 			}
 
 			return nil
 		}
 
-		if txErr := validateGrantsExist(tx, categoryGrants, tagGrants); txErr != nil {
+		if txErr := validateGrantsExist(tx, categoryGrants, tagGrants, paidByUserGrants); txErr != nil {
 			return txErr
 		}
 
-		role, txErr := roleRepository.CreateGroupRole(command.Name, command.Description, perms, categoryGrants, tagGrants)
+		role, txErr := roleRepository.CreateGroupRole(command.Name, command.Description, perms, categoryGrants, tagGrants, paidByUserGrants, command.IncludeOwnPaidReceipts)
 		if txErr != nil {
 			return txErr
 		}
 
 		roleView = structs.RoleView{
-			Id:             role.ID,
-			Name:           role.Name,
-			Description:    role.Description,
-			Scope:          permissions.ScopeGroup,
-			IsSystem:       role.IsSystem,
-			Permissions:    perms,
-			CategoryGrants: categoryGrants,
-			TagGrants:      tagGrants,
+			Id:                     role.ID,
+			Name:                   role.Name,
+			Description:            role.Description,
+			Scope:                  permissions.ScopeGroup,
+			IsSystem:               role.IsSystem,
+			Permissions:            perms,
+			CategoryGrants:         categoryGrants,
+			TagGrants:              tagGrants,
+			PaidByUserGrants:       paidByUserGrants,
+			IncludeOwnPaidReceipts: command.IncludeOwnPaidReceipts,
 		}
 
 		return nil
@@ -104,6 +108,7 @@ func (service RoleService) UpdateRole(id uint, command commands.UpsertRoleComman
 	}
 	categoryGrants := normalizeUintSlice(command.CategoryGrants)
 	tagGrants := normalizeUintSlice(command.TagGrants)
+	paidByUserGrants := normalizeUintSlice(command.PaidByUserGrants)
 
 	err := repositories.GetDB().Transaction(func(tx *gorm.DB) error {
 		roleRepository := repositories.NewRoleRepository(tx)
@@ -126,15 +131,16 @@ func (service RoleService) UpdateRole(id uint, command commands.UpsertRoleComman
 			}
 
 			roleView = structs.RoleView{
-				Id:             role.ID,
-				Name:           role.Name,
-				Description:    role.Description,
-				Scope:          permissions.ScopeApp,
-				IsDefault:      role.IsDefault,
-				IsSystem:       role.IsSystem,
-				Permissions:    perms,
-				CategoryGrants: []uint{},
-				TagGrants:      []uint{},
+				Id:               role.ID,
+				Name:             role.Name,
+				Description:      role.Description,
+				Scope:            permissions.ScopeApp,
+				IsDefault:        role.IsDefault,
+				IsSystem:         role.IsSystem,
+				Permissions:      perms,
+				CategoryGrants:   []uint{},
+				TagGrants:        []uint{},
+				PaidByUserGrants: []uint{},
 			}
 
 			return nil
@@ -151,25 +157,27 @@ func (service RoleService) UpdateRole(id uint, command commands.UpsertRoleComman
 			return ErrSystemRoleImmutable
 		}
 
-		if txErr := validateGrantsExist(tx, categoryGrants, tagGrants); txErr != nil {
+		if txErr := validateGrantsExist(tx, categoryGrants, tagGrants, paidByUserGrants); txErr != nil {
 			return txErr
 		}
 
-		role, txErr := roleRepository.UpdateGroupRole(id, command.Name, command.Description, perms, categoryGrants, tagGrants)
+		role, txErr := roleRepository.UpdateGroupRole(id, command.Name, command.Description, perms, categoryGrants, tagGrants, paidByUserGrants, command.IncludeOwnPaidReceipts)
 		if txErr != nil {
 			return txErr
 		}
 
 		roleView = structs.RoleView{
-			Id:             role.ID,
-			Name:           role.Name,
-			Description:    role.Description,
-			Scope:          permissions.ScopeGroup,
-			IsDefault:      role.IsDefault,
-			IsSystem:       role.IsSystem,
-			Permissions:    perms,
-			CategoryGrants: categoryGrants,
-			TagGrants:      tagGrants,
+			Id:                     role.ID,
+			Name:                   role.Name,
+			Description:            role.Description,
+			Scope:                  permissions.ScopeGroup,
+			IsDefault:              role.IsDefault,
+			IsSystem:               role.IsSystem,
+			Permissions:            perms,
+			CategoryGrants:         categoryGrants,
+			TagGrants:              tagGrants,
+			PaidByUserGrants:       paidByUserGrants,
+			IncludeOwnPaidReceipts: command.IncludeOwnPaidReceipts,
 		}
 
 		return nil
@@ -200,10 +208,11 @@ func normalizeUintSlice(ids []uint) []uint {
 	return ids
 }
 
-// validateGrantsExist confirms every category/tag grant id references a real
-// row. Because UpsertRoleCommand.Validate already rejects duplicate grant ids, a
-// matching count means all ids exist. Returns ErrInvalidGrant otherwise.
-func validateGrantsExist(tx *gorm.DB, categoryGrants []uint, tagGrants []uint) error {
+// validateGrantsExist confirms every category/tag/paid-by-user grant id
+// references a real row. Because UpsertRoleCommand.Validate already rejects
+// duplicate grant ids, a matching count means all ids exist. Returns
+// ErrInvalidGrant otherwise.
+func validateGrantsExist(tx *gorm.DB, categoryGrants []uint, tagGrants []uint, paidByUserGrants []uint) error {
 	if len(categoryGrants) > 0 {
 		categoryRepository := repositories.NewCategoryRepository(tx)
 		count, err := categoryRepository.CountByIds(categoryGrants)
@@ -222,6 +231,17 @@ func validateGrantsExist(tx *gorm.DB, categoryGrants []uint, tagGrants []uint) e
 			return err
 		}
 		if int(count) != len(tagGrants) {
+			return ErrInvalidGrant
+		}
+	}
+
+	if len(paidByUserGrants) > 0 {
+		userRepository := repositories.NewUserRepository(tx)
+		count, err := userRepository.CountByIds(paidByUserGrants)
+		if err != nil {
+			return err
+		}
+		if int(count) != len(paidByUserGrants) {
 			return ErrInvalidGrant
 		}
 	}
@@ -390,15 +410,16 @@ func appRoleToView(role models.AppRole, isDefault bool) structs.RoleView {
 	}
 
 	return structs.RoleView{
-		Id:             role.ID,
-		Name:           role.Name,
-		Description:    role.Description,
-		Scope:          permissions.ScopeApp,
-		IsDefault:      isDefault,
-		IsSystem:       role.IsSystem,
-		Permissions:    perms,
-		CategoryGrants: []uint{},
-		TagGrants:      []uint{},
+		Id:               role.ID,
+		Name:             role.Name,
+		Description:      role.Description,
+		Scope:            permissions.ScopeApp,
+		IsDefault:        isDefault,
+		IsSystem:         role.IsSystem,
+		Permissions:      perms,
+		CategoryGrants:   []uint{},
+		TagGrants:        []uint{},
+		PaidByUserGrants: []uint{},
 	}
 }
 
@@ -421,15 +442,22 @@ func groupRoleToView(role models.GroupRoleDefinition, isDefault bool) structs.Ro
 		tagGrants = append(tagGrants, grant.TagID)
 	}
 
+	paidByUserGrants := make([]uint, 0, len(role.PaidByUserGrants))
+	for _, grant := range role.PaidByUserGrants {
+		paidByUserGrants = append(paidByUserGrants, grant.UserID)
+	}
+
 	return structs.RoleView{
-		Id:             role.ID,
-		Name:           role.Name,
-		Description:    role.Description,
-		Scope:          permissions.ScopeGroup,
-		IsDefault:      isDefault,
-		IsSystem:       role.IsSystem,
-		Permissions:    perms,
-		CategoryGrants: categoryGrants,
-		TagGrants:      tagGrants,
+		Id:                     role.ID,
+		Name:                   role.Name,
+		Description:            role.Description,
+		Scope:                  permissions.ScopeGroup,
+		IsDefault:              isDefault,
+		IsSystem:               role.IsSystem,
+		Permissions:            perms,
+		CategoryGrants:         categoryGrants,
+		TagGrants:              tagGrants,
+		PaidByUserGrants:       paidByUserGrants,
+		IncludeOwnPaidReceipts: role.IncludeOwnPaidReceipts,
 	}
 }

--- a/api/internal/services/roles_test.go
+++ b/api/internal/services/roles_test.go
@@ -58,6 +58,52 @@ func TestCreateGroupRoleRejectsNonExistentGrant(t *testing.T) {
 	}
 }
 
+func TestCreateGroupRoleWithPaidByGrantsExposesGrantIds(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	payer := models.User{Username: "paidby-payer", Password: "x"}
+	repositories.GetDB().Create(&payer)
+
+	service := NewRoleService(nil)
+	command := commands.UpsertRoleCommand{
+		Name:                   "Paid-By Group Role",
+		Scope:                  permissions.ScopeGroup,
+		Permissions:            []string{permissions.GroupReceiptsRead},
+		PaidByUserGrants:       []uint{payer.ID},
+		IncludeOwnPaidReceipts: true,
+	}
+
+	roleView, err := service.CreateRole(command)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if len(roleView.PaidByUserGrants) != 1 || roleView.PaidByUserGrants[0] != payer.ID {
+		utils.PrintTestError(t, roleView.PaidByUserGrants, []uint{payer.ID})
+	}
+	if !roleView.IncludeOwnPaidReceipts {
+		utils.PrintTestError(t, roleView.IncludeOwnPaidReceipts, true)
+	}
+}
+
+func TestCreateGroupRoleRejectsNonExistentPaidByGrant(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	service := NewRoleService(nil)
+	command := commands.UpsertRoleCommand{
+		Name:             "Bad Paid-By Role",
+		Scope:            permissions.ScopeGroup,
+		Permissions:      []string{permissions.GroupReceiptsRead},
+		PaidByUserGrants: []uint{999999},
+	}
+
+	_, err := service.CreateRole(command)
+	if !errors.Is(err, ErrInvalidGrant) {
+		utils.PrintTestError(t, err, ErrInvalidGrant)
+	}
+}
+
 func TestUpdateGroupRoleServiceReplacesGrants(t *testing.T) {
 	defer repositories.TruncateTestDb()
 	roleRepository := repositories.NewRoleRepository(nil)
@@ -67,7 +113,7 @@ func TestUpdateGroupRoleServiceReplacesGrants(t *testing.T) {
 	catB := models.Category{Name: "B"}
 	repositories.GetDB().Create(&catB)
 
-	created, err := roleRepository.CreateGroupRole("Role", "", []string{permissions.GroupReceiptsRead}, []uint{catA.ID}, nil)
+	created, err := roleRepository.CreateGroupRole("Role", "", []string{permissions.GroupReceiptsRead}, []uint{catA.ID}, nil, nil, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return

--- a/api/internal/services/users_test.go
+++ b/api/internal/services/users_test.go
@@ -339,6 +339,35 @@ func TestDeleteUser_BasicDeletion(t *testing.T) {
 	assertCount(t, &models.User{}, "id = ?", []interface{}{user.ID}, 0, "user should be deleted")
 }
 
+func TestDeleteUser_WithPaidByGrant(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	user := createUserForDeletion(t, "paidbygrantuser")
+
+	// A group role that grants paid-by visibility of this user's receipts.
+	role, err := repositories.NewRoleRepository(nil).CreateGroupRole(
+		"PaidBy Cascade Role",
+		"",
+		[]string{permissions.GroupReceiptsRead},
+		nil,
+		nil,
+		[]uint{user.ID},
+		false,
+	)
+	if err != nil {
+		t.Fatalf("create group role: %v", err)
+	}
+	assertCount(t, &models.GroupRolePaidByUserGrant{}, "user_id = ?", []interface{}{user.ID}, 1, "paid-by grant should exist before delete")
+
+	if err := DeleteUser(utils.UintToString(user.ID)); err != nil {
+		t.Fatalf("DeleteUser failed: %v", err)
+	}
+
+	// The User FK is OnDelete:CASCADE, so deleting the user removes its paid-by
+	// grant rows without error; the role definition itself survives.
+	assertCount(t, &models.GroupRolePaidByUserGrant{}, "user_id = ?", []interface{}{user.ID}, 0, "paid-by grant should cascade-delete with the user")
+	assertCount(t, &models.GroupRoleDefinition{}, "id = ?", []interface{}{role.ID}, 1, "the group role should survive the user deletion")
+}
+
 func TestDeleteUser_WithReceipts(t *testing.T) {
 	defer repositories.TruncateTestDb()
 	user := createUserForDeletion(t, "receiptuser")

--- a/api/internal/structs/handler.go
+++ b/api/internal/structs/handler.go
@@ -25,4 +25,12 @@ type Handler struct {
 	AppPermissions   []string
 	GroupPermissions []string
 	OrAppPermissions []string
+
+	// SkipPaidByVisibilityCheck, when true, tells HandleRequest to skip the
+	// row-level "paid by" visibility check for receipts resolved from
+	// ReceiptId/ReceiptIds, while STILL enforcing the group permissions above. Set
+	// it on accounting/settlement endpoints (e.g. amount-owed) whose totals must be
+	// identical for every member regardless of their browse-time paid-by filter —
+	// paid-by restricts browsing, not the group's accounting.
+	SkipPaidByVisibilityCheck bool
 }

--- a/api/internal/structs/role_view.go
+++ b/api/internal/structs/role_view.go
@@ -16,4 +16,10 @@ type RoleView struct {
 	// app roles serialize empty slices.
 	CategoryGrants []uint `json:"categoryGrants"`
 	TagGrants      []uint `json:"tagGrants"`
+	// PaidByUserGrants are the user ids whose receipts a group role lets its
+	// members see; IncludeOwnPaidReceipts adds the member's own receipts. Empty +
+	// false means unrestricted. Always group-scoped; app roles serialize an empty
+	// slice and false.
+	PaidByUserGrants       []uint `json:"paidByUserGrants"`
+	IncludeOwnPaidReceipts bool   `json:"includeOwnPaidReceipts"`
 }

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -3085,6 +3085,21 @@ components:
           items:
             type: integer
             format: uint64
+        paidByUserGrants:
+          type: array
+          description: >-
+            User ids whose receipts a GROUP role lets its members see (by the
+            receipt's "paid by" user). Empty with includeOwnPaidReceipts false
+            means unrestricted (members see every payer's receipts). Always empty
+            for app roles.
+          items:
+            type: integer
+            format: uint64
+        includeOwnPaidReceipts:
+          type: boolean
+          description: >-
+            Whether a GROUP role lets each member see receipts they paid for. Part
+            of the paid-by visibility filter; always false for app roles.
     UpsertRoleCommand:
       type: object
       required:
@@ -3118,6 +3133,20 @@ components:
           items:
             type: integer
             format: uint64
+        paidByUserGrants:
+          type: array
+          description: >-
+            User ids whose receipts a GROUP role's members may see (by the
+            receipt's "paid by" user). Only valid on group roles; omit or leave
+            empty (with includeOwnPaidReceipts false) for unrestricted access.
+          items:
+            type: integer
+            format: uint64
+        includeOwnPaidReceipts:
+          type: boolean
+          description: >-
+            Whether to also let each member see receipts they paid for. Only valid
+            on group roles.
     SortDirection:
       type: string
       enum:

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -488,7 +488,10 @@ helpers `withAdminApi` + `apiDeleteUserByName` / `apiDeleteGroupById` / `apiDele
   its UI teardown leaks roles, the reason the new specs use API teardown), `group-viewer-visibility.spec.ts`
   (group member with a group role), `search-bar-visibility.spec.ts` (no `app.receipts.search` → header
   search bar never renders), `dashboard-read-redirect.spec.ts` (no `group.dashboards.read` →
-  `/dashboard/group/:id` redirects to `/receipts/group/:id`; an owner contrast still sees the dashboard).
+  `/dashboard/group/:id` redirects to `/receipts/group/:id`; an owner contrast still sees the dashboard),
+  `paid-by-visibility.spec.ts` (a group role limited to "their own receipts" → a hidden-payer receipt
+  `GET` 403s and is absent from the list, the member's own 200s; uses `withApiAs`/`apiCreateReceipt` and
+  the `createRole` `paidByOwn` option in `helpers/provisioning.ts`).
 
 ## Testing Requirements
 

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -133,6 +133,15 @@ gated by `appPermissionGuard` requiring `app.roles.read` (see **Permission-based
   pool objects by an effect once the pool arrives) and serialized back as id arrays on
   `UpsertRoleCommand` for group scope only. The grant pickers pass `[creatable]="false"` (pick from
   existing, never create). See `api/CLAUDE.md` → "Data model".
+- **Paid-by visibility (group roles only):** the same group-scoped grants section also shows a
+  "Paid-by visibility" picker — a single `app-autocomlete` multi-select over `paidByOptions()` (a
+  pinned **"Their own receipts"** sentinel option, id `OWN_PAID_RECEIPTS_OPTION_ID = -1`, followed by
+  every user from `UserState.users`). On submit the selections split into `includeOwnPaidReceipts`
+  (the sentinel is present) and `paidByUserGrants` (the remaining user ids, sentinel excluded); on
+  edit they rehydrate from `role.paidByUserGrants` / `role.includeOwnPaidReceipts` via an effect that
+  filters the shared `paidByOptions()` (stable references so the autocomplete excludes selected
+  options). Empty = members see every payer's receipts; it restricts which receipts a member can see,
+  not what they can edit. See `api/CLAUDE.md` → "Paid-by visibility enforcement".
 - **Default roles:** the role-list page shows two `app-select` controls above the filter bar —
   "Default application role" and "Default group role". Each is pre-selected from the role flagged
   `isDefault` for its scope and, on change, calls `RoleService.setDefaultRole(scope, roleId)` then

--- a/desktop/e2e/helpers/provisioning.ts
+++ b/desktop/e2e/helpers/provisioning.ts
@@ -4,7 +4,7 @@ import {
   type Page,
   request as pwRequest,
 } from '@playwright/test';
-import { creds } from './auth';
+import { creds, type Role } from './auth';
 
 // Shared provisioning for permission e2e specs. Roles/users/groups are CREATED
 // through the real app UI (the realistic flow under test); TEARDOWN goes through
@@ -32,6 +32,13 @@ export interface CreateRoleOptions {
    * and the row by its label (e.g. 'Read Dashboards').
    */
   disablePermissions?: { panelKey: string; label: string }[];
+  /**
+   * Group-role paid-by visibility (the "Visible paid-by users" picker). Pin
+   * "Their own receipts" and/or specific users by display name. Leaving both
+   * unset keeps the role unrestricted (members see every payer's receipts).
+   */
+  paidByOwn?: boolean;
+  paidByUsers?: string[];
 }
 
 /**
@@ -63,6 +70,27 @@ export async function createRole(page: Page, opts: CreateRoleOptions): Promise<v
     const subText = new RegExp(`${panelKey.replace(/\./g, '\\.')} \\u00b7`);
     await page.getByText(subText).click();
     await page.getByRole('button', { name: `Toggle ${label}` }).click();
+  }
+
+  if (opts.paidByOwn || (opts.paidByUsers?.length ?? 0) > 0) {
+    // The picker is a multi-select autocomplete; while its panel is open the
+    // listbox shares the field's label, so target the combobox role.
+    const paidByField = page.getByRole('combobox', {
+      name: 'Visible paid-by users',
+    });
+    if (opts.paidByOwn) {
+      await paidByField.click();
+      await page
+        .getByRole('option', { name: 'Their own receipts', exact: true })
+        .click();
+    }
+    for (const displayName of opts.paidByUsers ?? []) {
+      await paidByField.click();
+      await paidByField.fill(displayName);
+      await page.getByRole('option', { name: displayName, exact: true }).click();
+    }
+    // Selecting an option re-opens the panel; close it so Save is clickable.
+    await page.keyboard.press('Escape');
   }
 
   await page.getByRole('button', { name: 'Save Role' }).click();
@@ -138,23 +166,75 @@ const apiBaseUrl = (): string =>
   process.env.E2E_BASE_URL ?? 'http://localhost:4200';
 
 /**
+ * Opens an `APIRequestContext` authenticated as the given e2e [role], runs [fn],
+ * and disposes it. Use to drive API calls AS a specific user — e.g. asserting a
+ * restricted user's request is denied, or admin teardown.
+ */
+export async function withApiAs<T>(
+  role: Role,
+  fn: (api: APIRequestContext) => Promise<T>,
+): Promise<T> {
+  const api = await pwRequest.newContext({ baseURL: apiBaseUrl() });
+  try {
+    const { username, password } = creds(role);
+    const res = await api.post('/api/login', { data: { username, password } });
+    if (!res.ok()) {
+      throw new Error(`${role} API login failed: HTTP ${res.status()}`);
+    }
+    return await fn(api);
+  } finally {
+    await api.dispose();
+  }
+}
+
+/**
  * Opens an admin-authenticated `APIRequestContext`, runs [fn], and disposes it.
  * Use in `afterAll` for best-effort teardown of provisioned roles/users/groups.
  */
 export async function withAdminApi<T>(
   fn: (api: APIRequestContext) => Promise<T>,
 ): Promise<T> {
-  const api = await pwRequest.newContext({ baseURL: apiBaseUrl() });
-  try {
-    const { username, password } = creds('admin');
-    const res = await api.post('/api/login', { data: { username, password } });
-    if (!res.ok()) {
-      throw new Error(`admin API login failed: HTTP ${res.status()}`);
-    }
-    return await fn(api);
-  } finally {
-    await api.dispose();
+  return withApiAs('admin', fn);
+}
+
+/** Returns the id of the user with [username] (via the admin user list). */
+export async function apiGetUserId(
+  api: APIRequestContext,
+  username: string,
+): Promise<number> {
+  const users = (await (await api.get('/api/user/')).json()) as {
+    id: number;
+    username: string;
+  }[];
+  const user = users.find((u) => u.username === username);
+  if (!user) {
+    throw new Error(`user ${username} not found`);
   }
+  return user.id;
+}
+
+/** Creates a minimal OPEN receipt and returns its id. */
+export async function apiCreateReceipt(
+  api: APIRequestContext,
+  opts: { groupId: number | string; paidByUserId: number; name: string },
+): Promise<number> {
+  const res = await api.post('/api/receipt', {
+    data: {
+      name: opts.name,
+      amount: '10.00',
+      date: '2024-01-01T00:00:00Z',
+      groupId: Number(opts.groupId),
+      paidByUserId: opts.paidByUserId,
+      status: 'OPEN',
+    },
+  });
+  if (!res.ok()) {
+    throw new Error(
+      `create receipt failed: HTTP ${res.status()} ${await res.text()}`,
+    );
+  }
+  const receipt = (await res.json()) as { id: number };
+  return receipt.id;
 }
 
 /** Hard-deletes the user with [username] (frees any app-role assignment). */

--- a/desktop/e2e/paid-by-visibility.spec.ts
+++ b/desktop/e2e/paid-by-visibility.spec.ts
@@ -1,0 +1,127 @@
+import { BrowserContext, expect, Page, test } from '@playwright/test';
+import { creds, stubTokenRefresh } from './helpers/auth';
+import {
+  apiCreateReceipt,
+  apiDeleteGroupById,
+  apiDeleteRoleByName,
+  apiGetUserId,
+  createGroupWithMember,
+  createRole,
+  uniqueName,
+  withAdminApi,
+  withApiAs,
+} from './helpers/provisioning';
+
+// A group member whose group role restricts paid-by visibility to "their own
+// receipts" must not see — or be able to fetch — receipts paid by anyone else,
+// while still seeing their own. An admin context provisions the role (Viewer
+// preset, so the member holds group.receipts.read — the denial is paid-by, not a
+// missing permission) + a group with e2e-user as that member + two receipts (one
+// paid by admin, one by e2e-user). Assertions then run as e2e-user.
+//
+// The API assertions are the core guarantee (a hidden receipt GET must 403); the
+// UI assertions prove the list hides it and the receipt-view guard redirects
+// cleanly instead of admitting the user to a 403'd fetch.
+
+test.describe('Group role paid-by visibility', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let adminContext: BrowserContext;
+  let adminPage: Page;
+
+  const roleName = uniqueName('paidby-role');
+  const groupName = uniqueName('paidby-grp');
+  const hiddenReceiptName = uniqueName('paidby-hidden');
+  const ownReceiptName = uniqueName('paidby-own');
+
+  let groupId: string;
+  let hiddenReceiptId: number; // paid by admin — outside the member's grant
+  let ownReceiptId: number; // paid by e2e-user — their own
+
+  test.beforeAll(async ({ browser }) => {
+    adminContext = await browser.newContext({
+      storageState: 'e2e/.auth/admin.json',
+    });
+    adminPage = await adminContext.newPage();
+    await stubTokenRefresh(adminPage);
+
+    // Group role restricted to the member's own receipts on the paid-by axis.
+    await createRole(adminPage, {
+      name: roleName,
+      type: 'Group role',
+      preset: 'Viewer',
+      paidByOwn: true,
+    });
+
+    // Group with e2e-user (display name "E2E User") holding that role.
+    groupId = await createGroupWithMember(adminPage, {
+      groupName,
+      memberDisplayName: 'E2E User',
+      roleName,
+    });
+
+    // Seed a receipt paid by admin (hidden) and one paid by e2e-user (visible).
+    await withAdminApi(async (api) => {
+      const adminId = await apiGetUserId(api, creds('admin').username);
+      const userId = await apiGetUserId(api, creds('user').username);
+      hiddenReceiptId = await apiCreateReceipt(api, {
+        groupId,
+        paidByUserId: adminId,
+        name: hiddenReceiptName,
+      });
+      ownReceiptId = await apiCreateReceipt(api, {
+        groupId,
+        paidByUserId: userId,
+        name: ownReceiptName,
+      });
+    });
+  });
+
+  test.afterAll(async () => {
+    try {
+      await withAdminApi(async (api) => {
+        // Group delete frees the member's role assignment; then the role deletes.
+        await apiDeleteGroupById(api, groupId);
+        await apiDeleteRoleByName(api, roleName, 'GROUP');
+      });
+    } catch {
+      // Best-effort cleanup — don't mask a test failure with a cleanup error.
+    }
+    await adminContext?.close();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await stubTokenRefresh(page);
+  });
+
+  test('denies fetching a hidden-payer receipt but allows their own (API)', async () => {
+    await withApiAs('user', async (api) => {
+      const hidden = await api.get(`/api/receipt/${hiddenReceiptId}`);
+      expect(hidden.status()).toBe(403);
+
+      const own = await api.get(`/api/receipt/${ownReceiptId}`);
+      expect(own.status()).toBe(200);
+    });
+  });
+
+  test('receipts list shows their own receipt and hides the other-payer one', async ({
+    page,
+  }) => {
+    await page.goto(`/receipts/group/${groupId}`);
+    // Assert the own receipt first so the list has loaded before the negative check.
+    await expect(page.getByText(ownReceiptName)).toBeVisible();
+    await expect(page.getByText(hiddenReceiptName)).toHaveCount(0);
+  });
+
+  test('navigating directly to a hidden receipt redirects away', async ({
+    page,
+  }) => {
+    await page.goto(`/receipts/${hiddenReceiptId}/view`);
+    // The receipt-route guard's hasAccess probe is now paid-by-aware, so it
+    // redirects instead of admitting the member to a receipt that 403s on fetch.
+    await page.waitForURL(
+      (url) => !url.href.includes(`/receipts/${hiddenReceiptId}/view`),
+      { timeout: 10_000 },
+    );
+  });
+});

--- a/desktop/src/open-api/model/role.ts
+++ b/desktop/src/open-api/model/role.ts
@@ -34,6 +34,14 @@ export interface Role {
      * Tag ids a GROUP role restricts its members to. Empty means unrestricted (members may use every tag). Always empty for app roles.
      */
     tagGrants?: Array<number>;
+    /**
+     * User ids whose receipts a GROUP role lets its members see (by the receipt\'s \"paid by\" user). Empty with includeOwnPaidReceipts false means unrestricted (members see every payer\'s receipts). Always empty for app roles.
+     */
+    paidByUserGrants?: Array<number>;
+    /**
+     * Whether a GROUP role lets each member see receipts they paid for. Part of the paid-by visibility filter; always false for app roles.
+     */
+    includeOwnPaidReceipts?: boolean;
 }
 export namespace Role {
 }

--- a/desktop/src/open-api/model/upsertRoleCommand.ts
+++ b/desktop/src/open-api/model/upsertRoleCommand.ts
@@ -24,6 +24,14 @@ export interface UpsertRoleCommand {
      * Tag ids to restrict a GROUP role\'s members to. Only valid on group roles; omit or leave empty for unrestricted access.
      */
     tagGrants?: Array<number>;
+    /**
+     * User ids whose receipts a GROUP role\'s members may see (by the receipt\'s \"paid by\" user). Only valid on group roles; omit or leave empty (with includeOwnPaidReceipts false) for unrestricted access.
+     */
+    paidByUserGrants?: Array<number>;
+    /**
+     * Whether to also let each member see receipts they paid for. Only valid on group roles.
+     */
+    includeOwnPaidReceipts?: boolean;
 }
 export namespace UpsertRoleCommand {
 }

--- a/desktop/src/roles/role-form/role-form.component.html
+++ b/desktop/src/roles/role-form/role-form.component.html
@@ -220,6 +220,36 @@
               [readonly]="isViewMode()"
             ></app-tag-autocomplete>
           </div>
+
+          <div class="rw-card rw-form-section">
+            <div class="rw-perm-header">
+              <div>
+                <h2>Paid-by visibility</h2>
+                <div class="hint hint-inline">
+                  Limit members to receipts paid by specific people. Pin
+                  &ldquo;Their own receipts&rdquo; to include their own. Leave
+                  empty for access to everyone&rsquo;s receipts.
+                </div>
+              </div>
+            </div>
+
+            <app-autocomlete
+              class="w-100"
+              label="Visible paid-by users"
+              optionFilterKey="displayName"
+              [inputFormControl]="$any(grantedPaidByUsers)"
+              [options]="paidByOptions()"
+              [optionTemplate]="paidByOptionTemplate"
+              [optionChipTemplate]="paidByOptionTemplate"
+              [multiple]="true"
+              [creatable]="false"
+              [readonly]="isViewMode()"
+            ></app-autocomlete>
+
+            <ng-template #paidByOptionTemplate let-option="option"
+              >{{ option.displayName }}
+            </ng-template>
+          </div>
         }
       </div>
 

--- a/desktop/src/roles/role-form/role-form.component.spec.ts
+++ b/desktop/src/roles/role-form/role-form.component.spec.ts
@@ -14,6 +14,7 @@ import {
   Router,
   RouterModule,
 } from "@angular/router";
+import { Store } from "@ngxs/store";
 import { of, throwError } from "rxjs";
 import {
   ApiModule,
@@ -21,6 +22,7 @@ import {
   PermissionService,
   Role,
   RoleService,
+  User,
 } from "../../open-api";
 import { PipesModule } from "../../pipes";
 import { SnackbarService } from "../../services/snackbar.service";
@@ -74,6 +76,8 @@ interface SetupOptions {
   routeScope?: string;
   /** Roles returned by getRoles() when loading an existing role. */
   roles?: Role[];
+  /** Users returned by the mocked UserState snapshot (paid-by picker pool). */
+  users?: User[];
 }
 
 async function setup(
@@ -108,6 +112,9 @@ async function setup(
       provideHttpClientTesting(),
       { provide: SnackbarService, useValue: snackbar },
       { provide: ActivatedRoute, useValue: activatedRoute },
+      // The paid-by picker reads the user pool via UserState; the component only
+      // calls selectSnapshot(UserState.users), so a thin stub is sufficient.
+      { provide: Store, useValue: { selectSnapshot: () => options.users ?? [] } },
     ],
   }).compileComponents();
 
@@ -349,6 +356,60 @@ describe("RoleFormComponent", () => {
     expect(component.grantedCategories.length).toBe(0);
   });
 
+  it("includes paid-by grants and includeOwn in a GROUP payload", async () => {
+    const { component } = await setup();
+    component.pickType("group");
+    component.form.controls.name.setValue("Paid-By Role");
+    component.toggle("group.receipts.read");
+
+    // The picker drives this FormArray; push the "their own" sentinel + a user.
+    component.grantedPaidByUsers.push(
+      new FormControl({ id: RoleFormComponent.OWN_PAID_RECEIPTS_OPTION_ID, displayName: "Their own receipts" } as any),
+    );
+    component.grantedPaidByUsers.push(new FormControl({ id: 42, displayName: "Bob" } as any));
+
+    component.submit();
+
+    expect(component.lastPayload?.scope).toBe("GROUP");
+    expect(component.lastPayload?.includeOwnPaidReceipts).toBe(true);
+    expect(component.lastPayload?.paidByUserGrants).toEqual([42]);
+  });
+
+  it("treats a user-only selection as a pure reviewer (no own)", async () => {
+    const { component } = await setup();
+    component.pickType("group");
+    component.form.controls.name.setValue("Reviewer Role");
+    component.toggle("group.receipts.read");
+
+    component.grantedPaidByUsers.push(new FormControl({ id: 7, displayName: "Alice" } as any));
+
+    component.submit();
+
+    expect(component.lastPayload?.includeOwnPaidReceipts).toBe(false);
+    expect(component.lastPayload?.paidByUserGrants).toEqual([7]);
+  });
+
+  it("omits paid-by grants from an APP payload", async () => {
+    const { component } = await setup();
+    component.form.controls.name.setValue("App Role");
+    component.toggle("app.users.read");
+
+    component.submit();
+
+    expect(component.lastPayload?.paidByUserGrants).toBeUndefined();
+    expect(component.lastPayload?.includeOwnPaidReceipts).toBeUndefined();
+  });
+
+  it("resets paid-by grants when switching role type", async () => {
+    const { component } = await setup();
+    component.pickType("group");
+    component.grantedPaidByUsers.push(new FormControl({ id: 7, displayName: "Alice" } as any));
+    expect(component.grantedPaidByUsers.length).toBe(1);
+
+    component.pickType("app");
+    expect(component.grantedPaidByUsers.length).toBe(0);
+  });
+
   it("calls createRole, notifies, and navigates back to the list on submit", async () => {
     const { component, createRoleSpy, navigateSpy, snackbar } = await setup();
     component.form.controls.name.setValue("App Admin");
@@ -448,6 +509,32 @@ describe("RoleFormComponent", () => {
 
       expect(component.type()).toBe("group");
       expect(component.form.controls.name.value).toBe("Group Role 7");
+    });
+
+    it("rehydrates paid-by grants and the own toggle on edit", async () => {
+      const paidByGroupRole: Role = {
+        id: 11,
+        name: "Paid-By Group Role",
+        scope: "GROUP",
+        isDefault: false,
+        isSystem: false,
+        permissions: ["group.receipts.read"],
+        paidByUserGrants: [42],
+        includeOwnPaidReceipts: true,
+      };
+      const { component } = await setup(ALL_DESCRIPTORS, {
+        routeId: "11",
+        routeScope: "group",
+        roles: [paidByGroupRole],
+        users: [{ id: 42, username: "bob", displayName: "Bob" } as User],
+      });
+
+      TestBed.flushEffects();
+
+      const selectedIds = (component.grantedPaidByUsers.value as { id: number }[])
+        .map((option) => option.id)
+        .sort((a, b) => a - b);
+      expect(selectedIds).toEqual([RoleFormComponent.OWN_PAID_RECEIPTS_OPTION_ID, 42].sort((a, b) => a - b));
     });
 
     it("redirects to the list when the role is not found", async () => {

--- a/desktop/src/roles/role-form/role-form.component.spec.ts
+++ b/desktop/src/roles/role-form/role-form.component.spec.ts
@@ -5,6 +5,7 @@ import {
   CUSTOM_ELEMENTS_SCHEMA,
   Input,
   provideZonelessChangeDetection,
+  signal,
 } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { FormControl, ReactiveFormsModule } from "@angular/forms";
@@ -113,8 +114,8 @@ async function setup(
       { provide: SnackbarService, useValue: snackbar },
       { provide: ActivatedRoute, useValue: activatedRoute },
       // The paid-by picker reads the user pool via UserState; the component only
-      // calls selectSnapshot(UserState.users), so a thin stub is sufficient.
-      { provide: Store, useValue: { selectSnapshot: () => options.users ?? [] } },
+      // reads UserState.users reactively via selectSignal, so a thin stub is sufficient.
+      { provide: Store, useValue: { selectSignal: () => signal(options.users ?? []) } },
     ],
   }).compileComponents();
 

--- a/desktop/src/roles/role-form/role-form.component.ts
+++ b/desktop/src/roles/role-form/role-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, DestroyRef, computed, effect, signal } from "@angular/core";
+import { Component, DestroyRef, Signal, computed, effect, signal } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormArray, FormControl, FormGroup, Validators } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
@@ -102,13 +102,18 @@ export class RoleFormComponent {
     displayName: "Their own receipts",
   };
 
+  // The full user pool, read reactively so the picker repopulates if AppData lands
+  // after the form mounts (a snapshot inside the computed would cache once and drop
+  // granted users on edit). Assigned in the constructor — a field initializer can't
+  // reference this.store before it is set.
+  private usersSignal!: Signal<User[]>;
+
   // The picker options: the pinned "their own" sentinel first, then every user.
   // The role editor is admin-only and global (no group context), so it lists all
-  // users — sourced from AppData like every other user picker (read lazily via a
-  // snapshot inside the computed, matching app-user-autocomplete).
+  // users — sourced from AppData like every other user picker.
   public readonly paidByOptions = computed<PaidByGrantOption[]>(() => [
     this.ownPaidReceiptsOption,
-    ...this.store.selectSnapshot(UserState.users).map((user) => ({
+    ...this.usersSignal().map((user) => ({
       id: user.id,
       displayName: user.displayName?.length ? user.displayName : user.username,
     })),
@@ -219,6 +224,9 @@ export class RoleFormComponent {
     private readonly destroyRef: DestroyRef,
     private readonly store: Store,
   ) {
+    // Reactive user pool for the paid-by picker (see usersSignal above).
+    this.usersSignal = this.store.selectSignal(UserState.users);
+
     this.permissionService
       .getPermissions()
       .pipe(

--- a/desktop/src/roles/role-form/role-form.component.ts
+++ b/desktop/src/roles/role-form/role-form.component.ts
@@ -2,10 +2,12 @@ import { Component, DestroyRef, computed, effect, signal } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormArray, FormControl, FormGroup, Validators } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
+import { Store } from "@ngxs/store";
 import { catchError, EMPTY, take, tap } from "rxjs";
 import { FormMode } from "../../enums/form-mode.enum";
 import { SnackbarService } from "../../services/snackbar.service";
 import { BreadcrumbItem } from "../../shared-ui/breadcrumb/breadcrumb-item.interface";
+import { UserState } from "../../store";
 import {
   Category,
   CategoryService,
@@ -17,6 +19,7 @@ import {
   Tag,
   TagService,
   UpsertRoleCommand,
+  User,
 } from "../../open-api";
 import {
   CUSTOM_PRESET_ID,
@@ -43,6 +46,13 @@ export interface RoleResourceGroup {
   name: string;
   icon: string;
   rows: RolePermissionRow[];
+}
+
+// An option in the paid-by visibility picker: either a real user (id > 0) or the
+// pinned "their own receipts" sentinel (id === OWN_PAID_RECEIPTS_OPTION_ID).
+export interface PaidByGrantOption {
+  id: number;
+  displayName: string;
 }
 
 
@@ -81,6 +91,31 @@ export class RoleFormComponent {
   // once the pool arrives (pool and role load independently/asynchronously).
   private readonly pendingCategoryGrantIds = signal<number[]>([]);
   private readonly pendingTagGrantIds = signal<number[]>([]);
+
+  // ----- Paid-by visibility grants (group roles only) -----
+  // The sentinel id of the pinned "their own receipts" option. Real user ids are
+  // positive, so a negative sentinel never collides and is filtered out of the
+  // serialized paidByUserGrants (it maps to includeOwnPaidReceipts instead).
+  public static readonly OWN_PAID_RECEIPTS_OPTION_ID = -1;
+  private readonly ownPaidReceiptsOption: PaidByGrantOption = {
+    id: RoleFormComponent.OWN_PAID_RECEIPTS_OPTION_ID,
+    displayName: "Their own receipts",
+  };
+
+  // The picker options: the pinned "their own" sentinel first, then every user.
+  // The role editor is admin-only and global (no group context), so it lists all
+  // users — sourced from AppData like every other user picker (read lazily via a
+  // snapshot inside the computed, matching app-user-autocomplete).
+  public readonly paidByOptions = computed<PaidByGrantOption[]>(() => [
+    this.ownPaidReceiptsOption,
+    ...this.store.selectSnapshot(UserState.users).map((user) => ({
+      id: user.id,
+      displayName: user.displayName?.length ? user.displayName : user.username,
+    })),
+  ]);
+  public readonly grantedPaidByUsers = new FormArray<FormControl<PaidByGrantOption>>([]);
+  private readonly pendingPaidByUserGrantIds = signal<number[]>([]);
+  private readonly pendingIncludeOwnPaidReceipts = signal<boolean>(false);
 
   /** Grants are a group-role concept; hidden for app roles. */
   public readonly showGrants = computed<boolean>(() => this.type() === "group");
@@ -182,6 +217,7 @@ export class RoleFormComponent {
     private readonly route: ActivatedRoute,
     private readonly snackbar: SnackbarService,
     private readonly destroyRef: DestroyRef,
+    private readonly store: Store,
   ) {
     this.permissionService
       .getPermissions()
@@ -224,6 +260,22 @@ export class RoleFormComponent {
       const pool = this.tagPool();
       const ids = this.pendingTagGrantIds();
       this.setGrantArray(this.grantedTags, pool.filter((tag) => tag.id !== undefined && ids.includes(tag.id)));
+    });
+
+    // Resolve a loaded role's paid-by config to picker options, prepending the
+    // "their own receipts" sentinel when include-own is set. Filtering the shared
+    // paidByOptions list keeps object references stable so the autocomplete
+    // correctly excludes already-selected options.
+    effect(() => {
+      const options = this.paidByOptions();
+      const ids = this.pendingPaidByUserGrantIds();
+      const includeOwn = this.pendingIncludeOwnPaidReceipts();
+      const selected = options.filter(
+        (option) =>
+          (option.id === RoleFormComponent.OWN_PAID_RECEIPTS_OPTION_ID && includeOwn) ||
+          (option.id !== RoleFormComponent.OWN_PAID_RECEIPTS_OPTION_ID && ids.includes(option.id)),
+      );
+      this.setGrantArray(this.grantedPaidByUsers, selected);
     });
 
     const id = this.route.snapshot.paramMap.get("id");
@@ -273,6 +325,8 @@ export class RoleFormComponent {
         this.granted.set(new Set(role.permissions));
         this.pendingCategoryGrantIds.set(role.categoryGrants ?? []);
         this.pendingTagGrantIds.set(role.tagGrants ?? []);
+        this.pendingPaidByUserGrantIds.set(role.paidByUserGrants ?? []);
+        this.pendingIncludeOwnPaidReceipts.set(role.includeOwnPaidReceipts ?? false);
       });
   }
 
@@ -324,8 +378,11 @@ export class RoleFormComponent {
     // Grants only apply to group roles — reset them on a type switch.
     this.pendingCategoryGrantIds.set([]);
     this.pendingTagGrantIds.set([]);
+    this.pendingPaidByUserGrantIds.set([]);
+    this.pendingIncludeOwnPaidReceipts.set(false);
     this.setGrantArray(this.grantedCategories, []);
     this.setGrantArray(this.grantedTags, []);
+    this.setGrantArray(this.grantedPaidByUsers, []);
   }
 
   public pickPreset(preset: RolePreset): void {
@@ -390,7 +447,7 @@ export class RoleFormComponent {
       permissions: [...this.granted()] as Permission[],
     };
 
-    // Category/tag grants are only valid on group roles.
+    // Category/tag/paid-by grants are only valid on group roles.
     if (this.showGrants()) {
       payload.categoryGrants = (this.grantedCategories.value as Category[])
         .map((category) => category.id)
@@ -398,6 +455,16 @@ export class RoleFormComponent {
       payload.tagGrants = (this.grantedTags.value as Tag[])
         .map((tag) => tag.id)
         .filter((id): id is number => id !== undefined);
+
+      // Split the picker's selections into the relative "their own" toggle and
+      // the absolute user-id grants (the sentinel never goes to the backend).
+      const paidBySelections = this.grantedPaidByUsers.value as PaidByGrantOption[];
+      payload.includeOwnPaidReceipts = paidBySelections.some(
+        (option) => option.id === RoleFormComponent.OWN_PAID_RECEIPTS_OPTION_ID,
+      );
+      payload.paidByUserGrants = paidBySelections
+        .map((option) => option.id)
+        .filter((id) => id !== RoleFormComponent.OWN_PAID_RECEIPTS_OPTION_ID);
     }
 
     this.lastPayload = payload;

--- a/desktop/src/roles/roles.module.ts
+++ b/desktop/src/roles/roles.module.ts
@@ -5,6 +5,7 @@ import { MatIconModule } from "@angular/material/icon";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { RouterModule } from "@angular/router";
 import { PipesModule } from "src/pipes/pipes.module";
+import { AutocompleteModule } from "../autocomplete/autocomplete.module";
 import { ButtonModule } from "../button";
 import { CategoryAutocompleteComponent } from "../category-autocomplete/category-autocomplete.component";
 import { InputModule } from "../input";
@@ -33,6 +34,7 @@ import { RolesRoutingModule } from "./roles-routing.module";
     TableModule,
     TextareaModule,
     RolesRoutingModule,
+    AutocompleteModule,
     CategoryAutocompleteComponent,
     TagAutocompleteComponent,
   ],


### PR DESCRIPTION
## Summary

Group roles can now restrict **which receipts a member sees**, by the receipt's "paid by" user. It is opt-in and mirrors the existing category/tag grants, but is enforced at the **row level** (it hides the whole receipt rather than stripping fields off a still-visible one).

The allowed set combines a relative **"Their own receipts"** toggle (resolves to the member at query time) with zero or more specific users. Selecting only specific users (without "their own") gives a pure-reviewer role that sees someone else's receipts but not its own. An empty config is unchanged behavior — the member sees everyone's receipts.

## Backend
- New `GroupRolePaidByUserGrant` join table + `IncludeOwnPaidReceipts` column on `GroupRoleDefinition`; surfaced through `UpsertRoleCommand` / `RoleView` / swagger (desktop client regenerated).
- `GetGroupPaidByUserIdsForUser` resolves the allowed set, cached per role; the member's own id is unioned in at resolution time, never cached.
- Row-level enforcement (`services/paid_by_filter.go`): the paged list adds a per-group `WHERE` before the count — single-group `IN`, all-group disjunction so each group applies its own role — keeping `totalCount` correct; single-receipt and dependent reads deny **403** via the `HandleRequest` chokepoint; the `HasAccess` route-guard probe, search, and the group-ids list are covered too; pie chart and CSV export pass the same filter. No app-level bypass.
- Deleting a user cascades its grant rows away (the `user_id` FK is `ON DELETE CASCADE`).

## Desktop
- A "Paid-by visibility" multi-select on the group-role form (group scope only), with "Their own receipts" pinned ahead of the user list. Serializes to `includeOwnPaidReceipts` + `paidByUserGrants` and rehydrates on edit.

## Mobile
- No changes. Enforcement is server-side: mobile has no role editor, its receipts list/search are filtered automatically, and the single-receipt 403 is already handled gracefully.

## Tests
- Go unit/integration tests: resolution semantics, row-level filtering (incl. multi-group `totalCount` correctness), single-GET 403, `HasAccess` 403, and the user-delete cascade.
- Desktop role-form specs (serialize / rehydrate / reset).
- Playwright `paid-by-visibility.spec.ts`: a member restricted to their own receipts is denied (403) a hidden-payer receipt and allowed (200) their own; the list hides the hidden one and the view route redirects.

## Scope boundary
Group totals / splitting aggregates stay unfiltered (the per-viewer pie chart is filtered). This is read-visibility only — it does not restrict which payer a member may set on a receipt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “paid-by visibility” controls for **group roles**, including a permitted-payers list and an opt-in **“their own receipts”** option.
* **Bug Fixes**
  * Enforced paid-by receipt visibility across receipt pages, lists, access checks, search, charts, and CSV exports.
  * Pagination/counts and search results now reflect only visible receipts; exports by ID are denied if any selected receipt is hidden.
  * “Amount owed” settlement totals are exempt from the paid-by filter.
* **Documentation**
  * Updated API and UI docs/OpenAPI descriptions for the new controls and semantics.
* **Tests**
  * Added unit, handler, repository, service, and E2E coverage for enforcement, edge cases, and count correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->