### PR TITLE
fix(api): keep group_members.group_role nullable so upgrades can create groups

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -158,13 +158,16 @@ A configurable role/permission system. Administrators can define roles from gran
 strings at two scopes — **application** and **group** — and assign them to users / group members.
 **Handlers now enforce these permissions** (see "Enforcement status" below). The legacy
 `models.UserRole` (`ADMIN`/`USER`) and `models.GroupRole` (`OWNER`/`EDITOR`/`VIEWER`) enums have
-been **removed from the backend** — the Go types, the `User.UserRole`/`GroupMember.GroupRole` model
-fields, the `Claims.userRole` JWT field, and the `DeriveLegacy*` shims are all gone. "Admin" is now
+been **removed from the backend** — the Go enum types, the `User.UserRole` model field, the
+`Claims.userRole` JWT field, and the `DeriveLegacy*` shims are all gone. "Admin" is now
 defined by the app permission `app.users.read` (the seeded **Legacy Admin** role grants it; **Legacy
-User** omits it). The only legacy remnant is the **physical** `user_role`/`group_role` DB columns,
-intentionally retained on existing installs so the one-time data migration can still back-fill from
-them (see "Legacy role assignment" below); GORM never drops them and fresh installs never create
-them.
+User** omits it). The legacy remnants are the **physical** `user_role`/`group_role` DB columns,
+retained on existing installs so the one-time data migration can still back-fill from
+them (see "Legacy role assignment" below). `user_role` is purely physical (no Go field; GORM never
+creates it on fresh installs). `group_role` is the one exception: `GroupMember.GroupRole` is
+**temporarily re-declared** on the model as a plain nullable string (`json:"-"`, never read) — see
+"Legacy `group_role` column on upgrade" below — so AutoMigrate manages it on all installs again. Both
+will be dropped in a later release.
 
 ### Permission registry
 
@@ -300,12 +303,15 @@ them.
   matching `User.AppRoleID` (`ADMIN` → Legacy Admin, `USER` → Legacy User) and each member's
   `group_role` onto `GroupMember.GroupRoleID` (`OWNER`/`EDITOR`/`VIEWER` → Legacy
   Owner/Editor/Viewer). Lives in `repositories/data_migrations.go` (`assignLegacyEquivalentRoles`).
-- **Reads the retained physical columns, not Go fields.** The `UserRole`/`GroupRole` Go struct
-  fields were removed, so the migration matches the `user_role`/`group_role` values as plain strings
-  and **guards each back-fill loop with `tx.Migrator().HasColumn(...)`** — upgrading installs keep
-  the physical columns (GORM never drops them) so the back-fill runs, while fresh installs never
-  create them so the guard skips cleanly instead of erroring with "no such column". There is
-  deliberately **no drop-column migration**, to preserve this upgrade path.
+- **Reads the physical columns as plain strings, not enum Go fields.** The legacy enum types were
+  removed, so the migration matches the `user_role`/`group_role` values as plain strings and **guards
+  each back-fill loop with `tx.Migrator().HasColumn(...)`**. For `user_role` (no Go field) the guard
+  is the real safety net — upgrading installs keep the physical column so the back-fill runs, while
+  fresh installs never created it so the guard skips cleanly instead of erroring with "no such
+  column". For `group_role` the guard is now effectively always-true, since `GroupMember.GroupRole`
+  is re-declared on the model (so AutoMigrate always creates the column); the back-fill still no-ops
+  on fresh rows because their value is `""`, which matches no legacy enum. There is deliberately **no
+  drop-column migration**, to preserve this upgrade path.
 - **Tracking:** one-time data migrations are recorded in a `data_migrations` ledger
   (`models.DataMigration`, keyed by unique `name`) — distinct from GORM schema AutoMigrate. The
   runner `RunDataMigrations` skips any migration already in the ledger and otherwise runs it **and**
