### PR TITLE
Mobile: per-group category/tag catalogs + comment gating (role-rework parity)

### DIFF
--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -85,14 +85,23 @@ Uses `flutter_form_builder` for complex forms with validation. Receipt forms sup
 
 The mobile app gates UI on the caller's **effective permissions**, mirroring the desktop client
 (`desktop/CLAUDE.md` → "Permission-based UI gating") and the backend's enforcement (`api/CLAUDE.md` →
-"Roles & Permissions"). The JWT carries only the legacy `UserRole` and is a UI hint; the server
-re-checks real permissions on every request, so a stale action at worst returns 403.
+"Roles & Permissions"). The JWT no longer carries any role field — effective permissions are
+delivered on `AppData` and are a UI hint; the server re-checks real permissions on every request, so
+a stale action at worst returns 403.
 
 - **Delivery & hydration:** permissions arrive on `AppData` (`appPermissions`, and `groupPermissions`
   keyed by group id) and are stored in **`PermissionsModel`** (`lib/models/permissions_model.dart`)
   via `setPermissions`, called **only** from `storeAppData` (`lib/utils/auth.dart`) on login and
   app-init. Token-only refreshes never touch it. The `FutureBuilder` in `main.dart` blocks first
   paint until app-init completes, so permissions are present before any gated widget builds.
