### PR TITLE
Reorder system settings tabs by permission hierarchy

### DIFF
--- a/desktop/src/guards/system-settings-landing.guard.spec.ts
+++ b/desktop/src/guards/system-settings-landing.guard.spec.ts
@@ -38,13 +38,30 @@ describe("systemSettingsLandingGuard", () => {
     expect(run().toString()).toBe("/system-settings/prompts");
   });
 
-  it("falls through to a later tab when earlier ones are not readable", () => {
-    store.dispatch(new SetPermissions([Permission.AppSystemSettingsRead], {}));
+  it("lands on System Settings for a user who can read every tab", () => {
+    store.dispatch(
+      new SetPermissions(
+        [
+          Permission.AppSystemSettingsRead,
+          Permission.AppReceiptProcessingSettingsRead,
+          Permission.AppPromptsRead,
+          Permission.AppSystemEmailsRead,
+          Permission.AppSystemTasksRead,
+        ],
+        {}
+      )
+    );
 
     expect(run().toString()).toBe("/system-settings/settings/view");
   });
 
-  it("prefers system-emails when it is readable", () => {
+  it("falls through to a later tab when earlier ones are not readable", () => {
+    store.dispatch(new SetPermissions([Permission.AppSystemTasksRead], {}));
+
+    expect(run().toString()).toBe("/system-settings/system-tasks");
+  });
+
+  it("prefers an earlier-rendered tab over system-emails", () => {
     store.dispatch(
       new SetPermissions(
         [Permission.AppSystemEmailsRead, Permission.AppPromptsRead],
@@ -52,7 +69,7 @@ describe("systemSettingsLandingGuard", () => {
       )
     );
 
-    expect(run().toString()).toBe("/system-settings/system-emails");
+    expect(run().toString()).toBe("/system-settings/prompts");
   });
 
   it("redirects to the dashboard when no tab is readable", () => {

--- a/desktop/src/guards/system-settings-landing.guard.ts
+++ b/desktop/src/guards/system-settings-landing.guard.ts
@@ -15,14 +15,14 @@ export const systemSettingsLandingGuard: CanActivateFn = (): UrlTree => {
   const router: Router = inject(Router);
 
   const tabs: { path: string; permission: Permission }[] = [
-    { path: "system-emails", permission: Permission.AppSystemEmailsRead },
-    { path: "prompts", permission: Permission.AppPromptsRead },
+    { path: "settings/view", permission: Permission.AppSystemSettingsRead },
     {
       path: "receipt-processing-settings",
       permission: Permission.AppReceiptProcessingSettingsRead,
     },
+    { path: "prompts", permission: Permission.AppPromptsRead },
+    { path: "system-emails", permission: Permission.AppSystemEmailsRead },
     { path: "system-tasks", permission: Permission.AppSystemTasksRead },
-    { path: "settings/view", permission: Permission.AppSystemSettingsRead },
   ];
 
   for (const tab of tabs) {


### PR DESCRIPTION
## Summary
Reordered the system settings landing guard tab priority to follow a logical permission hierarchy, ensuring users are directed to the most fundamental settings first when multiple tabs are accessible.

## Changes
- **Tab ordering**: Reorganized the `tabs` array in `systemSettingsLandingGuard` to prioritize tabs in this order:
  1. System Settings (AppSystemSettingsRead)
  2. Receipt Processing Settings (AppReceiptProcessingSettingsRead)
  3. Prompts (AppPromptsRead)
  4. System Emails (AppSystemEmailsRead)
  5. System Tasks (AppSystemTasksRead)

- **Test updates**: Updated test cases to reflect the new tab priority:
  - "lands on System Settings for a user who can read every tab" - verifies users with all permissions land on the primary settings tab
  - "falls through to a later tab when earlier ones are not readable" - now tests with `AppSystemTasksRead` permission, expecting navigation to system-tasks
  - "prefers an earlier-rendered tab over system-emails" - renamed from "prefers system-emails..." and updated to verify that prompts (earlier in the list) takes precedence over system-emails

## Implementation Details
The guard iterates through the tabs array in order and redirects to the first tab the user has permission to access. By reordering the array, we ensure a sensible default navigation path that prioritizes core system settings over peripheral features like email and task management.

https://claude.ai/code/session_01TdN3UqJXSYW2995fQWvqbH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved where users land within System Settings when they have access to multiple tabs.
  * Updated the tab priority so the most appropriate available section opens first.
  * Users with access to all settings tabs now land on the main settings view.
  * Adjusted fallback behavior so redirects now match the intended tab order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->