@@ -319,9 +325,29 @@ them.
   rows; per-create assignment for *new* users / group creators is handled by the default-role wiring
   (see "Default roles" above).
 - Tests: `repositories/data_migrations_test.go` (assignment, idempotency, ledger short-circuit,
-  no-clobber, and the `HasColumn`-guard skip path when the legacy columns are absent). The tests
-  seed the legacy columns via raw `ALTER TABLE ... ADD COLUMN` DDL since AutoMigrate no longer
-  creates them.
+  no-clobber, and the `HasColumn`-guard skip path when the legacy `user_role` column is absent). The
+  tests seed `user_role` via raw `ALTER TABLE ... ADD COLUMN` DDL since AutoMigrate no longer creates
+  it; `group_role` is left to AutoMigrate (it is back on the model) and is never added/dropped by the
+  test helpers — dropping it would leave a field-without-column state that breaks later group_members
+  inserts in the package's test run.
+
+### Legacy `group_role` column on upgrade
+
+- On databases upgraded from before the role rework, the obsolete `group_members.group_role` column
+  survives **`NOT NULL` with no default** (AutoMigrate never drops columns). Because v7 stopped
+  writing it, every new `group_members` INSERT violated the constraint (HTTP 500 on creating a group,
+  a user — which auto-creates personal groups — or adding a member). Existing data, logins, reads,
+  and receipt CRUD were unaffected.
+- **Fix:** `GroupMember.GroupRole` is **temporarily re-declared** as a plain, nullable, `json:"-"`
+  string (`internal/models/group_member.go`). Two effects: GORM writes the zero value (`""`) on every
+  INSERT, satisfying any leftover `NOT NULL`; and because the model field is nullable, AutoMigrate
+  relaxes the existing `NOT NULL` column to nullable on upgraded installs (Postgres `ALTER COLUMN …
+  DROP NOT NULL`, MariaDB `MODIFY …`). `json:"-"` keeps it off the API contract, so **no swagger /
+  client regeneration**. Nothing reads the field. Targets PostgreSQL/MariaDB; SQLite is not a goal
+  (it is handled incidentally by GORM's portable migrator). `users.user_role` needs no such treatment
+  — it is already nullable with a default.
+- **Removal plan:** drop this field together with a one-time migration that drops the `group_role`
+  column once all installs have upgraded past this release.
 
 ### Permission checks (`PermissionService`)
 

--- a/api/internal/models/group_member.go
+++ b/api/internal/models/group_member.go
@@ -9,4 +9,12 @@ type GroupMember struct {
 	GroupID             uint                 `gorm:"primaryKey;autoIncrement:false" json:"groupId"`
 	GroupRoleID         *uint                `gorm:"index" json:"groupRoleId"`
 	GroupRoleDefinition *GroupRoleDefinition `gorm:"foreignKey:GroupRoleID;references:ID;constraint:OnDelete:RESTRICT" json:"groupRoleDefinition,omitempty"`
+	// GroupRole is the obsolete legacy role enum (OWNER/EDITOR/VIEWER) removed in the role
+	// rework, where GroupRoleID replaced it. It is temporarily re-declared here — nullable,
+	// never read, hidden from the API via json:"-" — so that on databases upgraded from
+	// before the rework GORM writes a value on INSERT and AutoMigrate relaxes the leftover
+	// NOT NULL group_role column (AutoMigrate never dropped it). Without this, every new
+	// group_members INSERT 500s on upgraded installs. Remove this field together with a
+	// migration that drops the column once all installs have upgraded.
+	GroupRole string `json:"-" gorm:"column:group_role"`
 }

--- a/api/internal/repositories/data_migrations_test.go
+++ b/api/internal/repositories/data_migrations_test.go
@@ -1,6 +1,7 @@
 package repositories
 
 import (
+	"database/sql"
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/permissions"
 	"receipt-wrangler/api/internal/utils"
@@ -8,13 +9,18 @@ import (
 	"time"
 )
 
-// The legacy user_role / group_role columns were removed from the Go models, so
-// AutoMigrate no longer creates them on the test database. The assignLegacyEquivalentRoles
-// migration still reads them as raw string columns on installs upgraded from the
-// legacy schema, guarded by HasColumn. These helpers reconstruct (and tear down)
-// those physical columns so the back-fill can be exercised end to end. They are
-// idempotent and guarded by HasColumn because the test DB schema persists across
-// subtests (TruncateTestDb only deletes rows).
+// The legacy user_role column was removed from the User model, so AutoMigrate no longer
+// creates it on the test database. assignLegacyEquivalentRoles still reads it as a raw
+// string column on installs upgraded from the legacy schema, guarded by HasColumn. These
+// helpers reconstruct (and tear down) that physical column so the back-fill can be
+// exercised end to end. They are idempotent and guarded by HasColumn because the test DB
+// schema persists across subtests (TruncateTestDb only deletes rows).
+//
+// group_role is different: GroupMember.GroupRole was re-declared on the model (nullable,
+// json:"-") to satisfy the leftover NOT NULL group_role column on upgraded installs, so
+// AutoMigrate now always creates it. It is therefore never added or dropped here — doing so
+// would leave a field-without-column state that breaks group_members inserts elsewhere in
+// this package's test run.
 
 func ensureLegacyUserRoleColumn(t *testing.T) {
 	db := GetDB()
@@ -25,25 +31,11 @@ func ensureLegacyUserRoleColumn(t *testing.T) {
 	}
 }
 
-func ensureLegacyGroupRoleColumn(t *testing.T) {
-	db := GetDB()
-	if !db.Migrator().HasColumn(&models.GroupMember{}, "group_role") {
-		if err := db.Exec("ALTER TABLE group_members ADD COLUMN group_role text").Error; err != nil {
-			utils.PrintTestError(t, err, "adding the legacy group_role column")
-		}
-	}
-}
-
-func dropLegacyRoleColumns(t *testing.T) {
+func dropLegacyUserRoleColumn(t *testing.T) {
 	db := GetDB()
 	if db.Migrator().HasColumn(&models.User{}, "user_role") {
 		if err := db.Exec("ALTER TABLE users DROP COLUMN user_role").Error; err != nil {
 			utils.PrintTestError(t, err, "dropping the legacy user_role column")
-		}
-	}
-	if db.Migrator().HasColumn(&models.GroupMember{}, "group_role") {
-		if err := db.Exec("ALTER TABLE group_members DROP COLUMN group_role").Error; err != nil {
-			utils.PrintTestError(t, err, "dropping the legacy group_role column")
 		}
 	}
 }
@@ -111,9 +103,8 @@ func assertGroupRoleId(t *testing.T, member models.GroupMember, expected uint) {
 
 func TestRunDataMigrationsAssignsLegacyEquivalentRoles(t *testing.T) {
 	defer TruncateTestDb()
-	defer dropLegacyRoleColumns(t)
+	defer dropLegacyUserRoleColumn(t)
 	ensureLegacyUserRoleColumn(t)
-	ensureLegacyGroupRoleColumn(t)
 	if err := SeedSystemRoles(); err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -181,7 +172,7 @@ func TestRunDataMigrationsAssignsLegacyEquivalentRoles(t *testing.T) {
 
 func TestRunDataMigrationsIsIdempotent(t *testing.T) {
 	defer TruncateTestDb()
-	defer dropLegacyRoleColumns(t)
+	defer dropLegacyUserRoleColumn(t)
 	ensureLegacyUserRoleColumn(t)
 	if err := SeedSystemRoles(); err != nil {
 		utils.PrintTestError(t, err, nil)
@@ -219,7 +210,7 @@ func TestRunDataMigrationsIsIdempotent(t *testing.T) {
 
 func TestRunDataMigrationsSkipsWhenAlreadyApplied(t *testing.T) {
 	defer TruncateTestDb()
-	defer dropLegacyRoleColumns(t)
+	defer dropLegacyUserRoleColumn(t)
 	ensureLegacyUserRoleColumn(t)
 	if err := SeedSystemRoles(); err != nil {
 		utils.PrintTestError(t, err, nil)
@@ -253,9 +244,8 @@ func TestRunDataMigrationsSkipsWhenAlreadyApplied(t *testing.T) {
 
 func TestRunDataMigrationsDoesNotClobberExistingAssignment(t *testing.T) {
 	defer TruncateTestDb()
-	defer dropLegacyRoleColumns(t)
+	defer dropLegacyUserRoleColumn(t)
 	ensureLegacyUserRoleColumn(t)
-	ensureLegacyGroupRoleColumn(t)
 	if err := SeedSystemRoles(); err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -307,11 +297,13 @@ func TestRunDataMigrationsDoesNotClobberExistingAssignment(t *testing.T) {
 func TestRunDataMigrationsSkipsBackfillWhenLegacyColumnsAbsent(t *testing.T) {
 	defer TruncateTestDb()
 
-	// A fresh install never had the legacy user_role / group_role columns. Make
-	// sure they are absent (a prior subtest may have added them), then confirm the
-	// HasColumn guard makes the back-fill a no-op rather than failing with
-	// "no such column".
-	dropLegacyRoleColumns(t)
+	// A fresh install never had the legacy user_role column. Make sure it is absent
+	// (a prior subtest may have added it), then confirm the HasColumn guard makes the
+	// app back-fill a no-op rather than failing with "no such column". The group_role
+	// column is always present now (GroupMember.GroupRole is back on the model), but a
+	// fresh member's value is "" — which matches no legacy enum — so the group back-fill
+	// is likewise a no-op.
+	dropLegacyUserRoleColumn(t)
 	if err := SeedSystemRoles(); err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -340,7 +332,7 @@ func TestRunDataMigrationsSkipsBackfillWhenLegacyColumnsAbsent(t *testing.T) {
 		return
 	}
 
-	// With the legacy columns absent, the back-fill leaves both FKs as they were
+	// With no legacy values to read, the back-fill leaves both FKs as they were
 	// (nil) instead of assigning a role.
 	if reloadUser(t, user.ID).AppRoleID != nil {
 		utils.PrintTestError(t, reloadUser(t, user.ID).AppRoleID, nil)
@@ -363,7 +355,7 @@ func TestRunDataMigrationsSkipsBackfillWhenLegacyColumnsAbsent(t *testing.T) {
 
 func TestRunDataMigrationsRollsBackOnFailure(t *testing.T) {
 	defer TruncateTestDb()
-	defer dropLegacyRoleColumns(t)
+	defer dropLegacyUserRoleColumn(t)
 	ensureLegacyUserRoleColumn(t)
 	db := GetDB()
 
@@ -394,5 +386,43 @@ func TestRunDataMigrationsRollsBackOnFailure(t *testing.T) {
 	// And no partial assignment persisted.
 	if reloadUser(t, admin.ID).AppRoleID != nil {
 		utils.PrintTestError(t, reloadUser(t, admin.ID).AppRoleID, nil)
+	}
+}
+
+// TestNewGroupMemberPopulatesLegacyGroupRoleColumn guards the upgrade fix: on databases
+// upgraded from before the role rework the obsolete group_role column survives NOT NULL
+// with no default. The re-declared GroupMember.GroupRole field makes GORM write a value
+// on every INSERT, so the constraint is satisfied and new group_members rows can be
+// created again. Here we assert that mechanism — a freshly created member persists a
+// non-NULL group_role (it is written, not omitted) — which is exactly what keeps the
+// leftover NOT NULL constraint from rejecting the insert.
+func TestNewGroupMemberPopulatesLegacyGroupRoleColumn(t *testing.T) {
+	defer TruncateTestDb()
+	db := GetDB()
+
+	user := models.User{Username: "legacy-col", Password: "password"}
+	if err := db.Create(&user).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	group := models.Group{Name: "legacy-col-group"}
+	if err := db.Create(&group).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	member := models.GroupMember{GroupID: group.ID, UserID: user.ID}
+	if err := db.Create(&member).Error; err != nil {
+		utils.PrintTestError(t, err, "creating a group member must not violate the legacy NOT NULL group_role column")
+		return
+	}
+
+	var groupRole sql.NullString
+	row := db.Raw("SELECT group_role FROM group_members WHERE user_id = ? AND group_id = ?", user.ID, group.ID).Row()
+	if err := row.Scan(&groupRole); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if !groupRole.Valid {
+		utils.PrintTestError(t, "group_role was NULL", "a non-NULL group_role value written on INSERT")
 	}
 }


### PR DESCRIPTION
## Problem

Upgrading in place from a pre-role-rework release breaks creating groups and users.

The role rework removed the legacy `GroupRole` enum field from the `GroupMember` model (replaced by the nullable `GroupRoleID` FK). GORM's `AutoMigrate` **never drops columns**, so on an upgraded database the obsolete `group_members.group_role` column survives **`NOT NULL` with no default** while the code no longer writes it. Every new `group_members` INSERT then fails:

```
ERROR: null value in column "group_role" of relation "group_members" violates not-null constraint
INSERT INTO "group_members" (...,"group_role_id") VALUES (...,NULL)   -- group_role omitted entirely
```

Blast radius: creating a group, creating a user (auto-creates personal groups), and adding a member all return HTTP 500. Existing data, logins, reads, and receipt CRUD are unaffected. (`users.user_role` also survives but is harmless: nullable + default.)

## Fix

Re-declare `GroupMember.GroupRole` as a **temporary, nullable, JSON-hidden** string:

```go
GroupRole string `json:"-" gorm:"column:group_role"`
```

- Non-pointer `string` → GORM writes the zero value (`""`) on every INSERT, satisfying any leftover `NOT NULL` regardless of dialect.
- Nullable in the model → `AutoMigrate` relaxes the existing `NOT NULL` column to nullable on upgraded installs (Postgres `ALTER COLUMN … DROP NOT NULL`, MariaDB `MODIFY …`).
- `json:"-"` → not serialized, so **no swagger / client regeneration** and no API contract change. Nothing reads the field.

Targets PostgreSQL and MariaDB. Marked for removal together with a drop-column migration once installs have upgraded past this release.

## Also

- Adapted the legacy-column test helpers in `data_migrations_test.go`: `group_role` is a model-managed column again, so it is no longer added/dropped by the helpers (dropping it would leave a field-without-column state that breaks later group-member inserts in the package's test run). Renamed `dropLegacyRoleColumns` → `dropLegacyUserRoleColumn`.
- Added `TestNewGroupMemberPopulatesLegacyGroupRoleColumn` asserting a newly created member persists a non-NULL `group_role`.
- Updated `api/CLAUDE.md`.

## Testing

- `go build ./...` clean.
- `go test ./...` — full suite green (exercises the real group-member insert paths in addition to the new/migration tests).