+- **Per-group category/tag catalogs:** `AppData` also delivers `groupCategories` / `groupTags` (keyed
+  by group id), each filtered to the caller's group-role grants (the full pool when unrestricted).
+  `storeAppData` indexes them into `CategoryModel` / `TagModel` (`setGroupCategories` /
+  `setGroupTags`); the receipt-form pickers (`category_select_field.dart` / `tag_select_field.dart`,
+  passed the receipt's `groupId`) source options via `categoriesForGroup(groupId)` /
+  `tagsForGroup(groupId)`. **Do not** source the pickers from the flat `categories` / `tags` arrays —
+  those are admin-only (populated only for holders of `app.categories.read` / `app.tags.read`), so a
+  normal user would see an empty picker. Mirrors desktop's per-group AppData catalog selectors.
 - **Matcher:** `lib/utils/permission_matcher.dart` (`permissionMatches` / `hasAll` / `hasAny`) is a
   faithful port of the backend matcher (`api/internal/permissions/matcher.go`) and its desktop twin
   (`desktop/src/utils/permission.utils.ts`), wildcard semantics included, so UI gating === backend.
@@ -112,6 +121,11 @@ re-checks real permissions on every request, so a stale action at worst returns 
   - `canEditReceipt(permissionsModel, groupId)` (`lib/shared/functions/permissions.dart`) →
     `group.receipts.update`, used by the receipt-edit popup (`receipt_edit_popup_menu.dart`) and the
     receipt swipe-to-edit (`receipt_list_item.dart`).
+  - `canCommentCreate` / `canCommentDelete` (same file) → `group.comments.create` /
+    `group.comments.delete`, scoped to the receipt's group. The comment-input bottom sheet
+    (`receipt_comment_screen.dart`) is hidden without create; the swipe-to-delete
+    (`receipt_comments.dart`) is disabled without delete (only in **edit** state — add-state comment
+    removal is a local model edit with no API call, so it stays enabled).
   - Activity rerun (`group_activity_list_item.dart`) → `group.activities.rerun`.
   - The add menu (`show_add_menu.dart`) shows "Add Manual Receipt" on `group.receipts.create` and
     "Quick Scan" on `group.receipts.quick-scan` — per-group when inside a group, or "held in any
@@ -187,12 +201,13 @@ generator emits invalid `_defaults` initializers for some fields, which `build_r
 compile (and it deletes the matching `.g.dart` first, so the package stops building). After
 regenerating, restore these hand-fixes (precedent: commits `fad192a0`, `a2ec7479`):
 
-- `model/claims.dart` — `..userRole = 'USER'` → `..userRole = UserRole.USER` (enum default emitted
-  as a string).
 - `model/user_preferences.dart` — `..quickScanDefaultStatus = 'OPEN'` →
   `..quickScanDefaultStatus = ReceiptStatus.OPEN`.
 - `model/system_settings.dart` — `..currencyDisplay = '$'` → `..currencyDisplay = r'$'` (a bare `$`
   in a non-raw string is invalid Dart).
+
+`model/claims.dart` **no longer** needs a `userRole` patch — the role rework dropped `userRole` from
+the swagger, so `Claims` carries only identity claims and the field is gone from the generated model.
 
 Run `flutter analyze` after a regen; these surface as compile errors. (Hand-editing generated files
 is otherwise forbidden — these are the documented exception.)

--- a/mobile/api/doc/AppData.md
+++ b/mobile/api/doc/AppData.md
@@ -26,6 +26,8 @@ Name | Type | Description | Notes
 **icons** | [**BuiltList&lt;Icon&gt;**](Icon.md) | Icons in the system | 
 **appPermissions** | [**BuiltList&lt;Permission&gt;**](Permission.md) | The calling user's effective app-level permissions. | 
 **groupPermissions** | [**BuiltMap&lt;String, BuiltList&lt;Permission&gt;&gt;**](BuiltList.md) | The calling user's effective group-level permissions, keyed by group id. | 
+**groupCategories** | [**BuiltMap&lt;String, BuiltList&lt;Category&gt;&gt;**](BuiltList.md) | The categories the calling user may use in each group, keyed by group id. Filtered to the user's group-role grants (the full pool when unrestricted). Non-admins receive categories only through this map. | [optional] 
+**groupTags** | [**BuiltMap&lt;String, BuiltList&lt;Tag&gt;&gt;**](BuiltList.md) | The tags the calling user may use in each group, keyed by group id. Filtered to the user's group-role grants (the full pool when unrestricted). Non-admins receive tags only through this map. | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/mobile/api/doc/CustomFieldValue.md
+++ b/mobile/api/doc/CustomFieldValue.md
@@ -15,6 +15,7 @@ Name | Type | Description | Notes
 **updatedAt** | **String** |  | [optional] [default to '']
 **receiptId** | **int** | Receipt Id | 
 **customFieldId** | **int** | Custom Field ID | 
+**customField** | [**CustomField**](CustomField.md) |  | [optional] 
 **stringValue** | **String** | Custom Field String Value | [optional] 
 **dateValue** | **String** | Custom Field Date Value | [optional] 
 **selectValue** | **int** | Custom Field Select Value | [optional] 

--- a/mobile/api/doc/Role.md
+++ b/mobile/api/doc/Role.md
@@ -16,6 +16,10 @@ Name | Type | Description | Notes
 **isSystem** | **bool** |  | 
 **permissions** | [**BuiltList&lt;Permission&gt;**](Permission.md) |  | 
 **assignedCount** | **int** | Number of users or group members currently assigned this role | [optional] 
+**categoryGrants** | **BuiltList&lt;int&gt;** | Category ids a GROUP role restricts its members to. Empty means unrestricted (members may use every category). Always empty for app roles. | [optional] 
+**tagGrants** | **BuiltList&lt;int&gt;** | Tag ids a GROUP role restricts its members to. Empty means unrestricted (members may use every tag). Always empty for app roles. | [optional] 
+**paidByUserGrants** | **BuiltList&lt;int&gt;** | User ids whose receipts a GROUP role lets its members see (by the receipt's \"paid by\" user). Empty with includeOwnPaidReceipts false means unrestricted (members see every payer's receipts). Always empty for app roles. | [optional] 
+**includeOwnPaidReceipts** | **bool** | Whether a GROUP role lets each member see receipts they paid for. Part of the paid-by visibility filter; always false for app roles. | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/mobile/api/doc/UpsertRoleCommand.md
+++ b/mobile/api/doc/UpsertRoleCommand.md
@@ -12,6 +12,10 @@ Name | Type | Description | Notes
 **description** | **String** |  | [optional] 
 **scope** | [**PermissionScope**](PermissionScope.md) |  | 
 **permissions** | [**BuiltList&lt;Permission&gt;**](Permission.md) |  | 
+**categoryGrants** | **BuiltList&lt;int&gt;** | Category ids to restrict a GROUP role's members to. Only valid on group roles; omit or leave empty for unrestricted access. | [optional] 
+**tagGrants** | **BuiltList&lt;int&gt;** | Tag ids to restrict a GROUP role's members to. Only valid on group roles; omit or leave empty for unrestricted access. | [optional] 
+**paidByUserGrants** | **BuiltList&lt;int&gt;** | User ids whose receipts a GROUP role's members may see (by the receipt's \"paid by\" user). Only valid on group roles; omit or leave empty (with includeOwnPaidReceipts false) for unrestricted access. | [optional] 
+**includeOwnPaidReceipts** | **bool** | Whether to also let each member see receipts they paid for. Only valid on group roles. | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/mobile/api/lib/src/model/app_data.dart
+++ b/mobile/api/lib/src/model/app_data.dart
@@ -42,6 +42,8 @@ part 'app_data.g.dart';
 /// * [icons] - Icons in the system
 /// * [appPermissions] - The calling user's effective app-level permissions.
 /// * [groupPermissions] - The calling user's effective group-level permissions, keyed by group id.
+/// * [groupCategories] - The categories the calling user may use in each group, keyed by group id. Filtered to the user's group-role grants (the full pool when unrestricted). Non-admins receive categories only through this map.
+/// * [groupTags] - The tags the calling user may use in each group, keyed by group id. Filtered to the user's group-role grants (the full pool when unrestricted). Non-admins receive tags only through this map.
 @BuiltValue()
 abstract class AppData implements Built<AppData, AppDataBuilder> {
   @BuiltValueField(wireName: r'about')
@@ -111,6 +113,14 @@ abstract class AppData implements Built<AppData, AppDataBuilder> {
   /// The calling user's effective group-level permissions, keyed by group id.
   @BuiltValueField(wireName: r'groupPermissions')
   BuiltMap<String, BuiltList<Permission>> get groupPermissions;
+
+  /// The categories the calling user may use in each group, keyed by group id. Filtered to the user's group-role grants (the full pool when unrestricted). Non-admins receive categories only through this map.
+  @BuiltValueField(wireName: r'groupCategories')
+  BuiltMap<String, BuiltList<Category>>? get groupCategories;
+
+  /// The tags the calling user may use in each group, keyed by group id. Filtered to the user's group-role grants (the full pool when unrestricted). Non-admins receive tags only through this map.
+  @BuiltValueField(wireName: r'groupTags')
+  BuiltMap<String, BuiltList<Tag>>? get groupTags;
 
   AppData._();
 
@@ -237,6 +247,20 @@ class _$AppDataSerializer implements PrimitiveSerializer<AppData> {
       object.groupPermissions,
       specifiedType: const FullType(BuiltMap, [FullType(String), FullType(BuiltList, [FullType(Permission)])]),
     );
+    if (object.groupCategories != null) {
+      yield r'groupCategories';
+      yield serializers.serialize(
+        object.groupCategories,
+        specifiedType: const FullType(BuiltMap, [FullType(String), FullType(BuiltList, [FullType(Category)])]),
+      );
+    }
+    if (object.groupTags != null) {
+      yield r'groupTags';
+      yield serializers.serialize(
+        object.groupTags,
+        specifiedType: const FullType(BuiltMap, [FullType(String), FullType(BuiltList, [FullType(Tag)])]),
+      );
+    }
   }
 
   @override
@@ -385,6 +409,20 @@ class _$AppDataSerializer implements PrimitiveSerializer<AppData> {
             specifiedType: const FullType(BuiltMap, [FullType(String), FullType(BuiltList, [FullType(Permission)])]),
           ) as BuiltMap<String, BuiltList<Permission>>;
           result.groupPermissions.replace(valueDes);
+          break;
+        case r'groupCategories':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(BuiltMap, [FullType(String), FullType(BuiltList, [FullType(Category)])]),
+          ) as BuiltMap<String, BuiltList<Category>>;
+          result.groupCategories.replace(valueDes);
+          break;
+        case r'groupTags':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(BuiltMap, [FullType(String), FullType(BuiltList, [FullType(Tag)])]),
+          ) as BuiltMap<String, BuiltList<Tag>>;
+          result.groupTags.replace(valueDes);
           break;
         default:
           unhandled.add(key);

--- a/mobile/api/lib/src/model/app_data.g.dart
+++ b/mobile/api/lib/src/model/app_data.g.dart
@@ -43,6 +43,10 @@ class _$AppData extends AppData {
   final BuiltList<Permission> appPermissions;
   @override
   final BuiltMap<String, BuiltList<Permission>> groupPermissions;
+  @override
+  final BuiltMap<String, BuiltList<Category>>? groupCategories;
+  @override
+  final BuiltMap<String, BuiltList<Tag>>? groupTags;
 
   factory _$AppData([void Function(AppDataBuilder)? updates]) =>
       (AppDataBuilder()..update(updates))._build();
@@ -65,7 +69,9 @@ class _$AppData extends AppData {
       this.currencyHideDecimalPlaces,
       required this.icons,
       required this.appPermissions,
-      required this.groupPermissions})
+      required this.groupPermissions,
+      this.groupCategories,
+      this.groupTags})
       : super._();
   @override
   AppData rebuild(void Function(AppDataBuilder) updates) =>
@@ -95,7 +101,9 @@ class _$AppData extends AppData {
         currencyHideDecimalPlaces == other.currencyHideDecimalPlaces &&
         icons == other.icons &&
         appPermissions == other.appPermissions &&
-        groupPermissions == other.groupPermissions;
+        groupPermissions == other.groupPermissions &&
+        groupCategories == other.groupCategories &&
+        groupTags == other.groupTags;
   }
 
   @override
@@ -119,6 +127,8 @@ class _$AppData extends AppData {
     _$hash = $jc(_$hash, icons.hashCode);
     _$hash = $jc(_$hash, appPermissions.hashCode);
     _$hash = $jc(_$hash, groupPermissions.hashCode);
+    _$hash = $jc(_$hash, groupCategories.hashCode);
+    _$hash = $jc(_$hash, groupTags.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -143,7 +153,9 @@ class _$AppData extends AppData {
           ..add('currencyHideDecimalPlaces', currencyHideDecimalPlaces)
           ..add('icons', icons)
           ..add('appPermissions', appPermissions)
-          ..add('groupPermissions', groupPermissions))
+          ..add('groupPermissions', groupPermissions)
+          ..add('groupCategories', groupCategories)
+          ..add('groupTags', groupTags))
         .toString();
   }
 }
@@ -243,6 +255,19 @@ class AppDataBuilder implements Builder<AppData, AppDataBuilder> {
           MapBuilder<String, BuiltList<Permission>>? groupPermissions) =>
       _$this._groupPermissions = groupPermissions;
 
+  MapBuilder<String, BuiltList<Category>>? _groupCategories;
+  MapBuilder<String, BuiltList<Category>> get groupCategories =>
+      _$this._groupCategories ??= MapBuilder<String, BuiltList<Category>>();
+  set groupCategories(
+          MapBuilder<String, BuiltList<Category>>? groupCategories) =>
+      _$this._groupCategories = groupCategories;
+
+  MapBuilder<String, BuiltList<Tag>>? _groupTags;
+  MapBuilder<String, BuiltList<Tag>> get groupTags =>
+      _$this._groupTags ??= MapBuilder<String, BuiltList<Tag>>();
+  set groupTags(MapBuilder<String, BuiltList<Tag>>? groupTags) =>
+      _$this._groupTags = groupTags;
+
   AppDataBuilder() {
     AppData._defaults(this);
   }
@@ -268,6 +293,8 @@ class AppDataBuilder implements Builder<AppData, AppDataBuilder> {
       _icons = $v.icons.toBuilder();
       _appPermissions = $v.appPermissions.toBuilder();
       _groupPermissions = $v.groupPermissions.toBuilder();
+      _groupCategories = $v.groupCategories?.toBuilder();
+      _groupTags = $v.groupTags?.toBuilder();
       _$v = null;
     }
     return this;
@@ -310,6 +337,8 @@ class AppDataBuilder implements Builder<AppData, AppDataBuilder> {
             icons: icons.build(),
             appPermissions: appPermissions.build(),
             groupPermissions: groupPermissions.build(),
+            groupCategories: _groupCategories?.build(),
+            groupTags: _groupTags?.build(),
           );
     } catch (_) {
       late String _$failedField;
@@ -337,6 +366,10 @@ class AppDataBuilder implements Builder<AppData, AppDataBuilder> {
         appPermissions.build();
         _$failedField = 'groupPermissions';
         groupPermissions.build();
+        _$failedField = 'groupCategories';
+        _groupCategories?.build();
+        _$failedField = 'groupTags';
+        _groupTags?.build();
       } catch (e) {
         throw BuiltValueNestedFieldError(
             r'AppData', _$failedField, e.toString());

--- a/mobile/api/lib/src/model/custom_field_value.dart
+++ b/mobile/api/lib/src/model/custom_field_value.dart
@@ -4,6 +4,7 @@
 
 // ignore_for_file: unused_element
 import 'package:openapi/src/model/base_model.dart';
+import 'package:openapi/src/model/custom_field.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 
@@ -19,6 +20,7 @@ part 'custom_field_value.g.dart';
 /// * [updatedAt] 
 /// * [receiptId] - Receipt Id
 /// * [customFieldId] - Custom Field ID
+/// * [customField] 
 /// * [stringValue] - Custom Field String Value
 /// * [dateValue] - Custom Field Date Value
 /// * [selectValue] - Custom Field Select Value
@@ -54,6 +56,9 @@ abstract class CustomFieldValue implements BaseModel, Built<CustomFieldValue, Cu
   @BuiltValueField(wireName: r'receiptId')
   int get receiptId;
 
+  @BuiltValueField(wireName: r'customField')
+  CustomField? get customField;
+
   CustomFieldValue._();
 
   factory CustomFieldValue([void updates(CustomFieldValueBuilder b)]) = _$CustomFieldValue;
@@ -87,6 +92,25 @@ class _$CustomFieldValueSerializer implements PrimitiveSerializer<CustomFieldVal
         specifiedType: const FullType(String),
       );
     }
+    if (object.selectValue != null) {
+      yield r'selectValue';
+      yield serializers.serialize(
+        object.selectValue,
+        specifiedType: const FullType(int),
+      );
+    }
+    yield r'customFieldId';
+    yield serializers.serialize(
+      object.customFieldId,
+      specifiedType: const FullType(int),
+    );
+    if (object.customField != null) {
+      yield r'customField';
+      yield serializers.serialize(
+        object.customField,
+        specifiedType: const FullType(CustomField),
+      );
+    }
     yield r'createdAt';
     yield serializers.serialize(
       object.createdAt,
@@ -97,13 +121,6 @@ class _$CustomFieldValueSerializer implements PrimitiveSerializer<CustomFieldVal
       yield serializers.serialize(
         object.stringValue,
         specifiedType: const FullType(String),
-      );
-    }
-    if (object.selectValue != null) {
-      yield r'selectValue';
-      yield serializers.serialize(
-        object.selectValue,
-        specifiedType: const FullType(int),
       );
     }
     if (object.createdBy != null) {
@@ -120,11 +137,6 @@ class _$CustomFieldValueSerializer implements PrimitiveSerializer<CustomFieldVal
         specifiedType: const FullType(String),
       );
     }
-    yield r'customFieldId';
-    yield serializers.serialize(
-      object.customFieldId,
-      specifiedType: const FullType(int),
-    );
     if (object.booleanValue != null) {
       yield r'booleanValue';
       yield serializers.serialize(
@@ -186,6 +198,27 @@ class _$CustomFieldValueSerializer implements PrimitiveSerializer<CustomFieldVal
           ) as String;
           result.dateValue = valueDes;
           break;
+        case r'selectValue':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(int),
+          ) as int;
+          result.selectValue = valueDes;
+          break;
+        case r'customFieldId':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(int),
+          ) as int;
+          result.customFieldId = valueDes;
+          break;
+        case r'customField':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(CustomField),
+          ) as CustomField;
+          result.customField.replace(valueDes);
+          break;
         case r'createdAt':
           final valueDes = serializers.deserialize(
             value,
@@ -200,13 +233,6 @@ class _$CustomFieldValueSerializer implements PrimitiveSerializer<CustomFieldVal
           ) as String;
           result.stringValue = valueDes;
           break;
-        case r'selectValue':
-          final valueDes = serializers.deserialize(
-            value,
-            specifiedType: const FullType(int),
-          ) as int;
-          result.selectValue = valueDes;
-          break;
         case r'createdBy':
           final valueDes = serializers.deserialize(
             value,
@@ -220,13 +246,6 @@ class _$CustomFieldValueSerializer implements PrimitiveSerializer<CustomFieldVal
             specifiedType: const FullType(String),
           ) as String;
           result.currencyValue = valueDes;
-          break;
-        case r'customFieldId':
-          final valueDes = serializers.deserialize(
-            value,
-            specifiedType: const FullType(int),
-          ) as int;
-          result.customFieldId = valueDes;
           break;
         case r'booleanValue':
           final valueDes = serializers.deserialize(

--- a/mobile/api/lib/src/model/custom_field_value.g.dart
+++ b/mobile/api/lib/src/model/custom_field_value.g.dart
@@ -22,6 +22,8 @@ class _$CustomFieldValue extends CustomFieldValue {
   @override
   final int receiptId;
   @override
+  final CustomField? customField;
+  @override
   final int id;
   @override
   final String createdAt;
@@ -44,6 +46,7 @@ class _$CustomFieldValue extends CustomFieldValue {
       required this.customFieldId,
       this.booleanValue,
       required this.receiptId,
+      this.customField,
       required this.id,
       required this.createdAt,
       this.createdBy,
@@ -69,6 +72,7 @@ class _$CustomFieldValue extends CustomFieldValue {
         customFieldId == other.customFieldId &&
         booleanValue == other.booleanValue &&
         receiptId == other.receiptId &&
+        customField == other.customField &&
         id == other.id &&
         createdAt == other.createdAt &&
         createdBy == other.createdBy &&
@@ -86,6 +90,7 @@ class _$CustomFieldValue extends CustomFieldValue {
     _$hash = $jc(_$hash, customFieldId.hashCode);
     _$hash = $jc(_$hash, booleanValue.hashCode);
     _$hash = $jc(_$hash, receiptId.hashCode);
+    _$hash = $jc(_$hash, customField.hashCode);
     _$hash = $jc(_$hash, id.hashCode);
     _$hash = $jc(_$hash, createdAt.hashCode);
     _$hash = $jc(_$hash, createdBy.hashCode);
@@ -105,6 +110,7 @@ class _$CustomFieldValue extends CustomFieldValue {
           ..add('customFieldId', customFieldId)
           ..add('booleanValue', booleanValue)
           ..add('receiptId', receiptId)
+          ..add('customField', customField)
           ..add('id', id)
           ..add('createdAt', createdAt)
           ..add('createdBy', createdBy)
@@ -153,6 +159,12 @@ class CustomFieldValueBuilder
   int? get receiptId => _$this._receiptId;
   set receiptId(covariant int? receiptId) => _$this._receiptId = receiptId;
 
+  CustomFieldBuilder? _customField;
+  CustomFieldBuilder get customField =>
+      _$this._customField ??= CustomFieldBuilder();
+  set customField(covariant CustomFieldBuilder? customField) =>
+      _$this._customField = customField;
+
   int? _id;
   int? get id => _$this._id;
   set id(covariant int? id) => _$this._id = id;
@@ -188,6 +200,7 @@ class CustomFieldValueBuilder
       _customFieldId = $v.customFieldId;
       _booleanValue = $v.booleanValue;
       _receiptId = $v.receiptId;
+      _customField = $v.customField?.toBuilder();
       _id = $v.id;
       _createdAt = $v.createdAt;
       _createdBy = $v.createdBy;
@@ -212,25 +225,39 @@ class CustomFieldValueBuilder
   CustomFieldValue build() => _build();
 
   _$CustomFieldValue _build() {
-    final _$result = _$v ??
-        _$CustomFieldValue._(
-          dateValue: dateValue,
-          stringValue: stringValue,
-          selectValue: selectValue,
-          currencyValue: currencyValue,
-          customFieldId: BuiltValueNullFieldError.checkNotNull(
-              customFieldId, r'CustomFieldValue', 'customFieldId'),
-          booleanValue: booleanValue,
-          receiptId: BuiltValueNullFieldError.checkNotNull(
-              receiptId, r'CustomFieldValue', 'receiptId'),
-          id: BuiltValueNullFieldError.checkNotNull(
-              id, r'CustomFieldValue', 'id'),
-          createdAt: BuiltValueNullFieldError.checkNotNull(
-              createdAt, r'CustomFieldValue', 'createdAt'),
-          createdBy: createdBy,
-          createdByString: createdByString,
-          updatedAt: updatedAt,
-        );
+    _$CustomFieldValue _$result;
+    try {
+      _$result = _$v ??
+          _$CustomFieldValue._(
+            dateValue: dateValue,
+            stringValue: stringValue,
+            selectValue: selectValue,
+            currencyValue: currencyValue,
+            customFieldId: BuiltValueNullFieldError.checkNotNull(
+                customFieldId, r'CustomFieldValue', 'customFieldId'),
+            booleanValue: booleanValue,
+            receiptId: BuiltValueNullFieldError.checkNotNull(
+                receiptId, r'CustomFieldValue', 'receiptId'),
+            customField: _customField?.build(),
+            id: BuiltValueNullFieldError.checkNotNull(
+                id, r'CustomFieldValue', 'id'),
+            createdAt: BuiltValueNullFieldError.checkNotNull(
+                createdAt, r'CustomFieldValue', 'createdAt'),
+            createdBy: createdBy,
+            createdByString: createdByString,
+            updatedAt: updatedAt,
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'customField';
+        _customField?.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'CustomFieldValue', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }

--- a/mobile/api/lib/src/model/role.dart
+++ b/mobile/api/lib/src/model/role.dart
@@ -22,6 +22,10 @@ part 'role.g.dart';
 /// * [isSystem] 
 /// * [permissions] 
 /// * [assignedCount] - Number of users or group members currently assigned this role
+/// * [categoryGrants] - Category ids a GROUP role restricts its members to. Empty means unrestricted (members may use every category). Always empty for app roles.
+/// * [tagGrants] - Tag ids a GROUP role restricts its members to. Empty means unrestricted (members may use every tag). Always empty for app roles.
+/// * [paidByUserGrants] - User ids whose receipts a GROUP role lets its members see (by the receipt's \"paid by\" user). Empty with includeOwnPaidReceipts false means unrestricted (members see every payer's receipts). Always empty for app roles.
+/// * [includeOwnPaidReceipts] - Whether a GROUP role lets each member see receipts they paid for. Part of the paid-by visibility filter; always false for app roles.
 @BuiltValue()
 abstract class Role implements Built<Role, RoleBuilder> {
   @BuiltValueField(wireName: r'id')
@@ -50,6 +54,22 @@ abstract class Role implements Built<Role, RoleBuilder> {
   /// Number of users or group members currently assigned this role
   @BuiltValueField(wireName: r'assignedCount')
   int? get assignedCount;
+
+  /// Category ids a GROUP role restricts its members to. Empty means unrestricted (members may use every category). Always empty for app roles.
+  @BuiltValueField(wireName: r'categoryGrants')
+  BuiltList<int>? get categoryGrants;
+
+  /// Tag ids a GROUP role restricts its members to. Empty means unrestricted (members may use every tag). Always empty for app roles.
+  @BuiltValueField(wireName: r'tagGrants')
+  BuiltList<int>? get tagGrants;
+
+  /// User ids whose receipts a GROUP role lets its members see (by the receipt's \"paid by\" user). Empty with includeOwnPaidReceipts false means unrestricted (members see every payer's receipts). Always empty for app roles.
+  @BuiltValueField(wireName: r'paidByUserGrants')
+  BuiltList<int>? get paidByUserGrants;
+
+  /// Whether a GROUP role lets each member see receipts they paid for. Part of the paid-by visibility filter; always false for app roles.
+  @BuiltValueField(wireName: r'includeOwnPaidReceipts')
+  bool? get includeOwnPaidReceipts;
 
   Role._();
 
@@ -116,6 +136,34 @@ class _$RoleSerializer implements PrimitiveSerializer<Role> {
       yield serializers.serialize(
         object.assignedCount,
         specifiedType: const FullType(int),
+      );
+    }
+    if (object.categoryGrants != null) {
+      yield r'categoryGrants';
+      yield serializers.serialize(
+        object.categoryGrants,
+        specifiedType: const FullType(BuiltList, [FullType(int)]),
+      );
+    }
+    if (object.tagGrants != null) {
+      yield r'tagGrants';
+      yield serializers.serialize(
+        object.tagGrants,
+        specifiedType: const FullType(BuiltList, [FullType(int)]),
+      );
+    }
+    if (object.paidByUserGrants != null) {
+      yield r'paidByUserGrants';
+      yield serializers.serialize(
+        object.paidByUserGrants,
+        specifiedType: const FullType(BuiltList, [FullType(int)]),
+      );
+    }
+    if (object.includeOwnPaidReceipts != null) {
+      yield r'includeOwnPaidReceipts';
+      yield serializers.serialize(
+        object.includeOwnPaidReceipts,
+        specifiedType: const FullType(bool),
       );
     }
   }
@@ -196,6 +244,34 @@ class _$RoleSerializer implements PrimitiveSerializer<Role> {
             specifiedType: const FullType(int),
           ) as int;
           result.assignedCount = valueDes;
+          break;
+        case r'categoryGrants':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(BuiltList, [FullType(int)]),
+          ) as BuiltList<int>;
+          result.categoryGrants.replace(valueDes);
+          break;
+        case r'tagGrants':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(BuiltList, [FullType(int)]),
+          ) as BuiltList<int>;
+          result.tagGrants.replace(valueDes);
+          break;
+        case r'paidByUserGrants':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(BuiltList, [FullType(int)]),
+          ) as BuiltList<int>;
+          result.paidByUserGrants.replace(valueDes);
+          break;
+        case r'includeOwnPaidReceipts':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(bool),
+          ) as bool;
+          result.includeOwnPaidReceipts = valueDes;
           break;
         default:
           unhandled.add(key);

--- a/mobile/api/lib/src/model/role.g.dart
+++ b/mobile/api/lib/src/model/role.g.dart
@@ -23,6 +23,14 @@ class _$Role extends Role {
   final BuiltList<Permission> permissions;
   @override
   final int? assignedCount;
+  @override
+  final BuiltList<int>? categoryGrants;
+  @override
+  final BuiltList<int>? tagGrants;
+  @override
+  final BuiltList<int>? paidByUserGrants;
+  @override
+  final bool? includeOwnPaidReceipts;
 
   factory _$Role([void Function(RoleBuilder)? updates]) =>
       (RoleBuilder()..update(updates))._build();
@@ -35,7 +43,11 @@ class _$Role extends Role {
       required this.isDefault,
       required this.isSystem,
       required this.permissions,
-      this.assignedCount})
+      this.assignedCount,
+      this.categoryGrants,
+      this.tagGrants,
+      this.paidByUserGrants,
+      this.includeOwnPaidReceipts})
       : super._();
   @override
   Role rebuild(void Function(RoleBuilder) updates) =>
@@ -55,7 +67,11 @@ class _$Role extends Role {
         isDefault == other.isDefault &&
         isSystem == other.isSystem &&
         permissions == other.permissions &&
-        assignedCount == other.assignedCount;
+        assignedCount == other.assignedCount &&
+        categoryGrants == other.categoryGrants &&
+        tagGrants == other.tagGrants &&
+        paidByUserGrants == other.paidByUserGrants &&
+        includeOwnPaidReceipts == other.includeOwnPaidReceipts;
   }
 
   @override
@@ -69,6 +85,10 @@ class _$Role extends Role {
     _$hash = $jc(_$hash, isSystem.hashCode);
     _$hash = $jc(_$hash, permissions.hashCode);
     _$hash = $jc(_$hash, assignedCount.hashCode);
+    _$hash = $jc(_$hash, categoryGrants.hashCode);
+    _$hash = $jc(_$hash, tagGrants.hashCode);
+    _$hash = $jc(_$hash, paidByUserGrants.hashCode);
+    _$hash = $jc(_$hash, includeOwnPaidReceipts.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -83,7 +103,11 @@ class _$Role extends Role {
           ..add('isDefault', isDefault)
           ..add('isSystem', isSystem)
           ..add('permissions', permissions)
-          ..add('assignedCount', assignedCount))
+          ..add('assignedCount', assignedCount)
+          ..add('categoryGrants', categoryGrants)
+          ..add('tagGrants', tagGrants)
+          ..add('paidByUserGrants', paidByUserGrants)
+          ..add('includeOwnPaidReceipts', includeOwnPaidReceipts))
         .toString();
   }
 }
@@ -126,6 +150,27 @@ class RoleBuilder implements Builder<Role, RoleBuilder> {
   set assignedCount(int? assignedCount) =>
       _$this._assignedCount = assignedCount;
 
+  ListBuilder<int>? _categoryGrants;
+  ListBuilder<int> get categoryGrants =>
+      _$this._categoryGrants ??= ListBuilder<int>();
+  set categoryGrants(ListBuilder<int>? categoryGrants) =>
+      _$this._categoryGrants = categoryGrants;
+
+  ListBuilder<int>? _tagGrants;
+  ListBuilder<int> get tagGrants => _$this._tagGrants ??= ListBuilder<int>();
+  set tagGrants(ListBuilder<int>? tagGrants) => _$this._tagGrants = tagGrants;
+
+  ListBuilder<int>? _paidByUserGrants;
+  ListBuilder<int> get paidByUserGrants =>
+      _$this._paidByUserGrants ??= ListBuilder<int>();
+  set paidByUserGrants(ListBuilder<int>? paidByUserGrants) =>
+      _$this._paidByUserGrants = paidByUserGrants;
+
+  bool? _includeOwnPaidReceipts;
+  bool? get includeOwnPaidReceipts => _$this._includeOwnPaidReceipts;
+  set includeOwnPaidReceipts(bool? includeOwnPaidReceipts) =>
+      _$this._includeOwnPaidReceipts = includeOwnPaidReceipts;
+
   RoleBuilder() {
     Role._defaults(this);
   }
@@ -141,6 +186,10 @@ class RoleBuilder implements Builder<Role, RoleBuilder> {
       _isSystem = $v.isSystem;
       _permissions = $v.permissions.toBuilder();
       _assignedCount = $v.assignedCount;
+      _categoryGrants = $v.categoryGrants?.toBuilder();
+      _tagGrants = $v.tagGrants?.toBuilder();
+      _paidByUserGrants = $v.paidByUserGrants?.toBuilder();
+      _includeOwnPaidReceipts = $v.includeOwnPaidReceipts;
       _$v = null;
     }
     return this;
@@ -175,12 +224,23 @@ class RoleBuilder implements Builder<Role, RoleBuilder> {
                 isSystem, r'Role', 'isSystem'),
             permissions: permissions.build(),
             assignedCount: assignedCount,
+            categoryGrants: _categoryGrants?.build(),
+            tagGrants: _tagGrants?.build(),
+            paidByUserGrants: _paidByUserGrants?.build(),
+            includeOwnPaidReceipts: includeOwnPaidReceipts,
           );
     } catch (_) {
       late String _$failedField;
       try {
         _$failedField = 'permissions';
         permissions.build();
+
+        _$failedField = 'categoryGrants';
+        _categoryGrants?.build();
+        _$failedField = 'tagGrants';
+        _tagGrants?.build();
+        _$failedField = 'paidByUserGrants';
+        _paidByUserGrants?.build();
       } catch (e) {
         throw BuiltValueNestedFieldError(r'Role', _$failedField, e.toString());
       }

--- a/mobile/api/lib/src/model/upsert_role_command.dart
+++ b/mobile/api/lib/src/model/upsert_role_command.dart
@@ -18,6 +18,10 @@ part 'upsert_role_command.g.dart';
 /// * [description] 
 /// * [scope] 
 /// * [permissions] 
+/// * [categoryGrants] - Category ids to restrict a GROUP role's members to. Only valid on group roles; omit or leave empty for unrestricted access.
+/// * [tagGrants] - Tag ids to restrict a GROUP role's members to. Only valid on group roles; omit or leave empty for unrestricted access.
+/// * [paidByUserGrants] - User ids whose receipts a GROUP role's members may see (by the receipt's \"paid by\" user). Only valid on group roles; omit or leave empty (with includeOwnPaidReceipts false) for unrestricted access.
+/// * [includeOwnPaidReceipts] - Whether to also let each member see receipts they paid for. Only valid on group roles.
 @BuiltValue()
 abstract class UpsertRoleCommand implements Built<UpsertRoleCommand, UpsertRoleCommandBuilder> {
   @BuiltValueField(wireName: r'name')
@@ -32,6 +36,22 @@ abstract class UpsertRoleCommand implements Built<UpsertRoleCommand, UpsertRoleC
 
   @BuiltValueField(wireName: r'permissions')
   BuiltList<Permission> get permissions;
+
+  /// Category ids to restrict a GROUP role's members to. Only valid on group roles; omit or leave empty for unrestricted access.
+  @BuiltValueField(wireName: r'categoryGrants')
+  BuiltList<int>? get categoryGrants;
+
+  /// Tag ids to restrict a GROUP role's members to. Only valid on group roles; omit or leave empty for unrestricted access.
+  @BuiltValueField(wireName: r'tagGrants')
+  BuiltList<int>? get tagGrants;
+
+  /// User ids whose receipts a GROUP role's members may see (by the receipt's \"paid by\" user). Only valid on group roles; omit or leave empty (with includeOwnPaidReceipts false) for unrestricted access.
+  @BuiltValueField(wireName: r'paidByUserGrants')
+  BuiltList<int>? get paidByUserGrants;
+
+  /// Whether to also let each member see receipts they paid for. Only valid on group roles.
+  @BuiltValueField(wireName: r'includeOwnPaidReceipts')
+  bool? get includeOwnPaidReceipts;
 
   UpsertRoleCommand._();
 
@@ -78,6 +98,34 @@ class _$UpsertRoleCommandSerializer implements PrimitiveSerializer<UpsertRoleCom
       object.permissions,
       specifiedType: const FullType(BuiltList, [FullType(Permission)]),
     );
+    if (object.categoryGrants != null) {
+      yield r'categoryGrants';
+      yield serializers.serialize(
+        object.categoryGrants,
+        specifiedType: const FullType(BuiltList, [FullType(int)]),
+      );
+    }
+    if (object.tagGrants != null) {
+      yield r'tagGrants';
+      yield serializers.serialize(
+        object.tagGrants,
+        specifiedType: const FullType(BuiltList, [FullType(int)]),
+      );
+    }
+    if (object.paidByUserGrants != null) {
+      yield r'paidByUserGrants';
+      yield serializers.serialize(
+        object.paidByUserGrants,
+        specifiedType: const FullType(BuiltList, [FullType(int)]),
+      );
+    }
+    if (object.includeOwnPaidReceipts != null) {
+      yield r'includeOwnPaidReceipts';
+      yield serializers.serialize(
+        object.includeOwnPaidReceipts,
+        specifiedType: const FullType(bool),
+      );
+    }
   }
 
   @override
@@ -128,6 +176,34 @@ class _$UpsertRoleCommandSerializer implements PrimitiveSerializer<UpsertRoleCom
             specifiedType: const FullType(BuiltList, [FullType(Permission)]),
           ) as BuiltList<Permission>;
           result.permissions.replace(valueDes);
+          break;
+        case r'categoryGrants':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(BuiltList, [FullType(int)]),
+          ) as BuiltList<int>;
+          result.categoryGrants.replace(valueDes);
+          break;
+        case r'tagGrants':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(BuiltList, [FullType(int)]),
+          ) as BuiltList<int>;
+          result.tagGrants.replace(valueDes);
+          break;
+        case r'paidByUserGrants':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(BuiltList, [FullType(int)]),
+          ) as BuiltList<int>;
+          result.paidByUserGrants.replace(valueDes);
+          break;
+        case r'includeOwnPaidReceipts':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(bool),
+          ) as bool;
+          result.includeOwnPaidReceipts = valueDes;
           break;
         default:
           unhandled.add(key);

--- a/mobile/api/lib/src/model/upsert_role_command.g.dart
+++ b/mobile/api/lib/src/model/upsert_role_command.g.dart
@@ -15,6 +15,14 @@ class _$UpsertRoleCommand extends UpsertRoleCommand {
   final PermissionScope scope;
   @override
   final BuiltList<Permission> permissions;
+  @override
+  final BuiltList<int>? categoryGrants;
+  @override
+  final BuiltList<int>? tagGrants;
+  @override
+  final BuiltList<int>? paidByUserGrants;
+  @override
+  final bool? includeOwnPaidReceipts;
 
   factory _$UpsertRoleCommand(
           [void Function(UpsertRoleCommandBuilder)? updates]) =>
@@ -24,7 +32,11 @@ class _$UpsertRoleCommand extends UpsertRoleCommand {
       {required this.name,
       this.description,
       required this.scope,
-      required this.permissions})
+      required this.permissions,
+      this.categoryGrants,
+      this.tagGrants,
+      this.paidByUserGrants,
+      this.includeOwnPaidReceipts})
       : super._();
   @override
   UpsertRoleCommand rebuild(void Function(UpsertRoleCommandBuilder) updates) =>
@@ -41,7 +53,11 @@ class _$UpsertRoleCommand extends UpsertRoleCommand {
         name == other.name &&
         description == other.description &&
         scope == other.scope &&
-        permissions == other.permissions;
+        permissions == other.permissions &&
+        categoryGrants == other.categoryGrants &&
+        tagGrants == other.tagGrants &&
+        paidByUserGrants == other.paidByUserGrants &&
+        includeOwnPaidReceipts == other.includeOwnPaidReceipts;
   }
 
   @override
@@ -51,6 +67,10 @@ class _$UpsertRoleCommand extends UpsertRoleCommand {
     _$hash = $jc(_$hash, description.hashCode);
     _$hash = $jc(_$hash, scope.hashCode);
     _$hash = $jc(_$hash, permissions.hashCode);
+    _$hash = $jc(_$hash, categoryGrants.hashCode);
+    _$hash = $jc(_$hash, tagGrants.hashCode);
+    _$hash = $jc(_$hash, paidByUserGrants.hashCode);
+    _$hash = $jc(_$hash, includeOwnPaidReceipts.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -61,7 +81,11 @@ class _$UpsertRoleCommand extends UpsertRoleCommand {
           ..add('name', name)
           ..add('description', description)
           ..add('scope', scope)
-          ..add('permissions', permissions))
+          ..add('permissions', permissions)
+          ..add('categoryGrants', categoryGrants)
+          ..add('tagGrants', tagGrants)
+          ..add('paidByUserGrants', paidByUserGrants)
+          ..add('includeOwnPaidReceipts', includeOwnPaidReceipts))
         .toString();
   }
 }
@@ -88,6 +112,27 @@ class UpsertRoleCommandBuilder
   set permissions(ListBuilder<Permission>? permissions) =>
       _$this._permissions = permissions;
 
+  ListBuilder<int>? _categoryGrants;
+  ListBuilder<int> get categoryGrants =>
+      _$this._categoryGrants ??= ListBuilder<int>();
+  set categoryGrants(ListBuilder<int>? categoryGrants) =>
+      _$this._categoryGrants = categoryGrants;
+
+  ListBuilder<int>? _tagGrants;
+  ListBuilder<int> get tagGrants => _$this._tagGrants ??= ListBuilder<int>();
+  set tagGrants(ListBuilder<int>? tagGrants) => _$this._tagGrants = tagGrants;
+
+  ListBuilder<int>? _paidByUserGrants;
+  ListBuilder<int> get paidByUserGrants =>
+      _$this._paidByUserGrants ??= ListBuilder<int>();
+  set paidByUserGrants(ListBuilder<int>? paidByUserGrants) =>
+      _$this._paidByUserGrants = paidByUserGrants;
+
+  bool? _includeOwnPaidReceipts;
+  bool? get includeOwnPaidReceipts => _$this._includeOwnPaidReceipts;
+  set includeOwnPaidReceipts(bool? includeOwnPaidReceipts) =>
+      _$this._includeOwnPaidReceipts = includeOwnPaidReceipts;
+
   UpsertRoleCommandBuilder() {
     UpsertRoleCommand._defaults(this);
   }
@@ -99,6 +144,10 @@ class UpsertRoleCommandBuilder
       _description = $v.description;
       _scope = $v.scope;
       _permissions = $v.permissions.toBuilder();
+      _categoryGrants = $v.categoryGrants?.toBuilder();
+      _tagGrants = $v.tagGrants?.toBuilder();
+      _paidByUserGrants = $v.paidByUserGrants?.toBuilder();
+      _includeOwnPaidReceipts = $v.includeOwnPaidReceipts;
       _$v = null;
     }
     return this;
@@ -128,12 +177,22 @@ class UpsertRoleCommandBuilder
             scope: BuiltValueNullFieldError.checkNotNull(
                 scope, r'UpsertRoleCommand', 'scope'),
             permissions: permissions.build(),
+            categoryGrants: _categoryGrants?.build(),
+            tagGrants: _tagGrants?.build(),
+            paidByUserGrants: _paidByUserGrants?.build(),
+            includeOwnPaidReceipts: includeOwnPaidReceipts,
           );
     } catch (_) {
       late String _$failedField;
       try {
         _$failedField = 'permissions';
         permissions.build();
+        _$failedField = 'categoryGrants';
+        _categoryGrants?.build();
+        _$failedField = 'tagGrants';
+        _tagGrants?.build();
+        _$failedField = 'paidByUserGrants';
+        _paidByUserGrants?.build();
       } catch (e) {
         throw BuiltValueNestedFieldError(
             r'UpsertRoleCommand', _$failedField, e.toString());

--- a/mobile/api/lib/src/serializers.g.dart
+++ b/mobile/api/lib/src/serializers.g.dart
@@ -169,6 +169,18 @@ Serializers _$serializers = (Serializers().toBuilder()
           ]),
           () => MapBuilder<String, BuiltList<Permission>>())
       ..addBuilderFactory(
+          const FullType(BuiltMap, const [
+            const FullType(String),
+            const FullType(BuiltList, const [const FullType(Category)])
+          ]),
+          () => MapBuilder<String, BuiltList<Category>>())
+      ..addBuilderFactory(
+          const FullType(BuiltMap, const [
+            const FullType(String),
+            const FullType(BuiltList, const [const FullType(Tag)])
+          ]),
+          () => MapBuilder<String, BuiltList<Tag>>())
+      ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(GroupMember)]),
           () => ListBuilder<GroupMember>())
       ..addBuilderFactory(
@@ -187,8 +199,26 @@ Serializers _$serializers = (Serializers().toBuilder()
           const FullType(BuiltList, const [const FullType(Permission)]),
           () => ListBuilder<Permission>())
       ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(int)]),
+          () => ListBuilder<int>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(int)]),
+          () => ListBuilder<int>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(int)]),
+          () => ListBuilder<int>())
+      ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(Permission)]),
           () => ListBuilder<Permission>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(int)]),
+          () => ListBuilder<int>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(int)]),
+          () => ListBuilder<int>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(int)]),
+          () => ListBuilder<int>())
       ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(PieChartDataPoint)]),
           () => ListBuilder<PieChartDataPoint>())

--- a/mobile/integration_test/helpers/permission_fixtures.dart
+++ b/mobile/integration_test/helpers/permission_fixtures.dart
@@ -298,6 +298,42 @@ Future<int> createReceipt({
   return (jsonDecode(res.body) as Map<String, dynamic>)['id'] as int;
 }
 
+/// Creates a global category (categories are app-wide; group visibility is via
+/// group-role grants) and returns its id. A group role with no category grants
+/// is unrestricted, so a freshly-created category shows up in every member's
+/// per-group catalog. Used to prove non-admins receive categories via the
+/// per-group `groupCategories` map (not the admin-only flat list).
+Future<int> createCategory({
+  required String name,
+  required String jwt,
+  String description = 'e2e category',
+}) async {
+  final res = await http
+      .post(
+        Uri.parse('${E2eEnv.baseUrl}/category/'),
+        headers: _jsonAuth(jwt),
+        body: jsonEncode({'name': name, 'description': description}),
+      )
+      .timeout(const Duration(seconds: 10));
+  if (res.statusCode != 200) {
+    throw StateError('createCategory($name) failed: '
+        'HTTP ${res.statusCode}: ${res.body}');
+  }
+  return (jsonDecode(res.body) as Map<String, dynamic>)['id'] as int;
+}
+
+/// Best-effort `DELETE /category/{id}`. Swallows errors like the other cleanups.
+Future<void> deleteCategory(int categoryId, {required String jwt}) async {
+  try {
+    await http
+        .delete(Uri.parse('${E2eEnv.baseUrl}/category/$categoryId'),
+            headers: _auth(jwt))
+        .timeout(const Duration(seconds: 5));
+  } catch (_) {
+    // best-effort
+  }
+}
+
 /// Provisions a fresh user and (optionally) a fixture group it belongs to,
 /// registering `addTearDown` to delete the group and user afterwards.
 ///

--- a/mobile/integration_test/permission_receipt_category_visibility_test.dart
+++ b/mobile/integration_test/permission_receipt_category_visibility_test.dart
@@ -1,0 +1,84 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'helpers/api.dart';
+import 'helpers/form_actions.dart';
+import 'helpers/login.dart';
+import 'helpers/nav.dart';
+import 'helpers/permission_fixtures.dart';
+import 'helpers/platform_mocks.dart';
+import 'helpers/pump.dart';
+
+/// Regression coverage for the receipt-form category picker (M2).
+///
+/// Categories/tags are now delivered per-group on `AppData` (`groupCategories`),
+/// filtered to the caller's group-role grants. The flat `categories` array is
+/// admin-only, so a normal (non-admin) user must source the picker from the
+/// per-group catalog — otherwise the picker is empty. This drives that path with
+/// a **Legacy Editor** (a non-admin app role: Legacy User, which lacks
+/// `app.categories.read`) and asserts a freshly-created category shows up in the
+/// receipt form's category multiselect.
+///
+/// Before the fix the mobile receipt pickers read the flat admin-only list, so
+/// this exact flow surfaced an empty picker — this test would have caught it.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    if (Platform.isLinux) {
+      installLinuxDesktopMocks();
+    }
+  });
+
+  testWidgets(
+    'receipt form: a non-admin sees the group catalog in the category picker',
+    (tester) async {
+      // A global category exists (unrestricted group roles see the whole pool).
+      // Create it BEFORE login so it lands in the non-admin's AppData catalog.
+      final adminJwt = await apiLogin();
+      final categoryName =
+          'e2e-cat-${DateTime.now().microsecondsSinceEpoch}';
+      final categoryId = await createCategory(name: categoryName, jwt: adminJwt);
+      addTearDown(() async => deleteCategory(categoryId, jwt: await apiLogin()));
+
+      // A Legacy Editor (app role: Legacy User — no app.categories.read) who can
+      // create receipts in the fixture group.
+      final fixture = await provisionPermUser(roleName: 'Legacy Editor');
+      await loginAs(
+        tester,
+        username: fixture.username,
+        password: fixture.password,
+      );
+      await enterGroup(tester, fixture.groupName!);
+
+      // Open the add-receipt form via the bottom-nav Add menu.
+      await tester.tap(find.text('Add').hitTestable());
+      await pumpUntilFound(
+          tester, find.text('Add Manual Receipt').hitTestable());
+      for (int i = 0; i < 5; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+      await tester.tap(find.text('Add Manual Receipt').hitTestable());
+      await pumpUntilFound(tester, find.text('Name'));
+
+      // Selecting the group makes the category field visible (its Visibility is
+      // gated on the group's receipt settings) and scopes the picker's source.
+      await selectDropdown(tester, 'groupId', fixture.groupName!);
+
+      // Open the category multiselect. The field renders the placeholder chip
+      // "No Categories selected" inside a tappable GestureDetector.
+      final categoryField = find.text('No Categories selected');
+      await pumpUntilFound(tester, categoryField);
+      await tester.ensureVisible(categoryField);
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.tap(categoryField);
+
+      // The per-group catalog is sourced into the multiselect sheet, so the
+      // category is offered. (Empty for a non-admin before the M2 fix.)
+      await pumpUntilFound(tester, find.text(categoryName));
+      expect(find.text(categoryName), findsWidgets);
+    },
+  );
+}

--- a/mobile/lib/models/category_model.dart
+++ b/mobile/lib/models/category_model.dart
@@ -4,11 +4,28 @@ import 'package:openapi/openapi.dart';
 class CategoryModel extends ChangeNotifier {
   List<Category> _categories = [];
 
+  // Per-group catalogs the caller may use, keyed by group id. Delivered on
+  // AppData (`groupCategories`) filtered to the user's group-role grants (the
+  // full pool when unrestricted). Non-admins receive categories only here — the
+  // flat `_categories` list is admin-only — so receipt pickers must source from
+  // this map, scoped to the receipt's group.
+  Map<int, List<Category>> _groupCategories = {};
+
   List<Category> get categories => _categories;
 
   void setCategories(List<Category> categories) {
     _categories = categories;
 
     notifyListeners();
+  }
+
+  void setGroupCategories(Map<int, List<Category>> groupCategories) {
+    _groupCategories = groupCategories;
+
+    notifyListeners();
+  }
+
+  List<Category> categoriesForGroup(int groupId) {
+    return _groupCategories[groupId] ?? const [];
   }
 }

--- a/mobile/lib/models/tag_model.dart
+++ b/mobile/lib/models/tag_model.dart
@@ -4,11 +4,28 @@ import 'package:openapi/openapi.dart';
 class TagModel extends ChangeNotifier {
   List<Tag> _tags = [];
 
+  // Per-group catalogs the caller may use, keyed by group id. Delivered on
+  // AppData (`groupTags`) filtered to the user's group-role grants (the full
+  // pool when unrestricted). Non-admins receive tags only here — the flat
+  // `_tags` list is admin-only — so receipt pickers must source from this map,
+  // scoped to the receipt's group.
+  Map<int, List<Tag>> _groupTags = {};
+
   List<Tag> get tags => _tags;
 
   void setTags(List<Tag> tags) {
     _tags = tags;
 
     notifyListeners();
+  }
+
+  void setGroupTags(Map<int, List<Tag>> groupTags) {
+    _groupTags = groupTags;
+
+    notifyListeners();
+  }
+
+  List<Tag> tagsForGroup(int groupId) {
+    return _groupTags[groupId] ?? const [];
   }
 }

--- a/mobile/lib/receipts/screens/receipt_comment_screen.dart
+++ b/mobile/lib/receipts/screens/receipt_comment_screen.dart
@@ -7,8 +7,10 @@ import 'package:rxdart/rxdart.dart';
 
 import '../../client/client.dart';
 import '../../models/auth_model.dart';
+import '../../models/permissions_model.dart';
 import '../../models/receipt_model.dart';
 import '../../enums/form_state.dart';
+import '../../shared/functions/permissions.dart';
 import '../../shared/widgets/screen_wrapper.dart';
 import '../../utils/snackbar.dart';
 import '../widgets/receipt_comments.dart';
@@ -70,6 +72,19 @@ class _ReceiptCommentScreenState extends State<ReceiptCommentScreen> {
   Widget _buildCommentBottomSheet() {
     if (formState == WranglerFormState.view) {
       return SizedBox.shrink();
+    }
+
+    // For an existing receipt, hide the input unless the caller may add comments
+    // in its group (mirrors the desktop comment gate). In add-state the receipt
+    // has no persisted group yet, so the client gate is skipped and the backend
+    // still enforces on submit.
+    final groupId = receipt.groupId;
+    if (groupId > 0) {
+      final permissionsModel =
+          Provider.of<PermissionsModel>(context, listen: false);
+      if (!canCommentCreate(permissionsModel, groupId)) {
+        return SizedBox.shrink();
+      }
     }
 
     var formKey = GlobalKey<FormBuilderState>();

--- a/mobile/lib/receipts/widgets/receipt_comments.dart
+++ b/mobile/lib/receipts/widgets/receipt_comments.dart
@@ -3,6 +3,8 @@ import 'package:openapi/openapi.dart' as api;
 import 'package:provider/provider.dart';
 import 'package:receipt_wrangler_mobile/enums/form_state.dart';
 import 'package:receipt_wrangler_mobile/models/auth_model.dart';
+import 'package:receipt_wrangler_mobile/models/permissions_model.dart';
+import 'package:receipt_wrangler_mobile/shared/functions/permissions.dart';
 import 'package:receipt_wrangler_mobile/shared/widgets/slidable_delete_button.dart';
 import 'package:receipt_wrangler_mobile/shared/widgets/slidable_widget.dart';
 import 'package:receipt_wrangler_mobile/utils/snackbar.dart';
@@ -27,8 +29,18 @@ class _ReceiptComments extends State<ReceiptComments> {
   late final formState = widget.formState;
 
   Widget buildWidgetList() {
-    var slideEnabled = formState == WranglerFormState.edit ||
-        formState == WranglerFormState.add;
+    // Add-state comments are local (removed from the in-progress model, no API
+    // call), so swiping stays enabled. Editing an existing receipt, the swipe
+    // issues a real DELETE, so gate it on `group.comments.delete` for the
+    // receipt's group (mirrors the desktop comment gate).
+    var slideEnabled = formState == WranglerFormState.add;
+    if (formState == WranglerFormState.edit) {
+      final receiptModel = Provider.of<ReceiptModel>(context, listen: false);
+      final permissionsModel =
+          Provider.of<PermissionsModel>(context, listen: false);
+      slideEnabled =
+          canCommentDelete(permissionsModel, receiptModel.receipt.groupId);
+    }
 
     return ListView.builder(
       itemCount: widget.comments.length,

--- a/mobile/lib/receipts/widgets/receipt_form.dart
+++ b/mobile/lib/receipts/widgets/receipt_form.dart
@@ -173,6 +173,7 @@ class _ReceiptForm extends State<ReceiptForm> {
     return CategorySelectField(
       fieldName: "categories",
       label: "Categories",
+      groupId: groupId,
       initialCategories: formKey.currentState?.fields["categories"]?.value ??
           modifiedReceipt.categories!.toList(),
       formState: formState,
@@ -188,6 +189,7 @@ class _ReceiptForm extends State<ReceiptForm> {
     return TagSelectField(
         label: "Tags",
         fieldName: "tags",
+        groupId: groupId,
         initialTags: formKey.currentState?.fields["tags"]?.value ??
             modifiedReceipt.tags!.toList(),
         formState: formState,

--- a/mobile/lib/receipts/widgets/receipt_item_items.dart
+++ b/mobile/lib/receipts/widgets/receipt_item_items.dart
@@ -206,6 +206,7 @@ class _ReceiptItemItems extends State<ReceiptItemItems> {
           child: CategorySelectField(
               label: "Categories",
               fieldName: categoryName,
+              groupId: widget.groupId,
               initialCategories: initialCategories,
               formState: formState,
               onCategoriesChanged: (categories) {
@@ -223,6 +224,7 @@ class _ReceiptItemItems extends State<ReceiptItemItems> {
             child: TagSelectField(
                 label: "Tags",
                 fieldName: tagName,
+                groupId: widget.groupId,
                 initialTags: initialTags,
                 formState: formState,
                 onTagsChanged: (tags) {

--- a/mobile/lib/shared/functions/permissions.dart
+++ b/mobile/lib/shared/functions/permissions.dart
@@ -9,3 +9,19 @@ bool canEditReceipt(PermissionsModel permissionsModel, int groupId) {
   return permissionsModel.hasGroupPermission(
       groupId, Permission.groupPeriodReceiptsPeriodUpdate);
 }
+
+/// Whether the current user may add comments to receipts in [groupId]. Gates on
+/// `group.comments.create`, mirroring the desktop comment gate and the backend
+/// enforcement.
+bool canCommentCreate(PermissionsModel permissionsModel, int groupId) {
+  return permissionsModel.hasGroupPermission(
+      groupId, Permission.groupPeriodCommentsPeriodCreate);
+}
+
+/// Whether the current user may delete comments on receipts in [groupId]. Gates
+/// on `group.comments.delete`, mirroring the desktop comment gate and the
+/// backend enforcement.
+bool canCommentDelete(PermissionsModel permissionsModel, int groupId) {
+  return permissionsModel.hasGroupPermission(
+      groupId, Permission.groupPeriodCommentsPeriodDelete);
+}

--- a/mobile/lib/shared/widgets/category_select_field.dart
+++ b/mobile/lib/shared/widgets/category_select_field.dart
@@ -15,11 +15,17 @@ class CategorySelectField extends StatefulWidget {
     required this.initialCategories,
     required this.formState,
     required this.onCategoriesChanged,
+    required this.groupId,
   });
 
   final String label;
 
   final String fieldName;
+
+  /// The receipt's group. Options are sourced from the caller's per-group
+  /// catalog for this group (grant-filtered on the backend), not the global
+  /// admin-only list — otherwise non-admins would see an empty picker.
+  final int groupId;
 
   final List<api.Category> initialCategories;
 
@@ -40,7 +46,7 @@ class _CategorySelectField extends State<CategorySelectField> {
         contextModel.shellContext,
         "Select Categories",
         "Select",
-        categoryModel.categories,
+        categoryModel.categoriesForGroup(widget.groupId),
         widget.initialCategories,
         (category) => category.name).then((value) {
       if (value != null) {

--- a/mobile/lib/shared/widgets/tag_select_field.dart
+++ b/mobile/lib/shared/widgets/tag_select_field.dart
@@ -15,11 +15,17 @@ class TagSelectField extends StatefulWidget {
     required this.initialTags,
     required this.formState,
     required this.onTagsChanged,
+    required this.groupId,
   });
 
   final String label;
 
   final String fieldName;
+
+  /// The receipt's group. Options are sourced from the caller's per-group
+  /// catalog for this group (grant-filtered on the backend), not the global
+  /// admin-only list — otherwise non-admins would see an empty picker.
+  final int groupId;
 
   final List<api.Tag> initialTags;
 
@@ -40,7 +46,7 @@ class _TagSelectField extends State<TagSelectField> {
         contextModel.shellContext,
         "Select Tags",
         "Select",
-        tagModel.tags,
+        tagModel.tagsForGroup(widget.groupId),
         widget.initialTags,
         (tag) => tag.name).then((value) {
       if (value != null) {

--- a/mobile/lib/utils/auth.dart
+++ b/mobile/lib/utils/auth.dart
@@ -1,3 +1,4 @@
+import 'package:built_collection/built_collection.dart';
 import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
 import 'package:openapi/openapi.dart';
 import 'package:receipt_wrangler_mobile/client/client.dart';
@@ -62,7 +63,9 @@ Future<void> storeAppData(
   userModel.setUsers(appData.users.toList());
   userPreferencesModel.setUserPreferences(appData.userPreferences);
   categoryModel.setCategories(appData.categories.toList());
+  categoryModel.setGroupCategories(_groupCatalogToMap(appData.groupCategories));
   tagModel.setTags(appData.tags.toList());
+  tagModel.setGroupTags(_groupCatalogToMap(appData.groupTags));
   systemSettingsModel.setCurrencyDisplay(appData.currencyDisplay);
   systemSettingsModel.setCurrencyDecimalSeparator(
       appData?.currencyDecimalSeparator ?? CurrencySeparator.period);
@@ -74,4 +77,19 @@ Future<void> storeAppData(
       appData?.currencyHideDecimalPlaces ?? false);
   permissionsModel.setPermissions(
       appData.appPermissions, appData.groupPermissions);
+}
+
+/// Converts an AppData per-group catalog (`groupCategories` / `groupTags`,
+/// keyed by group-id string) into a `Map<int, List<T>>` the models index by
+/// group id. Entries with an unparseable key are skipped.
+Map<int, List<T>> _groupCatalogToMap<T>(
+    BuiltMap<String, BuiltList<T>>? groupCatalog) {
+  final result = <int, List<T>>{};
+  groupCatalog?.forEach((groupId, items) {
+    final parsedGroupId = int.tryParse(groupId);
+    if (parsedGroupId != null) {
+      result[parsedGroupId] = items.toList();
+    }
+  });
+  return result;
 }

--- a/mobile/test/models/category_model_test.dart
+++ b/mobile/test/models/category_model_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openapi/openapi.dart';
+import 'package:receipt_wrangler_mobile/models/category_model.dart';
+
+Category _category(int id, String name) =>
+    Category((b) => b
+      ..id = id
+      ..name = name);
+
+void main() {
+  group('CategoryModel.categoriesForGroup', () {
+    test('returns the per-group catalog for a known group', () {
+      final model = CategoryModel();
+      final food = _category(1, 'Food');
+      model.setGroupCategories({
+        7: [food],
+      });
+
+      expect(model.categoriesForGroup(7), [food]);
+    });
+
+    test('isolates catalogs per group', () {
+      final model = CategoryModel();
+      final food = _category(1, 'Food');
+      final travel = _category(2, 'Travel');
+      model.setGroupCategories({
+        7: [food],
+        9: [travel],
+      });
+
+      expect(model.categoriesForGroup(7), [food]);
+      expect(model.categoriesForGroup(9), [travel]);
+    });
+
+    test('returns an empty list for an unknown group', () {
+      final model = CategoryModel();
+      model.setGroupCategories({
+        7: [_category(1, 'Food')],
+      });
+
+      expect(model.categoriesForGroup(99), isEmpty);
+    });
+
+    test('returns an empty list before hydration', () {
+      expect(CategoryModel().categoriesForGroup(7), isEmpty);
+    });
+
+    test('setGroupCategories notifies listeners', () {
+      final model = CategoryModel();
+      var notified = 0;
+      model.addListener(() => notified++);
+      model.setGroupCategories({});
+      expect(notified, 1);
+    });
+  });
+}

--- a/mobile/test/models/tag_model_test.dart
+++ b/mobile/test/models/tag_model_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openapi/openapi.dart';
+import 'package:receipt_wrangler_mobile/models/tag_model.dart';
+
+Tag _tag(int id, String name) =>
+    Tag((b) => b
+      ..id = id
+      ..name = name);
+
+void main() {
+  group('TagModel.tagsForGroup', () {
+    test('returns the per-group catalog for a known group', () {
+      final model = TagModel();
+      final urgent = _tag(1, 'Urgent');
+      model.setGroupTags({
+        7: [urgent],
+      });
+
+      expect(model.tagsForGroup(7), [urgent]);
+    });
+
+    test('isolates catalogs per group', () {
+      final model = TagModel();
+      final urgent = _tag(1, 'Urgent');
+      final personal = _tag(2, 'Personal');
+      model.setGroupTags({
+        7: [urgent],
+        9: [personal],
+      });
+
+      expect(model.tagsForGroup(7), [urgent]);
+      expect(model.tagsForGroup(9), [personal]);
+    });
+
+    test('returns an empty list for an unknown group', () {
+      final model = TagModel();
+      model.setGroupTags({
+        7: [_tag(1, 'Urgent')],
+      });
+
+      expect(model.tagsForGroup(99), isEmpty);
+    });
+
+    test('returns an empty list before hydration', () {
+      expect(TagModel().tagsForGroup(7), isEmpty);
+    });
+
+    test('setGroupTags notifies listeners', () {
+      final model = TagModel();
+      var notified = 0;
+      model.addListener(() => notified++);
+      model.setGroupTags({});
+      expect(notified, 1);
+    });
+  });
+}

--- a/mobile/test/shared/functions/permissions_test.dart
+++ b/mobile/test/shared/functions/permissions_test.dart
@@ -35,4 +35,38 @@ void main() {
       expect(canEditReceipt(model, 99), false);
     });
   });
+
+  group('canCommentCreate', () {
+    test('true when the user holds group.comments.create in the group', () {
+      final model =
+          _modelWithGroup(4, [Permission.groupPeriodCommentsPeriodCreate]);
+      expect(canCommentCreate(model, 4), true);
+    });
+
+    test('false when the group does not grant comment create', () {
+      final model =
+          _modelWithGroup(4, [Permission.groupPeriodReceiptsPeriodRead]);
+      expect(canCommentCreate(model, 4), false);
+    });
+
+    test('false for a group the user is not a member of', () {
+      final model =
+          _modelWithGroup(4, [Permission.groupPeriodCommentsPeriodCreate]);
+      expect(canCommentCreate(model, 99), false);
+    });
+  });
+
+  group('canCommentDelete', () {
+    test('true when the user holds group.comments.delete in the group', () {
+      final model =
+          _modelWithGroup(4, [Permission.groupPeriodCommentsPeriodDelete]);
+      expect(canCommentDelete(model, 4), true);
+    });
+
+    test('false when the group only grants comment create', () {
+      final model =
+          _modelWithGroup(4, [Permission.groupPeriodCommentsPeriodCreate]);
+      expect(canCommentDelete(model, 4), false);
+    });
+  });
 }


### PR DESCRIPTION
## Why

A review of the role-rework branch found the mobile app a slice behind backend/desktop. The mobile API client was last generated **before** the category/tag-grant work, so it never received the per-group catalogs on `AppData`, and the receipt-form pickers still read the now **admin-only** flat `categories`/`tags` arrays. Net effect: **every non-admin mobile user** (default role = Legacy User, which lacks `app.categories.read`) saw an **empty category/tag picker** when adding/editing a receipt. The mobile comment surfaces were also ungated vs desktop, and the regen docs referenced a `userRole` field the rework had removed.

Backend and desktop were found complete and consistent; this PR is the mobile remediation.

## What

- **Regenerate the mobile client** so `AppData` carries `groupCategories`/`groupTags` (and `Role` carries the grant fields). Re-applied the documented dart-dio default patches; dropped the obsolete `claims.userRole` patch (field removed from swagger).
- **Per-group catalog sourcing**: `CategoryModel`/`TagModel` index per-group catalogs from `AppData`; the receipt-form pickers are group-aware and source from the caller's grant-filtered catalog (mirrors desktop). Restores categories/tags for non-admin users.
- **Comment gating**: add-comment input gated on `group.comments.create`, edit-state swipe-delete on `group.comments.delete` (scoped to the receipt's group). Add-state local removal stays enabled.
- **Docs**: per-group sourcing + comment gates documented in `mobile/CLAUDE.md`; stale `userRole` regen note removed.

## Testing

- `flutter analyze` — clean (no new issues).
- `flutter test` — 150/150 green, including new unit tests for `categoriesForGroup`/`tagsForGroup` and the comment helpers.
- Mobile e2e (Linux desktop, against a fresh local API): new spec `permission_receipt_category_visibility_test` (a non-admin sees the group catalog in the picker — the regression that would have caught this) passes, alongside the receipt-form and permission specs. Two specs (`receipt_comments`, `receipt_add_share`) fail in this headless container, but they fail **identically on the base branch** (verified) — pre-existing environmental tap/timing flakes, not introduced here; the mobile-e2e workflow is advisory.

## Notes

- Only `mobile/` is touched — no backend or desktop changes.
- `desktop/src/open-api` and `mobile/api` are generated; the `mobile/api` changes are a clean swagger resync plus the two documented dart-dio hand-patches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Categories and tags now update based on the selected group, so pickers show the right options per receipt group.
  * Receipt comments now respect group permissions for creating and deleting comments.
  * Added support for additional role access controls, including category, tag, and paid-by visibility filters.

* **Bug Fixes**
  * Improved comment and delete behavior in the receipt editor to match edit/add states.
  * Fixed metadata handling so custom field values now include their linked field details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->