### PR TITLE
fix(api): enforce RBAC grants and paid-by visibility in MCP read tools

### DIFF
--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -10,15 +10,13 @@ name: E2E - Mobile (Android + iOS)
 # continue-on-error flags to make this gating.
 #
 # Triggers:
-#   pull_request to main  -- run during PR review so reviewers can see
-#                            mobile e2e results before merging.
-#   push to main          -- post-merge verification after the PR lands.
+#   push to main          -- post-merge verification after a PR lands.
 #   push to tech/mobile-e2e -- iteration on the e2e setup itself.
 #   workflow_dispatch     -- manual trigger from the Actions tab.
+# Intentionally NOT run on pull_request: the mobile e2e suite is advisory and
+# slow, so it runs post-merge / on demand rather than gating every PR.
 
 on:
-  pull_request:
-    branches: [main]
   push:
     branches: [main, tech/mobile-e2e]
   workflow_dispatch:

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -580,16 +580,22 @@ Claude can read a user's data. It is **off by default** and Go-native (no separa
 - **Packages**: `internal/oauth/` (authorization server) and `internal/mcp/`
   (server + read-only tools). Tools call the service/repository layer in-process with the
   authenticated user's claims and enforce the same authorization as the REST handlers — not just
-  group-scope but also the category/tag grants and paid-by visibility (the tools don't pass through
-  `HandleRequest`, so each replicates the enforcement explicitly via `PermissionService`). v1 tools
-  are read-only: `search_receipts`, `get_receipt`, `list_groups`, `list_categories`, `list_tags`,
-  `list_dashboards`. Specifically (`internal/mcp/tools.go`): `list_categories`/`list_tags` return the
-  caller's grant-visible catalog (the full pool only for `app.categories.read`/`app.tags.read`
-  holders, else the union of their group roles' grants — `visibleByGrants`); `get_receipt` checks
-  `group.receipts.read`, then `ReceiptPaidByVisible` (non-leaking "not found" when hidden), then strips
-  categories/tags via `FilterReceiptCategoriesTagsForReceipt`; `search_receipts` requires
-  `app.receipts.search` and applies the paid-by disjunction in SQL before the limit (the MCP-only
-  `ReceiptRepository.SearchReceiptsByGroupIds` takes a `PaidByAllowedResolver`).
+  group-scope but also the category/tag grants and paid-by visibility. The tools don't pass through
+  `HandleRequest`, so for the two operations that have a REST twin the enforcement is **shared via
+  `ReceiptService`** (the single source of truth, so the two ingress points can't drift):
+  `get_receipt` and the REST `GetReceipt` handler both call
+  `ReceiptService.GetReceiptForUser(userId, id)` (fetch → `group.receipts.read` →
+  `ReceiptPaidByVisible` → `FilterReceiptCategoriesTagsForReceipt`, returning `ErrReceiptAccessDenied`
+  on any miss/deny — mapped to a non-leaking MCP "receipt not found" / REST 403); `search_receipts`
+  and the REST `Search` handler both call `ReceiptService.SearchReceiptsForUser(userId, query, limit)`
+  (`app.receipts.search` → group scope → paid-by disjunction in SQL before the limit → `SearchResult`
+  mapping; `ErrSearchForbidden` → MCP "unauthorized" / REST 403; blank query → empty). These two REST
+  handlers therefore intentionally omit the declarative `HandleRequest` permission/`ReceiptId` gates —
+  enforcement lives once, in the service. v1 tools are read-only: `search_receipts`, `get_receipt`,
+  `list_groups`, `list_categories`, `list_tags`, `list_dashboards`. `list_categories`/`list_tags` have
+  no REST twin and stay MCP-local in `tools.go`: they return the caller's grant-visible catalog (the
+  full pool only for `app.categories.read`/`app.tags.read` holders, else the union of their group
+  roles' grants — `visibleByGrants`).
 - **Storage**: `models.OAuthClient` + `models.OAuthAuthorizationCode` (registered in
   `MakeMigrations`). Refresh tokens reuse the existing `models.RefreshToken` flow.
 - **Production**: `docker/default.conf` proxies the new root paths to the backend; the `/mcp`

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -579,9 +579,17 @@ Claude can read a user's data. It is **off by default** and Go-native (no separa
   per-tool scope enforcement.
 - **Packages**: `internal/oauth/` (authorization server) and `internal/mcp/`
   (server + read-only tools). Tools call the service/repository layer in-process with the
-  authenticated user's claims and enforce the same group-scoped authorization as the REST
-  handlers. v1 tools are read-only: `search_receipts`, `get_receipt`, `list_groups`,
-  `list_categories`, `list_tags`, `list_dashboards`.
+  authenticated user's claims and enforce the same authorization as the REST handlers — not just
+  group-scope but also the category/tag grants and paid-by visibility (the tools don't pass through
+  `HandleRequest`, so each replicates the enforcement explicitly via `PermissionService`). v1 tools
+  are read-only: `search_receipts`, `get_receipt`, `list_groups`, `list_categories`, `list_tags`,
+  `list_dashboards`. Specifically (`internal/mcp/tools.go`): `list_categories`/`list_tags` return the
+  caller's grant-visible catalog (the full pool only for `app.categories.read`/`app.tags.read`
+  holders, else the union of their group roles' grants — `visibleByGrants`); `get_receipt` checks
+  `group.receipts.read`, then `ReceiptPaidByVisible` (non-leaking "not found" when hidden), then strips
+  categories/tags via `FilterReceiptCategoriesTagsForReceipt`; `search_receipts` requires
+  `app.receipts.search` and applies the paid-by disjunction in SQL before the limit (the MCP-only
+  `ReceiptRepository.SearchReceiptsByGroupIds` takes a `PaidByAllowedResolver`).
 - **Storage**: `models.OAuthClient` + `models.OAuthAuthorizationCode` (registered in
   `MakeMigrations`). Refresh tokens reuse the existing `models.RefreshToken` flow.
 - **Production**: `docker/default.conf` proxies the new root paths to the backend; the `/mcp`

--- a/api/internal/handlers/receipts.go
+++ b/api/internal/handlers/receipts.go
@@ -299,27 +299,24 @@ func QuickScan(w http.ResponseWriter, r *http.Request) {
 
 // TODO: move to repository call
 func GetReceipt(w http.ResponseWriter, r *http.Request) {
-	receiptId := chi.URLParam(r, "id")
-
 	handler := structs.Handler{
-		ErrorMessage:     "Error retrieving receipt.",
-		Writer:           w,
-		Request:          r,
-		ReceiptId:        receiptId,
-		GroupPermissions: []string{permissions.GroupReceiptsRead},
-		ResponseType:     constants.ApplicationJson,
+		ErrorMessage: "Error retrieving receipt.",
+		Writer:       w,
+		Request:      r,
+		ResponseType: constants.ApplicationJson,
+		// Enforcement (group.receipts.read, paid-by visibility, category/tag
+		// stripping) lives in ReceiptService.GetReceiptForUser — the single shared
+		// path also used by the MCP get_receipt tool — so the declarative gates are
+		// intentionally omitted here to avoid two sources of truth.
 		HandlerFunction: func(w http.ResponseWriter, r *http.Request) (int, error) {
 			id := chi.URLParam(r, "id")
 			token := structs.GetClaims(r)
-			receiptRepository := repositories.NewReceiptRepository(nil)
 
-			receipt, err := receiptRepository.GetFullyLoadedReceiptById(id)
+			receipt, err := services.NewReceiptService(nil).GetReceiptForUser(token.UserId, id)
 			if err != nil {
-				return http.StatusInternalServerError, err
-			}
-
-			err = services.NewPermissionService(nil).FilterReceiptCategoriesTagsForReceipt(token.UserId, &receipt)
-			if err != nil {
+				if errors.Is(err, services.ErrReceiptAccessDenied) {
+					return http.StatusForbidden, err
+				}
 				return http.StatusInternalServerError, err
 			}
 

--- a/api/internal/handlers/search.go
+++ b/api/internal/handlers/search.go
@@ -1,92 +1,47 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 	"receipt-wrangler/api/internal/constants"
-	"receipt-wrangler/api/internal/models"
-	"receipt-wrangler/api/internal/permissions"
-	"receipt-wrangler/api/internal/repositories"
 	"receipt-wrangler/api/internal/services"
 	"receipt-wrangler/api/internal/structs"
 	"receipt-wrangler/api/internal/utils"
 )
 
+// searchResultLimit caps how many receipts a REST search returns (unchanged from
+// the previous inline limit).
+const searchResultLimit = 100
+
 func Search(w http.ResponseWriter, r *http.Request) {
 	handler := structs.Handler{
-		ErrorMessage:   "Error searching",
-		Writer:         w,
-		Request:        r,
-		AppPermissions: []string{permissions.AppReceiptsSearch},
-		ResponseType:   constants.ApplicationJson,
+		ErrorMessage: "Error searching",
+		Writer:       w,
+		Request:      r,
+		ResponseType: constants.ApplicationJson,
+		// Enforcement (app.receipts.search, group scope, paid-by visibility) lives in
+		// ReceiptService.SearchReceiptsForUser — the single shared path also used by
+		// the MCP search_receipts tool — so the declarative gate is intentionally
+		// omitted here to avoid two sources of truth.
 		HandlerFunction: func(w http.ResponseWriter, r *http.Request) (int, error) {
+			token := structs.GetClaims(r)
 			searchTerm := r.URL.Query().Get("searchTerm")
 
-			if len(searchTerm) > 0 {
-				searchTerm = "%" + searchTerm + "%"
-
-				db := repositories.GetDB()
-				var receipts []models.Receipt
-
-				results := make([]structs.SearchResult, 0)
-
-				token := structs.GetClaims(r)
-				groupMemberRepository := repositories.NewGroupMemberRepository(nil)
-				groupIds, err := groupMemberRepository.GetGroupIdsByUserId(utils.UintToString(token.UserId))
-				if err != nil {
-					return http.StatusInternalServerError, err
+			results, err := services.NewReceiptService(nil).SearchReceiptsForUser(token.UserId, searchTerm, searchResultLimit)
+			if err != nil {
+				if errors.Is(err, services.ErrSearchForbidden) {
+					return http.StatusForbidden, err
 				}
-
-				query := db.Table("receipts").Where("group_id IN ? AND name LIKE ?", groupIds, searchTerm)
-
-				// Apply the caller's paid-by visibility in SQL BEFORE the limit —
-				// SearchResult exposes paidByUserId, and a post-fetch filter would drop
-				// visible matches whenever hidden receipts fill the first 100 rows.
-				receiptRepository := repositories.NewReceiptRepository(nil)
-				query, err = receiptRepository.ApplyPaidByDisjunction(
-					query,
-					groupIds,
-					services.NewPermissionService(nil).PaidByListResolver(token.UserId),
-				)
-				if err != nil {
-					return http.StatusInternalServerError, err
-				}
-
-				err = query.Limit(100).Order("date desc").Find(&receipts).Error
-				if err != nil {
-					return http.StatusInternalServerError, err
-				}
-
-				for _, receipt := range receipts {
-					results = append(results, structs.SearchResult{
-						ID:            receipt.ID,
-						GroupID:       receipt.GroupId,
-						Name:          receipt.Name,
-						Date:          receipt.Date,
-						Type:          "Receipt",
-						Amount:        receipt.Amount,
-						ReceiptStatus: receipt.Status,
-						PaidByUserId:  receipt.PaidByUserID,
-						CreatedAt:     receipt.CreatedAt,
-					})
-				}
-
-				bytes, err := utils.MarshalResponseData(results)
-				if err != nil {
-					return http.StatusInternalServerError, err
-				}
-
-				w.WriteHeader(200)
-				w.Write(bytes)
-			} else {
-				results := make([]structs.SearchResult, 0)
-				bytes, err := utils.MarshalResponseData(results)
-				if err != nil {
-					return http.StatusInternalServerError, err
-				}
-
-				w.WriteHeader(200)
-				w.Write(bytes)
+				return http.StatusInternalServerError, err
 			}
+
+			bytes, err := utils.MarshalResponseData(results)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			w.WriteHeader(200)
+			w.Write(bytes)
 
 			return 0, nil
 		},

--- a/api/internal/mcp/mcp_test.go
+++ b/api/internal/mcp/mcp_test.go
@@ -487,8 +487,16 @@ func TestSearchReceiptsEnforcesPaidByVisibility(t *testing.T) {
 func TestSearchReceiptsRequiresSearchPermission(t *testing.T) {
 	defer repositories.TruncateTestDb()
 
-	// No app role -> no app.receipts.search.
+	// Group read access and a matching receipt exist, but no app role -> no
+	// app.receipts.search, so the denial is specifically tied to the missing
+	// search permission rather than a lack of data or membership.
 	user := createUser(t, "nosearch")
+	group := models.Group{Name: "g"}
+	if err := repositories.GetDB().Create(&group).Error; err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+	addGroupMember(t, user.ID, group.ID, []string{permissions.GroupReceiptsRead})
+	createReceiptInGroup(t, "anything", group.ID, user.ID)
 
 	_, _, err := handleSearchReceipts(context.Background(), requestForUser(user.ID), searchReceiptsInput{Query: "anything"})
 	if err == nil {

--- a/api/internal/mcp/mcp_test.go
+++ b/api/internal/mcp/mcp_test.go
@@ -129,8 +129,26 @@ func createReceiptInGroup(t *testing.T, name string, groupId uint, paidByUserId 
 
 func addGroupMember(t *testing.T, userId uint, groupId uint, perms []string) {
 	t.Helper()
+	addGroupMemberWithGrants(t, userId, groupId, "mcp-test-role", perms, nil, nil, nil, false)
+}
+
+// addGroupMemberWithGrants creates a group role with the given permissions and
+// category/tag/paid-by grants, then assigns the user to the group with it. Use a
+// distinct roleName when a single test needs more than one role (names are unique).
+func addGroupMemberWithGrants(
+	t *testing.T,
+	userId uint,
+	groupId uint,
+	roleName string,
+	perms []string,
+	categoryGrants []uint,
+	tagGrants []uint,
+	paidByGrants []uint,
+	includeOwn bool,
+) {
+	t.Helper()
 	role, err := repositories.NewRoleRepository(nil).CreateGroupRole(
-		"mcp-test-role", "", perms, nil, nil, nil, false)
+		roleName, "", perms, categoryGrants, tagGrants, paidByGrants, includeOwn)
 	if err != nil {
 		t.Fatalf("failed to create group role: %v", err)
 	}
@@ -145,23 +163,136 @@ func addGroupMember(t *testing.T, userId uint, groupId uint, perms []string) {
 	services.ClearGroupRoleGrantCacheForTests()
 }
 
-func TestListCategoriesReturnsCategories(t *testing.T) {
-	defer repositories.TruncateTestDb()
+// setAppRole creates an app role with the given permissions and assigns it to the
+// user, so app-scoped checks (e.g. app.receipts.search, app.categories.read)
+// resolve to it.
+func setAppRole(t *testing.T, userId uint, roleName string, perms []string) {
+	t.Helper()
+	role, err := repositories.NewRoleRepository(nil).CreateAppRole(roleName, "", perms)
+	if err != nil {
+		t.Fatalf("failed to create app role: %v", err)
+	}
+	if err := repositories.GetDB().Model(&models.User{}).Where("id = ?", userId).
+		Update("app_role_id", role.ID).Error; err != nil {
+		t.Fatalf("failed to assign app role: %v", err)
+	}
+	services.ClearRolePermissionCacheForTests()
+}
 
-	user := createUser(t, "catuser")
-	repositories.CreateTestCategories()
-
-	_, out, err := handleListCategories(context.Background(), requestForUser(user.ID), emptyInput{})
+func listCategories(t *testing.T, userId uint) []models.Category {
+	t.Helper()
+	_, out, err := handleListCategories(context.Background(), requestForUser(userId), emptyInput{})
 	if err != nil {
 		t.Fatalf("handleListCategories returned error: %v", err)
 	}
-
 	categories, ok := out.([]models.Category)
 	if !ok {
 		t.Fatalf("expected []models.Category, got %T", out)
 	}
-	if len(categories) != 3 {
-		t.Errorf("expected 3 categories, got %d", len(categories))
+	return categories
+}
+
+// An app.categories.read holder (admin / category manager) sees the whole pool,
+// matching the admin-only REST global list.
+func TestListCategoriesAppReaderSeesAll(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	user := createUser(t, "catadmin")
+	repositories.CreateTestCategories()
+	setAppRole(t, user.ID, "cat-reader", []string{permissions.AppCategoriesRead})
+
+	if got := len(listCategories(t, user.ID)); got != 3 {
+		t.Errorf("expected the app reader to see all 3 categories, got %d", got)
+	}
+}
+
+// A member whose group role restricts categories sees only the granted subset.
+func TestListCategoriesRestrictedToGroupGrants(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	user := createUser(t, "catmember")
+	group := models.Group{Name: "g"}
+	if err := repositories.GetDB().Create(&group).Error; err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+	repositories.CreateTestCategories()
+	var categories []models.Category
+	if err := repositories.GetDB().Order("id asc").Find(&categories).Error; err != nil {
+		t.Fatalf("failed to load categories: %v", err)
+	}
+
+	// Grant only the first category.
+	addGroupMemberWithGrants(t, user.ID, group.ID, "cat-grant-role",
+		[]string{permissions.GroupReceiptsRead}, []uint{categories[0].ID}, nil, nil, false)
+
+	visible := listCategories(t, user.ID)
+	if len(visible) != 1 || visible[0].ID != categories[0].ID {
+		t.Errorf("expected only the granted category, got %+v", visible)
+	}
+}
+
+// A member whose group role has no category grants is unrestricted (sees all).
+func TestListCategoriesUnrestrictedGroupMemberSeesAll(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	user := createUser(t, "catunrestricted")
+	group := models.Group{Name: "g"}
+	if err := repositories.GetDB().Create(&group).Error; err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+	repositories.CreateTestCategories()
+	addGroupMember(t, user.ID, group.ID, []string{permissions.GroupReceiptsRead})
+
+	if got := len(listCategories(t, user.ID)); got != 3 {
+		t.Errorf("expected an unrestricted member to see all 3 categories, got %d", got)
+	}
+}
+
+// A user with no app read permission and no groups sees nothing — the global pool
+// is not leaked, matching the REST behavior where non-admins only get per-group
+// filtered catalogs.
+func TestListCategoriesNoAccessSeesNone(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	user := createUser(t, "catnoaccess")
+	repositories.CreateTestCategories()
+
+	if got := len(listCategories(t, user.ID)); got != 0 {
+		t.Errorf("expected a user with no grants to see 0 categories, got %d", got)
+	}
+}
+
+// list_tags is grant-filtered the same way (spot-check the restricted path).
+func TestListTagsRestrictedToGroupGrants(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	user := createUser(t, "tagmember")
+	group := models.Group{Name: "g"}
+	if err := repositories.GetDB().Create(&group).Error; err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+	allowedTag := models.Tag{Name: "allowed"}
+	hiddenTag := models.Tag{Name: "hidden"}
+	if err := repositories.GetDB().Create(&allowedTag).Error; err != nil {
+		t.Fatalf("failed to create tag: %v", err)
+	}
+	if err := repositories.GetDB().Create(&hiddenTag).Error; err != nil {
+		t.Fatalf("failed to create tag: %v", err)
+	}
+
+	addGroupMemberWithGrants(t, user.ID, group.ID, "tag-grant-role",
+		[]string{permissions.GroupReceiptsRead}, nil, []uint{allowedTag.ID}, nil, false)
+
+	_, out, err := handleListTags(context.Background(), requestForUser(user.ID), emptyInput{})
+	if err != nil {
+		t.Fatalf("handleListTags returned error: %v", err)
+	}
+	tags, ok := out.([]models.Tag)
+	if !ok {
+		t.Fatalf("expected []models.Tag, got %T", out)
+	}
+	if len(tags) != 1 || tags[0].ID != allowedTag.ID {
+		t.Errorf("expected only the granted tag, got %+v", tags)
 	}
 }
 
@@ -212,6 +343,7 @@ func TestSearchReceiptsScopesToUserGroups(t *testing.T) {
 	if err := repositories.GetDB().Create(&otherGroup).Error; err != nil {
 		t.Fatalf("failed to create other group: %v", err)
 	}
+	setAppRole(t, user.ID, "searcher-role", []string{permissions.AppReceiptsSearch})
 	addGroupMember(t, user.ID, memberGroup.ID, []string{permissions.GroupReceiptsRead})
 
 	createReceiptInGroup(t, "Coffee shop", memberGroup.ID, user.ID)
@@ -234,5 +366,135 @@ func TestSearchReceiptsScopesToUserGroups(t *testing.T) {
 		if result.GroupID != memberGroup.ID {
 			t.Errorf("search returned a receipt from group %d outside the user's groups", result.GroupID)
 		}
+	}
+}
+
+func TestGetReceiptStripsCategoriesAndTags(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	db := repositories.GetDB()
+
+	user := createUser(t, "stripuser")
+	group := models.Group{Name: "g"}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+
+	allowedCategory := models.Category{Name: "allowed-cat"}
+	hiddenCategory := models.Category{Name: "hidden-cat"}
+	allowedTag := models.Tag{Name: "allowed-tag"}
+	hiddenTag := models.Tag{Name: "hidden-tag"}
+	for _, m := range []interface{}{&allowedCategory, &hiddenCategory, &allowedTag, &hiddenTag} {
+		if err := db.Create(m).Error; err != nil {
+			t.Fatalf("failed to create fixture: %v", err)
+		}
+	}
+
+	// The role grants read plus exactly one category and one tag.
+	addGroupMemberWithGrants(t, user.ID, group.ID, "strip-role",
+		[]string{permissions.GroupReceiptsRead},
+		[]uint{allowedCategory.ID}, []uint{allowedTag.ID}, nil, false)
+
+	receipt := createReceiptInGroup(t, "lunch", group.ID, user.ID)
+	if err := db.Model(&receipt).Association("Categories").Append([]models.Category{allowedCategory, hiddenCategory}); err != nil {
+		t.Fatalf("failed to attach categories: %v", err)
+	}
+	if err := db.Model(&receipt).Association("Tags").Append([]models.Tag{allowedTag, hiddenTag}); err != nil {
+		t.Fatalf("failed to attach tags: %v", err)
+	}
+
+	_, out, err := handleGetReceipt(context.Background(), requestForUser(user.ID), getReceiptInput{Id: utils.UintToString(receipt.ID)})
+	if err != nil {
+		t.Fatalf("handleGetReceipt returned error: %v", err)
+	}
+	got, ok := out.(models.Receipt)
+	if !ok {
+		t.Fatalf("expected models.Receipt, got %T", out)
+	}
+	if len(got.Categories) != 1 || got.Categories[0].ID != allowedCategory.ID {
+		t.Errorf("expected only the granted category, got %+v", got.Categories)
+	}
+	if len(got.Tags) != 1 || got.Tags[0].ID != allowedTag.ID {
+		t.Errorf("expected only the granted tag, got %+v", got.Tags)
+	}
+}
+
+func TestGetReceiptEnforcesPaidByVisibility(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	db := repositories.GetDB()
+
+	user := createUser(t, "pbviewer")
+	allowedPayer := createUser(t, "allowedpayer")
+	hiddenPayer := createUser(t, "hiddenpayer")
+
+	group := models.Group{Name: "g"}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+	// Restrict the member to receipts paid by allowedPayer only.
+	addGroupMemberWithGrants(t, user.ID, group.ID, "pb-role",
+		[]string{permissions.GroupReceiptsRead}, nil, nil, []uint{allowedPayer.ID}, false)
+
+	allowedReceipt := createReceiptInGroup(t, "allowed", group.ID, allowedPayer.ID)
+	hiddenReceipt := createReceiptInGroup(t, "hidden", group.ID, hiddenPayer.ID)
+
+	// A receipt paid by an allowed payer is visible.
+	if _, _, err := handleGetReceipt(context.Background(), requestForUser(user.ID), getReceiptInput{Id: utils.UintToString(allowedReceipt.ID)}); err != nil {
+		t.Fatalf("expected the allowed receipt to be visible: %v", err)
+	}
+
+	// A receipt paid by a hidden payer reports the non-leaking "not found".
+	_, _, err := handleGetReceipt(context.Background(), requestForUser(user.ID), getReceiptInput{Id: utils.UintToString(hiddenReceipt.ID)})
+	if err == nil {
+		t.Fatalf("expected the paid-by-hidden receipt to be denied")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected a non-leaking 'not found' error, got %v", err)
+	}
+}
+
+func TestSearchReceiptsEnforcesPaidByVisibility(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	db := repositories.GetDB()
+
+	user := createUser(t, "pbsearcher")
+	allowedPayer := createUser(t, "spallowed")
+	hiddenPayer := createUser(t, "sphidden")
+
+	group := models.Group{Name: "g"}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+	setAppRole(t, user.ID, "pb-search-app-role", []string{permissions.AppReceiptsSearch})
+	addGroupMemberWithGrants(t, user.ID, group.ID, "pb-search-role",
+		[]string{permissions.GroupReceiptsRead}, nil, nil, []uint{allowedPayer.ID}, false)
+
+	createReceiptInGroup(t, "Coffee allowed", group.ID, allowedPayer.ID)
+	createReceiptInGroup(t, "Coffee hidden", group.ID, hiddenPayer.ID)
+
+	_, out, err := handleSearchReceipts(context.Background(), requestForUser(user.ID), searchReceiptsInput{Query: "Coffee"})
+	if err != nil {
+		t.Fatalf("handleSearchReceipts returned error: %v", err)
+	}
+	results, ok := out.([]structs.SearchResult)
+	if !ok {
+		t.Fatalf("expected []structs.SearchResult, got %T", out)
+	}
+	if len(results) != 1 || results[0].PaidByUserId != allowedPayer.ID {
+		t.Errorf("expected only the receipt paid by the allowed payer, got %+v", results)
+	}
+}
+
+func TestSearchReceiptsRequiresSearchPermission(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	// No app role -> no app.receipts.search.
+	user := createUser(t, "nosearch")
+
+	_, _, err := handleSearchReceipts(context.Background(), requestForUser(user.ID), searchReceiptsInput{Query: "anything"})
+	if err == nil {
+		t.Fatalf("expected a user without app.receipts.search to be denied")
+	}
+	if !strings.Contains(err.Error(), "unauthorized") {
+		t.Errorf("expected an 'unauthorized' error, got %v", err)
 	}
 }

--- a/api/internal/mcp/tools.go
+++ b/api/internal/mcp/tools.go
@@ -75,47 +75,20 @@ func handleSearchReceipts(ctx context.Context, req *mcpsdk.CallToolRequest, in s
 		return nil, nil, err
 	}
 
-	// Enforce the same app.receipts.search gate as handlers.Search.
-	permissionService := services.NewPermissionService(nil)
-	hasAccess, err := permissionService.HasAppPermissions(claims.UserId, permissions.AppReceiptsSearch)
-	if err != nil || !hasAccess {
-		return nil, nil, errors.New("unauthorized")
-	}
-
 	limit := in.MaxResults
 	if limit <= 0 || limit > maxSearchResults {
 		limit = maxSearchResults
 	}
 
-	// Scope to the user's groups exactly like handlers.Search, then delegate
-	// the query to the repository layer. The paid-by resolver is applied in SQL
-	// before the limit so a member restricted by paid-by visibility cannot see
-	// receipts paid by users outside their allowed set.
-	groupMemberRepository := repositories.NewGroupMemberRepository(nil)
-	groupIds, err := groupMemberRepository.GetGroupIdsByUserId(utils.UintToString(claims.UserId))
+	// Delegate to the shared enforced read so REST and MCP can't drift: it
+	// enforces app.receipts.search, scopes to the user's groups, and applies
+	// paid-by visibility in SQL before the limit.
+	results, err := services.NewReceiptService(nil).SearchReceiptsForUser(claims.UserId, in.Query, limit)
 	if err != nil {
+		if errors.Is(err, services.ErrSearchForbidden) {
+			return nil, nil, errors.New("unauthorized")
+		}
 		return nil, nil, err
-	}
-
-	receiptRepository := repositories.NewReceiptRepository(nil)
-	receipts, err := receiptRepository.SearchReceiptsByGroupIds(groupIds, in.Query, limit, permissionService.PaidByListResolver(claims.UserId))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	results := make([]structs.SearchResult, 0, len(receipts))
-	for _, receipt := range receipts {
-		results = append(results, structs.SearchResult{
-			ID:            receipt.ID,
-			GroupID:       receipt.GroupId,
-			Name:          receipt.Name,
-			Date:          receipt.Date,
-			Type:          "Receipt",
-			Amount:        receipt.Amount,
-			ReceiptStatus: receipt.Status,
-			PaidByUserId:  receipt.PaidByUserID,
-			CreatedAt:     receipt.CreatedAt,
-		})
 	}
 
 	return nil, results, nil
@@ -131,32 +104,15 @@ func handleGetReceipt(ctx context.Context, req *mcpsdk.CallToolRequest, in getRe
 		return nil, nil, errors.New("id is required")
 	}
 
-	receiptRepository := repositories.NewReceiptRepository(nil)
-	receipt, err := receiptRepository.GetFullyLoadedReceiptById(in.Id)
+	// Delegate to the shared enforced read (permission + paid-by visibility +
+	// category/tag stripping). Collapse every access failure to a non-leaking
+	// "receipt not found" so we don't disclose the existence of receipts in
+	// other users' groups.
+	receipt, err := services.NewReceiptService(nil).GetReceiptForUser(claims.UserId, in.Id)
 	if err != nil {
-		return nil, nil, errors.New("receipt not found")
-	}
-
-	// Enforce the same group.receipts.read check the REST handler relies on.
-	// Use an identical "not found" error for missing and unauthorized so we
-	// don't leak the existence of receipts in other users' groups.
-	permissionService := services.NewPermissionService(nil)
-	hasAccess, err := permissionService.HasGroupPermissions(claims.UserId, receipt.GroupId, permissions.GroupReceiptsRead)
-	if err != nil || !hasAccess {
-		return nil, nil, errors.New("receipt not found")
-	}
-
-	// Enforce paid-by visibility: a member restricted by their group role's
-	// paid-by filter must not reach a receipt hidden from them. Reuse the
-	// non-leaking "not found" error so existence isn't disclosed.
-	visible, err := permissionService.ReceiptPaidByVisible(claims.UserId, receipt.GroupId, receipt.PaidByUserID)
-	if err != nil || !visible {
-		return nil, nil, errors.New("receipt not found")
-	}
-
-	// Strip categories/tags the user's group role grants don't allow (receipt-,
-	// item-, and linked-item-level), exactly like the REST GetReceipt handler.
-	if err := permissionService.FilterReceiptCategoriesTagsForReceipt(claims.UserId, &receipt); err != nil {
+		if errors.Is(err, services.ErrReceiptAccessDenied) {
+			return nil, nil, errors.New("receipt not found")
+		}
 		return nil, nil, err
 	}
 

--- a/api/internal/mcp/tools.go
+++ b/api/internal/mcp/tools.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"errors"
+	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/permissions"
 	"receipt-wrangler/api/internal/repositories"
 	"receipt-wrangler/api/internal/services"
@@ -54,12 +55,12 @@ func registerTools(server *mcpsdk.Server) {
 
 	mcpsdk.AddTool(server, &mcpsdk.Tool{
 		Name:        "list_categories",
-		Description: "List all receipt categories available in the system.",
+		Description: "List the receipt categories available to the authenticated user (filtered by the user's group role grants).",
 	}, handleListCategories)
 
 	mcpsdk.AddTool(server, &mcpsdk.Tool{
 		Name:        "list_tags",
-		Description: "List all receipt tags available in the system.",
+		Description: "List the receipt tags available to the authenticated user (filtered by the user's group role grants).",
 	}, handleListTags)
 
 	mcpsdk.AddTool(server, &mcpsdk.Tool{
@@ -74,13 +75,22 @@ func handleSearchReceipts(ctx context.Context, req *mcpsdk.CallToolRequest, in s
 		return nil, nil, err
 	}
 
+	// Enforce the same app.receipts.search gate as handlers.Search.
+	permissionService := services.NewPermissionService(nil)
+	hasAccess, err := permissionService.HasAppPermissions(claims.UserId, permissions.AppReceiptsSearch)
+	if err != nil || !hasAccess {
+		return nil, nil, errors.New("unauthorized")
+	}
+
 	limit := in.MaxResults
 	if limit <= 0 || limit > maxSearchResults {
 		limit = maxSearchResults
 	}
 
 	// Scope to the user's groups exactly like handlers.Search, then delegate
-	// the query to the repository layer.
+	// the query to the repository layer. The paid-by resolver is applied in SQL
+	// before the limit so a member restricted by paid-by visibility cannot see
+	// receipts paid by users outside their allowed set.
 	groupMemberRepository := repositories.NewGroupMemberRepository(nil)
 	groupIds, err := groupMemberRepository.GetGroupIdsByUserId(utils.UintToString(claims.UserId))
 	if err != nil {
@@ -88,7 +98,7 @@ func handleSearchReceipts(ctx context.Context, req *mcpsdk.CallToolRequest, in s
 	}
 
 	receiptRepository := repositories.NewReceiptRepository(nil)
-	receipts, err := receiptRepository.SearchReceiptsByGroupIds(groupIds, in.Query, limit)
+	receipts, err := receiptRepository.SearchReceiptsByGroupIds(groupIds, in.Query, limit, permissionService.PaidByListResolver(claims.UserId))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -136,6 +146,20 @@ func handleGetReceipt(ctx context.Context, req *mcpsdk.CallToolRequest, in getRe
 		return nil, nil, errors.New("receipt not found")
 	}
 
+	// Enforce paid-by visibility: a member restricted by their group role's
+	// paid-by filter must not reach a receipt hidden from them. Reuse the
+	// non-leaking "not found" error so existence isn't disclosed.
+	visible, err := permissionService.ReceiptPaidByVisible(claims.UserId, receipt.GroupId, receipt.PaidByUserID)
+	if err != nil || !visible {
+		return nil, nil, errors.New("receipt not found")
+	}
+
+	// Strip categories/tags the user's group role grants don't allow (receipt-,
+	// item-, and linked-item-level), exactly like the REST GetReceipt handler.
+	if err := permissionService.FilterReceiptCategoriesTagsForReceipt(claims.UserId, &receipt); err != nil {
+		return nil, nil, err
+	}
+
 	return nil, receipt, nil
 }
 
@@ -155,31 +179,108 @@ func handleListGroups(ctx context.Context, req *mcpsdk.CallToolRequest, _ emptyI
 }
 
 func handleListCategories(ctx context.Context, req *mcpsdk.CallToolRequest, _ emptyInput) (*mcpsdk.CallToolResult, any, error) {
-	if _, err := claimsFromRequest(req); err != nil {
-		return nil, nil, err
-	}
-
-	categoryRepository := repositories.NewCategoryRepository(nil)
-	categories, err := categoryRepository.GetAllCategories("*")
+	claims, err := claimsFromRequest(req)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return nil, categories, nil
+	categories, err := repositories.NewCategoryRepository(nil).GetAllCategories("*")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	permissionService := services.NewPermissionService(nil)
+	visible, err := visibleByGrants(
+		claims.UserId,
+		categories,
+		func(category models.Category) uint { return category.ID },
+		permissions.AppCategoriesRead,
+		func(groupId uint) (map[uint]struct{}, bool, error) {
+			return permissionService.GetGroupCategoryIdsForUser(claims.UserId, groupId)
+		},
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return nil, visible, nil
 }
 
 func handleListTags(ctx context.Context, req *mcpsdk.CallToolRequest, _ emptyInput) (*mcpsdk.CallToolResult, any, error) {
-	if _, err := claimsFromRequest(req); err != nil {
-		return nil, nil, err
-	}
-
-	tagsRepository := repositories.NewTagsRepository(nil)
-	tags, err := tagsRepository.GetAllTags("*")
+	claims, err := claimsFromRequest(req)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return nil, tags, nil
+	tags, err := repositories.NewTagsRepository(nil).GetAllTags("*")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	permissionService := services.NewPermissionService(nil)
+	visible, err := visibleByGrants(
+		claims.UserId,
+		tags,
+		func(tag models.Tag) uint { return tag.ID },
+		permissions.AppTagsRead,
+		func(groupId uint) (map[uint]struct{}, bool, error) {
+			return permissionService.GetGroupTagIdsForUser(claims.UserId, groupId)
+		},
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return nil, visible, nil
+}
+
+// visibleByGrants filters a global catalog (categories or tags) to what the user
+// may actually see, mirroring how GetAppData builds the per-group catalogs.
+// Holders of the app-level read permission see the whole pool (consistent with
+// the admin-only REST global list); everyone else sees the union of their group
+// roles' grants across their groups — being unrestricted in any group means the
+// full pool, and a user with no groups or no grants sees nothing.
+func visibleByGrants[T any](
+	userId uint,
+	all []T,
+	idOf func(T) uint,
+	appReadPermission string,
+	resolve func(groupId uint) (map[uint]struct{}, bool, error),
+) ([]T, error) {
+	bypass, err := services.NewPermissionService(nil).HasAppPermissions(userId, appReadPermission)
+	if err != nil {
+		return nil, err
+	}
+	if bypass {
+		return all, nil
+	}
+
+	groupIds, err := repositories.NewGroupMemberRepository(nil).GetGroupIdsByUserId(utils.UintToString(userId))
+	if err != nil {
+		return nil, err
+	}
+
+	allowed := make(map[uint]struct{})
+	for _, groupId := range groupIds {
+		ids, unrestricted, err := resolve(groupId)
+		if err != nil {
+			return nil, err
+		}
+		if unrestricted {
+			return all, nil
+		}
+		for id := range ids {
+			allowed[id] = struct{}{}
+		}
+	}
+
+	visible := make([]T, 0, len(allowed))
+	for _, item := range all {
+		if _, ok := allowed[idOf(item)]; ok {
+			visible = append(visible, item)
+		}
+	}
+	return visible, nil
 }
 
 func handleListDashboards(ctx context.Context, req *mcpsdk.CallToolRequest, in listDashboardsInput) (*mcpsdk.CallToolResult, any, error) {

--- a/api/internal/repositories/receipts.go
+++ b/api/internal/repositories/receipts.go
@@ -918,8 +918,10 @@ func (repository ReceiptRepository) GetReceiptsByGroupIds(groupIds []string, que
 // SearchReceiptsByGroupIds returns receipts within the given groups whose name
 // matches nameQuery (a substring match; an empty nameQuery matches all),
 // ordered by most recent date first and capped at limit. Scoping to the
-// caller's group ids is the caller's responsibility.
-func (repository ReceiptRepository) SearchReceiptsByGroupIds(groupIds []uint, nameQuery string, limit int) ([]models.Receipt, error) {
+// caller's group ids is the caller's responsibility. The paidByResolver applies
+// the caller's paid-by visibility in SQL BEFORE the limit, so hidden receipts
+// can't push visible matches out of the capped result set.
+func (repository ReceiptRepository) SearchReceiptsByGroupIds(groupIds []uint, nameQuery string, limit int, paidByResolver PaidByAllowedResolver) ([]models.Receipt, error) {
 	db := repository.GetDB()
 	var receipts []models.Receipt
 
@@ -928,7 +930,12 @@ func (repository ReceiptRepository) SearchReceiptsByGroupIds(groupIds []uint, na
 		query = query.Where("name LIKE ?", "%"+nameQuery+"%")
 	}
 
-	err := query.Order("date desc").Limit(limit).Find(&receipts).Error
+	query, err := repository.ApplyPaidByDisjunction(query, groupIds, paidByResolver)
+	if err != nil {
+		return nil, err
+	}
+
+	err = query.Order("date desc").Limit(limit).Find(&receipts).Error
 	if err != nil {
 		return nil, err
 	}

--- a/api/internal/repositories/receipts.go
+++ b/api/internal/repositories/receipts.go
@@ -854,6 +854,25 @@ func (repository ReceiptRepository) GetReceiptGroupIdByReceiptId(id string) (uin
 	return receipt.GroupId, nil
 }
 
+// GetReceiptForAuthorization loads only the fields needed to authorize a receipt
+// read (id, group_id, paid_by_user_id). It uses First, so a missing row returns
+// gorm.ErrRecordNotFound — letting callers authorize (and detect not-found)
+// before paying to preload the full receipt's associations.
+func (repository ReceiptRepository) GetReceiptForAuthorization(id string) (models.Receipt, error) {
+	db := repository.GetDB()
+	var receipt models.Receipt
+
+	err := db.Model(models.Receipt{}).
+		Where("id = ?", id).
+		Select("id", "group_id", "paid_by_user_id").
+		First(&receipt).Error
+	if err != nil {
+		return models.Receipt{}, err
+	}
+
+	return receipt, nil
+}
+
 func (repository ReceiptRepository) FilterLinkedItemsFromReceiptItems(receipt *models.Receipt) {
 	if len(receipt.ReceiptItems) == 0 {
 		return

--- a/api/internal/services/receipts.go
+++ b/api/internal/services/receipts.go
@@ -53,7 +53,10 @@ func (service ReceiptService) GetReceiptForUser(userId uint, receiptId string) (
 	receiptRepository := repositories.NewReceiptRepository(service.TX)
 	permissionService := NewPermissionService(service.TX)
 
-	receipt, err := receiptRepository.GetFullyLoadedReceiptById(receiptId)
+	// Authorize on the lightweight auth fields first (this fetch uses First, so a
+	// missing row surfaces as ErrRecordNotFound). Only load the full receipt with
+	// its associations once the read is allowed.
+	authReceipt, err := receiptRepository.GetReceiptForAuthorization(receiptId)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return models.Receipt{}, ErrReceiptAccessDenied
@@ -61,7 +64,7 @@ func (service ReceiptService) GetReceiptForUser(userId uint, receiptId string) (
 		return models.Receipt{}, err
 	}
 
-	hasAccess, err := permissionService.HasGroupPermissions(userId, receipt.GroupId, permissions.GroupReceiptsRead)
+	hasAccess, err := permissionService.HasGroupPermissions(userId, authReceipt.GroupId, permissions.GroupReceiptsRead)
 	if err != nil {
 		return models.Receipt{}, err
 	}
@@ -69,12 +72,17 @@ func (service ReceiptService) GetReceiptForUser(userId uint, receiptId string) (
 		return models.Receipt{}, ErrReceiptAccessDenied
 	}
 
-	visible, err := permissionService.ReceiptPaidByVisible(userId, receipt.GroupId, receipt.PaidByUserID)
+	visible, err := permissionService.ReceiptPaidByVisible(userId, authReceipt.GroupId, authReceipt.PaidByUserID)
 	if err != nil {
 		return models.Receipt{}, err
 	}
 	if !visible {
 		return models.Receipt{}, ErrReceiptAccessDenied
+	}
+
+	receipt, err := receiptRepository.GetFullyLoadedReceiptById(receiptId)
+	if err != nil {
+		return models.Receipt{}, err
 	}
 
 	if err := permissionService.FilterReceiptCategoriesTagsForReceipt(userId, &receipt); err != nil {

--- a/api/internal/services/receipts.go
+++ b/api/internal/services/receipts.go
@@ -85,6 +85,16 @@ func (service ReceiptService) GetReceiptForUser(userId uint, receiptId string) (
 		return models.Receipt{}, err
 	}
 
+	// Guard the window between the authorization read and this full load: if the
+	// receipt's identity, group, or payer changed (or it was deleted — Find leaves
+	// a zero-value row), the prior authorization no longer applies, so deny rather
+	// than return data that was never authorized.
+	if receipt.ID != authReceipt.ID ||
+		receipt.GroupId != authReceipt.GroupId ||
+		receipt.PaidByUserID != authReceipt.PaidByUserID {
+		return models.Receipt{}, ErrReceiptAccessDenied
+	}
+
 	if err := permissionService.FilterReceiptCategoriesTagsForReceipt(userId, &receipt); err != nil {
 		return models.Receipt{}, err
 	}

--- a/api/internal/services/receipts.go
+++ b/api/internal/services/receipts.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/jinzhu/copier"
 	"gorm.io/gorm"
@@ -9,11 +10,25 @@ import (
 	"os"
 	"receipt-wrangler/api/internal/commands"
 	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/permissions"
 	"receipt-wrangler/api/internal/repositories"
 	"receipt-wrangler/api/internal/structs"
 	"receipt-wrangler/api/internal/utils"
 	"strconv"
+	"strings"
 	"time"
+)
+
+// Sentinel errors for the shared, enforced read operations. They let each ingress
+// point (REST handlers, MCP tools) map a single enforcement outcome to its own
+// transport without re-implementing the checks.
+var (
+	// ErrReceiptAccessDenied is returned when a receipt is missing, the caller
+	// lacks group.receipts.read, or the receipt is hidden by paid-by visibility.
+	// It is intentionally indistinct so callers don't leak a receipt's existence.
+	ErrReceiptAccessDenied = errors.New("receipt access denied")
+	// ErrSearchForbidden is returned when the caller lacks app.receipts.search.
+	ErrSearchForbidden = errors.New("not authorized to search receipts")
 )
 
 type ReceiptService struct {
@@ -26,6 +41,96 @@ func NewReceiptService(tx *gorm.DB) ReceiptService {
 		TX: tx,
 	}}
 	return service
+}
+
+// GetReceiptForUser is the single, shared "read one receipt" operation used by
+// both the REST handler and the MCP tool. It fetches the receipt and applies the
+// full read enforcement chain — group.receipts.read, paid-by visibility, and
+// category/tag grant stripping — so the two ingress points cannot drift. Missing,
+// forbidden, and paid-by-hidden receipts all collapse to ErrReceiptAccessDenied so
+// the caller cannot infer a receipt's existence.
+func (service ReceiptService) GetReceiptForUser(userId uint, receiptId string) (models.Receipt, error) {
+	receiptRepository := repositories.NewReceiptRepository(service.TX)
+	permissionService := NewPermissionService(service.TX)
+
+	receipt, err := receiptRepository.GetFullyLoadedReceiptById(receiptId)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return models.Receipt{}, ErrReceiptAccessDenied
+		}
+		return models.Receipt{}, err
+	}
+
+	hasAccess, err := permissionService.HasGroupPermissions(userId, receipt.GroupId, permissions.GroupReceiptsRead)
+	if err != nil {
+		return models.Receipt{}, err
+	}
+	if !hasAccess {
+		return models.Receipt{}, ErrReceiptAccessDenied
+	}
+
+	visible, err := permissionService.ReceiptPaidByVisible(userId, receipt.GroupId, receipt.PaidByUserID)
+	if err != nil {
+		return models.Receipt{}, err
+	}
+	if !visible {
+		return models.Receipt{}, ErrReceiptAccessDenied
+	}
+
+	if err := permissionService.FilterReceiptCategoriesTagsForReceipt(userId, &receipt); err != nil {
+		return models.Receipt{}, err
+	}
+
+	return receipt, nil
+}
+
+// SearchReceiptsForUser is the single, shared receipt-search operation used by both
+// the REST handler and the MCP tool. It enforces app.receipts.search, scopes to the
+// caller's groups, applies paid-by visibility in SQL before the limit, and maps to
+// SearchResult. A blank query returns no results (matching the REST search bar).
+func (service ReceiptService) SearchReceiptsForUser(userId uint, query string, limit int) ([]structs.SearchResult, error) {
+	permissionService := NewPermissionService(service.TX)
+
+	hasAccess, err := permissionService.HasAppPermissions(userId, permissions.AppReceiptsSearch)
+	if err != nil {
+		return nil, err
+	}
+	if !hasAccess {
+		return nil, ErrSearchForbidden
+	}
+
+	results := make([]structs.SearchResult, 0)
+	if len(strings.TrimSpace(query)) == 0 {
+		return results, nil
+	}
+
+	groupMemberRepository := repositories.NewGroupMemberRepository(service.TX)
+	groupIds, err := groupMemberRepository.GetGroupIdsByUserId(utils.UintToString(userId))
+	if err != nil {
+		return nil, err
+	}
+
+	receiptRepository := repositories.NewReceiptRepository(service.TX)
+	receipts, err := receiptRepository.SearchReceiptsByGroupIds(groupIds, query, limit, permissionService.PaidByListResolver(userId))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, receipt := range receipts {
+		results = append(results, structs.SearchResult{
+			ID:            receipt.ID,
+			GroupID:       receipt.GroupId,
+			Name:          receipt.Name,
+			Date:          receipt.Date,
+			Type:          "Receipt",
+			Amount:        receipt.Amount,
+			ReceiptStatus: receipt.Status,
+			PaidByUserId:  receipt.PaidByUserID,
+			CreatedAt:     receipt.CreatedAt,
+		})
+	}
+
+	return results, nil
 }
 
 func (service ReceiptService) GetReceiptByReceiptImageId(receiptImageId string) (models.Receipt, error) {

--- a/api/internal/services/receipts_test.go
+++ b/api/internal/services/receipts_test.go
@@ -1,0 +1,222 @@
+package services
+
+import (
+	"errors"
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/permissions"
+	"receipt-wrangler/api/internal/repositories"
+	"receipt-wrangler/api/internal/utils"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm/clause"
+)
+
+// seedReceipt persists a receipt (no associations) paid by the given user.
+func seedReceipt(t *testing.T, name string, groupId uint, paidByUserId uint) models.Receipt {
+	t.Helper()
+	receipt := models.Receipt{
+		Name:         name,
+		Amount:       decimal.NewFromInt(10),
+		Date:         time.Now(),
+		Status:       models.OPEN,
+		GroupId:      groupId,
+		PaidByUserID: paidByUserId,
+	}
+	if err := repositories.GetDB().Omit(clause.Associations).Create(&receipt).Error; err != nil {
+		t.Fatalf("seed receipt: %v", err)
+	}
+	return receipt
+}
+
+// seedReceiptMember creates a group, a group role with the given permissions and
+// grants, and a member assigned to it. Returns the member's user id and group id.
+func seedReceiptMember(
+	t *testing.T,
+	username string,
+	roleName string,
+	perms []string,
+	categoryGrants []uint,
+	tagGrants []uint,
+	paidByGrants []uint,
+	includeOwn bool,
+) (uint, uint) {
+	t.Helper()
+	db := repositories.GetDB()
+
+	group := models.Group{Name: "grp-" + username}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("seed group: %v", err)
+	}
+
+	role, err := repositories.NewRoleRepository(nil).CreateGroupRole(roleName, "", perms, categoryGrants, tagGrants, paidByGrants, includeOwn)
+	if err != nil {
+		t.Fatalf("seed group role: %v", err)
+	}
+
+	user := models.User{Username: username, Password: "password"}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("seed member user: %v", err)
+	}
+	member := models.GroupMember{GroupID: group.ID, UserID: user.ID, GroupRoleID: &role.ID}
+	if err := db.Create(&member).Error; err != nil {
+		t.Fatalf("seed group member: %v", err)
+	}
+
+	ClearRolePermissionCacheForTests()
+	ClearGroupRoleGrantCacheForTests()
+	return user.ID, group.ID
+}
+
+// giveAppRole assigns an app role with the given permissions to a user.
+func giveAppRole(t *testing.T, userId uint, roleName string, perms []string) {
+	t.Helper()
+	role, err := repositories.NewRoleRepository(nil).CreateAppRole(roleName, "", perms)
+	if err != nil {
+		t.Fatalf("create app role: %v", err)
+	}
+	if err := repositories.GetDB().Model(&models.User{}).Where("id = ?", userId).Update("app_role_id", role.ID).Error; err != nil {
+		t.Fatalf("assign app role: %v", err)
+	}
+	ClearRolePermissionCacheForTests()
+}
+
+func TestGetReceiptForUserReturnsReceiptForMember(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	userId, groupId := seedReceiptMember(t, "getok", "getok-role", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false)
+	receipt := seedReceipt(t, "Lunch", groupId, userId)
+
+	got, err := NewReceiptService(nil).GetReceiptForUser(userId, utils.UintToString(receipt.ID))
+	if err != nil {
+		t.Fatalf("GetReceiptForUser returned error: %v", err)
+	}
+	if got.ID != receipt.ID {
+		t.Errorf("expected receipt %d, got %d", receipt.ID, got.ID)
+	}
+}
+
+func TestGetReceiptForUserDeniesNonMember(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	ownerId, groupId := seedReceiptMember(t, "owner", "owner-role", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false)
+	receipt := seedReceipt(t, "Lunch", groupId, ownerId)
+	outsider := makeUser(t, "outsider")
+
+	_, err := NewReceiptService(nil).GetReceiptForUser(outsider, utils.UintToString(receipt.ID))
+	if !errors.Is(err, ErrReceiptAccessDenied) {
+		t.Errorf("expected ErrReceiptAccessDenied for a non-member, got %v", err)
+	}
+}
+
+func TestGetReceiptForUserDeniesPaidByHidden(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	allowedPayer := makeUser(t, "allowedpayer")
+	hiddenPayer := makeUser(t, "hiddenpayer")
+	// Restrict the member to receipts paid by allowedPayer only.
+	userId, groupId := seedReceiptMember(t, "pbviewer", "pb-role", []string{permissions.GroupReceiptsRead}, nil, nil, []uint{allowedPayer}, false)
+
+	visibleReceipt := seedReceipt(t, "allowed", groupId, allowedPayer)
+	hiddenReceipt := seedReceipt(t, "hidden", groupId, hiddenPayer)
+
+	if _, err := NewReceiptService(nil).GetReceiptForUser(userId, utils.UintToString(visibleReceipt.ID)); err != nil {
+		t.Fatalf("expected the allowed receipt to be visible: %v", err)
+	}
+	if _, err := NewReceiptService(nil).GetReceiptForUser(userId, utils.UintToString(hiddenReceipt.ID)); !errors.Is(err, ErrReceiptAccessDenied) {
+		t.Errorf("expected ErrReceiptAccessDenied for a paid-by-hidden receipt, got %v", err)
+	}
+}
+
+func TestGetReceiptForUserStripsCategoriesToGrants(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	db := repositories.GetDB()
+
+	allowed := models.Category{Name: "allowed-cat"}
+	hidden := models.Category{Name: "hidden-cat"}
+	if err := db.Create(&allowed).Error; err != nil {
+		t.Fatalf("create category: %v", err)
+	}
+	if err := db.Create(&hidden).Error; err != nil {
+		t.Fatalf("create category: %v", err)
+	}
+
+	userId, groupId := seedReceiptMember(t, "stripper", "strip-role", []string{permissions.GroupReceiptsRead}, []uint{allowed.ID}, nil, nil, false)
+	receipt := seedReceipt(t, "with-cats", groupId, userId)
+	if err := db.Model(&receipt).Association("Categories").Append([]models.Category{allowed, hidden}); err != nil {
+		t.Fatalf("attach categories: %v", err)
+	}
+
+	got, err := NewReceiptService(nil).GetReceiptForUser(userId, utils.UintToString(receipt.ID))
+	if err != nil {
+		t.Fatalf("GetReceiptForUser returned error: %v", err)
+	}
+	if len(got.Categories) != 1 || got.Categories[0].ID != allowed.ID {
+		t.Errorf("expected only the granted category, got %+v", got.Categories)
+	}
+}
+
+func TestGetReceiptForUserDeniesMissingReceipt(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	userId := makeUser(t, "any")
+	if _, err := NewReceiptService(nil).GetReceiptForUser(userId, "999999"); !errors.Is(err, ErrReceiptAccessDenied) {
+		t.Errorf("expected ErrReceiptAccessDenied for a missing receipt, got %v", err)
+	}
+}
+
+func TestSearchReceiptsForUserRequiresSearchPermission(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	userId := makeUser(t, "nosearch")
+	if _, err := NewReceiptService(nil).SearchReceiptsForUser(userId, "coffee", 100); !errors.Is(err, ErrSearchForbidden) {
+		t.Errorf("expected ErrSearchForbidden without app.receipts.search, got %v", err)
+	}
+}
+
+func TestSearchReceiptsForUserScopesAndAppliesPaidBy(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	allowedPayer := makeUser(t, "spallowed")
+	hiddenPayer := makeUser(t, "sphidden")
+	userId, groupId := seedReceiptMember(t, "spsearcher", "sp-role", []string{permissions.GroupReceiptsRead}, nil, nil, []uint{allowedPayer}, false)
+	giveAppRole(t, userId, "sp-app-role", []string{permissions.AppReceiptsSearch})
+
+	// A receipt in another group the user does not belong to must be excluded by scope.
+	otherGroup := models.Group{Name: "other"}
+	if err := repositories.GetDB().Create(&otherGroup).Error; err != nil {
+		t.Fatalf("create other group: %v", err)
+	}
+
+	seedReceipt(t, "Coffee allowed", groupId, allowedPayer)
+	seedReceipt(t, "Coffee hidden", groupId, hiddenPayer)
+	seedReceipt(t, "Coffee elsewhere", otherGroup.ID, allowedPayer)
+
+	results, err := NewReceiptService(nil).SearchReceiptsForUser(userId, "Coffee", 100)
+	if err != nil {
+		t.Fatalf("SearchReceiptsForUser returned error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected exactly 1 visible result, got %d (%+v)", len(results), results)
+	}
+	if results[0].GroupID != groupId || results[0].PaidByUserId != allowedPayer {
+		t.Errorf("expected the allowed-payer receipt in the member's group, got %+v", results[0])
+	}
+}
+
+func TestSearchReceiptsForUserBlankQueryReturnsEmpty(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	userId, groupId := seedReceiptMember(t, "blank", "blank-role", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false)
+	giveAppRole(t, userId, "blank-app-role", []string{permissions.AppReceiptsSearch})
+	seedReceipt(t, "Coffee", groupId, userId)
+
+	results, err := NewReceiptService(nil).SearchReceiptsForUser(userId, "   ", 100)
+	if err != nil {
+		t.Fatalf("SearchReceiptsForUser returned error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected a blank query to return no results, got %d", len(results))
+	}
+}

--- a/api/internal/services/receipts_test.go
+++ b/api/internal/services/receipts_test.go
@@ -110,6 +110,20 @@ func TestGetReceiptForUserDeniesNonMember(t *testing.T) {
 	}
 }
 
+func TestGetReceiptForUserDeniesMemberWithoutReadPermission(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	// A member whose group role lacks group.receipts.read is denied — proving the
+	// permission gate is enforced independently of group membership.
+	userId, groupId := seedReceiptMember(t, "noread", "noread-role", []string{}, nil, nil, nil, false)
+	receipt := seedReceipt(t, "Lunch", groupId, userId)
+
+	_, err := NewReceiptService(nil).GetReceiptForUser(userId, utils.UintToString(receipt.ID))
+	if !errors.Is(err, ErrReceiptAccessDenied) {
+		t.Errorf("expected ErrReceiptAccessDenied for a member without group.receipts.read, got %v", err)
+	}
+}
+
 func TestGetReceiptForUserDeniesPaidByHidden(t *testing.T) {
 	defer repositories.TruncateTestDb()
 
@@ -129,31 +143,40 @@ func TestGetReceiptForUserDeniesPaidByHidden(t *testing.T) {
 	}
 }
 
-func TestGetReceiptForUserStripsCategoriesToGrants(t *testing.T) {
+func TestGetReceiptForUserStripsCategoriesAndTagsToGrants(t *testing.T) {
 	defer repositories.TruncateTestDb()
 	db := repositories.GetDB()
 
-	allowed := models.Category{Name: "allowed-cat"}
-	hidden := models.Category{Name: "hidden-cat"}
-	if err := db.Create(&allowed).Error; err != nil {
-		t.Fatalf("create category: %v", err)
-	}
-	if err := db.Create(&hidden).Error; err != nil {
-		t.Fatalf("create category: %v", err)
+	allowedCategory := models.Category{Name: "allowed-cat"}
+	hiddenCategory := models.Category{Name: "hidden-cat"}
+	allowedTag := models.Tag{Name: "allowed-tag"}
+	hiddenTag := models.Tag{Name: "hidden-tag"}
+	for _, m := range []interface{}{&allowedCategory, &hiddenCategory, &allowedTag, &hiddenTag} {
+		if err := db.Create(m).Error; err != nil {
+			t.Fatalf("create fixture: %v", err)
+		}
 	}
 
-	userId, groupId := seedReceiptMember(t, "stripper", "strip-role", []string{permissions.GroupReceiptsRead}, []uint{allowed.ID}, nil, nil, false)
-	receipt := seedReceipt(t, "with-cats", groupId, userId)
-	if err := db.Model(&receipt).Association("Categories").Append([]models.Category{allowed, hidden}); err != nil {
+	// The role grants read plus exactly one category and one tag.
+	userId, groupId := seedReceiptMember(t, "stripper", "strip-role",
+		[]string{permissions.GroupReceiptsRead}, []uint{allowedCategory.ID}, []uint{allowedTag.ID}, nil, false)
+	receipt := seedReceipt(t, "with-cats-and-tags", groupId, userId)
+	if err := db.Model(&receipt).Association("Categories").Append([]models.Category{allowedCategory, hiddenCategory}); err != nil {
 		t.Fatalf("attach categories: %v", err)
+	}
+	if err := db.Model(&receipt).Association("Tags").Append([]models.Tag{allowedTag, hiddenTag}); err != nil {
+		t.Fatalf("attach tags: %v", err)
 	}
 
 	got, err := NewReceiptService(nil).GetReceiptForUser(userId, utils.UintToString(receipt.ID))
 	if err != nil {
 		t.Fatalf("GetReceiptForUser returned error: %v", err)
 	}
-	if len(got.Categories) != 1 || got.Categories[0].ID != allowed.ID {
+	if len(got.Categories) != 1 || got.Categories[0].ID != allowedCategory.ID {
 		t.Errorf("expected only the granted category, got %+v", got.Categories)
+	}
+	if len(got.Tags) != 1 || got.Tags[0].ID != allowedTag.ID {
+		t.Errorf("expected only the granted tag, got %+v", got.Tags)
 	}
 }
 


### PR DESCRIPTION
Two related commits on one branch (no stacking).

## 1. Enforce RBAC grants + paid-by visibility in the MCP read tools

The native MCP tools (`internal/mcp/tools.go`) bypass the REST `HandleRequest` chokepoint and were skipping enforcement the REST layer applies, so any authenticated MCP user could see data their group role should hide:

- `list_categories` / `list_tags` returned the **entire global pool** → now return the caller's grant-visible catalog (full pool only for `app.categories.read` / `app.tags.read` holders, else the union of their group roles' grants).
- `get_receipt` returned categories/tags **unfiltered** and ignored **paid-by visibility** → now strips to the caller's grants and denies (non-leaking "receipt not found") paid-by-hidden receipts.
- `search_receipts` had no `app.receipts.search` gate and no **paid-by** filtering → now enforces both (paid-by applied in SQL before the limit).

`list_groups` / `list_dashboards` already enforced correctly.

## 2. Unify the enforcement so REST and MCP can't drift again

The drift above happened because the REST handlers and MCP tools each independently orchestrated the same chain. `ReceiptService` is now the **single source of truth** for the two reads that have both a REST and an MCP entry point:

- **`GetReceiptForUser(userId, id)`** — fetch → `group.receipts.read` → `ReceiptPaidByVisible` → `FilterReceiptCategoriesTagsForReceipt`; returns `ErrReceiptAccessDenied` (non-leaking) for missing/forbidden/hidden.
- **`SearchReceiptsForUser(userId, query, limit)`** — `app.receipts.search` → group scope → paid-by disjunction in SQL before the limit → `SearchResult` mapping; returns `ErrSearchForbidden`; blank query → empty.

REST `GetReceipt`/`Search` and MCP `get_receipt`/`search_receipts` are now thin adapters that call these and map the sentinel errors to their transport (MCP "not found"/"unauthorized"; REST 403). The two REST handlers drop their declarative `HandleRequest` permission/`ReceiptId` gates so enforcement lives in exactly one place; every other endpoint keeps `HandleRequest` unchanged. No new enforcement logic, no swagger/client changes.

## Behavior

Preserved: REST status codes (403 on denied/hidden/missing), search results, MCP non-leaking errors. **One intentional change:** a blank search query now returns no results on both surfaces (REST already did; the MCP tool previously returned everything).

## Testing

- `go build ./...` clean.
- New MCP enforcement tests + new `internal/services/receipts_test.go` (GetReceiptForUser: member success, non-member denied, paid-by hidden, category stripping, missing id; SearchReceiptsForUser: permission required, scope + paid-by exclusion, blank query).
- Full `go test ./...` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Category and tag lists now only display items visible to the signed-in user based on their grants.
  * Receipt search and receipt details apply enhanced visibility rules, including “paid by” access and category/tag grant filtering.

* **Bug Fixes**
  * Unauthorized or “paid-by-hidden” receipts are no longer leaked; access-denied returns a generic “not found” response, and search returns “unauthorized” when permission is missing.
  * Receipt details omit categories and tags the user can’t view.
  * Receipt search consistently requires the search permission and returns no results for empty/whitespace-only queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->