### PR TITLE
Fix Angular unit tests for new pdfDpi system setting

### DIFF
--- a/desktop/src/system-settings/system-settings-form/system-settings-form.component.spec.ts
+++ b/desktop/src/system-settings/system-settings-form/system-settings-form.component.spec.ts
@@ -89,6 +89,7 @@ describe("SystemSettingsFormComponent", () => {
       currencyDecimalSeparator: null,
       currencySymbolPosition: null,
       currencyHideDecimalPlaces: null,
+      pdfDpi: null,
       taskConcurrency: null,
       taskQueueConfigurations: [
         { name: "email_polling", priority: 1 },
@@ -114,6 +115,7 @@ describe("SystemSettingsFormComponent", () => {
       currencyDecimalSeparator: CurrencySeparator.Period,
       currencySymbolPosition: CurrencySymbolPosition.Start,
       currencyHideDecimalPlaces: true,
+      pdfDpi: 300,
       taskConcurrency: 12,
       taskQueueConfigurations: [{
         name: QueueName.QuickScan,
@@ -136,6 +138,7 @@ describe("SystemSettingsFormComponent", () => {
       currencyDecimalSeparator: CurrencySeparator.Period,
       currencySymbolPosition: CurrencySymbolPosition.Start,
       currencyHideDecimalPlaces: true,
+      pdfDpi: 300,
       taskConcurrency: 12,
       taskQueueConfigurations: [{
         name: QueueName.QuickScan,
@@ -171,6 +174,7 @@ describe("SystemSettingsFormComponent", () => {
       currencyDecimalSeparator: CurrencySeparator.Period,
       currencySymbolPosition: CurrencySymbolPosition.Start,
       currencyHideDecimalPlaces: false,
+      pdfDpi: "300",
       taskConcurrency: "12",
       mcpEnabled: true,
       mcpPublicUrl: "https://receipts.example.com",
@@ -198,6 +202,7 @@ describe("SystemSettingsFormComponent", () => {
       currencyDecimalSeparator: CurrencySeparator.Period,
       currencySymbolPosition: CurrencySymbolPosition.Start,
       currencyHideDecimalPlaces: false,
+      pdfDpi: 300,
       taskConcurrency: 12,
       taskQueueConfigurations: [
         { name: 'email_polling', priority: 1 },


### PR DESCRIPTION
## Summary

The `pdfDpi` form control was added to `SystemSettingsFormComponent` but the accompanying spec was never updated, leaving three failing tests on `main`:

- `init form with no data`
- `init form with data`
- `should submit form`

Each assertion compared against an object literal that omitted `pdfDpi`, so the new control's value (`null`, then `NaN` after `parseInt`) caused mismatches.

## Changes

Updated `system-settings-form.component.spec.ts` to include `pdfDpi`:
- Added `pdfDpi: null` to the empty-form value assertion.
- Added `pdfDpi: 300` to the populated systemSettings input and its `getRawValue()` assertion.
- Patched `pdfDpi: "300"` in the submit test and expect the parsed `300` in the update payload (mirroring the existing `emailPollingInterval` / `taskConcurrency` pattern).

## Testing

`npm test` — all 786 tests across 195 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LrQtAyoCYcnRwrCZMNsz

---
_Generated by [Claude Code](https://claude.ai/code/session_01K2LrQtAyoCYcnRwrCZMNsz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system settings coverage so the PDF resolution field is handled correctly in form loading and saving.
  * Settings changes now correctly preserve and submit the PDF DPI value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->