### PR TITLE
Permission gating: test coverage, gating fixes, and the /groups over-gate fix

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -219,6 +219,12 @@ gated by `appPermissionGuard` requiring `app.roles.read` (see **Permission-based
     read/create asymmetry — Legacy User holds `app.groups.create` but **not** `app.groups.read`, so
     they create via the sidebar FAB (the groups-list page itself is `app.groups.read`-gated and off
     limits to them), exactly like categories/tags.
+  - **Dashboard CRUD** (`group-dashboards.component.html`): the Add / Edit / Delete dashboard buttons
+    gate on `group.dashboards.create` / `.update` / `.delete` via `*hasGroupPermission` (the group id
+    comes from a `selectedGroupIdNum` computed). Previously ungated — the buttons rendered for every
+    member and 403'd on the backend; now they only render for holders, matching the receipts-table.
+  - **Notification delete** (`notification/notification.component.html`): the per-notification delete
+    control gates on `app.notifications.delete` via `*hasAppPermission`.
 
 ## Signals & Zoneless Change Detection
 
@@ -491,7 +497,22 @@ helpers `withAdminApi` + `apiDeleteUserByName` / `apiDeleteGroupById` / `apiDele
   `/dashboard/group/:id` redirects to `/receipts/group/:id`; an owner contrast still sees the dashboard),
   `paid-by-visibility.spec.ts` (a group role limited to "their own receipts" → a hidden-payer receipt
   `GET` 403s and is absent from the list, the member's own 200s; uses `withApiAs`/`apiCreateReceipt` and
-  the `createRole` `paidByOwn` option in `helpers/provisioning.ts`).
+  the `createRole` `paidByOwn` option in `helpers/provisioning.ts`),
+  `dashboard-crud-gating.spec.ts` (a Viewer holding `group.dashboards.read` but not create/update/delete
+  sees no Add/Edit/Delete dashboard buttons; owner contrast does),
+  `comment-gating.spec.ts` (Receipt-Editor-preset members minus `group.comments.create` / `.delete` →
+  no composer / no delete control; uses `apiCreateComment`),
+  `receipt-feature-gating.spec.ts` (Quick Scan / Poll Email / Magic Fill controls hidden for a Viewer —
+  positive contrast is a `test.fixme` because all three also sit behind the `aiPoweredReceipts` feature
+  flag, which is `false` in the dev/CI API),
+  `receipt-action-gating.spec.ts` (a Legacy Viewer sees no duplicate/delete row action, the
+  `/receipts/:id/edit` route redirects, and `POST /api/receipt` **403s** via `withApiAs('user')`).
+  `legacy-user-visibility.spec.ts` likewise carries **API-403** assertions (`DELETE /api/category|tag/:id`)
+  so server enforcement is proven, not just the hidden control. Note: the receipts-table **edit** action
+  is not template-gated (only duplicate/delete are); the edit *route* is guarded, so the edit denial is
+  asserted at the route level, not button absence. (`receipt-action-gating.spec.ts` is a standalone
+  spec rather than an extension of `group-viewer-visibility.spec.ts`, whose serial block has a known
+  pre-existing failure — a Legacy User can't load `/groups` — that would skip any test appended to it.)
 
 ## Testing Requirements
 

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -431,10 +431,18 @@ In CI the same spec files run against the demo URL. GitHub secrets populate the 
 
 ### Best practices (follow these when adding new e2e tests)
 
-**Locators — use user-facing, auto-retrying selectors.**
-- Prefer `page.getByRole('button', { name: 'Login' })`, `page.getByLabel('Password')`, `page.getByPlaceholder(...)`, `page.getByText(...)`.
-- Use `page.getByTestId(...)` only when no accessible role/label exists. The codebase has no `data-testid` convention yet — add one on a component only when role/label truly can't identify the element.
-- Avoid raw CSS/XPath (`page.locator('.btn-primary')`) — brittle to refactors.
+**Locators — prefer `data-testid`; auto-retrying selectors only.**
+- **Use `page.getByTestId(...)` as the standard selector.** Icon-only controls (the shared
+  `app-add-button` / `app-edit-button` / `app-delete-button` / `app-cancel-button`, filter/menu icon
+  buttons, etc.) and any element without a stable accessible name **must** carry a `data-testid`. Name
+  it `<resource>-<action>` — e.g. `group-delete`, `comment-delete`, `receipt-duplicate`,
+  `add-group-member`, `dialog-submit-button`. The `data-testid` passes through the shared button
+  components to the host element, so `getByTestId('comment-delete')` resolves it directly.
+- `page.getByRole('button', { name: '...' })` / `page.getByLabel(...)` / `page.getByPlaceholder(...)`
+  remain fine for elements that already have a real accessible name (text buttons, labelled inputs).
+- **Never** use structural CSS chains (`page.locator('app-receipt-comments app-delete-button')`) or raw
+  CSS/XPath (`page.locator('.btn-primary')`) — they're brittle to component-structure refactors. Add a
+  `data-testid` to the control instead.
 
 **Assertions — rely on web-first expects, never `waitForTimeout`.**
 - Use `await expect(locator).toBeVisible()`, `toHaveText()`, `toHaveURL()`, `toHaveCount()` — they auto-retry until `expect.timeout`.

--- a/desktop/e2e/comment-gating.spec.ts
+++ b/desktop/e2e/comment-gating.spec.ts
@@ -1,0 +1,189 @@
+import { BrowserContext, expect, Page, test } from '@playwright/test';
+import { creds, stubTokenRefresh } from './helpers/auth';
+import {
+  apiCreateComment,
+  apiCreateReceipt,
+  apiDeleteGroupById,
+  apiDeleteRoleByName,
+  apiGetUserId,
+  createGroupWithMember,
+  createRole,
+  uniqueName,
+  withAdminApi,
+  withApiAs,
+} from './helpers/provisioning';
+
+// Comment controls in the receipt form are permission-gated:
+//   - the "Leave a Comment" composer renders only when the member holds
+//     group.comments.create (canCreateComments()),
+//   - the per-comment delete button renders only for the member's OWN comment
+//     AND when they hold group.comments.delete (canDeleteComments()).
+// Both controls only appear in EDIT mode (the receipt /:id/edit route, gated on
+// group.receipts.update) — the read-only /view mode never shows them. So each
+// fixture role starts from the "Receipt Editor" preset (which grants
+// group.receipts.update + read + group.comments.create, but NOT
+// group.comments.delete):
+//   - the CREATE-deny member drops group.comments.create from that preset,
+//   - the DELETE-deny member keeps the preset as-is (it already lacks delete),
+//     and a comment owned by e2e-user is seeded via the API so the delete
+//     control would otherwise render.
+// Each member lives in its own group with its own seeded receipt; assertions
+// run as e2e-user. A positive contrast (unmodified Receipt Editor → composer
+// visible) proves the create gating is selective.
+
+test.describe('Receipt comment create/delete gating', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let adminContext: BrowserContext;
+  let adminPage: Page;
+
+  // CREATE-deny fixture: Receipt Editor minus group.comments.create.
+  const noCreateRole = uniqueName('no-comment-create-role');
+  const noCreateGroup = uniqueName('no-comment-create-grp');
+  let noCreateGroupId: string;
+  let noCreateReceiptId: number;
+
+  // CREATE-allow contrast fixture: unmodified Receipt Editor.
+  const editorRole = uniqueName('comment-editor-role');
+  const editorGroup = uniqueName('comment-editor-grp');
+  let editorGroupId: string;
+  let editorReceiptId: number;
+
+  // DELETE-deny fixture: Receipt Editor (already lacks group.comments.delete)
+  // with a comment owned by e2e-user seeded via the API.
+  const noDeleteRole = uniqueName('no-comment-delete-role');
+  const noDeleteGroup = uniqueName('no-comment-delete-grp');
+  let noDeleteGroupId: string;
+  let noDeleteReceiptId: number;
+
+  test.beforeAll(async ({ browser }) => {
+    adminContext = await browser.newContext({
+      storageState: 'e2e/.auth/admin.json',
+    });
+    adminPage = await adminContext.newPage();
+    await stubTokenRefresh(adminPage);
+
+    // Receipt Editor minus the comment-create permission.
+    await createRole(adminPage, {
+      name: noCreateRole,
+      type: 'Group role',
+      preset: 'Receipt Editor',
+      disablePermissions: [
+        { panelKey: 'group.comments', label: 'Create Comments' },
+      ],
+    });
+    noCreateGroupId = await createGroupWithMember(adminPage, {
+      groupName: noCreateGroup,
+      memberDisplayName: 'E2E User',
+      roleName: noCreateRole,
+    });
+
+    // Unmodified Receipt Editor — holds comment-create (positive contrast).
+    await createRole(adminPage, {
+      name: editorRole,
+      type: 'Group role',
+      preset: 'Receipt Editor',
+    });
+    editorGroupId = await createGroupWithMember(adminPage, {
+      groupName: editorGroup,
+      memberDisplayName: 'E2E User',
+      roleName: editorRole,
+    });
+
+    // Receipt Editor — holds create + update + read but NOT delete.
+    await createRole(adminPage, {
+      name: noDeleteRole,
+      type: 'Group role',
+      preset: 'Receipt Editor',
+    });
+    noDeleteGroupId = await createGroupWithMember(adminPage, {
+      groupName: noDeleteGroup,
+      memberDisplayName: 'E2E User',
+      roleName: noDeleteRole,
+    });
+
+    // Seed one receipt per group (paid by e2e-user so it's plainly visible),
+    // and a comment owned by e2e-user on the delete-fixture receipt.
+    await withAdminApi(async (api) => {
+      const userId = await apiGetUserId(api, creds('user').username);
+      noCreateReceiptId = await apiCreateReceipt(api, {
+        groupId: noCreateGroupId,
+        paidByUserId: userId,
+        name: uniqueName('no-create-rcpt'),
+      });
+      editorReceiptId = await apiCreateReceipt(api, {
+        groupId: editorGroupId,
+        paidByUserId: userId,
+        name: uniqueName('editor-rcpt'),
+      });
+      noDeleteReceiptId = await apiCreateReceipt(api, {
+        groupId: noDeleteGroupId,
+        paidByUserId: userId,
+        name: uniqueName('no-delete-rcpt'),
+      });
+    });
+
+    // Seed the comment AS e2e-user so it's owned by them (the delete control
+    // only renders for the logged-in user's own comments).
+    await withApiAs('user', async (api) => {
+      await apiCreateComment(api, {
+        receiptId: noDeleteReceiptId,
+        comment: 'e2e-user own comment',
+      });
+    });
+  });
+
+  test.afterAll(async () => {
+    try {
+      await withAdminApi(async (api) => {
+        // Group delete frees the members' role assignment; then the roles delete.
+        await apiDeleteGroupById(api, noCreateGroupId);
+        await apiDeleteGroupById(api, editorGroupId);
+        await apiDeleteGroupById(api, noDeleteGroupId);
+        await apiDeleteRoleByName(api, noCreateRole, 'GROUP');
+        await apiDeleteRoleByName(api, editorRole, 'GROUP');
+        await apiDeleteRoleByName(api, noDeleteRole, 'GROUP');
+      });
+    } catch {
+      // Best-effort cleanup — don't mask a test failure with a cleanup error.
+    }
+    await adminContext?.close();
+  });
+
+  // Assertions run as the default project user (e2e-user = the member).
+  test.beforeEach(async ({ page }) => {
+    await stubTokenRefresh(page);
+  });
+
+  test('without group.comments.create the comment composer is absent', async ({
+    page,
+  }) => {
+    await page.goto(`/receipts/${noCreateReceiptId}/edit`);
+    // Edit mode loads (the member holds group.receipts.update).
+    await expect(page.getByLabel('Name')).toBeVisible();
+    // The "Leave a Comment" composer is gated on group.comments.create.
+    await expect(page.getByText('Leave a Comment')).toHaveCount(0);
+  });
+
+  test('with group.comments.create the comment composer renders (contrast)', async ({
+    page,
+  }) => {
+    await page.goto(`/receipts/${editorReceiptId}/edit`);
+    await expect(page.getByLabel('Name')).toBeVisible();
+    // The Receipt Editor preset grants group.comments.create.
+    await expect(page.getByText('Leave a Comment')).toBeVisible();
+  });
+
+  test('without group.comments.delete the own-comment delete control is absent', async ({
+    page,
+  }) => {
+    await page.goto(`/receipts/${noDeleteReceiptId}/edit`);
+    await expect(page.getByLabel('Name')).toBeVisible();
+    // The seeded comment (owned by e2e-user) is shown...
+    await expect(page.getByText('e2e-user own comment')).toBeVisible();
+    // ...but its delete control is gated on group.comments.delete (not held).
+    await expect(page.locator('app-receipt-comments app-delete-button')).toHaveCount(
+      0,
+    );
+  });
+});

--- a/desktop/e2e/comment-gating.spec.ts
+++ b/desktop/e2e/comment-gating.spec.ts
@@ -182,8 +182,6 @@ test.describe('Receipt comment create/delete gating', () => {
     // The seeded comment (owned by e2e-user) is shown...
     await expect(page.getByText('e2e-user own comment')).toBeVisible();
     // ...but its delete control is gated on group.comments.delete (not held).
-    await expect(page.locator('app-receipt-comments app-delete-button')).toHaveCount(
-      0,
-    );
+    await expect(page.getByTestId('comment-delete')).toHaveCount(0);
   });
 });

--- a/desktop/e2e/dashboard-crud-gating.spec.ts
+++ b/desktop/e2e/dashboard-crud-gating.spec.ts
@@ -1,0 +1,100 @@
+import { BrowserContext, expect, Page, test } from '@playwright/test';
+import { stubTokenRefresh } from './helpers/auth';
+import {
+  apiDeleteGroupById,
+  apiDeleteRoleByName,
+  createGroupWithMember,
+  createRole,
+  uniqueName,
+  withAdminApi,
+} from './helpers/provisioning';
+
+// The group-dashboards header Add/Edit/Delete buttons are gated with
+// *hasGroupPermission on group.dashboards.create/update/delete
+// (group-dashboards.component.html). A member holding group.dashboards.read (so
+// they can VIEW dashboards) but lacking create/update/delete must not see the
+// Add Dashboard control, while an owner of their own group does.
+//
+// The "Viewer" group preset grants group.dashboards.read but NOT
+// create/update/delete (see role-presets.ts VIEWER_KEYS), so it is the exact
+// fixture: an admin context provisions that role + a group with e2e-user as the
+// member, then asserts as e2e-user. The admin who creates the group is its Owner
+// (full perms incl. group.dashboards.create), giving the allow contrast.
+
+test.describe('Group dashboard CRUD gating', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let adminContext: BrowserContext;
+  let adminPage: Page;
+  let roleName: string;
+  let groupName: string;
+  let groupId: string;
+
+  test.beforeAll(async ({ browser }) => {
+    roleName = uniqueName('dash-crud-role');
+    groupName = uniqueName('dash-crud-grp');
+
+    adminContext = await browser.newContext({
+      storageState: 'e2e/.auth/admin.json',
+    });
+    adminPage = await adminContext.newPage();
+    await stubTokenRefresh(adminPage);
+
+    // Viewer holds group.dashboards.read but not create/update/delete.
+    await createRole(adminPage, {
+      name: roleName,
+      type: 'Group role',
+      preset: 'Viewer',
+    });
+
+    groupId = await createGroupWithMember(adminPage, {
+      groupName,
+      memberDisplayName: 'E2E User',
+      roleName,
+    });
+  });
+
+  test.afterAll(async () => {
+    try {
+      await withAdminApi(async (api) => {
+        // Delete the group first (frees the member's group-role assignment),
+        // then the now-unassigned role.
+        await apiDeleteGroupById(api, groupId);
+        await apiDeleteRoleByName(api, roleName, 'GROUP');
+      });
+    } catch {
+      // Best-effort cleanup — don't mask a test failure with a cleanup error.
+    }
+    await adminContext?.close();
+  });
+
+  // Runs as the default project user (e2e-user = the read-only viewer).
+  test('a viewer holding only dashboards.read sees no Add Dashboard button', async ({
+    page,
+  }) => {
+    await stubTokenRefresh(page);
+    await page.goto(`/dashboard/group/${groupId}`);
+    // The dashboards header heading renders for a member who holds .read.
+    await expect(
+      page.getByRole('heading', { name: /Dashboards$/ }),
+    ).toBeVisible();
+    // Add/Edit/Delete are gated on create/update/delete which the Viewer lacks.
+    await expect(page.locator('app-add-button')).toHaveCount(0);
+    await expect(page.locator('app-edit-button')).toHaveCount(0);
+    await expect(page.locator('app-delete-button')).toHaveCount(0);
+  });
+
+  test.describe('owner with dashboards.create', () => {
+    // The admin created the group, so they are its Owner and hold the permission.
+    test.use({ storageState: 'e2e/.auth/admin.json' });
+
+    test('sees the Add Dashboard button (contrast)', async ({ page }) => {
+      await stubTokenRefresh(page);
+      await page.goto(`/dashboard/group/${groupId}`);
+      await expect(
+        page.getByRole('heading', { name: /Dashboards$/ }),
+      ).toBeVisible();
+      await expect(page.locator('app-add-button')).toBeVisible();
+    });
+  });
+});

--- a/desktop/e2e/helpers/provisioning.ts
+++ b/desktop/e2e/helpers/provisioning.ts
@@ -237,6 +237,27 @@ export async function apiCreateReceipt(
   return receipt.id;
 }
 
+/**
+ * Creates a comment on [receiptId] and returns its id. The comment is owned by
+ * whoever the [api] context is authenticated as (the per-comment delete control
+ * only renders for the logged-in user's own comments).
+ */
+export async function apiCreateComment(
+  api: APIRequestContext,
+  opts: { receiptId: number; comment: string },
+): Promise<number> {
+  const res = await api.post('/api/comment/', {
+    data: { comment: opts.comment, receiptId: opts.receiptId },
+  });
+  if (!res.ok()) {
+    throw new Error(
+      `create comment failed: HTTP ${res.status()} ${await res.text()}`,
+    );
+  }
+  const comment = (await res.json()) as { id: number };
+  return comment.id;
+}
+
 /** Hard-deletes the user with [username] (frees any app-role assignment). */
 export async function apiDeleteUserByName(
   api: APIRequestContext,

--- a/desktop/e2e/legacy-user-visibility.spec.ts
+++ b/desktop/e2e/legacy-user-visibility.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { stubTokenRefresh } from './helpers/auth';
+import { uniqueName, withAdminApi, withApiAs } from './helpers/provisioning';
 
 // A "Legacy User" is the app role assigned to converted/normal users; its
 // permission set is canonical and stable. These tests lock in that, post
@@ -96,5 +97,62 @@ test.describe('Admin can reach admin-only areas (contrast)', () => {
     await page.goto('/system-settings');
     // The landing guard redirects to the first tab the admin can read.
     await expect(page).toHaveURL(/\/system-settings\//);
+  });
+});
+
+// The UI hides the category/tag edit/delete row actions for a Legacy User, but
+// the server is the real enforcer: it must 403 a direct DELETE even if the UI is
+// bypassed. An admin context seeds a category and a tag via the API; the Legacy
+// User's DELETE on each must 403; admin teardown removes the survivors.
+test.describe('Legacy User category/tag delete is denied (API 403)', () => {
+  // Runs against the default project user (e2e-user = Legacy User) for the API
+  // assertions; provisioning/teardown go through the admin API.
+  test.describe.configure({ mode: 'serial' });
+
+  let categoryId: number;
+  let tagId: number;
+
+  test.beforeAll(async () => {
+    await withAdminApi(async (api) => {
+      const catRes = await api.post('/api/category/', {
+        data: { name: uniqueName('legacy-del-cat') },
+      });
+      expect(catRes.ok()).toBeTruthy();
+      categoryId = ((await catRes.json()) as { id: number }).id;
+
+      const tagRes = await api.post('/api/tag/', {
+        data: { name: uniqueName('legacy-del-tag') },
+      });
+      expect(tagRes.ok()).toBeTruthy();
+      tagId = ((await tagRes.json()) as { id: number }).id;
+    });
+  });
+
+  test.afterAll(async () => {
+    try {
+      await withAdminApi(async (api) => {
+        // The deletes above are denied, so both resources survive — remove them.
+        await api.delete(`/api/category/${categoryId}`);
+        await api.delete(`/api/tag/${tagId}`);
+      });
+    } catch {
+      // Best-effort cleanup — don't mask a test failure with a cleanup error.
+    }
+  });
+
+  test('DELETE /api/category/:id 403s for a Legacy User', async () => {
+    await withApiAs('user', async (api) => {
+      const res = await api.delete(`/api/category/${categoryId}`);
+      // Legacy User lacks app.categories.delete — the backend 403s.
+      expect(res.status()).toBe(403);
+    });
+  });
+
+  test('DELETE /api/tag/:id 403s for a Legacy User', async () => {
+    await withApiAs('user', async (api) => {
+      const res = await api.delete(`/api/tag/${tagId}`);
+      // Legacy User lacks app.tags.delete — the backend 403s.
+      expect(res.status()).toBe(403);
+    });
   });
 });

--- a/desktop/e2e/legacy-user-visibility.spec.ts
+++ b/desktop/e2e/legacy-user-visibility.spec.ts
@@ -57,11 +57,28 @@ test.describe('Legacy User visibility', () => {
     page,
   }) => {
     await page.goto('/groups/create');
-    // Legacy User holds app.groups.create (but not app.groups.read, so the
-    // /groups list is off-limits). The newly-added appPermissionGuard on the
-    // create route must therefore admit them rather than redirect.
+    // Legacy User holds app.groups.create, so the create route's
+    // appPermissionGuard admits them rather than redirecting.
     await expect(page).toHaveURL(/\/groups\/create/);
     await expect(page.getByLabel('Group Name')).toBeVisible();
+  });
+
+  test('groups: can open the groups table (own groups) without the all-groups filter', async ({
+    page,
+  }) => {
+    await page.goto('/groups');
+    // The groups-table route is NOT gated on app.groups.read: it lists the
+    // caller's OWN groups (backend GetGroupsForUser is auth-only), so a Legacy
+    // User reaches it instead of being redirected. (Regression fix — the route
+    // used to require app.groups.read, locking normal users out of managing
+    // their own groups.)
+    await expect(page).toHaveURL(/\/groups$/);
+    // The Create Group button renders (app.groups.create, held) — page loaded.
+    await expect(page.getByTestId('group-create')).toBeVisible();
+    // The "all groups" Filter button stays admin-only (app.groups.read) — absent.
+    await expect(
+      page.locator('mat-icon', { hasText: 'filter_alt' }),
+    ).toHaveCount(0);
   });
 
   test('header search bar renders (holds app.receipts.search)', async ({

--- a/desktop/e2e/receipt-action-gating.spec.ts
+++ b/desktop/e2e/receipt-action-gating.spec.ts
@@ -18,11 +18,10 @@ import {
 // the edit denial is asserted at the route level, plus an API-403 proves the
 // backend enforces create independently of the hidden UI.
 //
-// Self-contained (not folded into group-viewer-visibility.spec.ts): that file's
-// serial block has a known pre-existing failure ("group row exposes no edit or
-// delete action" — a Legacy User can't load /groups), which would skip every
-// following test in the same block. This spec provisions its own Legacy Viewer
-// group + receipt so the assertions always run.
+// A focused, self-contained spec: it provisions its own Legacy Viewer group +
+// receipt and asserts as e2e-user. Kept separate from
+// group-viewer-visibility.spec.ts (which covers GROUP-level gating) to keep each
+// spec's concern narrow.
 test.describe('Group Viewer is denied receipt write actions', () => {
   test.describe.configure({ mode: 'serial' });
 

--- a/desktop/e2e/receipt-action-gating.spec.ts
+++ b/desktop/e2e/receipt-action-gating.spec.ts
@@ -1,0 +1,120 @@
+import { BrowserContext, expect, Page, test } from '@playwright/test';
+import { creds, stubTokenRefresh } from './helpers/auth';
+import {
+  apiCreateReceipt,
+  apiDeleteGroupById,
+  apiGetUserId,
+  createGroupWithMember,
+  uniqueName,
+  withAdminApi,
+  withApiAs,
+} from './helpers/provisioning';
+
+// Receipt write actions are gated by group permissions a Legacy Viewer lacks:
+// the receipts-table row's Duplicate (group.receipts.duplicate) and Delete
+// (group.receipts.delete) actions, the receipt edit route (group.receipts.update,
+// via receiptGuardGuard), and creating a receipt (group.receipts.create, server-
+// enforced). The receipts-table *edit* action itself is not template-gated, so
+// the edit denial is asserted at the route level, plus an API-403 proves the
+// backend enforces create independently of the hidden UI.
+//
+// Self-contained (not folded into group-viewer-visibility.spec.ts): that file's
+// serial block has a known pre-existing failure ("group row exposes no edit or
+// delete action" — a Legacy User can't load /groups), which would skip every
+// following test in the same block. This spec provisions its own Legacy Viewer
+// group + receipt so the assertions always run.
+test.describe('Group Viewer is denied receipt write actions', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let adminContext: BrowserContext;
+  let adminPage: Page;
+  const groupName = uniqueName('rcpt-action-grp');
+  const receiptName = uniqueName('rcpt-action');
+  let groupId: string;
+  let receiptId: number;
+  let userId: number; // e2e-user's id (admin-only user list)
+
+  test.beforeAll(async ({ browser }) => {
+    adminContext = await browser.newContext({
+      storageState: 'e2e/.auth/admin.json',
+    });
+    adminPage = await adminContext.newPage();
+    await stubTokenRefresh(adminPage);
+
+    // Group with e2e-user ("E2E User") as a Legacy Viewer (holds
+    // group.receipts.read, none of update/delete/duplicate/create).
+    groupId = await createGroupWithMember(adminPage, {
+      groupName,
+      memberDisplayName: 'E2E User',
+      roleName: 'Legacy Viewer',
+    });
+
+    // Seed a receipt paid by admin so it appears in the Viewer's list (the
+    // Viewer holds read, no paid-by restriction).
+    await withAdminApi(async (api) => {
+      const adminId = await apiGetUserId(api, creds('admin').username);
+      userId = await apiGetUserId(api, creds('user').username);
+      receiptId = await apiCreateReceipt(api, {
+        groupId,
+        paidByUserId: adminId,
+        name: receiptName,
+      });
+    });
+  });
+
+  test.afterAll(async () => {
+    try {
+      // Deleting the group cascades its receipt and frees the member's role.
+      await withAdminApi(async (api) => apiDeleteGroupById(api, groupId));
+    } catch {
+      // Best-effort cleanup — don't mask a test failure with a cleanup error.
+    }
+    await adminContext?.close();
+  });
+
+  // Assertions run as the default project user (e2e-user = the Viewer).
+  test.beforeEach(async ({ page }) => {
+    await stubTokenRefresh(page);
+  });
+
+  test('receipts row exposes no duplicate or delete action', async ({
+    page,
+  }) => {
+    await page.goto(`/receipts/group/${groupId}`);
+    // The Viewer holds group.receipts.read, so the seeded receipt is listed.
+    const row = page.getByRole('row').filter({ hasText: receiptName }).first();
+    await expect(row).toBeVisible();
+    // Duplicate / delete row actions are gated on permissions not held.
+    await expect(row.getByTestId('receipt-duplicate')).toHaveCount(0);
+    await expect(row.getByTestId('receipt-delete')).toHaveCount(0);
+  });
+
+  test('navigating to the receipt edit route redirects away', async ({
+    page,
+  }) => {
+    await page.goto(`/receipts/${receiptId}/edit`);
+    // receiptGuardGuard checks group.receipts.update (not held) and redirects
+    // rather than admitting a 403'd edit.
+    await page.waitForURL(
+      (url) => !url.href.includes(`/receipts/${receiptId}/edit`),
+      { timeout: 10_000 },
+    );
+  });
+
+  test('creating a receipt in the group is denied (API 403)', async () => {
+    await withApiAs('user', async (api) => {
+      const res = await api.post('/api/receipt', {
+        data: {
+          name: uniqueName('viewer-denied-rcpt'),
+          amount: '10.00',
+          date: '2024-01-01T00:00:00Z',
+          groupId: Number(groupId),
+          paidByUserId: userId,
+          status: 'OPEN',
+        },
+      });
+      // The Viewer lacks group.receipts.create — the backend 403s.
+      expect(res.status()).toBe(403);
+    });
+  });
+});

--- a/desktop/e2e/receipt-feature-gating.spec.ts
+++ b/desktop/e2e/receipt-feature-gating.spec.ts
@@ -1,0 +1,134 @@
+import { BrowserContext, expect, Page, test } from '@playwright/test';
+import { creds, stubTokenRefresh } from './helpers/auth';
+import {
+  apiCreateReceipt,
+  apiDeleteGroupById,
+  apiDeleteRoleByName,
+  apiGetUserId,
+  createGroupWithMember,
+  createRole,
+  uniqueName,
+  withAdminApi,
+} from './helpers/provisioning';
+
+// The AI-powered receipt features are permission-gated in the UI:
+//   - Quick Scan  -> group.receipts.quick-scan (sidebar + receipts-table header),
+//   - Poll Email  -> group.email.poll (receipts-table header),
+//   - Magic Fill  -> group.receipts.magic-fill (receipt form image toolbar).
+// A "Viewer" group role holds none of these, so an admin context provisions a
+// Viewer group with e2e-user + a seeded receipt and asserts (as e2e-user) that
+// none of the three controls render.
+//
+// IMPORTANT CONFOUND: all three controls ALSO sit behind the `aiPoweredReceipts`
+// feature flag (`*appFeature="'aiPoweredReceipts'"` for Quick Scan/Poll Email,
+// and `aiPoweredReceipts()` for Magic Fill). That flag is server-config
+// (FeatureConfig) and is currently `false` in the dev/CI API, so these controls
+// are hidden for EVERYONE regardless of permission. These tests therefore prove
+// the permission-denied member sees no control (the negative axis), but they
+// cannot prove the positive contrast (a permitted member WOULD see it) without
+// enabling the feature flag on the API — which this harness must not modify. The
+// positive-contrast tests below are left as test.fixme for that reason.
+
+test.describe('Receipt feature gating (quick-scan / poll-email / magic-fill)', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let adminContext: BrowserContext;
+  let adminPage: Page;
+  const roleName = uniqueName('no-ai-role');
+  const groupName = uniqueName('no-ai-grp');
+  let groupId: string;
+  let receiptId: number;
+
+  test.beforeAll(async ({ browser }) => {
+    adminContext = await browser.newContext({
+      storageState: 'e2e/.auth/admin.json',
+    });
+    adminPage = await adminContext.newPage();
+    await stubTokenRefresh(adminPage);
+
+    // Viewer: holds group.receipts.read (so the list/form load) but none of
+    // quick-scan / magic-fill / email.poll.
+    await createRole(adminPage, {
+      name: roleName,
+      type: 'Group role',
+      preset: 'Viewer',
+    });
+
+    groupId = await createGroupWithMember(adminPage, {
+      groupName,
+      memberDisplayName: 'E2E User',
+      roleName,
+    });
+
+    await withAdminApi(async (api) => {
+      const userId = await apiGetUserId(api, creds('user').username);
+      receiptId = await apiCreateReceipt(api, {
+        groupId,
+        paidByUserId: userId,
+        name: uniqueName('no-ai-rcpt'),
+      });
+    });
+  });
+
+  test.afterAll(async () => {
+    try {
+      await withAdminApi(async (api) => {
+        await apiDeleteGroupById(api, groupId);
+        await apiDeleteRoleByName(api, roleName, 'GROUP');
+      });
+    } catch {
+      // Best-effort cleanup — don't mask a test failure with a cleanup error.
+    }
+    await adminContext?.close();
+  });
+
+  // Assertions run as the default project user (e2e-user = the Viewer).
+  test.beforeEach(async ({ page }) => {
+    await stubTokenRefresh(page);
+  });
+
+  test('the receipts header shows no Quick Scan button', async ({ page }) => {
+    await page.goto(`/receipts/group/${groupId}`);
+    // The table renders for a member who holds group.receipts.read.
+    await expect(page.getByTestId('configure-columns')).toBeVisible();
+    // Quick Scan (group.receipts.quick-scan, also feature-flagged) is absent.
+    await expect(
+      page.getByRole('button', { name: 'Quick Scan' }),
+    ).toHaveCount(0);
+  });
+
+  test('the receipts header shows no Poll Email button', async ({ page }) => {
+    await page.goto(`/receipts/group/${groupId}`);
+    await expect(page.getByTestId('configure-columns')).toBeVisible();
+    // Poll Email (group.email.poll, also feature-flagged + needs email
+    // integration enabled) is absent.
+    await expect(
+      page.getByRole('button', { name: 'Poll email(s)' }),
+    ).toHaveCount(0);
+  });
+
+  test('the receipt form shows no Magic Fill button', async ({ page }) => {
+    await page.goto(`/receipts/${receiptId}/view`);
+    // The receipt form renders for a member who holds group.receipts.read.
+    await expect(page.getByLabel('Name')).toBeVisible();
+    // Magic Fill (group.receipts.magic-fill, also feature-flagged) is absent.
+    await expect(page.getByRole('button', { name: 'Magic fill' })).toHaveCount(
+      0,
+    );
+  });
+
+  // Positive contrasts require the aiPoweredReceipts feature flag enabled on the
+  // API, which this harness must not modify (FeatureConfig is server config and
+  // is `false` in dev/CI). Left as fixme so the gap is explicit rather than a
+  // false green: with the flag on, a member holding the permission WOULD see the
+  // control while a Viewer still would not.
+  test.fixme(
+    'positive contrast: a member with the permission sees the control (needs aiPoweredReceipts enabled)',
+    async () => {
+      // Cannot run: aiPoweredReceipts is false in the dev/CI API and the harness
+      // must not change API config. Enabling it would let us assert e.g. a
+      // Receipt Editor (group.receipts.magic-fill) sees the Magic Fill button
+      // while the Viewer does not.
+    },
+  );
+});

--- a/desktop/e2e/role-assignment.spec.ts
+++ b/desktop/e2e/role-assignment.spec.ts
@@ -89,3 +89,45 @@ test.describe('assigning modern roles (admin)', () => {
     await expect(dialog).toBeHidden();
   });
 });
+
+// Deny-path contrast: a non-admin who lacks app.roles.read still reaches the
+// group-create form (Legacy User holds app.groups.create), but the role selector
+// degrades to EMPTY instead of erroring. The group-member-form loads roles with
+// RoleService.getRoles() wrapped in catchError(() => of([])), so the background
+// GET /role 403 is swallowed and groupRoleOptions() is empty — the dialog still
+// opens and the page doesn't redirect/crash.
+test.describe('role selector degrades for a non-admin (no app.roles.read)', () => {
+  // Inherits the chromium project's e2e/.auth/user.json (e2e-user = Legacy User,
+  // which lacks app.roles.read).
+  test.beforeEach(async ({ page }) => {
+    await stubTokenRefresh(page);
+  });
+
+  test('the Add Group Member role selector is empty rather than erroring', async ({
+    page,
+  }) => {
+    await page.goto('/groups/create');
+    // Legacy User holds app.groups.create, so the form loads (no redirect).
+    await expect(page).toHaveURL(/\/groups\/create/);
+    await expect(page.getByLabel('Group Name')).toBeVisible();
+
+    await page.getByTestId('add-group-member').click();
+    const dialog = page
+      .getByRole('dialog')
+      .filter({ hasText: 'Add Group Member' });
+    await expect(dialog).toBeVisible();
+
+    // Open the Role select: getRoles() 403'd and was caught, so it has no
+    // options (the empty list is the graceful-degrade path, not an error).
+    await dialog.getByRole('combobox', { name: 'Role' }).click();
+    await expect(page.getByRole('option')).toHaveCount(0);
+
+    // The dialog is still usable (no crash/redirect) — the Preview button is
+    // simply disabled because no role can be selected (app-button binds the
+    // disabled state onto its inner native button).
+    await page.keyboard.press('Escape');
+    await expect(
+      dialog.getByTestId('role-preview').locator('button'),
+    ).toBeDisabled();
+  });
+});

--- a/desktop/e2e/search-bar-visibility.spec.ts
+++ b/desktop/e2e/search-bar-visibility.spec.ts
@@ -107,3 +107,20 @@ test.describe('Header search bar gating (no app.receipts.search)', () => {
     await expect(page.getByPlaceholder('Search receipts')).toHaveCount(0);
   });
 });
+
+// Positive contrast (same axis, opposite direction): the default e2e-user is a
+// Legacy User, which HOLDS app.receipts.search — so the always-visible header
+// search input renders for them. This proves the gate is selective rather than
+// the bar simply never rendering in this app build.
+test.describe('Header search bar contrast (holds app.receipts.search)', () => {
+  // Inherits the chromium project's e2e/.auth/user.json (e2e-user = Legacy User).
+  test.beforeEach(async ({ page }) => {
+    await stubTokenRefresh(page);
+  });
+
+  test('the search bar renders with app.receipts.search', async ({ page }) => {
+    await page.goto('/groups/create');
+    await expect(page.getByLabel('Group Name')).toBeVisible();
+    await expect(page.getByPlaceholder('Search receipts')).toBeVisible();
+  });
+});

--- a/desktop/src/dashboard/group-dashboards/group-dashboards.component.html
+++ b/desktop/src/dashboard/group-dashboards/group-dashboards.component.html
@@ -1,15 +1,23 @@
 <div class="d-flex align-items-center">
   <h1>{{ (selectedGroupId() ?? "" | group)?.name }} Dashboards</h1>
-  <app-add-button (clicked)="openDashboardDialog(true)"></app-add-button>
+  <app-add-button
+    *hasGroupPermission="{ groupId: selectedGroupIdNum(), permission: Permission.GroupDashboardsCreate }"
+    (clicked)="openDashboardDialog(true)"
+  ></app-add-button>
 
   @if (selectedDashboardId()) {
     @if (selectedGroupId()) {
       <app-edit-button
+        *hasGroupPermission="{ groupId: selectedGroupIdNum(), permission: Permission.GroupDashboardsUpdate }"
         color="accent"
         (clicked)="openDashboardDialog()"
       ></app-edit-button>
     }
-    <app-delete-button color="warn" (clicked)="openDeleteConfirmationDialog()">
+    <app-delete-button
+      *hasGroupPermission="{ groupId: selectedGroupIdNum(), permission: Permission.GroupDashboardsDelete }"
+      color="warn"
+      (clicked)="openDeleteConfirmationDialog()"
+    >
     </app-delete-button>
   }
 </div>

--- a/desktop/src/dashboard/group-dashboards/group-dashboards.component.spec.ts
+++ b/desktop/src/dashboard/group-dashboards/group-dashboards.component.spec.ts
@@ -12,6 +12,9 @@ import { DashboardState } from "src/store/dashboard.state";
 import { ButtonModule } from "../../button";
 import { Dashboard, DashboardService } from "../../open-api";
 import { GroupState, SetSelectedDashboardId } from "../../store";
+import { AuthState } from "../../store/auth.state";
+import { SetPermissions } from "../../store/auth.state.actions";
+import { DirectivesModule } from "../../directives/directives.module";
 import { GroupDashboardsComponent } from "./group-dashboards.component";
 
 describe("GroupDashboardsComponent", () => {
@@ -25,9 +28,10 @@ describe("GroupDashboardsComponent", () => {
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
       imports: [PipesModule,
         MatDialogModule,
-        NgxsModule.forRoot([GroupState, DashboardState]),
+        NgxsModule.forRoot([GroupState, DashboardState, AuthState]),
         PipesModule,
         ButtonModule,
+        DirectivesModule,
         MatSnackBarModule],
       providers: [
         DashboardService,
@@ -167,5 +171,64 @@ describe("GroupDashboardsComponent", () => {
     component.setSelectedDashboardId(1);
 
     expect(storeSpy).toHaveBeenCalledWith(new SetSelectedDashboardId("1"));
+  });
+
+  describe("dashboard CRUD permission gating", () => {
+    const addButton = () =>
+      fixture.nativeElement.querySelector("app-add-button");
+    const editButton = () =>
+      fixture.nativeElement.querySelector("app-edit-button");
+    const deleteButton = () =>
+      fixture.nativeElement.querySelector("app-delete-button");
+
+    // The edit/delete controls only render once a dashboard is selected; seed
+    // the selection so the permission gate is the only variable under test.
+    const selectDashboard = () => {
+      store.reset({
+        ...store.snapshot(),
+        groups: {
+          ...store.snapshot().groups,
+          selectedGroupId: "1",
+          selectedDashboardId: "5",
+        },
+      });
+    };
+
+    const render = async () => {
+      fixture.detectChanges();
+      await fixture.whenStable();
+    };
+
+    it("shows the Add Dashboard button only with group.dashboards.create", async () => {
+      store.dispatch(new SetPermissions([], { 1: ["group.dashboards.read"] }));
+      await render();
+      expect(addButton()).toBeFalsy();
+
+      store.dispatch(new SetPermissions([], { 1: ["group.dashboards.create"] }));
+      await render();
+      expect(addButton()).toBeTruthy();
+    });
+
+    it("shows the Edit Dashboard button only with group.dashboards.update", async () => {
+      selectDashboard();
+      store.dispatch(new SetPermissions([], { 1: ["group.dashboards.read"] }));
+      await render();
+      expect(editButton()).toBeFalsy();
+
+      store.dispatch(new SetPermissions([], { 1: ["group.dashboards.update"] }));
+      await render();
+      expect(editButton()).toBeTruthy();
+    });
+
+    it("shows the Delete Dashboard button only with group.dashboards.delete", async () => {
+      selectDashboard();
+      store.dispatch(new SetPermissions([], { 1: ["group.dashboards.update"] }));
+      await render();
+      expect(deleteButton()).toBeFalsy();
+
+      store.dispatch(new SetPermissions([], { 1: ["group.dashboards.delete"] }));
+      await render();
+      expect(deleteButton()).toBeTruthy();
+    });
   });
 });

--- a/desktop/src/dashboard/group-dashboards/group-dashboards.component.ts
+++ b/desktop/src/dashboard/group-dashboards/group-dashboards.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, signal } from "@angular/core";
+import { Component, computed, OnInit, signal } from "@angular/core";
 import { MatDialog } from "@angular/material/dialog";
 import { Router } from "@angular/router";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
@@ -8,7 +8,7 @@ import { DEFAULT_DIALOG_CONFIG } from "src/constants";
 import { ConfirmationDialogComponent } from "src/shared-ui/confirmation-dialog/confirmation-dialog.component";
 import { DashboardState } from "src/store/dashboard.state";
 import { AddDashboardToGroup, DeleteDashboardFromGroup, UpdateDashBoardForGroup, } from "src/store/dashboard.state.actions";
-import { Dashboard, DashboardService } from "../../open-api";
+import { Dashboard, DashboardService, Permission } from "../../open-api";
 import { SnackbarService } from "../../services";
 import { GroupState, SetSelectedDashboardId } from "../../store";
 import { DashboardFormComponent } from "../dashboard-form/dashboard-form.component";
@@ -30,6 +30,15 @@ export class GroupDashboardsComponent implements OnInit {
   ) {}
 
   public selectedGroupId = this.store.selectSignal(GroupState.selectedGroupId);
+
+  // Dashboard CRUD buttons gate on the group-scoped permissions via
+  // *hasGroupPermission, which needs a numeric group id (selectedGroupId is a
+  // string). Falls back to 0 (no permissions for a non-existent group → hidden).
+  protected readonly Permission = Permission;
+
+  protected readonly selectedGroupIdNum = computed(
+    () => +(this.selectedGroupId() ?? 0)
+  );
 
   public selectedDashboardId = this.store.selectSignal(GroupState.selectedDashboardId);
 

--- a/desktop/src/group/group-routing.module.ts
+++ b/desktop/src/group/group-routing.module.ts
@@ -17,12 +17,14 @@ import { systemEmailsResolver } from "./resolvers/system-emails.resolver";
 
 const routes: Routes = [
   {
+    // No app-permission guard: the groups table shows the caller's OWN groups
+    // (backend GET /group/ -> GetGroupsForUser is auth-only), exactly like
+    // legacy. The "all groups" filter button is gated on app.groups.read inside
+    // group-table.component.html, and per-row Edit/Delete on group.update /
+    // group.delete — so a non-admin sees their own groups without the admin
+    // all-groups view. The parent shell route already enforces AuthGuard.
     path: "",
     component: GroupTableComponent,
-    canActivate: [appPermissionGuard],
-    data: {
-      appPermissions: [Permission.AppGroupsRead],
-    },
   },
   {
     path: "create",

--- a/desktop/src/notifications/notification/notification.component.html
+++ b/desktop/src/notifications/notification/notification.component.html
@@ -8,5 +8,8 @@
       </div>
     </div>
   </a>
-  <app-cancel-button (clicked)="deleteNotification()"></app-cancel-button>
+  <app-cancel-button
+    *hasAppPermission="Permission.AppNotificationsDelete"
+    (clicked)="deleteNotification()"
+  ></app-cancel-button>
 </div>

--- a/desktop/src/notifications/notification/notification.component.spec.ts
+++ b/desktop/src/notifications/notification/notification.component.spec.ts
@@ -6,6 +6,9 @@ import { NgxsModule, Store } from "@ngxs/store";
 import { of } from "rxjs";
 import { ApiModule, NotificationsService } from "../../open-api";
 import { GroupState } from "../../store";
+import { AuthState } from "../../store/auth.state";
+import { SetPermissions } from "../../store/auth.state.actions";
+import { DirectivesModule } from "../../directives/directives.module";
 import { NotificationComponent } from "./notification.component";
 import { provideHttpClient, withInterceptorsFromDi } from "@angular/common/http";
 
@@ -20,7 +23,8 @@ describe("NotificationComponent", () => {
     declarations: [NotificationComponent],
     schemas: [CUSTOM_ELEMENTS_SCHEMA],
     imports: [ApiModule,
-        NgxsModule.forRoot([GroupState]),
+        NgxsModule.forRoot([GroupState, AuthState]),
+        DirectivesModule,
         RouterTestingModule],
     providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
 });
@@ -81,5 +85,29 @@ describe("NotificationComponent", () => {
 
     expect(serviceSpy).toHaveBeenCalledWith(1);
     expect(emitterSpy).toHaveBeenCalledWith(1);
+  });
+
+  describe("delete button permission gating", () => {
+    const deleteButton = () =>
+      fixture.nativeElement.querySelector("app-cancel-button");
+
+    const render = async () => {
+      fixture.detectChanges();
+      await fixture.whenStable();
+    };
+
+    it("hides the delete button without app.notifications.delete", async () => {
+      store.dispatch(new SetPermissions(["app.notifications.read"], {}));
+      await render();
+
+      expect(deleteButton()).toBeFalsy();
+    });
+
+    it("shows the delete button with app.notifications.delete", async () => {
+      store.dispatch(new SetPermissions(["app.notifications.delete"], {}));
+      await render();
+
+      expect(deleteButton()).toBeTruthy();
+    });
   });
 });

--- a/desktop/src/notifications/notification/notification.component.ts
+++ b/desktop/src/notifications/notification/notification.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, input, output } from "@angular/core";
 import { take, tap } from "rxjs";
 import { ParameterizedDataParser } from "src/utils";
-import { Notification, NotificationsService } from "../../open-api";
+import { Notification, NotificationsService, Permission } from "../../open-api";
 
 @Component({
     selector: "app-notification",
@@ -13,6 +13,8 @@ export class NotificationComponent implements OnInit {
   public readonly notification = input.required<Notification>();
 
   public readonly notificationDeleted = output<number>();
+
+  protected readonly Permission = Permission;
 
   public link?: string;
 

--- a/desktop/src/receipts/receipt-comments/receipt-comments.component.html
+++ b/desktop/src/receipts/receipt-comments/receipt-comments.component.html
@@ -76,6 +76,7 @@
       "
     >
       <app-delete-button
+        data-testid="comment-delete"
         (clicked)="deleteComment(commentIndex)"
       ></app-delete-button>
     </ng-container>

--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -126,7 +126,9 @@ a stale action at worst returns 403.
     (`receipt_comment_screen.dart`) is hidden without create; the swipe-to-delete
     (`receipt_comments.dart`) is disabled without delete (only in **edit** state — add-state comment
     removal is a local model edit with no API call, so it stays enabled).
-  - Activity rerun (`group_activity_list_item.dart`) → `group.activities.rerun`.
+  - Activity rerun (`group_activity_list_item.dart`) → `group.activities.rerun`. Covered by a widget
+    test (`test/widgets/group_activity_list_item_test.dart`) only — there is **no e2e** for it because
+    a failed activity's `canBeRestarted` backend state isn't deterministically seedable from the API.
   - The add menu (`show_add_menu.dart`) shows "Add Manual Receipt" on `group.receipts.create` and
     "Quick Scan" on `group.receipts.quick-scan` — per-group when inside a group, or "held in any
     group" on the group-select / all-groups view, where there is no single current group.
@@ -143,6 +145,15 @@ a stale action at worst returns 403.
   - `receiptsSearchRedirect` on `/search` → bounces deep links to the originating group's `/receipts`
     (or `/groups`) when the caller lacks `app.receipts.search`. Defense-in-depth behind the hidden
     search buttons; it also runs before the search shell's `state.extra as Map` cast.
+- **403 handling (`lib/interceptors/auth_interceptor.dart`):** the backend returns **403 for both** an
+  expired session and a permission denial (it never sends 401), so the interceptor distinguishes them
+  by **token validity** (mirroring desktop's `http-interceptor.ts`): a 403 with a still-valid token is
+  a permission denial and is surfaced untouched — **no token refresh, no logout** (refreshing can't
+  grant a missing permission, and force-refreshing would burn the one-time refresh token / risk a
+  logout). Only an expired/invalid token triggers a refresh + retry. Token freshness is otherwise kept
+  current proactively (the 15-min timer in `main.dart` and the auth guard on navigation). **Paid-by
+  visibility** rides on this: a group role limited to "their own receipts" gets a server-filtered
+  receipts list, and any stray 403 on a hidden receipt is surfaced without disturbing the session.
 
 ## Development Notes
 
@@ -388,6 +399,9 @@ All three runners source `api/dev/switch-to-sqlite.sh` for the four `E2E_*` cred
 - `integration_test/permission_add_menu_test.dart` / `permission_receipt_edit_test.dart` — permission-gating coverage (add-menu gate, edit-popup gate, swipe-to-edit gate) using per-spec provisioned users/groups.
 - `integration_test/permission_search_test.dart` — search bottom-nav destination gated on `app.receipts.search` (deny via a custom app role minus that permission; allow via a Legacy User).
 - `integration_test/permission_dashboard_redirect_test.dart` — group dashboards route gated on `group.dashboards.read` (deny → redirected to the receipts list via a custom group role minus that permission; allow via a Legacy Viewer). Landing is told apart by `GroupReceiptsList` vs `GroupDashboardWrapper`.
+- `integration_test/permission_comments_test.dart` — comment **deny** paths on the edit-state comment screen: `group.comments.create` hidden → no input; `group.comments.delete` hidden → swipe-to-delete disabled. Members are provisioned from the **Legacy Editor** baseline (holds `group.receipts.update`, needed to reach edit state) minus the permission under test, via `provisionGroupMemberWithoutPermission(..., baselineRole: 'Legacy Editor')`.
+- `integration_test/permission_paid_by_visibility_test.dart` — group-role paid-by visibility: a member restricted to "their own receipts" (via `provisionPaidByOwnMember` → `createRole(..., includeOwnPaidReceipts: true)`) sees only their own receipt in the group list; the admin-paid receipt is filtered out server-side. Mirrors desktop `paid-by-visibility.spec.ts` (list axis).
+- `integration_test/permission_receipt_category_visibility_test.dart` — non-admin sees the per-group **category and tag** catalogs in the receipt-form pickers (sourced from `groupCategories` / `groupTags`, not the admin-only flat lists).
 - `integration_test/helpers/env.dart` — dart-define consumption + guards.
 - `integration_test/helpers/pump.dart` — `pumpUntilFound` polling helper.
 - `integration_test/helpers/platform_mocks.dart` — Linux-desktop platform-channel stubs for `permission_handler`, `gal`, `flutter_secure_storage`.

--- a/mobile/integration_test/helpers/permission_fixtures.dart
+++ b/mobile/integration_test/helpers/permission_fixtures.dart
@@ -172,17 +172,28 @@ Future<int> createRole({
   required List<String> permissions,
   required String jwt,
   String description = 'e2e custom role',
+  bool includeOwnPaidReceipts = false,
+  List<int> paidByUserGrants = const [],
 }) async {
+  final body = <String, dynamic>{
+    'name': name,
+    'description': description,
+    'scope': scope,
+    'permissions': permissions,
+  };
+  // Group-role paid-by visibility (group scope only; empty/false = unrestricted,
+  // i.e. members see every payer's receipts). Mirrors the desktop createRole
+  // `paidByOwn` / `paidByUsers` options. Only sent when restricting, so APP-role
+  // creates are unaffected.
+  if (includeOwnPaidReceipts || paidByUserGrants.isNotEmpty) {
+    body['includeOwnPaidReceipts'] = includeOwnPaidReceipts;
+    body['paidByUserGrants'] = paidByUserGrants;
+  }
   final res = await http
       .post(
         Uri.parse('${E2eEnv.baseUrl}/role/'),
         headers: _jsonAuth(jwt),
-        body: jsonEncode({
-          'name': name,
-          'description': description,
-          'scope': scope,
-          'permissions': permissions,
-        }),
+        body: jsonEncode(body),
       )
       .timeout(const Duration(seconds: 10));
   if (res.statusCode != 200) {
@@ -322,12 +333,66 @@ Future<int> createCategory({
   return (jsonDecode(res.body) as Map<String, dynamic>)['id'] as int;
 }
 
+/// Creates a comment on [receiptId] (as the caller behind [jwt]) and returns its
+/// id. Seeds an existing comment so the comment swipe-to-delete gate
+/// (`group.comments.delete`) has something to render.
+Future<int> createComment({
+  required int receiptId,
+  required String jwt,
+  String comment = 'e2e seeded comment',
+}) async {
+  final res = await http
+      .post(
+        Uri.parse('${E2eEnv.baseUrl}/comment/'),
+        headers: _jsonAuth(jwt),
+        body: jsonEncode({'comment': comment, 'receiptId': receiptId}),
+      )
+      .timeout(const Duration(seconds: 10));
+  if (res.statusCode != 200) {
+    throw StateError('createComment($receiptId) failed: '
+        'HTTP ${res.statusCode}: ${res.body}');
+  }
+  return (jsonDecode(res.body) as Map<String, dynamic>)['id'] as int;
+}
+
 /// Best-effort `DELETE /category/{id}`. Swallows errors like the other cleanups.
 Future<void> deleteCategory(int categoryId, {required String jwt}) async {
   try {
     await http
         .delete(Uri.parse('${E2eEnv.baseUrl}/category/$categoryId'),
             headers: _auth(jwt))
+        .timeout(const Duration(seconds: 5));
+  } catch (_) {
+    // best-effort
+  }
+}
+
+/// Creates a global tag (the tag analogue of [createCategory]) and returns its
+/// id. Used to prove non-admins receive tags via the per-group `groupTags` map.
+Future<int> createTag({
+  required String name,
+  required String jwt,
+  String description = 'e2e tag',
+}) async {
+  final res = await http
+      .post(
+        Uri.parse('${E2eEnv.baseUrl}/tag/'),
+        headers: _jsonAuth(jwt),
+        body: jsonEncode({'name': name, 'description': description}),
+      )
+      .timeout(const Duration(seconds: 10));
+  if (res.statusCode != 200) {
+    throw StateError('createTag($name) failed: '
+        'HTTP ${res.statusCode}: ${res.body}');
+  }
+  return (jsonDecode(res.body) as Map<String, dynamic>)['id'] as int;
+}
+
+/// Best-effort `DELETE /tag/{id}`. Swallows errors like the other cleanups.
+Future<void> deleteTag(int tagId, {required String jwt}) async {
+  try {
+    await http
+        .delete(Uri.parse('${E2eEnv.baseUrl}/tag/$tagId'), headers: _auth(jwt))
         .timeout(const Duration(seconds: 5));
   } catch (_) {
     // best-effort
@@ -438,9 +503,14 @@ Future<PermFixture> provisionUserWithoutAppPermission(String permission) async {
   return provisionPermUser(appRoleId: roleId);
 }
 
-/// Provisions a user in a fixture group whose GROUP role is "Legacy Viewer"
+/// Provisions a user in a fixture group whose GROUP role is [baselineRole]
 /// **minus** [permission], registering teardown for the user, group and custom
 /// role. Use for negative group-permission specs (e.g. `group.dashboards.read`).
+///
+/// [baselineRole] defaults to "Legacy Viewer". Pass "Legacy Editor" when the
+/// scenario needs a permission the Viewer lacks — e.g. the comment-gate specs
+/// reach the edit-state comment screen, which requires `group.receipts.update`
+/// (Viewer is read-only).
 ///
 /// Same minus-one rationale and LIFO teardown ordering as
 /// [provisionUserWithoutAppPermission]: the role-delete is registered first so
@@ -448,9 +518,10 @@ Future<PermFixture> provisionUserWithoutAppPermission(String permission) async {
 Future<PermFixture> provisionGroupMemberWithoutPermission(
   String permission, {
   bool withReceipt = false,
+  String baselineRole = 'Legacy Viewer',
 }) async {
   final jwt = await apiLogin(); // admin
-  final perms = (await rolePermissionsByName('Legacy Viewer', 'GROUP', jwt: jwt))
+  final perms = (await rolePermissionsByName(baselineRole, 'GROUP', jwt: jwt))
       .where((p) => p != permission)
       .toList();
   final roleId = await createRole(
@@ -463,4 +534,78 @@ Future<PermFixture> provisionGroupMemberWithoutPermission(
       () async => deleteRole(roleId, scope: 'GROUP', jwt: await apiLogin()));
 
   return provisionPermUser(groupRoleId: roleId, withReceipt: withReceipt);
+}
+
+/// A [PermFixture] plus the two receipts seeded for a paid-by-visibility spec:
+/// [ownReceiptName] is paid by the member (visible to them) and
+/// [hiddenReceiptName] is paid by the admin (filtered out by the role's
+/// "their own receipts" paid-by grant).
+class PaidByFixture {
+  PaidByFixture({
+    required this.fixture,
+    required this.ownReceiptId,
+    required this.ownReceiptName,
+    required this.hiddenReceiptId,
+    required this.hiddenReceiptName,
+  });
+
+  final PermFixture fixture;
+  final int ownReceiptId;
+  final String ownReceiptName;
+  final int hiddenReceiptId;
+  final String hiddenReceiptName;
+}
+
+/// Provisions a group member whose GROUP role holds the full Legacy Viewer
+/// permission set (so `group.receipts.read` is held — the denial is paid-by, not
+/// a missing permission) but is restricted to **their own receipts** on the
+/// paid-by axis. Seeds two receipts in the group: one paid by the member (own,
+/// visible) and one paid by the admin (hidden). Mirrors the desktop
+/// `paid-by-visibility.spec.ts` provisioning.
+///
+/// Teardown follows the same LIFO ordering as the other negative-permission
+/// fixtures: the role delete is registered before [provisionPermUser]'s
+/// user/group deletes, so it runs last (once the assignment is gone). The seeded
+/// receipts are cascade-deleted with the group.
+Future<PaidByFixture> provisionPaidByOwnMember() async {
+  final jwt = await apiLogin(); // admin
+  final adminId = await userIdByUsername(E2eEnv.adminUsername, jwt: jwt);
+  final viewerPerms =
+      await rolePermissionsByName('Legacy Viewer', 'GROUP', jwt: jwt);
+  final roleId = await createRole(
+    name: 'e2e-paidby-${_unique()}',
+    scope: 'GROUP',
+    permissions: viewerPerms,
+    jwt: jwt,
+    includeOwnPaidReceipts: true,
+  );
+  addTearDown(
+      () async => deleteRole(roleId, scope: 'GROUP', jwt: await apiLogin()));
+
+  final fixture = await provisionPermUser(groupRoleId: roleId);
+
+  final suffix = _unique();
+  final ownReceiptName = 'e2e-paidby-own-$suffix';
+  final hiddenReceiptName = 'e2e-paidby-hidden-$suffix';
+  final seedJwt = await apiLogin();
+  final hiddenReceiptId = await createReceipt(
+    groupId: fixture.groupId!,
+    paidByUserId: adminId,
+    jwt: seedJwt,
+    name: hiddenReceiptName,
+  );
+  final ownReceiptId = await createReceipt(
+    groupId: fixture.groupId!,
+    paidByUserId: fixture.userId,
+    jwt: seedJwt,
+    name: ownReceiptName,
+  );
+
+  return PaidByFixture(
+    fixture: fixture,
+    ownReceiptId: ownReceiptId,
+    ownReceiptName: ownReceiptName,
+    hiddenReceiptId: hiddenReceiptId,
+    hiddenReceiptName: hiddenReceiptName,
+  );
 }

--- a/mobile/integration_test/permission_comments_test.dart
+++ b/mobile/integration_test/permission_comments_test.dart
@@ -1,0 +1,149 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:receipt_wrangler_mobile/shared/widgets/bottom_submit_button.dart';
+import 'package:receipt_wrangler_mobile/shared/widgets/slidable_widget.dart';
+
+import 'helpers/api.dart';
+import 'helpers/login.dart';
+import 'helpers/nav.dart';
+import 'helpers/permission_fixtures.dart';
+import 'helpers/platform_mocks.dart';
+import 'helpers/pump.dart';
+
+/// Permission-gating coverage for receipt comments on the edit-state comment
+/// screen:
+///   - the comment-input bottom sheet (`receipt_comment_screen.dart`) is hidden
+///     without `group.comments.create`, and
+///   - the comment swipe-to-delete (`receipt_comments.dart`,
+///     `SlidableWidget.slideEnabled`) is disabled without `group.comments.delete`.
+///
+/// Both gates only apply in **edit** state, which requires `group.receipts.update`
+/// to reach — so the members are provisioned from the "Legacy Editor" baseline
+/// (which holds update + both comment perms) minus the single permission under
+/// test. The existing `receipt_comments_test.dart` already proves the positive
+/// path (an admin can add + delete), so this spec covers the deny paths.
+void main() {
+  final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    if (Platform.isLinux) {
+      installLinuxDesktopMocks();
+    }
+  });
+
+  testWidgets(
+    'member without group.comments.create sees no comment input',
+    (tester) async {
+      await binding.setSurfaceSize(const Size(1280, 900));
+      addTearDown(() => binding.setSurfaceSize(null));
+
+      final fixture = await provisionGroupMemberWithoutPermission(
+        'group.comments.create',
+        baselineRole: 'Legacy Editor',
+        withReceipt: true,
+      );
+      await loginAs(
+        tester,
+        username: fixture.username,
+        password: fixture.password,
+      );
+      await _openReceiptCommentsInEditMode(
+        tester,
+        fixture.groupName!,
+        fixture.receiptName!,
+      );
+
+      // The comment-input bottom sheet renders SizedBox.shrink without
+      // group.comments.create, so the field never mounts.
+      expect(_commentField(), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'member without group.comments.delete cannot swipe-delete a comment',
+    (tester) async {
+      await binding.setSurfaceSize(const Size(1280, 900));
+      addTearDown(() => binding.setSurfaceSize(null));
+
+      final fixture = await provisionGroupMemberWithoutPermission(
+        'group.comments.delete',
+        baselineRole: 'Legacy Editor',
+        withReceipt: true,
+      );
+      // Seed a comment (as admin) so the swipe-to-delete gate has a row to show.
+      const seededComment = 'e2e-seeded-comment';
+      await createComment(
+        receiptId: fixture.receiptId!,
+        jwt: await apiLogin(),
+        comment: seededComment,
+      );
+
+      await loginAs(
+        tester,
+        username: fixture.username,
+        password: fixture.password,
+      );
+      await _openReceiptCommentsInEditMode(
+        tester,
+        fixture.groupName!,
+        fixture.receiptName!,
+      );
+
+      await pumpUntilFound(tester, find.text(seededComment));
+
+      // The comment renders, but swipe-to-delete is disabled without
+      // group.comments.delete.
+      final slidable = tester.widget<SlidableWidget>(
+        find.ancestor(
+          of: find.text(seededComment),
+          matching: find.byType(SlidableWidget),
+        ),
+      );
+      expect(slidable.slideEnabled, isFalse);
+
+      // Sanity: this member still holds group.comments.create, so the input is
+      // present — proving the delete gate is independent of the create gate.
+      expect(_commentField(), findsOneWidget);
+    },
+  );
+}
+
+Finder _commentField() => find.byWidgetPredicate(
+      (w) => w is FormBuilderTextField && w.name == 'comment',
+    );
+
+/// Opens [receiptName] in [groupName] and navigates to its **edit-state**
+/// comment screen — the same path as `receipt_comments_test.dart`: receipt list
+/// → receipt view → Edit popup → edit form → "View Comments". Reaching edit
+/// state requires `group.receipts.update`, held by the Legacy Editor baseline.
+Future<void> _openReceiptCommentsInEditMode(
+  WidgetTester tester,
+  String groupName,
+  String receiptName,
+) async {
+  await openGroupReceipts(tester, groupName, receiptName);
+
+  // Open the receipt view (same as permission_receipt_edit_test.dart).
+  await tester.tap(find.text(receiptName));
+
+  // Move to the edit form via the edit popup (gated on group.receipts.update).
+  final menuButton = find.byType(PopupMenuButton<dynamic>);
+  await pumpUntilFound(tester, menuButton);
+  await tester.tap(menuButton);
+  await pumpUntilFound(tester, find.text('Edit').hitTestable());
+  for (int i = 0; i < 5; i++) {
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+  await tester.tap(find.text('Edit').hitTestable());
+  await pumpUntilFound(tester, find.byType(BottomSubmitButton));
+
+  // Open the comments screen in edit state via the form's "View Comments" action.
+  final commentsButton = find.byTooltip('View Comments');
+  await pumpUntilFound(tester, commentsButton);
+  await tester.tap(commentsButton);
+  await pumpUntilFound(tester, find.text('Receipt Comments'));
+}

--- a/mobile/integration_test/permission_paid_by_visibility_test.dart
+++ b/mobile/integration_test/permission_paid_by_visibility_test.dart
@@ -1,0 +1,51 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'helpers/login.dart';
+import 'helpers/nav.dart';
+import 'helpers/permission_fixtures.dart';
+import 'helpers/platform_mocks.dart';
+
+/// Permission coverage for group-role **paid-by visibility**. A member whose
+/// group role restricts paid-by visibility to "their own receipts" must see only
+/// the receipts they paid for: the backend filters the receipts list, so the
+/// other-payer receipt never reaches the app. Mirrors the list assertion in the
+/// desktop `paid-by-visibility.spec.ts` (the API-403 / direct-nav cases there are
+/// desktop-only — mobile opens receipts by tapping the list, so a filtered-out
+/// receipt is simply unreachable from the UI).
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    if (Platform.isLinux) {
+      installLinuxDesktopMocks();
+    }
+  });
+
+  testWidgets(
+    'paid-by-own member sees only their own receipt in the group list',
+    (tester) async {
+      final paidBy = await provisionPaidByOwnMember();
+      await loginAs(
+        tester,
+        username: paidBy.fixture.username,
+        password: paidBy.fixture.password,
+      );
+
+      // Opening the group's receipt list waits for the member's own receipt,
+      // proving the list has loaded.
+      await openGroupReceipts(
+        tester,
+        paidBy.fixture.groupName!,
+        paidBy.ownReceiptName,
+      );
+
+      // The own receipt is visible; the admin-paid receipt is filtered out by
+      // the role's paid-by grant server-side, so it never appears in the list.
+      expect(find.text(paidBy.ownReceiptName), findsOneWidget);
+      expect(find.text(paidBy.hiddenReceiptName), findsNothing);
+    },
+  );
+}

--- a/mobile/integration_test/permission_receipt_category_visibility_test.dart
+++ b/mobile/integration_test/permission_receipt_category_visibility_test.dart
@@ -32,96 +32,84 @@ void main() {
     }
   });
 
+  // The category and tag picker flows are identical except for the catalog
+  // create/delete helpers, the placeholder text, and the asserted name — so the
+  // shared "non-admin sees the per-group catalog in the picker" flow lives here.
+  // A global catalog item is created BEFORE login so it lands in the non-admin's
+  // AppData catalog; a Legacy Editor (app role Legacy User, no
+  // app.categories.read / app.tags.read) then opens the add-receipt form and the
+  // multiselect, and the item must be offered (it would be empty if the picker
+  // read the flat admin-only list instead of the per-group catalog).
+  Future<void> assertGroupCatalogPicker(
+    WidgetTester tester, {
+    required String namePrefix,
+    required String placeholder,
+    required Future<int> Function({required String name, required String jwt})
+        createFn,
+    required Future<void> Function(int id, {required String jwt}) deleteFn,
+  }) async {
+    final adminJwt = await apiLogin();
+    final itemName = '$namePrefix-${DateTime.now().microsecondsSinceEpoch}';
+    final itemId = await createFn(name: itemName, jwt: adminJwt);
+    addTearDown(() async => deleteFn(itemId, jwt: await apiLogin()));
+
+    final fixture = await provisionPermUser(roleName: 'Legacy Editor');
+    await loginAs(
+      tester,
+      username: fixture.username,
+      password: fixture.password,
+    );
+    await enterGroup(tester, fixture.groupName!);
+
+    // Open the add-receipt form via the bottom-nav Add menu.
+    await tester.tap(find.text('Add').hitTestable());
+    await pumpUntilFound(tester, find.text('Add Manual Receipt').hitTestable());
+    for (int i = 0; i < 5; i++) {
+      await tester.pump(const Duration(milliseconds: 100));
+    }
+    await tester.tap(find.text('Add Manual Receipt').hitTestable());
+    await pumpUntilFound(tester, find.text('Name'));
+
+    // Selecting the group makes the picker field visible (gated on the group's
+    // receipt settings) and scopes the picker's source to that group's catalog.
+    await selectDropdown(tester, 'groupId', fixture.groupName!);
+
+    // Open the multiselect via its placeholder chip (a tappable GestureDetector).
+    final field = find.text(placeholder);
+    await pumpUntilFound(tester, field);
+    await tester.ensureVisible(field);
+    await tester.pump(const Duration(milliseconds: 200));
+    await tester.tap(field);
+
+    // The per-group catalog is sourced into the multiselect sheet, so the item
+    // is offered. (Empty for a non-admin before the M2 fix.)
+    await pumpUntilFound(tester, find.text(itemName));
+    expect(find.text(itemName), findsWidgets);
+  }
+
   testWidgets(
     'receipt form: a non-admin sees the group catalog in the category picker',
     (tester) async {
-      // A global category exists (unrestricted group roles see the whole pool).
-      // Create it BEFORE login so it lands in the non-admin's AppData catalog.
-      final adminJwt = await apiLogin();
-      final categoryName =
-          'e2e-cat-${DateTime.now().microsecondsSinceEpoch}';
-      final categoryId = await createCategory(name: categoryName, jwt: adminJwt);
-      addTearDown(() async => deleteCategory(categoryId, jwt: await apiLogin()));
-
-      // A Legacy Editor (app role: Legacy User — no app.categories.read) who can
-      // create receipts in the fixture group.
-      final fixture = await provisionPermUser(roleName: 'Legacy Editor');
-      await loginAs(
+      await assertGroupCatalogPicker(
         tester,
-        username: fixture.username,
-        password: fixture.password,
+        namePrefix: 'e2e-cat',
+        placeholder: 'No Categories selected',
+        createFn: createCategory,
+        deleteFn: deleteCategory,
       );
-      await enterGroup(tester, fixture.groupName!);
-
-      // Open the add-receipt form via the bottom-nav Add menu.
-      await tester.tap(find.text('Add').hitTestable());
-      await pumpUntilFound(
-          tester, find.text('Add Manual Receipt').hitTestable());
-      for (int i = 0; i < 5; i++) {
-        await tester.pump(const Duration(milliseconds: 100));
-      }
-      await tester.tap(find.text('Add Manual Receipt').hitTestable());
-      await pumpUntilFound(tester, find.text('Name'));
-
-      // Selecting the group makes the category field visible (its Visibility is
-      // gated on the group's receipt settings) and scopes the picker's source.
-      await selectDropdown(tester, 'groupId', fixture.groupName!);
-
-      // Open the category multiselect. The field renders the placeholder chip
-      // "No Categories selected" inside a tappable GestureDetector.
-      final categoryField = find.text('No Categories selected');
-      await pumpUntilFound(tester, categoryField);
-      await tester.ensureVisible(categoryField);
-      await tester.pump(const Duration(milliseconds: 200));
-      await tester.tap(categoryField);
-
-      // The per-group catalog is sourced into the multiselect sheet, so the
-      // category is offered. (Empty for a non-admin before the M2 fix.)
-      await pumpUntilFound(tester, find.text(categoryName));
-      expect(find.text(categoryName), findsWidgets);
     },
   );
 
   testWidgets(
     'receipt form: a non-admin sees the group catalog in the tag picker',
     (tester) async {
-      // Same per-group catalog path as the category picker, for tags
-      // (`groupTags` on AppData, sourced by `tag_select_field.dart`). A global
-      // tag created before login lands in the non-admin's per-group catalog.
-      final adminJwt = await apiLogin();
-      final tagName = 'e2e-tag-${DateTime.now().microsecondsSinceEpoch}';
-      final tagId = await createTag(name: tagName, jwt: adminJwt);
-      addTearDown(() async => deleteTag(tagId, jwt: await apiLogin()));
-
-      final fixture = await provisionPermUser(roleName: 'Legacy Editor');
-      await loginAs(
+      await assertGroupCatalogPicker(
         tester,
-        username: fixture.username,
-        password: fixture.password,
+        namePrefix: 'e2e-tag',
+        placeholder: 'No Tags selected',
+        createFn: createTag,
+        deleteFn: deleteTag,
       );
-      await enterGroup(tester, fixture.groupName!);
-
-      await tester.tap(find.text('Add').hitTestable());
-      await pumpUntilFound(
-          tester, find.text('Add Manual Receipt').hitTestable());
-      for (int i = 0; i < 5; i++) {
-        await tester.pump(const Duration(milliseconds: 100));
-      }
-      await tester.tap(find.text('Add Manual Receipt').hitTestable());
-      await pumpUntilFound(tester, find.text('Name'));
-
-      await selectDropdown(tester, 'groupId', fixture.groupName!);
-
-      // Open the tag multiselect (placeholder "No Tags selected").
-      final tagField = find.text('No Tags selected');
-      await pumpUntilFound(tester, tagField);
-      await tester.ensureVisible(tagField);
-      await tester.pump(const Duration(milliseconds: 200));
-      await tester.tap(tagField);
-
-      // The per-group tag catalog is sourced into the multiselect sheet.
-      await pumpUntilFound(tester, find.text(tagName));
-      expect(find.text(tagName), findsWidgets);
     },
   );
 }

--- a/mobile/integration_test/permission_receipt_category_visibility_test.dart
+++ b/mobile/integration_test/permission_receipt_category_visibility_test.dart
@@ -81,4 +81,47 @@ void main() {
       expect(find.text(categoryName), findsWidgets);
     },
   );
+
+  testWidgets(
+    'receipt form: a non-admin sees the group catalog in the tag picker',
+    (tester) async {
+      // Same per-group catalog path as the category picker, for tags
+      // (`groupTags` on AppData, sourced by `tag_select_field.dart`). A global
+      // tag created before login lands in the non-admin's per-group catalog.
+      final adminJwt = await apiLogin();
+      final tagName = 'e2e-tag-${DateTime.now().microsecondsSinceEpoch}';
+      final tagId = await createTag(name: tagName, jwt: adminJwt);
+      addTearDown(() async => deleteTag(tagId, jwt: await apiLogin()));
+
+      final fixture = await provisionPermUser(roleName: 'Legacy Editor');
+      await loginAs(
+        tester,
+        username: fixture.username,
+        password: fixture.password,
+      );
+      await enterGroup(tester, fixture.groupName!);
+
+      await tester.tap(find.text('Add').hitTestable());
+      await pumpUntilFound(
+          tester, find.text('Add Manual Receipt').hitTestable());
+      for (int i = 0; i < 5; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+      await tester.tap(find.text('Add Manual Receipt').hitTestable());
+      await pumpUntilFound(tester, find.text('Name'));
+
+      await selectDropdown(tester, 'groupId', fixture.groupName!);
+
+      // Open the tag multiselect (placeholder "No Tags selected").
+      final tagField = find.text('No Tags selected');
+      await pumpUntilFound(tester, tagField);
+      await tester.ensureVisible(tagField);
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.tap(tagField);
+
+      // The per-group tag catalog is sourced into the multiselect sheet.
+      await pumpUntilFound(tester, find.text(tagName));
+      expect(find.text(tagName), findsWidgets);
+    },
+  );
 }

--- a/mobile/lib/interceptors/auth_interceptor.dart
+++ b/mobile/lib/interceptors/auth_interceptor.dart
@@ -1,11 +1,21 @@
 import 'package:dio/dio.dart';
 import 'package:receipt_wrangler_mobile/client/client.dart';
 import 'package:receipt_wrangler_mobile/services/token_refresh_service.dart';
+import 'package:receipt_wrangler_mobile/utils/auth.dart';
 
-/// Dio interceptor that catches 401/403 responses, attempts a token
-/// refresh via [TokenRefreshService], and retries the original request.
+/// Dio interceptor that recovers an *expired-session* request by refreshing the
+/// token via [TokenRefreshService] and retrying once.
 ///
-/// Mirrors the desktop's http-interceptor.ts behavior.
+/// The backend returns **403 for every access denial** — an expired session and
+/// a genuine permission denial both surface as 403 (it never sends 401). So the
+/// status code alone can't tell the two apart; we distinguish by **token
+/// validity**, mirroring the desktop's http-interceptor.ts: a 403 with a
+/// still-valid token is a permission denial and must pass through untouched
+/// (refreshing can't grant a missing permission, and force-refreshing here would
+/// burn the one-time refresh token and risk logging the user out). Only an
+/// expired/invalid token is an auth failure worth a refresh + retry. Token
+/// freshness is otherwise kept current proactively (the 15-min timer in
+/// `main.dart` and the auth guard on navigation).
 class AuthInterceptor extends Interceptor {
   static const _retryHeader = 'X-Token-Retry';
 
@@ -24,23 +34,30 @@ class AuthInterceptor extends Interceptor {
     }
 
     if (statusCode == 401 || statusCode == 403) {
-      try {
-        final success =
-            await TokenRefreshService().refreshTokens(force: true);
-        if (success) {
-          final jwt = await TokenRefreshService().getCurrentJwt();
-          final opts = err.requestOptions;
-          opts.headers[_retryHeader] = 'true';
-          if (jwt != null) {
-            opts.headers['Authorization'] = 'Bearer $jwt';
-          }
+      // A 403 with a still-valid token is a permission denial, not an auth
+      // failure — pass it through so the caller can handle it, without burning
+      // the one-time refresh token or risking a logout. Only an expired/invalid
+      // token warrants a refresh + retry.
+      final currentJwt = await TokenRefreshService().getCurrentJwt();
+      if (!isTokenValid(currentJwt)) {
+        try {
+          final success =
+              await TokenRefreshService().refreshTokens(force: true);
+          if (success) {
+            final jwt = await TokenRefreshService().getCurrentJwt();
+            final opts = err.requestOptions;
+            opts.headers[_retryHeader] = 'true';
+            if (jwt != null) {
+              opts.headers['Authorization'] = 'Bearer $jwt';
+            }
 
-          // Retry the request using the current client's Dio instance
-          final retryResponse = await OpenApiClient.client.dio.fetch(opts);
-          return handler.resolve(retryResponse);
+            // Retry the request using the current client's Dio instance
+            final retryResponse = await OpenApiClient.client.dio.fetch(opts);
+            return handler.resolve(retryResponse);
+          }
+        } catch (_) {
+          // Refresh failed — fall through to original error
         }
-      } catch (_) {
-        // Refresh failed — fall through to original error
       }
     }
 

--- a/mobile/test/interceptors/auth_interceptor_test.dart
+++ b/mobile/test/interceptors/auth_interceptor_test.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:openapi/openapi.dart';
 import 'package:receipt_wrangler_mobile/client/client.dart';
 import 'package:receipt_wrangler_mobile/interceptors/auth_interceptor.dart';
 import 'package:receipt_wrangler_mobile/models/permissions_model.dart';
@@ -212,7 +211,10 @@ void main() {
       expect(handler.resolvedResponse?.statusCode, 200);
     });
 
-    test('attempts refresh on 403 and retries request on success', () async {
+    test('refreshes and retries on a 403 when the token is expired', () async {
+      // The backend returns 403 for an expired session too (it never sends
+      // 401). With an expired token in hand, the interceptor still refreshes
+      // and retries — the recovery path is keyed on token validity, not status.
       final dio = _setUpSuccessfulRetryScenario(
         mockAuthModel: mockAuthModel,
         mockGroupModel: mockGroupModel,
@@ -246,7 +248,35 @@ void main() {
 
       final action = await handler.result.timeout(const Duration(seconds: 5));
       expect(action, 'resolve',
-          reason: 'Should resolve with retried response on 403');
+          reason: 'Should resolve with retried response on an expired-token 403');
+    });
+
+    test(
+        'does not refresh on a 403 when the token is still valid '
+        '(permission denial)', () async {
+      // A valid access token means the 403 is a permission denial, not an
+      // expired session: the interceptor must surface it untouched — no token
+      // refresh (which would burn the one-time refresh token / risk logout) and
+      // no retry (a new token can't grant a missing permission).
+      when(() => mockAuthModel.getJwt()).thenAnswer((_) async => validJwt);
+
+      final requestOptions = RequestOptions(path: '/receipts');
+      final error = DioException(
+        requestOptions: requestOptions,
+        response: Response(
+          statusCode: 403,
+          requestOptions: requestOptions,
+        ),
+      );
+
+      final handler = TestErrorHandler();
+      interceptor.onError(error, handler);
+
+      final action = await handler.result.timeout(const Duration(seconds: 2));
+      expect(action, 'next',
+          reason: 'A permission 403 should pass through without interception');
+      verifyNever(() => mockAuthModel.setTokens(any(), any()));
+      verifyNever(() => mockAuthModel.getRefreshToken());
     });
 
     test('falls through to next when token refresh fails', () async {

--- a/mobile/test/widgets/receipt_comments_test.dart
+++ b/mobile/test/widgets/receipt_comments_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openapi/openapi.dart' as api;
+import 'package:openapi/openapi.dart' show Permission;
+import 'package:provider/provider.dart';
+import 'package:receipt_wrangler_mobile/enums/form_state.dart';
+import 'package:receipt_wrangler_mobile/models/auth_model.dart';
+import 'package:receipt_wrangler_mobile/models/receipt_model.dart';
+import 'package:receipt_wrangler_mobile/models/user_model.dart';
+import 'package:receipt_wrangler_mobile/receipts/widgets/receipt_comments.dart';
+import 'package:receipt_wrangler_mobile/shared/widgets/slidable_widget.dart';
+import 'package:receipt_wrangler_mobile/utils/receipts.dart';
+
+import '../helpers/permission_test_helpers.dart';
+
+/// Widget-level coverage for the comment swipe-to-delete gate
+/// (`receipt_comments.dart` → `SlidableWidget.slideEnabled` =
+/// `canCommentDelete`, i.e. `group.comments.delete`, in edit state).
+/// Complements the e2e in `integration_test/permission_comments_test.dart`.
+void main() {
+  const groupId = 7;
+
+  api.Comment comment() => (api.CommentBuilder()
+        ..id = 1
+        ..comment = 'hello'
+        ..receiptId = 1
+        ..userId = 1
+        ..createdAt = DateTime.now().toIso8601String())
+      .build();
+
+  UserModel userModelWithTester() {
+    final model = UserModel();
+    model.setUsers([
+      (api.UserViewBuilder()
+            ..id = 1
+            ..username = 'tester'
+            ..displayName = 'Tester'
+            ..isDummyUser = false)
+          .build(),
+    ]);
+    return model;
+  }
+
+  Widget wrap(List<Permission> groupPermissions, List<api.Comment> comments) {
+    final receiptModel = ReceiptModel();
+    receiptModel.setReceipt(
+      getDefaultReceipt().rebuild((b) => b
+        ..id = 1
+        ..groupId = groupId),
+      false,
+    );
+
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider.value(
+          value: seededPermissions(group: {groupId: groupPermissions}),
+        ),
+        ChangeNotifierProvider.value(value: receiptModel),
+        ChangeNotifierProvider.value(value: userModelWithTester()),
+        ChangeNotifierProvider.value(value: AuthModel()),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: ReceiptComments(
+            comments: comments,
+            formState: WranglerFormState.edit,
+          ),
+        ),
+      ),
+    );
+  }
+
+  SlidableWidget firstSlidable(WidgetTester tester) =>
+      tester.widget<SlidableWidget>(find.byType(SlidableWidget).first);
+
+  group('ReceiptComments swipe-to-delete gate (edit state)', () {
+    testWidgets('enabled with group.comments.delete', (tester) async {
+      await tester.pumpWidget(
+          wrap([Permission.groupPeriodCommentsPeriodDelete], [comment()]));
+      await tester.pump();
+
+      expect(firstSlidable(tester).slideEnabled, isTrue);
+    });
+
+    testWidgets('disabled without group.comments.delete', (tester) async {
+      // Holds create but not delete (a Legacy Editor minus delete) — proves the
+      // delete gate is independent of the create gate.
+      await tester.pumpWidget(
+          wrap([Permission.groupPeriodCommentsPeriodCreate], [comment()]));
+      await tester.pump();
+
+      expect(firstSlidable(tester).slideEnabled, isFalse);
+    });
+  });
+}

--- a/mobile/test/widgets/receipt_comments_test.dart
+++ b/mobile/test/widgets/receipt_comments_test.dart
@@ -41,27 +41,34 @@ void main() {
     return model;
   }
 
-  Widget wrap(List<Permission> groupPermissions, List<api.Comment> comments) {
-    final receiptModel = ReceiptModel();
-    receiptModel.setReceipt(
-      getDefaultReceipt().rebuild((b) => b
-        ..id = 1
-        ..groupId = groupId),
-      false,
-    );
+  // Key the widget under test so the slidable is located via find.descendant
+  // rather than a brittle bare find.byType (house rule in mobile/CLAUDE.md).
+  const commentsKey = ValueKey('comments-under-test');
 
+  Widget wrap(List<Permission> groupPermissions, List<api.Comment> comments) {
     return MultiProvider(
       providers: [
-        ChangeNotifierProvider.value(
-          value: seededPermissions(group: {groupId: groupPermissions}),
+        // Test-owned notifiers are injected with create: so the provider owns
+        // their lifecycle (mobile/CLAUDE.md).
+        ChangeNotifierProvider(
+          create: (_) => seededPermissions(group: {groupId: groupPermissions}),
         ),
-        ChangeNotifierProvider.value(value: receiptModel),
-        ChangeNotifierProvider.value(value: userModelWithTester()),
-        ChangeNotifierProvider.value(value: AuthModel()),
+        ChangeNotifierProvider(
+          create: (_) => ReceiptModel()
+            ..setReceipt(
+              getDefaultReceipt().rebuild((b) => b
+                ..id = 1
+                ..groupId = groupId),
+              false,
+            ),
+        ),
+        ChangeNotifierProvider(create: (_) => userModelWithTester()),
+        ChangeNotifierProvider(create: (_) => AuthModel()),
       ],
       child: MaterialApp(
         home: Scaffold(
           body: ReceiptComments(
+            key: commentsKey,
             comments: comments,
             formState: WranglerFormState.edit,
           ),
@@ -71,7 +78,14 @@ void main() {
   }
 
   SlidableWidget firstSlidable(WidgetTester tester) =>
-      tester.widget<SlidableWidget>(find.byType(SlidableWidget).first);
+      tester.widget<SlidableWidget>(
+        find
+            .descendant(
+              of: find.byKey(commentsKey),
+              matching: find.byType(SlidableWidget),
+            )
+            .first,
+      );
 
   group('ReceiptComments swipe-to-delete gate (edit state)', () {
     testWidgets('enabled with group.comments.delete', (tester) async {

--- a/mobile/test/widgets/receipt_list_item_test.dart
+++ b/mobile/test/widgets/receipt_list_item_test.dart
@@ -46,18 +46,26 @@ void main() {
     return model;
   }
 
+  // Key the widget under test so the slidable is located via find.descendant
+  // rather than a brittle bare find.byType (house rule in mobile/CLAUDE.md).
+  const itemKey = ValueKey('receipt-item-under-test');
+
   Widget wrap(List<Permission> groupPermissions) {
     return MultiProvider(
       providers: [
-        ChangeNotifierProvider.value(
-          value: seededPermissions(group: {groupId: groupPermissions}),
+        // Test-owned notifiers are injected with create: so the provider owns
+        // their lifecycle (mobile/CLAUDE.md).
+        ChangeNotifierProvider(
+          create: (_) => seededPermissions(group: {groupId: groupPermissions}),
         ),
-        ChangeNotifierProvider.value(value: GroupModel()),
-        ChangeNotifierProvider.value(value: userModelWithTester()),
-        ChangeNotifierProvider.value(value: SystemSettingsModel()),
+        ChangeNotifierProvider(create: (_) => GroupModel()),
+        ChangeNotifierProvider(create: (_) => userModelWithTester()),
+        ChangeNotifierProvider(create: (_) => SystemSettingsModel()),
       ],
       child: MaterialApp(
-        home: Scaffold(body: ReceiptListItem(receipt: receiptInGroup())),
+        home: Scaffold(
+          body: ReceiptListItem(key: itemKey, receipt: receiptInGroup()),
+        ),
       ),
     );
   }
@@ -67,14 +75,22 @@ void main() {
     await tester.pumpWidget(wrap(groupPermissions));
     // ListItemLead packs the formatted date into a fixed 50px lead, which
     // overflows the headless test canvas by a few px (it renders fine on a real
-    // device). That's incidental to the swipe-to-edit gate under test, so
-    // consume the layout exception rather than coupling this test to that
-    // sub-widget's pixel layout.
-    tester.takeException();
+    // device) — incidental to the swipe-to-edit gate under test. Consume ONLY
+    // that known overflow; re-fail on any other exception.
+    final exception = tester.takeException();
+    if (exception != null) {
+      expect(exception, isA<FlutterError>());
+      expect(exception.toString(), contains('overflowed'));
+    }
   }
 
   SlidableWidget slidable(WidgetTester tester) =>
-      tester.widget<SlidableWidget>(find.byType(SlidableWidget));
+      tester.widget<SlidableWidget>(
+        find.descendant(
+          of: find.byKey(itemKey),
+          matching: find.byType(SlidableWidget),
+        ),
+      );
 
   group('ReceiptListItem swipe-to-edit gate', () {
     testWidgets('enabled with group.receipts.update', (tester) async {

--- a/mobile/test/widgets/receipt_list_item_test.dart
+++ b/mobile/test/widgets/receipt_list_item_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openapi/openapi.dart' as api;
+import 'package:openapi/openapi.dart' show Permission;
+import 'package:provider/provider.dart';
+import 'package:receipt_wrangler_mobile/groups/widgets/receipt_list_item.dart';
+import 'package:receipt_wrangler_mobile/models/group_model.dart';
+import 'package:receipt_wrangler_mobile/models/system_settings_model.dart';
+import 'package:receipt_wrangler_mobile/models/user_model.dart';
+import 'package:receipt_wrangler_mobile/shared/widgets/slidable_widget.dart';
+import 'package:receipt_wrangler_mobile/utils/receipts.dart';
+
+import '../helpers/permission_test_helpers.dart';
+import '../helpers/widget_test_helpers.dart';
+
+/// Widget-level coverage for the receipt-list swipe-to-edit gate
+/// (`receipt_list_item.dart` → `SlidableWidget.slideEnabled` =
+/// `canEditReceipt`, i.e. `group.receipts.update`). Complements the e2e in
+/// `integration_test/permission_receipt_edit_test.dart` with a fast,
+/// deterministic check on the exact production input.
+void main() {
+  const groupId = 7;
+
+  // The list item renders the receipt amount via formatCurrency, which needs the
+  // app's custom currency registered in money2's process-wide registry.
+  setUpAll(registerCustomCurrencyForTests);
+
+  api.Receipt receiptInGroup() => getDefaultReceipt().rebuild((b) => b
+    ..id = 1
+    ..groupId = groupId
+    ..paidByUserId = 1
+    ..name = 'Test Receipt'
+    ..amount = '12.34'
+    ..createdAt = DateTime.now().toIso8601String());
+
+  UserModel userModelWithTester() {
+    final model = UserModel();
+    model.setUsers([
+      (api.UserViewBuilder()
+            ..id = 1
+            ..username = 'tester'
+            ..displayName = 'Tester'
+            ..isDummyUser = false)
+          .build(),
+    ]);
+    return model;
+  }
+
+  Widget wrap(List<Permission> groupPermissions) {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider.value(
+          value: seededPermissions(group: {groupId: groupPermissions}),
+        ),
+        ChangeNotifierProvider.value(value: GroupModel()),
+        ChangeNotifierProvider.value(value: userModelWithTester()),
+        ChangeNotifierProvider.value(value: SystemSettingsModel()),
+      ],
+      child: MaterialApp(
+        home: Scaffold(body: ReceiptListItem(receipt: receiptInGroup())),
+      ),
+    );
+  }
+
+  Future<void> pumpItem(
+      WidgetTester tester, List<Permission> groupPermissions) async {
+    await tester.pumpWidget(wrap(groupPermissions));
+    // ListItemLead packs the formatted date into a fixed 50px lead, which
+    // overflows the headless test canvas by a few px (it renders fine on a real
+    // device). That's incidental to the swipe-to-edit gate under test, so
+    // consume the layout exception rather than coupling this test to that
+    // sub-widget's pixel layout.
+    tester.takeException();
+  }
+
+  SlidableWidget slidable(WidgetTester tester) =>
+      tester.widget<SlidableWidget>(find.byType(SlidableWidget));
+
+  group('ReceiptListItem swipe-to-edit gate', () {
+    testWidgets('enabled with group.receipts.update', (tester) async {
+      await pumpItem(tester, [Permission.groupPeriodReceiptsPeriodUpdate]);
+
+      expect(slidable(tester).slideEnabled, isTrue);
+    });
+
+    testWidgets('disabled without group.receipts.update', (tester) async {
+      await pumpItem(tester, [Permission.groupPeriodReceiptsPeriodRead]);
+
+      expect(slidable(tester).slideEnabled, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Hardens permission gating across mobile + desktop before the role-rework merge: closes test-coverage
gaps, fixes three gating bugs found along the way, and includes a legacy-parity audit confirming the
seeded "Legacy *" roles match the old enum roles 1:1.

## Gating fixes

- **`/groups` over-gating (regression).** The groups table route required `app.groups.read`, which the
  seeded **Legacy User** role doesn't hold — so normal users could no longer open the table to manage
  **their own** groups. That's stricter than legacy (the route had no guard) and stricter than the
  backend (`GET /group/` serves the caller's own groups). The all-groups filter is already gated on
  `app.groups.read` inside the component, and per-row Edit/Delete on `group.update`/`group.delete`, so
  the route guard was redundant and harmful. Removed it; the parent shell still enforces `AuthGuard`.
- **Dashboard CRUD was ungated (desktop).** Add/Edit/Delete dashboard buttons rendered for every group
  member and 403'd on the backend; now gated on `group.dashboards.create/update/delete`.
- **Notification delete (desktop).** Gated on `app.notifications.delete` to match the rest of the app.
- **Mobile 403 interceptor.** The backend returns 403 for both an expired session and a permission
  denial (never 401). The interceptor force-refreshed the token on every 403 — burning the one-time
  refresh token and risking logout on a permission denial. Now it distinguishes by token validity: a
  403 with a valid token is surfaced untouched (no refresh, no logout); only an expired token refreshes.

## Test coverage added

- **Mobile e2e:** paid-by visibility (own-only list filtering), comment create/delete deny paths,
  tag-picker per-group catalog; widget tests for the receipt-list and comment swipe gates.
- **Desktop e2e:** dashboard CRUD gating, comment create/delete gating, receipt action/route gating +
  create API-403, magic-fill/quick-scan/email-poll gating, category/tag delete API-403, search-bar
  positive contrast, role-selector graceful-degrade, and a Legacy-User-opens-`/groups` lock-in.
- Unit specs for the dashboard and notification gates.

## Legacy-parity audit (no code changes; findings only)

Rebuilt the legacy capability matrix from the actual pre-rework handler gating and diffed it against
the seeded roles:

- **Group roles (Viewer/Editor/Owner): clean 1:1.** (Resolved a prior ambiguity — legacy comment
  *create* was VIEWER-level, comment *delete* was auth-only; the modern system tightened delete to
  `group.comments.delete` without removing the Viewer's ability.)
- **App roles: 1:1 except the three documented, intentional lock-downs** — Legacy User omits
  `app.users.read` (unused admin listing), `app.categories.read` / `app.tags.read` (categories/tags
  now delivered via per-group grant catalogs; inline create still works).
- The `/groups` over-gate was the only true regression, and it's fixed here.

## Verification

- Mobile: full unit/widget suite green (155); new e2e specs pass against the local stack.
- Desktop: changed unit specs green; permission e2e specs pass (`/groups` fix verified — the previously
  skipped serial-block tests now run).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced permission-gated visibility for group dashboard CRUD actions, notification delete controls, receipt write actions, and receipt/comment UI behavior.
  * Improved access handling so denied actions no longer surface edit flows and 403 enforcement is consistent.
* **Documentation**
  * Expanded permission-gating guidance and standardized E2E locator conventions for more reliable assertions.
* **Tests**
  * Added/extended E2E and integration/widget coverage for dashboard, comments, receipt actions/features, search visibility, role selection, and paid-by filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->