### PR TITLE
refactor(api): unify receipt read enforcement across REST and MCP

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -580,16 +580,22 @@ Claude can read a user's data. It is **off by default** and Go-native (no separa
 - **Packages**: `internal/oauth/` (authorization server) and `internal/mcp/`
   (server + read-only tools). Tools call the service/repository layer in-process with the
   authenticated user's claims and enforce the same authorization as the REST handlers — not just
-  group-scope but also the category/tag grants and paid-by visibility (the tools don't pass through
-  `HandleRequest`, so each replicates the enforcement explicitly via `PermissionService`). v1 tools
-  are read-only: `search_receipts`, `get_receipt`, `list_groups`, `list_categories`, `list_tags`,
-  `list_dashboards`. Specifically (`internal/mcp/tools.go`): `list_categories`/`list_tags` return the
-  caller's grant-visible catalog (the full pool only for `app.categories.read`/`app.tags.read`
-  holders, else the union of their group roles' grants — `visibleByGrants`); `get_receipt` checks
-  `group.receipts.read`, then `ReceiptPaidByVisible` (non-leaking "not found" when hidden), then strips
-  categories/tags via `FilterReceiptCategoriesTagsForReceipt`; `search_receipts` requires
-  `app.receipts.search` and applies the paid-by disjunction in SQL before the limit (the MCP-only
-  `ReceiptRepository.SearchReceiptsByGroupIds` takes a `PaidByAllowedResolver`).
+  group-scope but also the category/tag grants and paid-by visibility. The tools don't pass through
+  `HandleRequest`, so for the two operations that have a REST twin the enforcement is **shared via
+  `ReceiptService`** (the single source of truth, so the two ingress points can't drift):
+  `get_receipt` and the REST `GetReceipt` handler both call
+  `ReceiptService.GetReceiptForUser(userId, id)` (fetch → `group.receipts.read` →
+  `ReceiptPaidByVisible` → `FilterReceiptCategoriesTagsForReceipt`, returning `ErrReceiptAccessDenied`
+  on any miss/deny — mapped to a non-leaking MCP "receipt not found" / REST 403); `search_receipts`
+  and the REST `Search` handler both call `ReceiptService.SearchReceiptsForUser(userId, query, limit)`
+  (`app.receipts.search` → group scope → paid-by disjunction in SQL before the limit → `SearchResult`
+  mapping; `ErrSearchForbidden` → MCP "unauthorized" / REST 403; blank query → empty). These two REST
+  handlers therefore intentionally omit the declarative `HandleRequest` permission/`ReceiptId` gates —
+  enforcement lives once, in the service. v1 tools are read-only: `search_receipts`, `get_receipt`,
+  `list_groups`, `list_categories`, `list_tags`, `list_dashboards`. `list_categories`/`list_tags` have
+  no REST twin and stay MCP-local in `tools.go`: they return the caller's grant-visible catalog (the
+  full pool only for `app.categories.read`/`app.tags.read` holders, else the union of their group
+  roles' grants — `visibleByGrants`).
 - **Storage**: `models.OAuthClient` + `models.OAuthAuthorizationCode` (registered in
   `MakeMigrations`). Refresh tokens reuse the existing `models.RefreshToken` flow.
 - **Production**: `docker/default.conf` proxies the new root paths to the backend; the `/mcp`

--- a/api/internal/handlers/receipts.go
+++ b/api/internal/handlers/receipts.go
@@ -299,27 +299,24 @@ func QuickScan(w http.ResponseWriter, r *http.Request) {
 
 // TODO: move to repository call
 func GetReceipt(w http.ResponseWriter, r *http.Request) {
-	receiptId := chi.URLParam(r, "id")
-
 	handler := structs.Handler{
-		ErrorMessage:     "Error retrieving receipt.",
-		Writer:           w,
-		Request:          r,
-		ReceiptId:        receiptId,
-		GroupPermissions: []string{permissions.GroupReceiptsRead},
-		ResponseType:     constants.ApplicationJson,
+		ErrorMessage: "Error retrieving receipt.",
+		Writer:       w,
+		Request:      r,
+		ResponseType: constants.ApplicationJson,
+		// Enforcement (group.receipts.read, paid-by visibility, category/tag
+		// stripping) lives in ReceiptService.GetReceiptForUser — the single shared
+		// path also used by the MCP get_receipt tool — so the declarative gates are
+		// intentionally omitted here to avoid two sources of truth.
 		HandlerFunction: func(w http.ResponseWriter, r *http.Request) (int, error) {
 			id := chi.URLParam(r, "id")
 			token := structs.GetClaims(r)
-			receiptRepository := repositories.NewReceiptRepository(nil)
 
-			receipt, err := receiptRepository.GetFullyLoadedReceiptById(id)
+			receipt, err := services.NewReceiptService(nil).GetReceiptForUser(token.UserId, id)
 			if err != nil {
-				return http.StatusInternalServerError, err
-			}
-
-			err = services.NewPermissionService(nil).FilterReceiptCategoriesTagsForReceipt(token.UserId, &receipt)
-			if err != nil {
+				if errors.Is(err, services.ErrReceiptAccessDenied) {
+					return http.StatusForbidden, err
+				}
 				return http.StatusInternalServerError, err
 			}
 

--- a/api/internal/handlers/search.go
+++ b/api/internal/handlers/search.go
@@ -1,92 +1,47 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 	"receipt-wrangler/api/internal/constants"
-	"receipt-wrangler/api/internal/models"
-	"receipt-wrangler/api/internal/permissions"
-	"receipt-wrangler/api/internal/repositories"
 	"receipt-wrangler/api/internal/services"
 	"receipt-wrangler/api/internal/structs"
 	"receipt-wrangler/api/internal/utils"
 )
 
+// searchResultLimit caps how many receipts a REST search returns (unchanged from
+// the previous inline limit).
+const searchResultLimit = 100
+
 func Search(w http.ResponseWriter, r *http.Request) {
 	handler := structs.Handler{
-		ErrorMessage:   "Error searching",
-		Writer:         w,
-		Request:        r,
-		AppPermissions: []string{permissions.AppReceiptsSearch},
-		ResponseType:   constants.ApplicationJson,
+		ErrorMessage: "Error searching",
+		Writer:       w,
+		Request:      r,
+		ResponseType: constants.ApplicationJson,
+		// Enforcement (app.receipts.search, group scope, paid-by visibility) lives in
+		// ReceiptService.SearchReceiptsForUser — the single shared path also used by
+		// the MCP search_receipts tool — so the declarative gate is intentionally
+		// omitted here to avoid two sources of truth.
 		HandlerFunction: func(w http.ResponseWriter, r *http.Request) (int, error) {
+			token := structs.GetClaims(r)
 			searchTerm := r.URL.Query().Get("searchTerm")
 
-			if len(searchTerm) > 0 {
-				searchTerm = "%" + searchTerm + "%"
-
-				db := repositories.GetDB()
-				var receipts []models.Receipt
-
-				results := make([]structs.SearchResult, 0)
-
-				token := structs.GetClaims(r)
-				groupMemberRepository := repositories.NewGroupMemberRepository(nil)
-				groupIds, err := groupMemberRepository.GetGroupIdsByUserId(utils.UintToString(token.UserId))
-				if err != nil {
-					return http.StatusInternalServerError, err
+			results, err := services.NewReceiptService(nil).SearchReceiptsForUser(token.UserId, searchTerm, searchResultLimit)
+			if err != nil {
+				if errors.Is(err, services.ErrSearchForbidden) {
+					return http.StatusForbidden, err
 				}
-
-				query := db.Table("receipts").Where("group_id IN ? AND name LIKE ?", groupIds, searchTerm)
-
-				// Apply the caller's paid-by visibility in SQL BEFORE the limit —
-				// SearchResult exposes paidByUserId, and a post-fetch filter would drop
-				// visible matches whenever hidden receipts fill the first 100 rows.
-				receiptRepository := repositories.NewReceiptRepository(nil)
-				query, err = receiptRepository.ApplyPaidByDisjunction(
-					query,
-					groupIds,
-					services.NewPermissionService(nil).PaidByListResolver(token.UserId),
-				)
-				if err != nil {
-					return http.StatusInternalServerError, err
-				}
-
-				err = query.Limit(100).Order("date desc").Find(&receipts).Error
-				if err != nil {
-					return http.StatusInternalServerError, err
-				}
-
-				for _, receipt := range receipts {
-					results = append(results, structs.SearchResult{
-						ID:            receipt.ID,
-						GroupID:       receipt.GroupId,
-						Name:          receipt.Name,
-						Date:          receipt.Date,
-						Type:          "Receipt",
-						Amount:        receipt.Amount,
-						ReceiptStatus: receipt.Status,
-						PaidByUserId:  receipt.PaidByUserID,
-						CreatedAt:     receipt.CreatedAt,
-					})
-				}
-
-				bytes, err := utils.MarshalResponseData(results)
-				if err != nil {
-					return http.StatusInternalServerError, err
-				}
-
-				w.WriteHeader(200)
-				w.Write(bytes)
-			} else {
-				results := make([]structs.SearchResult, 0)
-				bytes, err := utils.MarshalResponseData(results)
-				if err != nil {
-					return http.StatusInternalServerError, err
-				}
-
-				w.WriteHeader(200)
-				w.Write(bytes)
+				return http.StatusInternalServerError, err
 			}
+
+			bytes, err := utils.MarshalResponseData(results)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			w.WriteHeader(200)
+			w.Write(bytes)
 
 			return 0, nil
 		},

--- a/api/internal/mcp/tools.go
+++ b/api/internal/mcp/tools.go
@@ -75,47 +75,20 @@ func handleSearchReceipts(ctx context.Context, req *mcpsdk.CallToolRequest, in s
 		return nil, nil, err
 	}
 
-	// Enforce the same app.receipts.search gate as handlers.Search.
-	permissionService := services.NewPermissionService(nil)
-	hasAccess, err := permissionService.HasAppPermissions(claims.UserId, permissions.AppReceiptsSearch)
-	if err != nil || !hasAccess {
-		return nil, nil, errors.New("unauthorized")
-	}
-
 	limit := in.MaxResults
 	if limit <= 0 || limit > maxSearchResults {
 		limit = maxSearchResults
 	}
 
-	// Scope to the user's groups exactly like handlers.Search, then delegate
-	// the query to the repository layer. The paid-by resolver is applied in SQL
-	// before the limit so a member restricted by paid-by visibility cannot see
-	// receipts paid by users outside their allowed set.
-	groupMemberRepository := repositories.NewGroupMemberRepository(nil)
-	groupIds, err := groupMemberRepository.GetGroupIdsByUserId(utils.UintToString(claims.UserId))
+	// Delegate to the shared enforced read so REST and MCP can't drift: it
+	// enforces app.receipts.search, scopes to the user's groups, and applies
+	// paid-by visibility in SQL before the limit.
+	results, err := services.NewReceiptService(nil).SearchReceiptsForUser(claims.UserId, in.Query, limit)
 	if err != nil {
+		if errors.Is(err, services.ErrSearchForbidden) {
+			return nil, nil, errors.New("unauthorized")
+		}
 		return nil, nil, err
-	}
-
-	receiptRepository := repositories.NewReceiptRepository(nil)
-	receipts, err := receiptRepository.SearchReceiptsByGroupIds(groupIds, in.Query, limit, permissionService.PaidByListResolver(claims.UserId))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	results := make([]structs.SearchResult, 0, len(receipts))
-	for _, receipt := range receipts {
-		results = append(results, structs.SearchResult{
-			ID:            receipt.ID,
-			GroupID:       receipt.GroupId,
-			Name:          receipt.Name,
-			Date:          receipt.Date,
-			Type:          "Receipt",
-			Amount:        receipt.Amount,
-			ReceiptStatus: receipt.Status,
-			PaidByUserId:  receipt.PaidByUserID,
-			CreatedAt:     receipt.CreatedAt,
-		})
 	}
 
 	return nil, results, nil
@@ -131,32 +104,15 @@ func handleGetReceipt(ctx context.Context, req *mcpsdk.CallToolRequest, in getRe
 		return nil, nil, errors.New("id is required")
 	}
 
-	receiptRepository := repositories.NewReceiptRepository(nil)
-	receipt, err := receiptRepository.GetFullyLoadedReceiptById(in.Id)
+	// Delegate to the shared enforced read (permission + paid-by visibility +
+	// category/tag stripping). Collapse every access failure to a non-leaking
+	// "receipt not found" so we don't disclose the existence of receipts in
+	// other users' groups.
+	receipt, err := services.NewReceiptService(nil).GetReceiptForUser(claims.UserId, in.Id)
 	if err != nil {
-		return nil, nil, errors.New("receipt not found")
-	}
-
-	// Enforce the same group.receipts.read check the REST handler relies on.
-	// Use an identical "not found" error for missing and unauthorized so we
-	// don't leak the existence of receipts in other users' groups.
-	permissionService := services.NewPermissionService(nil)
-	hasAccess, err := permissionService.HasGroupPermissions(claims.UserId, receipt.GroupId, permissions.GroupReceiptsRead)
-	if err != nil || !hasAccess {
-		return nil, nil, errors.New("receipt not found")
-	}
-
-	// Enforce paid-by visibility: a member restricted by their group role's
-	// paid-by filter must not reach a receipt hidden from them. Reuse the
-	// non-leaking "not found" error so existence isn't disclosed.
-	visible, err := permissionService.ReceiptPaidByVisible(claims.UserId, receipt.GroupId, receipt.PaidByUserID)
-	if err != nil || !visible {
-		return nil, nil, errors.New("receipt not found")
-	}
-
-	// Strip categories/tags the user's group role grants don't allow (receipt-,
-	// item-, and linked-item-level), exactly like the REST GetReceipt handler.
-	if err := permissionService.FilterReceiptCategoriesTagsForReceipt(claims.UserId, &receipt); err != nil {
+		if errors.Is(err, services.ErrReceiptAccessDenied) {
+			return nil, nil, errors.New("receipt not found")
+		}
 		return nil, nil, err
 	}
 

--- a/api/internal/services/receipts.go
+++ b/api/internal/services/receipts.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/jinzhu/copier"
 	"gorm.io/gorm"
@@ -9,11 +10,25 @@ import (
 	"os"
 	"receipt-wrangler/api/internal/commands"
 	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/permissions"
 	"receipt-wrangler/api/internal/repositories"
 	"receipt-wrangler/api/internal/structs"
 	"receipt-wrangler/api/internal/utils"
 	"strconv"
+	"strings"
 	"time"
+)
+
+// Sentinel errors for the shared, enforced read operations. They let each ingress
+// point (REST handlers, MCP tools) map a single enforcement outcome to its own
+// transport without re-implementing the checks.
+var (
+	// ErrReceiptAccessDenied is returned when a receipt is missing, the caller
+	// lacks group.receipts.read, or the receipt is hidden by paid-by visibility.
+	// It is intentionally indistinct so callers don't leak a receipt's existence.
+	ErrReceiptAccessDenied = errors.New("receipt access denied")
+	// ErrSearchForbidden is returned when the caller lacks app.receipts.search.
+	ErrSearchForbidden = errors.New("not authorized to search receipts")
 )
 
 type ReceiptService struct {
@@ -26,6 +41,96 @@ func NewReceiptService(tx *gorm.DB) ReceiptService {
 		TX: tx,
 	}}
 	return service
+}
+
+// GetReceiptForUser is the single, shared "read one receipt" operation used by
+// both the REST handler and the MCP tool. It fetches the receipt and applies the
+// full read enforcement chain — group.receipts.read, paid-by visibility, and
+// category/tag grant stripping — so the two ingress points cannot drift. Missing,
+// forbidden, and paid-by-hidden receipts all collapse to ErrReceiptAccessDenied so
+// the caller cannot infer a receipt's existence.
+func (service ReceiptService) GetReceiptForUser(userId uint, receiptId string) (models.Receipt, error) {
+	receiptRepository := repositories.NewReceiptRepository(service.TX)
+	permissionService := NewPermissionService(service.TX)
+
+	receipt, err := receiptRepository.GetFullyLoadedReceiptById(receiptId)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return models.Receipt{}, ErrReceiptAccessDenied
+		}
+		return models.Receipt{}, err
+	}
+
+	hasAccess, err := permissionService.HasGroupPermissions(userId, receipt.GroupId, permissions.GroupReceiptsRead)
+	if err != nil {
+		return models.Receipt{}, err
+	}
+	if !hasAccess {
+		return models.Receipt{}, ErrReceiptAccessDenied
+	}
+
+	visible, err := permissionService.ReceiptPaidByVisible(userId, receipt.GroupId, receipt.PaidByUserID)
+	if err != nil {
+		return models.Receipt{}, err
+	}
+	if !visible {
+		return models.Receipt{}, ErrReceiptAccessDenied
+	}
+
+	if err := permissionService.FilterReceiptCategoriesTagsForReceipt(userId, &receipt); err != nil {
+		return models.Receipt{}, err
+	}
+
+	return receipt, nil
+}
+
+// SearchReceiptsForUser is the single, shared receipt-search operation used by both
+// the REST handler and the MCP tool. It enforces app.receipts.search, scopes to the
+// caller's groups, applies paid-by visibility in SQL before the limit, and maps to
+// SearchResult. A blank query returns no results (matching the REST search bar).
+func (service ReceiptService) SearchReceiptsForUser(userId uint, query string, limit int) ([]structs.SearchResult, error) {
+	permissionService := NewPermissionService(service.TX)
+
+	hasAccess, err := permissionService.HasAppPermissions(userId, permissions.AppReceiptsSearch)
+	if err != nil {
+		return nil, err
+	}
+	if !hasAccess {
+		return nil, ErrSearchForbidden
+	}
+
+	results := make([]structs.SearchResult, 0)
+	if len(strings.TrimSpace(query)) == 0 {
+		return results, nil
+	}
+
+	groupMemberRepository := repositories.NewGroupMemberRepository(service.TX)
+	groupIds, err := groupMemberRepository.GetGroupIdsByUserId(utils.UintToString(userId))
+	if err != nil {
+		return nil, err
+	}
+
+	receiptRepository := repositories.NewReceiptRepository(service.TX)
+	receipts, err := receiptRepository.SearchReceiptsByGroupIds(groupIds, query, limit, permissionService.PaidByListResolver(userId))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, receipt := range receipts {
+		results = append(results, structs.SearchResult{
+			ID:            receipt.ID,
+			GroupID:       receipt.GroupId,
+			Name:          receipt.Name,
+			Date:          receipt.Date,
+			Type:          "Receipt",
+			Amount:        receipt.Amount,
+			ReceiptStatus: receipt.Status,
+			PaidByUserId:  receipt.PaidByUserID,
+			CreatedAt:     receipt.CreatedAt,
+		})
+	}
+
+	return results, nil
 }
 
 func (service ReceiptService) GetReceiptByReceiptImageId(receiptImageId string) (models.Receipt, error) {

--- a/api/internal/services/receipts_test.go
+++ b/api/internal/services/receipts_test.go
@@ -1,0 +1,222 @@
+package services
+
+import (
+	"errors"
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/permissions"
+	"receipt-wrangler/api/internal/repositories"
+	"receipt-wrangler/api/internal/utils"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm/clause"
+)
+
+// seedReceipt persists a receipt (no associations) paid by the given user.
+func seedReceipt(t *testing.T, name string, groupId uint, paidByUserId uint) models.Receipt {
+	t.Helper()
+	receipt := models.Receipt{
+		Name:         name,
+		Amount:       decimal.NewFromInt(10),
+		Date:         time.Now(),
+		Status:       models.OPEN,
+		GroupId:      groupId,
+		PaidByUserID: paidByUserId,
+	}
+	if err := repositories.GetDB().Omit(clause.Associations).Create(&receipt).Error; err != nil {
+		t.Fatalf("seed receipt: %v", err)
+	}
+	return receipt
+}
+
+// seedReceiptMember creates a group, a group role with the given permissions and
+// grants, and a member assigned to it. Returns the member's user id and group id.
+func seedReceiptMember(
+	t *testing.T,
+	username string,
+	roleName string,
+	perms []string,
+	categoryGrants []uint,
+	tagGrants []uint,
+	paidByGrants []uint,
+	includeOwn bool,
+) (uint, uint) {
+	t.Helper()
+	db := repositories.GetDB()
+
+	group := models.Group{Name: "grp-" + username}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("seed group: %v", err)
+	}
+
+	role, err := repositories.NewRoleRepository(nil).CreateGroupRole(roleName, "", perms, categoryGrants, tagGrants, paidByGrants, includeOwn)
+	if err != nil {
+		t.Fatalf("seed group role: %v", err)
+	}
+
+	user := models.User{Username: username, Password: "password"}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("seed member user: %v", err)
+	}
+	member := models.GroupMember{GroupID: group.ID, UserID: user.ID, GroupRoleID: &role.ID}
+	if err := db.Create(&member).Error; err != nil {
+		t.Fatalf("seed group member: %v", err)
+	}
+
+	ClearRolePermissionCacheForTests()
+	ClearGroupRoleGrantCacheForTests()
+	return user.ID, group.ID
+}
+
+// giveAppRole assigns an app role with the given permissions to a user.
+func giveAppRole(t *testing.T, userId uint, roleName string, perms []string) {
+	t.Helper()
+	role, err := repositories.NewRoleRepository(nil).CreateAppRole(roleName, "", perms)
+	if err != nil {
+		t.Fatalf("create app role: %v", err)
+	}
+	if err := repositories.GetDB().Model(&models.User{}).Where("id = ?", userId).Update("app_role_id", role.ID).Error; err != nil {
+		t.Fatalf("assign app role: %v", err)
+	}
+	ClearRolePermissionCacheForTests()
+}
+
+func TestGetReceiptForUserReturnsReceiptForMember(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	userId, groupId := seedReceiptMember(t, "getok", "getok-role", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false)
+	receipt := seedReceipt(t, "Lunch", groupId, userId)
+
+	got, err := NewReceiptService(nil).GetReceiptForUser(userId, utils.UintToString(receipt.ID))
+	if err != nil {
+		t.Fatalf("GetReceiptForUser returned error: %v", err)
+	}
+	if got.ID != receipt.ID {
+		t.Errorf("expected receipt %d, got %d", receipt.ID, got.ID)
+	}
+}
+
+func TestGetReceiptForUserDeniesNonMember(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	ownerId, groupId := seedReceiptMember(t, "owner", "owner-role", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false)
+	receipt := seedReceipt(t, "Lunch", groupId, ownerId)
+	outsider := makeUser(t, "outsider")
+
+	_, err := NewReceiptService(nil).GetReceiptForUser(outsider, utils.UintToString(receipt.ID))
+	if !errors.Is(err, ErrReceiptAccessDenied) {
+		t.Errorf("expected ErrReceiptAccessDenied for a non-member, got %v", err)
+	}
+}
+
+func TestGetReceiptForUserDeniesPaidByHidden(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	allowedPayer := makeUser(t, "allowedpayer")
+	hiddenPayer := makeUser(t, "hiddenpayer")
+	// Restrict the member to receipts paid by allowedPayer only.
+	userId, groupId := seedReceiptMember(t, "pbviewer", "pb-role", []string{permissions.GroupReceiptsRead}, nil, nil, []uint{allowedPayer}, false)
+
+	visibleReceipt := seedReceipt(t, "allowed", groupId, allowedPayer)
+	hiddenReceipt := seedReceipt(t, "hidden", groupId, hiddenPayer)
+
+	if _, err := NewReceiptService(nil).GetReceiptForUser(userId, utils.UintToString(visibleReceipt.ID)); err != nil {
+		t.Fatalf("expected the allowed receipt to be visible: %v", err)
+	}
+	if _, err := NewReceiptService(nil).GetReceiptForUser(userId, utils.UintToString(hiddenReceipt.ID)); !errors.Is(err, ErrReceiptAccessDenied) {
+		t.Errorf("expected ErrReceiptAccessDenied for a paid-by-hidden receipt, got %v", err)
+	}
+}
+
+func TestGetReceiptForUserStripsCategoriesToGrants(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	db := repositories.GetDB()
+
+	allowed := models.Category{Name: "allowed-cat"}
+	hidden := models.Category{Name: "hidden-cat"}
+	if err := db.Create(&allowed).Error; err != nil {
+		t.Fatalf("create category: %v", err)
+	}
+	if err := db.Create(&hidden).Error; err != nil {
+		t.Fatalf("create category: %v", err)
+	}
+
+	userId, groupId := seedReceiptMember(t, "stripper", "strip-role", []string{permissions.GroupReceiptsRead}, []uint{allowed.ID}, nil, nil, false)
+	receipt := seedReceipt(t, "with-cats", groupId, userId)
+	if err := db.Model(&receipt).Association("Categories").Append([]models.Category{allowed, hidden}); err != nil {
+		t.Fatalf("attach categories: %v", err)
+	}
+
+	got, err := NewReceiptService(nil).GetReceiptForUser(userId, utils.UintToString(receipt.ID))
+	if err != nil {
+		t.Fatalf("GetReceiptForUser returned error: %v", err)
+	}
+	if len(got.Categories) != 1 || got.Categories[0].ID != allowed.ID {
+		t.Errorf("expected only the granted category, got %+v", got.Categories)
+	}
+}
+
+func TestGetReceiptForUserDeniesMissingReceipt(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	userId := makeUser(t, "any")
+	if _, err := NewReceiptService(nil).GetReceiptForUser(userId, "999999"); !errors.Is(err, ErrReceiptAccessDenied) {
+		t.Errorf("expected ErrReceiptAccessDenied for a missing receipt, got %v", err)
+	}
+}
+
+func TestSearchReceiptsForUserRequiresSearchPermission(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	userId := makeUser(t, "nosearch")
+	if _, err := NewReceiptService(nil).SearchReceiptsForUser(userId, "coffee", 100); !errors.Is(err, ErrSearchForbidden) {
+		t.Errorf("expected ErrSearchForbidden without app.receipts.search, got %v", err)
+	}
+}
+
+func TestSearchReceiptsForUserScopesAndAppliesPaidBy(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	allowedPayer := makeUser(t, "spallowed")
+	hiddenPayer := makeUser(t, "sphidden")
+	userId, groupId := seedReceiptMember(t, "spsearcher", "sp-role", []string{permissions.GroupReceiptsRead}, nil, nil, []uint{allowedPayer}, false)
+	giveAppRole(t, userId, "sp-app-role", []string{permissions.AppReceiptsSearch})
+
+	// A receipt in another group the user does not belong to must be excluded by scope.
+	otherGroup := models.Group{Name: "other"}
+	if err := repositories.GetDB().Create(&otherGroup).Error; err != nil {
+		t.Fatalf("create other group: %v", err)
+	}
+
+	seedReceipt(t, "Coffee allowed", groupId, allowedPayer)
+	seedReceipt(t, "Coffee hidden", groupId, hiddenPayer)
+	seedReceipt(t, "Coffee elsewhere", otherGroup.ID, allowedPayer)
+
+	results, err := NewReceiptService(nil).SearchReceiptsForUser(userId, "Coffee", 100)
+	if err != nil {
+		t.Fatalf("SearchReceiptsForUser returned error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected exactly 1 visible result, got %d (%+v)", len(results), results)
+	}
+	if results[0].GroupID != groupId || results[0].PaidByUserId != allowedPayer {
+		t.Errorf("expected the allowed-payer receipt in the member's group, got %+v", results[0])
+	}
+}
+
+func TestSearchReceiptsForUserBlankQueryReturnsEmpty(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	userId, groupId := seedReceiptMember(t, "blank", "blank-role", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false)
+	giveAppRole(t, userId, "blank-app-role", []string{permissions.AppReceiptsSearch})
+	seedReceipt(t, "Coffee", groupId, userId)
+
+	results, err := NewReceiptService(nil).SearchReceiptsForUser(userId, "   ", 100)
+	if err != nil {
+		t.Fatalf("SearchReceiptsForUser returned error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected a blank query to return no results, got %d", len(results))
+	}
+}


### PR DESCRIPTION
Stacked on #615 (base `fix/mcp-tools-rbac-enforcement`) — retarget to `main` once that merges.

## Why

The REST handlers and the MCP tools each **independently orchestrate** the same enforcement chain (permission → paid-by visibility → category/tag stripping) for reading a single receipt and for search. That duplication just caused a real drift — the MCP tools were missing paid-by and grant enforcement entirely (#615). This makes the orchestration a single shared implementation so the two ingress points can't fall out of sync again.

## What

`ReceiptService` becomes the single source of truth for the two reads that have both a REST and an MCP entry point:

- **`GetReceiptForUser(userId, id)`** — fetch → `group.receipts.read` → `ReceiptPaidByVisible` → `FilterReceiptCategoriesTagsForReceipt`. Returns `ErrReceiptAccessDenied` (non-leaking) for missing / forbidden / paid-by-hidden.
- **`SearchReceiptsForUser(userId, query, limit)`** — `app.receipts.search` → group scope → paid-by disjunction in SQL **before** the limit → `SearchResult` mapping. Returns `ErrSearchForbidden`; blank query → empty.

Both ingress points are now thin adapters:
- MCP `get_receipt` / `search_receipts` delegate and map the sentinels to "receipt not found" / "unauthorized".
- REST `GetReceipt` / `Search` delegate and map the sentinels to **403** (their existing status). These two handlers intentionally drop their declarative `HandleRequest` permission/`ReceiptId` gates so enforcement lives in exactly one place; all other endpoints keep `HandleRequest` unchanged.

No new enforcement logic — only the existing `PermissionService` / repository primitives, reorganized. No swagger/client changes.

## Behavior

Preserved: REST status codes (403 on denied/hidden/missing), search results (same scope + paid-by SQL + mapping), MCP non-leaking errors. **One intentional change:** a blank search query now returns no results on both surfaces (REST already did; MCP previously returned everything).

## Testing

- `go build ./...` clean.
- New `internal/services/receipts_test.go`: `GetReceiptForUser` (member success, non-member denied, paid-by hidden, category stripping, missing id) and `SearchReceiptsForUser` (permission required, group scope + paid-by exclusion, blank query).
- The MCP enforcement tests (from #615) and the REST handler tests stay green — they now validate the delegation end-to-end.
- Full `go test ./...` green.