### PR TITLE
Resolve role ids by scope to prevent app/group id collisions

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -161,7 +161,10 @@ gated by `appPermissionGuard` requiring `app.roles.read` (see **Permission-based
 - **Member-table role display:** the admin user-list (`src/user/user-list/`) and `group-form`
   (`src/group/group-form/`, loaded by every group view including non-admins) resolve each user's
   `appRoleId` / each member's `groupRoleId` to the role **name** via the shared `RoleNamePipe`
-  (`src/pipes/role-name.pipe.ts` — `{{ id | roleName : roles() }}`). Both load roles with
+  (`src/pipes/role-name.pipe.ts` — `{{ id | roleName : roles() : scope }}`). The pipe matches on
+  **id _and_ `PermissionScope`** because app- and group-role ids are independent sequences and can
+  collide (e.g. group role `id=1` vs app role `id=1`); callers pass `PermissionScope.App` (user-list)
+  / `PermissionScope.Group` (group-form) so the wrong-scope role is never matched. Both load roles with
   `RoleService.getRoles()` wrapped in `catchError`, so a non-admin lacking `app.roles.read` sees a
   blank name rather than a 403-driven logout. There is no longer any legacy `groupRole` enum sync,
   and `group-form` no longer enforces a "keep an owner" rule — the backend dropped the owner concept,

--- a/desktop/src/group/group-form/group-form.component.html
+++ b/desktop/src/group/group-form/group-form.component.html
@@ -70,7 +70,7 @@
 </ng-template>
 
 <ng-template #roleCell let-element="element">
-  {{ element.groupRoleId | roleName : roles() }}
+  {{ element.groupRoleId | roleName : roles() : PermissionScope.Group }}
 </ng-template>
 
 <ng-template #actionsCell let-index="index">

--- a/desktop/src/group/group-form/group-form.component.ts
+++ b/desktop/src/group/group-form/group-form.component.ts
@@ -15,7 +15,7 @@ import {FormConfig} from "src/interfaces/form-config.interface";
 import {TableColumn} from "src/table/table-column.interface";
 import {TableComponent} from "src/table/table/table.component";
 import {SortByDisplayName} from "src/utils/sort-by-displayname";
-import {Group, GroupMember, GroupsService, GroupStatus, Permission, Role, RoleService} from "../../open-api";
+import {Group, GroupMember, GroupsService, GroupStatus, Permission, PermissionScope, Role, RoleService} from "../../open-api";
 import {loadAssignableRoles} from "../../roles/role-loading.util";
 import {AppInitService, SnackbarService} from "../../services";
 import {AddGroup, AuthState, UpdateGroup} from "../../store";
@@ -31,6 +31,8 @@ import {buildGroupMemberForm} from "../utils/group-member.utils";
     standalone: false
 })
 export class GroupFormComponent implements OnInit, AfterViewInit {
+  protected readonly PermissionScope = PermissionScope;
+
   public readonly nameCell = viewChild.required<TemplateRef<any>>("nameCell");
 
   public readonly roleCell = viewChild.required<TemplateRef<any>>("roleCell");

--- a/desktop/src/group/group-member-form/group-member-form.component.spec.ts
+++ b/desktop/src/group/group-member-form/group-member-form.component.spec.ts
@@ -84,6 +84,25 @@ describe("GroupMemberFormComponent", () => {
     expect(component.selectedRole()).toEqual(defaultGroupRole);
   });
 
+  it("resolves the selected group role when an app role shares its id", async () => {
+    // App and group role ids are independent and can collide. An app role
+    // listed first with the same id must not be returned for the group selection.
+    const collidingAppRole: Role = {
+      id: 10,
+      name: "Some App Role",
+      description: "App role",
+      scope: PermissionScope.App,
+      isDefault: false,
+      isSystem: false,
+      permissions: [],
+    };
+    getRolesMock.mockReturnValue(of([collidingAppRole, defaultGroupRole]));
+    await createComponent();
+
+    expect(component.form.get("groupRoleId")?.value).toBe(10);
+    expect(component.selectedRole()).toEqual(defaultGroupRole);
+  });
+
   it("leaves the selector empty when roles fail to load", async () => {
     getRolesMock.mockReturnValue(throwError(() => new Error("forbidden")));
     await createComponent();

--- a/desktop/src/group/group-member-form/group-member-form.component.ts
+++ b/desktop/src/group/group-member-form/group-member-form.component.ts
@@ -44,7 +44,10 @@ export class GroupMemberFormComponent implements OnInit {
   );
   private readonly selectedGroupRoleId = signal<number | null>(null);
   public readonly selectedRole = computed<Role | null>(
-    () => this.roles().find((role) => role.id === this.selectedGroupRoleId()) ?? null
+    () =>
+      this.groupRoleOptions().find(
+        (role) => role.id === this.selectedGroupRoleId()
+      ) ?? null
   );
 
   constructor(

--- a/desktop/src/pipes/role-name.pipe.spec.ts
+++ b/desktop/src/pipes/role-name.pipe.spec.ts
@@ -25,24 +25,56 @@ describe("RoleNamePipe", () => {
     expect(new RoleNamePipe()).toBeTruthy();
   });
 
-  it("resolves the role name for a matching id", () => {
+  it("resolves the role name for a matching id and scope", () => {
     const pipe = new RoleNamePipe();
-    expect(pipe.transform(2, roles)).toEqual("Legacy Owner");
+    expect(pipe.transform(2, roles, PermissionScope.Group)).toEqual("Legacy Owner");
   });
 
   it("returns empty string for an unknown id", () => {
     const pipe = new RoleNamePipe();
-    expect(pipe.transform(99, roles)).toEqual("");
+    expect(pipe.transform(99, roles, PermissionScope.App)).toEqual("");
+  });
+
+  it("returns empty string when the id exists only in the other scope", () => {
+    const pipe = new RoleNamePipe();
+    // id 1 is an app role; resolving it as a group role must not match.
+    expect(pipe.transform(1, roles, PermissionScope.Group)).toEqual("");
+  });
+
+  it("resolves by scope when app and group role ids collide", () => {
+    const pipe = new RoleNamePipe();
+    // App and group roles have independent id sequences, so the same id can
+    // exist in both scopes. The scope argument disambiguates them.
+    const collidingRoles: Role[] = [
+      {
+        id: 1,
+        name: "Legacy Admin",
+        scope: PermissionScope.App,
+        isDefault: false,
+        isSystem: true,
+        permissions: [],
+      },
+      {
+        id: 1,
+        name: "Legacy Viewer",
+        scope: PermissionScope.Group,
+        isDefault: false,
+        isSystem: true,
+        permissions: [],
+      },
+    ];
+    expect(pipe.transform(1, collidingRoles, PermissionScope.Group)).toEqual("Legacy Viewer");
+    expect(pipe.transform(1, collidingRoles, PermissionScope.App)).toEqual("Legacy Admin");
   });
 
   it("returns empty string for a null/undefined id", () => {
     const pipe = new RoleNamePipe();
-    expect(pipe.transform(null, roles)).toEqual("");
-    expect(pipe.transform(undefined, roles)).toEqual("");
+    expect(pipe.transform(null, roles, PermissionScope.App)).toEqual("");
+    expect(pipe.transform(undefined, roles, PermissionScope.App)).toEqual("");
   });
 
   it("returns empty string when roles are not yet loaded", () => {
     const pipe = new RoleNamePipe();
-    expect(pipe.transform(1, [])).toEqual("");
+    expect(pipe.transform(1, [], PermissionScope.App)).toEqual("");
   });
 });

--- a/desktop/src/pipes/role-name.pipe.ts
+++ b/desktop/src/pipes/role-name.pipe.ts
@@ -1,15 +1,23 @@
 import { Pipe, PipeTransform } from "@angular/core";
-import { Role } from "../open-api";
+import { PermissionScope, Role } from "../open-api";
 
 @Pipe({
     name: "roleName",
     standalone: false
 })
 export class RoleNamePipe implements PipeTransform {
-  public transform(id: number | undefined | null, roles: Role[]): string {
+  // App and group roles have independent id sequences, so a role id is only
+  // unique within a scope. Callers pass the scope of the id being resolved
+  // (e.g. PermissionScope.App for a user's appRoleId) so a colliding id from
+  // the other scope is never matched.
+  public transform(
+    id: number | undefined | null,
+    roles: Role[],
+    scope: PermissionScope
+  ): string {
     if (id == null) {
       return "";
     }
-    return roles.find((role) => role.id === id)?.name ?? "";
+    return roles.find((role) => role.id === id && role.scope === scope)?.name ?? "";
   }
 }

--- a/desktop/src/user/user-form/user-form.component.spec.ts
+++ b/desktop/src/user/user-form/user-form.component.spec.ts
@@ -330,6 +330,25 @@ describe("UserFormComponent", () => {
     expect(freshComponent.selectedRole()).toEqual(defaultAppRole);
   });
 
+  it("resolves the selected app role when a group role shares its id", async () => {
+    // App and group role ids are independent and can collide. A group role
+    // listed first with the same id must not be returned for the app selection.
+    const collidingGroupRole: Role = {
+      id: 7,
+      name: "Some Group Role",
+      scope: PermissionScope.Group,
+      isDefault: false,
+      isSystem: false,
+      permissions: [],
+    };
+    const freshComponent = await createWithRoles(
+      of([collidingGroupRole, defaultAppRole])
+    );
+
+    expect(freshComponent.form.get("appRoleId")?.value).toBe(7);
+    expect(freshComponent.selectedRole()).toEqual(defaultAppRole);
+  });
+
   it("leaves the selector empty when roles fail to load", async () => {
     const freshComponent = await createWithRoles(
       throwError(() => new Error("forbidden"))

--- a/desktop/src/user/user-form/user-form.component.ts
+++ b/desktop/src/user/user-form/user-form.component.ts
@@ -69,7 +69,10 @@ export class UserFormComponent implements OnInit {
   );
   private readonly selectedAppRoleId = signal<number | null>(null);
   public readonly selectedRole = computed<Role | null>(
-    () => this.roles().find((role) => role.id === this.selectedAppRoleId()) ?? null
+    () =>
+      this.appRoleOptions().find(
+        (role) => role.id === this.selectedAppRoleId()
+      ) ?? null
   );
 
   public ngOnInit(): void {

--- a/desktop/src/user/user-list/user-list.component.html
+++ b/desktop/src/user/user-list/user-list.component.html
@@ -36,7 +36,7 @@
 </ng-template>
 
 <ng-template #appRoleCell let-element="element">
-  {{ element.appRoleId | roleName : roles() }}
+  {{ element.appRoleId | roleName : roles() : PermissionScope.App }}
 </ng-template>
 
 <ng-template #createdAtCell let-element="element">

--- a/desktop/src/user/user-list/user-list.component.ts
+++ b/desktop/src/user/user-list/user-list.component.ts
@@ -10,7 +10,7 @@ import { DEFAULT_DIALOG_CONFIG } from "src/constants/dialog.constant";
 import { ConfirmationDialogComponent } from "src/shared-ui/confirmation-dialog/confirmation-dialog.component";
 import { TableColumn } from "src/table/table-column.interface";
 import { TableComponent } from "src/table/table/table.component";
-import { BulkUserDeleteCommand, Permission, Role, RoleService, User, UserService } from "../../open-api";
+import { BulkUserDeleteCommand, Permission, PermissionScope, Role, RoleService, User, UserService } from "../../open-api";
 import { loadAssignableRoles } from "../../roles/role-loading.util";
 import { SnackbarService } from "../../services";
 import { AuthState, RemoveUser, RemoveUsers, UserState } from "../../store";
@@ -28,6 +28,7 @@ import { UserFormComponent } from "../user-form/user-form.component";
 })
 export class UserListComponent implements AfterViewInit {
   protected readonly Permission = Permission;
+  protected readonly PermissionScope = PermissionScope;
 
   userId = this.store.selectSignal(AuthState.userId);
 


### PR DESCRIPTION
## Summary

Role-id → name/object lookups matched by id only, ignoring scope. App and group roles have
independent id sequences, so the same id can exist in both scopes — the combined role list
(`loadAssignableRoles` returns both) was searched with `.find(r => r.id === id)`, returning whichever
scope sorted first.

User-visible effect: in the **Group Members** table, a member assigned **Legacy Viewer** (group id 1)
or **Legacy Editor** (group id 2) rendered as **Legacy Admin** / **Legacy User** (app ids 1 / 2).

## Changes

- `RoleNamePipe` now takes a `PermissionScope` and matches on **id and scope**; the user-list and
  group-form templates pass `PermissionScope.App` / `PermissionScope.Group`.
- `user-form` and `group-member-form` resolve the previewed role from the existing scope-filtered
  `appRoleOptions()` / `groupRoleOptions()` instead of the combined list (fixes the role Preview
  button on an id collision).
- Added a collision regression test to each of the three specs.
- Updated `desktop/CLAUDE.md` to document the new `{{ id | roleName : roles() : scope }}` signature.

## Testing

- `npx jest role-name.pipe user-form.component group-member-form.component user-list.component group-form.component` — all pass.
- Verified live in the running app: a group member assigned Legacy Viewer / Legacy Editor now renders
  the correct name instead of Legacy Admin / Legacy User.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Role names and default role selections now resolve correctly when app and group roles share the same ID.
  * User and group screens now display the matching role for the correct permission scope.
  * Empty or missing role values continue to show nothing as expected.

* **Tests**
  * Added coverage for role ID collisions across scopes to confirm the right role is selected and shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->