### PR TITLE
fix(api): stop CreateReceipt losing its transaction on read-back

### DIFF
--- a/api/internal/repositories/receipts.go
+++ b/api/internal/repositories/receipts.go
@@ -447,7 +447,13 @@ func (repository ReceiptRepository) CreateReceipt(
 			return err
 		}
 
-		repository.ClearTransaction()
+		// Restore the DB/transaction this method was invoked with (captured as
+		// `db` above) so the read-back below runs on the same connection that
+		// created the receipt. Clearing to nil would fall back to a fresh pooled
+		// connection which, when CreateReceipt runs inside an outer transaction
+		// (e.g. QuickScan, email attachment ingest), cannot see the still
+		// uncommitted receipt row and would return a zero-ID receipt.
+		repository.SetTransaction(db)
 		notificationRepository.ClearTransaction()
 		return nil
 	})
@@ -460,6 +466,17 @@ func (repository ReceiptRepository) CreateReceipt(
 
 	fullyLoadedReceipt, err := repository.GetFullyLoadedReceiptById(utils.UintToString(receipt.ID))
 	if err != nil {
+		if !createSystemTask {
+			createFailedUpdateSystemTask(systemTask, err)
+		}
+		return models.Receipt{}, err
+	}
+
+	// GetFullyLoadedReceiptById uses Find, which returns an empty receipt (ID 0)
+	// with no error when the row is not visible. Guard against that so callers get
+	// a clear failure here instead of a downstream foreign key violation.
+	if fullyLoadedReceipt.ID == 0 {
+		err = fmt.Errorf("created receipt %s could not be reloaded", utils.UintToString(receipt.ID))
 		if !createSystemTask {
 			createFailedUpdateSystemTask(systemTask, err)
 		}

--- a/api/internal/repositories/receipts_test.go
+++ b/api/internal/repositories/receipts_test.go
@@ -119,6 +119,53 @@ func TestShouldCreateReceipt(t *testing.T) {
 	}
 }
 
+// TestShouldCreateReceiptWithinOuterTransaction guards against a regression where
+// CreateReceipt, when bound to an outer transaction (as QuickScan and email
+// attachment ingest do), reloaded the receipt on a fresh pooled connection that
+// could not see the still-uncommitted row and returned a zero-ID receipt. That
+// zero id then broke the receipt-image foreign key with `receipt_id = 0`.
+func TestShouldCreateReceiptWithinOuterTransaction(t *testing.T) {
+	defer teardownReceiptTest()
+	setupReceiptTest()
+
+	tx := GetDB().Begin()
+	defer tx.Rollback()
+
+	repository := NewReceiptRepository(tx)
+
+	command := commands.UpsertReceiptCommand{
+		Name:         "Tx Receipt",
+		Amount:       decimal.NewFromFloat(10.00),
+		Date:         time.Now(),
+		PaidByUserID: 1,
+		Status:       models.OPEN,
+		GroupId:      1,
+	}
+
+	createdReceipt, err := repository.CreateReceipt(command, 1, false)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if createdReceipt.ID == 0 {
+		utils.PrintTestError(t, "Receipt ID should not be 0 when created within an outer transaction", nil)
+		return
+	}
+
+	// The receipt-image foreign key must be satisfiable within the same
+	// transaction (the test DB has the foreign_keys pragma enabled).
+	fileData := models.FileData{
+		Name:      "receipt.pdf",
+		FileType:  "application/pdf",
+		Size:      1,
+		ReceiptId: createdReceipt.ID,
+	}
+	if err := tx.Create(&fileData).Error; err != nil {
+		utils.PrintTestError(t, err, "FileData insert should satisfy the receipt foreign key")
+	}
+}
+
 func TestShouldGetReceiptById(t *testing.T) {
 	defer teardownReceiptTest()
 	setupReceiptTest()


### PR DESCRIPTION
## Summary

`CreateReceipt` cleared its transaction before reloading the newly created receipt. When `CreateReceipt` runs inside an outer transaction (as scan upload / QuickScan and email attachment ingest do), the read-back ran on a fresh pooled connection that could not see the still-uncommitted receipt row. `GetFullyLoadedReceiptById` uses `Find`, which returns an empty receipt (ID `0`) with no error in that case — and the zero ID then broke the receipt-image foreign key with `receipt_id = 0`, failing the upload.

## Changes

- **Keep the read-back on the creating transaction** — replace `ClearTransaction()` with `SetTransaction(db)` in `CreateReceipt` so the reload runs on the same connection that created the receipt and can see the uncommitted row.
- **Fail loudly on a zero-ID reload** — guard against a reloaded receipt with `ID == 0` so callers get a clear error at the source instead of a confusing downstream foreign-key violation (and the failure is recorded on the system task).

## Testing

- Added `TestShouldCreateReceiptWithinOuterTransaction`, which runs `CreateReceipt` inside an outer transaction and asserts the receipt gets a non-zero ID and that a `FileData` row referencing it satisfies the foreign key (the test DB has the `foreign_keys` pragma enabled).
- `go build ./...` — no build errors.
- `go vet ./internal/repositories/...` — clean.
- Full suite `go test ./...` — all packages pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved receipt creation so newly created receipts are reliably reloaded in the current transaction.
  * Prevented receipt creation from continuing with an empty receipt record when the saved data is not immediately visible.
  * Added safer failure handling to stop downstream record creation from using an invalid receipt ID.

* **Tests**
  * Added coverage for creating a receipt inside an outer transaction and confirming related records can be saved successfully before commit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->