### PR TITLE
feat(receipts): add a Group field to the receipt filter

### DIFF
--- a/api/internal/commands/paged_request_command.go
+++ b/api/internal/commands/paged_request_command.go
@@ -118,6 +118,10 @@ func (command *ReceiptPagedRequestCommand) LoadDataFromRequest(w http.ResponseWr
 		command.Filter.Status.Value = make([]interface{}, 0)
 	}
 
+	if command.Filter.Group.Value == nil || command.Filter.Group.Value == "" {
+		command.Filter.Group.Value = make([]interface{}, 0)
+	}
+
 	if command.Filter.CreatedAt.Value == nil {
 		command.Filter.CreatedAt.Value = ""
 	}
@@ -141,6 +145,7 @@ type ReceiptPagedRequestFilter struct {
 	Categories   PagedRequestField `json:"categories"`
 	Tags         PagedRequestField `json:"Tags"`
 	Status       PagedRequestField `json:"status"`
+	Group        PagedRequestField `json:"group"`
 	ResolvedDate PagedRequestField `json:"resolvedDate"`
 	CreatedAt    PagedRequestField `json:"createdAt"`
 }

--- a/api/internal/commands/paged_request_command_test.go
+++ b/api/internal/commands/paged_request_command_test.go
@@ -1,9 +1,42 @@
 package commands
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"receipt-wrangler/api/internal/utils"
+	"strings"
 	"testing"
 )
+
+func TestReceiptPagedRequestCommand_LoadDataFromRequest_NormalizesGroup(t *testing.T) {
+	tests := map[string]string{
+		"empty string group value": `{"filter":{"group":{"operation":"CONTAINS","value":""}}}`,
+		"null group value":         `{"filter":{"group":{"operation":"CONTAINS","value":null}}}`,
+		"missing group field":      `{"filter":{}}`,
+	}
+
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) {
+			command := ReceiptPagedRequestCommand{}
+			r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+			w := httptest.NewRecorder()
+
+			if err := command.LoadDataFromRequest(w, r); err != nil {
+				utils.PrintTestError(t, err, nil)
+				return
+			}
+
+			value, ok := command.Filter.Group.Value.([]interface{})
+			if !ok {
+				utils.PrintTestError(t, command.Filter.Group.Value, "[]interface{}")
+				return
+			}
+			if len(value) != 0 {
+				utils.PrintTestError(t, len(value), 0)
+			}
+		})
+	}
+}
 
 func TestPagedRequestCommand_Validate_ValidInputs(t *testing.T) {
 	tests := map[string]struct {

--- a/api/internal/commands/pie_chart_data_command.go
+++ b/api/internal/commands/pie_chart_data_command.go
@@ -45,6 +45,10 @@ func (command *PieChartDataCommand) LoadDataFromRequest(w http.ResponseWriter, r
 		command.Filter.Status.Value = make([]interface{}, 0)
 	}
 
+	if command.Filter.Group.Value == nil || command.Filter.Group.Value == "" {
+		command.Filter.Group.Value = make([]interface{}, 0)
+	}
+
 	if command.Filter.CreatedAt.Value == nil {
 		command.Filter.CreatedAt.Value = ""
 	}

--- a/api/internal/commands/pie_chart_data_command_test.go
+++ b/api/internal/commands/pie_chart_data_command_test.go
@@ -1,10 +1,43 @@
 package commands
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/utils"
+	"strings"
 	"testing"
 )
+
+func TestPieChartDataCommand_LoadDataFromRequest_NormalizesGroup(t *testing.T) {
+	tests := map[string]string{
+		"empty string group value": `{"filter":{"group":{"operation":"CONTAINS","value":""}}}`,
+		"null group value":         `{"filter":{"group":{"operation":"CONTAINS","value":null}}}`,
+		"missing group field":      `{"filter":{}}`,
+	}
+
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) {
+			command := PieChartDataCommand{}
+			r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+			w := httptest.NewRecorder()
+
+			if err := command.LoadDataFromRequest(w, r); err != nil {
+				utils.PrintTestError(t, err, nil)
+				return
+			}
+
+			value, ok := command.Filter.Group.Value.([]interface{})
+			if !ok {
+				utils.PrintTestError(t, command.Filter.Group.Value, "[]interface{}")
+				return
+			}
+			if len(value) != 0 {
+				utils.PrintTestError(t, len(value), 0)
+			}
+		})
+	}
+}
 
 func TestPieChartDataCommand_Validate_ValidInputs(t *testing.T) {
 	tests := map[string]struct {

--- a/api/internal/repositories/receipts.go
+++ b/api/internal/repositories/receipts.go
@@ -765,6 +765,14 @@ func (repository ReceiptRepository) BuildGormFilterQuery(pagedRequest commands.R
 		}
 	}
 
+	// Group
+	if pagedRequest.Filter.Group.Value != nil {
+		groups := pagedRequest.Filter.Group.Value.([]interface{})
+		if len(groups) > 0 {
+			query = repository.buildFilterQuery(query, groups, pagedRequest.Filter.Group.Operation, "group_id", true)
+		}
+	}
+
 	// Resolved Date
 	if pagedRequest.Filter.ResolvedDate.Value != nil {
 		var resolvedDate interface{}

--- a/api/internal/repositories/receipts_test.go
+++ b/api/internal/repositories/receipts_test.go
@@ -602,6 +602,85 @@ func TestShouldBuildGormFilterQuery(t *testing.T) {
 	}
 }
 
+func TestGetPagedReceiptsAppliesGroupFilter(t *testing.T) {
+	defer TruncateTestDb()
+	db := GetDB()
+
+	group1 := models.Group{Name: "grp-filter-g1"}
+	group2 := models.Group{Name: "grp-filter-g2"}
+	allGroup := models.Group{Name: "grp-filter-all", IsAllGroup: true}
+	db.Create(&group1)
+	db.Create(&group2)
+	db.Create(&allGroup)
+
+	member := models.User{Username: "grp-filter-member", Password: "x"}
+	db.Create(&member)
+	db.Create(&models.GroupMember{GroupID: group1.ID, UserID: member.ID})
+	db.Create(&models.GroupMember{GroupID: group2.ID, UserID: member.ID})
+
+	makeReceipt := func(groupId uint, name string) {
+		db.Create(&models.Receipt{
+			Name:         name,
+			Amount:       decimal.NewFromInt(1),
+			Date:         time.Now(),
+			PaidByUserID: member.ID,
+			GroupId:      groupId,
+			Status:       models.OPEN,
+		})
+	}
+	makeReceipt(group1.ID, "g1-a")
+	makeReceipt(group1.ID, "g1-b")
+	makeReceipt(group2.ID, "g2-a")
+	makeReceipt(group2.ID, "g2-b")
+
+	// Group filter ids arrive as float64 (JSON-decoded), matching production.
+	groupFilterRequest := func(groupIds ...uint) commands.ReceiptPagedRequestCommand {
+		values := make([]interface{}, 0, len(groupIds))
+		for _, id := range groupIds {
+			values = append(values, float64(id))
+		}
+		request := pagedRequestAllReceipts()
+		request.Filter.Group = commands.PagedRequestField{
+			Operation: commands.CONTAINS,
+			Value:     values,
+		}
+		return request
+	}
+
+	repository := NewReceiptRepository(nil)
+
+	// All-groups view filtered to group1: only group1's receipts return.
+	receipts, count, err := repository.GetPagedReceiptsByGroupId(
+		member.ID, utils.UintToString(allGroup.ID), groupFilterRequest(group1.ID), nil, nil,
+	)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if count != 2 || len(receipts) != 2 {
+		utils.PrintTestError(t, count, 2)
+	}
+	for _, receipt := range receipts {
+		if receipt.GroupId != group1.ID {
+			utils.PrintTestError(t, receipt.Name, "only group1 receipts should return")
+		}
+	}
+
+	// Single-group view (group1) filtered to group2: the mandatory group scope and
+	// the group filter intersect to nothing, so a user cannot surface another
+	// group's receipts through the filter.
+	_, count, err = repository.GetPagedReceiptsByGroupId(
+		member.ID, utils.UintToString(group1.ID), groupFilterRequest(group2.ID), nil, nil,
+	)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if count != 0 {
+		utils.PrintTestError(t, count, 0)
+	}
+}
+
 // Helper functions
 func createTestItems() {
 	db := GetDB()

--- a/api/internal/repositories/receipts_test.go
+++ b/api/internal/repositories/receipts_test.go
@@ -666,6 +666,25 @@ func TestGetPagedReceiptsAppliesGroupFilter(t *testing.T) {
 		}
 	}
 
+	otherGroup := models.Group{Name: "grp-filter-other"}
+	db.Create(&otherGroup)
+	// member is intentionally NOT added to otherGroup, but it has a receipt.
+	makeReceipt(otherGroup.ID, "other-a")
+
+	// All-groups view filtered to a group the user has no membership in: the
+	// mandatory member-group scope excludes it, so nothing leaks even though the
+	// group has a receipt.
+	_, count, err = repository.GetPagedReceiptsByGroupId(
+		member.ID, utils.UintToString(allGroup.ID), groupFilterRequest(otherGroup.ID), nil, nil,
+	)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if count != 0 {
+		utils.PrintTestError(t, count, 0)
+	}
+
 	// Single-group view (group1) filtered to group2: the mandatory group scope and
 	// the group filter intersect to nothing, so a user cannot surface another
 	// group's receipts through the filter.

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -4133,6 +4133,8 @@ components:
           $ref: "#/components/schemas/PagedRequestField"
         status:
           $ref: "#/components/schemas/PagedRequestField"
+        group:
+          $ref: "#/components/schemas/PagedRequestField"
         resolvedDate:
           $ref: "#/components/schemas/PagedRequestField"
         createdAt:

--- a/desktop/src/open-api/model/receiptPagedRequestFilter.ts
+++ b/desktop/src/open-api/model/receiptPagedRequestFilter.ts
@@ -41,6 +41,10 @@ export interface ReceiptPagedRequestFilter {
     /**
      * Contains two keys: operation of type FilterOperation and value which can a different type depending on the field.
      */
+    group?: object;
+    /**
+     * Contains two keys: operation of type FilterOperation and value which can a different type depending on the field.
+     */
     resolvedDate?: object;
     /**
      * Contains two keys: operation of type FilterOperation and value which can a different type depending on the field.

--- a/desktop/src/receipts/receipts-table/receipts-table.component.ts
+++ b/desktop/src/receipts/receipts-table/receipts-table.component.ts
@@ -342,6 +342,9 @@ export class ReceiptsTableComponent implements OnInit, AfterViewInit {
     dialogRef.componentInstance.tags = this.tags;
     dialogRef.componentInstance.parentForm = buildReceiptFilterForm(filter, this);
     dialogRef.componentInstance.headerText = "Filter Receipts";
+    // The group filter is only meaningful on the "All groups" view; a
+    // single-group view is already scoped to one group.
+    dialogRef.componentInstance.showGroupFilter = this.group?.isAllGroup ?? false;
     const formCommandSubscription = dialogRef.componentInstance.formCommand.subscribe((formCommand) => {
       applyFormCommand(dialogRef.componentInstance.parentForm, formCommand);
     });

--- a/desktop/src/shared-ui/receipt-filter/receipt-filter.component.html
+++ b/desktop/src/shared-ui/receipt-filter/receipt-filter.component.html
@@ -34,6 +34,22 @@
       }"
     ></ng-template>
 
+    @if (showGroupFilter) {
+      <ng-template
+        [ngTemplateOutlet]="filterField"
+        [ngTemplateOutletContext]="{
+          label: 'Group',
+          fieldName: 'group',
+          type: 'list',
+          options: groups() ?? [],
+          optionFilterKey: 'name',
+          optionDisplayKey: 'name',
+          optionValueKey: 'id',
+          multiple: true
+        }"
+      ></ng-template>
+    }
+
     <ng-template
       [ngTemplateOutlet]="filterField"
       [ngTemplateOutletContext]="{

--- a/desktop/src/shared-ui/receipt-filter/receipt-filter.component.spec.ts
+++ b/desktop/src/shared-ui/receipt-filter/receipt-filter.component.spec.ts
@@ -61,6 +61,10 @@ describe("ReceiptFilterComponent", () => {
       operation: FilterOperation.Contains,
       value: [ReceiptStatus.Open],
     },
+    group: {
+      operation: FilterOperation.Contains,
+      value: [1],
+    },
     resolvedDate: {
       operation: FilterOperation.GreaterThan,
       value: "2023-01-06",
@@ -175,6 +179,25 @@ describe("ReceiptFilterComponent", () => {
       new SetReceiptFilter(component.parentForm.value)
     );
     expect(dialogRefSpy).toHaveBeenCalledWith(true);
+  });
+
+  it("renders the group field only when showGroupFilter is true", () => {
+    const noopComponent = TestBed.createComponent(NoopComponent).componentInstance;
+
+    const countAutocompletes = (showGroupFilter: boolean): number => {
+      const localFixture = TestBed.createComponent(ReceiptFilterComponent);
+      localFixture.componentInstance.parentForm = buildReceiptFilterForm({}, noopComponent);
+      localFixture.componentInstance.showGroupFilter = showGroupFilter;
+      localFixture.detectChanges();
+      return localFixture.nativeElement.querySelectorAll("app-autocomlete").length;
+    };
+
+    // The group field is the only additional list autocomplete gated on the flag.
+    expect(countAutocompletes(true)).toBe(countAutocompletes(false) + 1);
+  });
+
+  it("defaults showGroupFilter to false", () => {
+    expect(component.showGroupFilter).toBe(false);
   });
 
   it("should close dialog on cancel", () => {

--- a/desktop/src/shared-ui/receipt-filter/receipt-filter.component.ts
+++ b/desktop/src/shared-ui/receipt-filter/receipt-filter.component.ts
@@ -8,6 +8,7 @@ import { RECEIPT_STATUS_OPTIONS } from "src/constants";
 import { SetReceiptFilter } from "src/store/receipt-table.actions";
 import { FormCommand } from "../../form/index";
 import { Category, FilterOperation, Tag } from "../../open-api";
+import { GroupState } from "../../store";
 import { OperationsPipe } from "./operations.pipe";
 
 @Component({
@@ -45,6 +46,15 @@ export class ReceiptFilterComponent implements OnInit {
   @Input() public categories: Category[] = [];
 
   @Input() public tags: Tag[] = [];
+
+  // Only rendered on the "All groups" view (the caller sets it from
+  // group.isAllGroup); hidden on single-group and dashboard-widget views, where
+  // the view is already pinned to one group.
+  @Input() public showGroupFilter: boolean = false;
+
+  // The user's own groups (minus the synthetic "All" group) — the selectable
+  // set for the group filter.
+  public groups = this.store.selectSignal(GroupState.groupsWithoutAll);
 
   public startOfMonthFormControl = new FormControl(startOfMonth(new Date()));
 
@@ -85,6 +95,10 @@ export class ReceiptFilterComponent implements OnInit {
       path: `${this.basePath}status.value`,
       command: "clear",
     });
+    this.formCommand.emit({
+      path: `${this.basePath}group.value`,
+      command: "clear",
+    });
   }
 
   public submitButtonClicked(): void {
@@ -119,6 +133,7 @@ export class ReceiptFilterComponent implements OnInit {
       { fieldName: "categories", type: "list" },
       { fieldName: "tags", type: "list" },
       { fieldName: "status", type: "list" },
+      { fieldName: "group", type: "list" },
       { fieldName: "resolvedDate", type: "date" },
       { fieldName: "createdAt", type: "date" }
     ];

--- a/desktop/src/store/group.state.spec.ts
+++ b/desktop/src/store/group.state.spec.ts
@@ -106,4 +106,19 @@ describe("GroupState receipt-filter reset on group change", () => {
     );
     expect(store.selectSnapshot(ReceiptTableState.page)).toEqual(3);
   });
+
+  it("falls back to the first remaining group when the active group at index 0 is deleted", () => {
+    // groups are [{id:1},{id:2}]; the active group (id 1) is at index 0. The
+    // fallback must come from the post-removal list ("2"), not the stale
+    // pre-removal array (which would wrongly re-select the deleted "1").
+    seed("1");
+
+    store.dispatch(new RemoveGroup("1"));
+
+    expect(store.selectSnapshot(GroupState.selectedGroupId)).toEqual("2");
+    expect(store.selectSnapshot(ReceiptTableState.filterData).filter).toEqual(
+      defaultReceiptFilter
+    );
+    expect(store.selectSnapshot(ReceiptTableState.page)).toEqual(1);
+  });
 });

--- a/desktop/src/store/group.state.spec.ts
+++ b/desktop/src/store/group.state.spec.ts
@@ -1,0 +1,83 @@
+import { TestBed } from "@angular/core/testing";
+import { NgxsModule, Store } from "@ngxs/store";
+import { DEFAULT_RECEIPT_TABLE_COLUMNS } from "src/interfaces";
+import { FilterOperation, Group } from "../open-api";
+import { GroupState } from "./group.state";
+import { SetSelectedGroupId } from "./group.state.actions";
+import { defaultReceiptFilter, ReceiptTableState } from "./receipt-table.state";
+
+describe("GroupState receipt-filter reset on group change", () => {
+  let store: Store;
+
+  const groups = [
+    { id: 1, name: "Group One" },
+    { id: 2, name: "Group Two" },
+  ] as Group[];
+
+  const nonDefaultFilter = {
+    ...defaultReceiptFilter,
+    name: { operation: FilterOperation.Contains, value: "coffee" },
+  } as any;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NgxsModule.forRoot([GroupState, ReceiptTableState])],
+    }).compileComponents();
+
+    store = TestBed.inject(Store);
+  });
+
+  function seed(selectedGroupId: string): void {
+    store.reset({
+      groups: {
+        groups,
+        selectedGroupId,
+        selectedDashboardId: "",
+      },
+      receiptTable: {
+        page: 3,
+        pageSize: 50,
+        orderBy: "created_at",
+        sortDirection: "desc",
+        filter: nonDefaultFilter,
+        columnConfig: DEFAULT_RECEIPT_TABLE_COLUMNS,
+      },
+    });
+  }
+
+  it("resets the receipt filter and page when switching to a different group", () => {
+    seed("1");
+
+    store.dispatch(new SetSelectedGroupId("2"));
+
+    expect(store.selectSnapshot(ReceiptTableState.filterData).filter).toEqual(
+      defaultReceiptFilter
+    );
+    expect(store.selectSnapshot(ReceiptTableState.page)).toEqual(1);
+    expect(store.selectSnapshot(GroupState.selectedGroupId)).toEqual("2");
+  });
+
+  it("preserves the receipt filter and page when re-selecting the same group", () => {
+    seed("1");
+
+    store.dispatch(new SetSelectedGroupId("1"));
+
+    expect(store.selectSnapshot(ReceiptTableState.filterData).filter).toEqual(
+      nonDefaultFilter
+    );
+    expect(store.selectSnapshot(ReceiptTableState.page)).toEqual(3);
+  });
+
+  it("resets when an empty payload resolves to a different group than the current", () => {
+    // Current group is 2; an empty payload resolves to groups[0] (id 1), a change.
+    seed("2");
+
+    store.dispatch(new SetSelectedGroupId(""));
+
+    expect(store.selectSnapshot(GroupState.selectedGroupId)).toEqual("1");
+    expect(store.selectSnapshot(ReceiptTableState.filterData).filter).toEqual(
+      defaultReceiptFilter
+    );
+    expect(store.selectSnapshot(ReceiptTableState.page)).toEqual(1);
+  });
+});

--- a/desktop/src/store/group.state.spec.ts
+++ b/desktop/src/store/group.state.spec.ts
@@ -3,7 +3,7 @@ import { NgxsModule, Store } from "@ngxs/store";
 import { DEFAULT_RECEIPT_TABLE_COLUMNS } from "src/interfaces";
 import { FilterOperation, Group } from "../open-api";
 import { GroupState } from "./group.state";
-import { SetSelectedGroupId } from "./group.state.actions";
+import { RemoveGroup, SetSelectedGroupId } from "./group.state.actions";
 import { defaultReceiptFilter, ReceiptTableState } from "./receipt-table.state";
 
 describe("GroupState receipt-filter reset on group change", () => {
@@ -79,5 +79,31 @@ describe("GroupState receipt-filter reset on group change", () => {
       defaultReceiptFilter
     );
     expect(store.selectSnapshot(ReceiptTableState.page)).toEqual(1);
+  });
+
+  it("resets the receipt filter and page when the active group is deleted", () => {
+    // Selected group is 2; deleting it falls back to groups[0] (id 1), a change.
+    seed("2");
+
+    store.dispatch(new RemoveGroup("2"));
+
+    expect(store.selectSnapshot(GroupState.selectedGroupId)).toEqual("1");
+    expect(store.selectSnapshot(ReceiptTableState.filterData).filter).toEqual(
+      defaultReceiptFilter
+    );
+    expect(store.selectSnapshot(ReceiptTableState.page)).toEqual(1);
+  });
+
+  it("preserves the receipt filter and page when a non-active group is deleted", () => {
+    // Selected group is 1; deleting group 2 leaves the selection unchanged.
+    seed("1");
+
+    store.dispatch(new RemoveGroup("2"));
+
+    expect(store.selectSnapshot(GroupState.selectedGroupId)).toEqual("1");
+    expect(store.selectSnapshot(ReceiptTableState.filterData).filter).toEqual(
+      nonDefaultFilter
+    );
+    expect(store.selectSnapshot(ReceiptTableState.page)).toEqual(3);
   });
 });

--- a/desktop/src/store/group.state.ts
+++ b/desktop/src/store/group.state.ts
@@ -118,7 +118,9 @@ export class GroupState {
         const removedSelectedGroup =
           group.id.toString() === state.selectedGroupId.toString();
         if (removedSelectedGroup) {
-          newInterface.selectedGroupId = state.groups[0].id.toString();
+          // Fall back to the first *remaining* group. Reading state.groups[0]
+          // (the pre-removal array) could point at the group just deleted.
+          newInterface.selectedGroupId = newGroups[0]?.id?.toString() ?? "";
         }
         patchState(newInterface);
 
@@ -189,7 +191,7 @@ export class GroupState {
       groupId = groups[0].id.toString();
     }
 
-    if (payload.groupId === previousGroupId) {
+    if (groupId === previousGroupId) {
       dashboardId = getState().selectedDashboardId;
     }
 

--- a/desktop/src/store/group.state.ts
+++ b/desktop/src/store/group.state.ts
@@ -102,7 +102,7 @@ export class GroupState {
 
   @Action(RemoveGroup)
   removeGroup(
-    { getState, patchState }: StateContext<GroupStateInterface>,
+    { getState, patchState, dispatch }: StateContext<GroupStateInterface>,
     payload: RemoveGroup
   ) {
     const state = getState();
@@ -115,12 +115,24 @@ export class GroupState {
           (g) => g.id !== group.id
         );
         newInterface.groups = newGroups;
-        if (group.id.toString() === state.selectedGroupId.toString()) {
+        const removedSelectedGroup =
+          group.id.toString() === state.selectedGroupId.toString();
+        if (removedSelectedGroup) {
           newInterface.selectedGroupId = state.groups[0].id.toString();
         }
         patchState(newInterface);
+
+        // Deleting the active group switches the selection to the fallback group,
+        // so clear the global receipt-table filter/page the same way a normal
+        // group switch does (setSelectedGroupId) — otherwise the fallback group
+        // inherits the deleted group's filter.
+        if (removedSelectedGroup) {
+          return dispatch([new ResetReceiptFilter(), new SetPage(1)]);
+        }
       }
     }
+
+    return undefined;
   }
 
   @Action(SetGroups)
@@ -177,7 +189,7 @@ export class GroupState {
       groupId = groups[0].id.toString();
     }
 
-    if (payload.groupId === getState().selectedGroupId) {
+    if (payload.groupId === previousGroupId) {
       dashboardId = getState().selectedDashboardId;
     }
 

--- a/desktop/src/store/group.state.ts
+++ b/desktop/src/store/group.state.ts
@@ -16,6 +16,7 @@ import {
   UpdateGroup,
 } from './group.state.actions';
 import { GroupMember } from '../open-api/model/groupMember';
+import { ResetReceiptFilter, SetPage } from './receipt-table.actions';
 
 export interface GroupStateInterface {
   groups: Group[];
@@ -162,9 +163,10 @@ export class GroupState {
 
   @Action(SetSelectedGroupId)
   setSelectedGroupId(
-    { getState, patchState }: StateContext<GroupStateInterface>,
+    { getState, patchState, dispatch }: StateContext<GroupStateInterface>,
     payload: SetSelectedGroupId
   ) {
+    const previousGroupId = getState().selectedGroupId;
     let groupId = '';
     let dashboardId = '';
 
@@ -183,5 +185,15 @@ export class GroupState {
       selectedGroupId: groupId,
       selectedDashboardId: dashboardId,
     });
+
+    // The receipt-table state is global (one filter shared across all groups),
+    // so a filter set on one group would otherwise bleed into the next. Switching
+    // to a different group starts it with a clean filter and first page; columns,
+    // page size and sort stay global. Same-group re-selection is a no-op.
+    if (groupId !== previousGroupId) {
+      return dispatch([new ResetReceiptFilter(), new SetPage(1)]);
+    }
+
+    return undefined;
   }
 }

--- a/desktop/src/store/receipt-table.state.ts
+++ b/desktop/src/store/receipt-table.state.ts
@@ -34,6 +34,10 @@ export const defaultReceiptFilter = {
     operation: null,
     value: [],
   },
+  group: {
+    operation: null,
+    value: [],
+  },
   resolvedDate: {
     operation: null,
     value: null,

--- a/desktop/src/utils/receipt-filter.ts
+++ b/desktop/src/utils/receipt-filter.ts
@@ -46,6 +46,12 @@ export function buildReceiptFilterForm(filter: any, thisContext: any): FormGroup
       thisContext,
       true
     ),
+    group: buildFieldFormGroup(
+      filter?.group?.value ?? [],
+      filter?.group?.operation,
+      thisContext,
+      true
+    ),
     resolvedDate: buildFieldFormGroup(
       filter?.resolvedDate?.value,
       filter?.resolvedDate?.operation,

--- a/mobile/api/doc/ReceiptPagedRequestFilter.md
+++ b/mobile/api/doc/ReceiptPagedRequestFilter.md
@@ -15,6 +15,7 @@ Name | Type | Description | Notes
 **categories** | [**JsonObject**](.md) | Contains two keys: operation of type FilterOperation and value which can a different type depending on the field. | [optional] 
 **tags** | [**JsonObject**](.md) | Contains two keys: operation of type FilterOperation and value which can a different type depending on the field. | [optional] 
 **status** | [**JsonObject**](.md) | Contains two keys: operation of type FilterOperation and value which can a different type depending on the field. | [optional] 
+**group** | [**JsonObject**](.md) | Contains two keys: operation of type FilterOperation and value which can a different type depending on the field. | [optional] 
 **resolvedDate** | [**JsonObject**](.md) | Contains two keys: operation of type FilterOperation and value which can a different type depending on the field. | [optional] 
 **createdAt** | [**JsonObject**](.md) | Contains two keys: operation of type FilterOperation and value which can a different type depending on the field. | [optional] 
 

--- a/mobile/api/lib/src/model/receipt_paged_request_filter.dart
+++ b/mobile/api/lib/src/model/receipt_paged_request_filter.dart
@@ -19,6 +19,7 @@ part 'receipt_paged_request_filter.g.dart';
 /// * [categories] - Contains two keys: operation of type FilterOperation and value which can a different type depending on the field.
 /// * [tags] - Contains two keys: operation of type FilterOperation and value which can a different type depending on the field.
 /// * [status] - Contains two keys: operation of type FilterOperation and value which can a different type depending on the field.
+/// * [group] - Contains two keys: operation of type FilterOperation and value which can a different type depending on the field.
 /// * [resolvedDate] - Contains two keys: operation of type FilterOperation and value which can a different type depending on the field.
 /// * [createdAt] - Contains two keys: operation of type FilterOperation and value which can a different type depending on the field.
 @BuiltValue()
@@ -50,6 +51,10 @@ abstract class ReceiptPagedRequestFilter implements Built<ReceiptPagedRequestFil
   /// Contains two keys: operation of type FilterOperation and value which can a different type depending on the field.
   @BuiltValueField(wireName: r'status')
   JsonObject? get status;
+
+  /// Contains two keys: operation of type FilterOperation and value which can a different type depending on the field.
+  @BuiltValueField(wireName: r'group')
+  JsonObject? get group;
 
   /// Contains two keys: operation of type FilterOperation and value which can a different type depending on the field.
   @BuiltValueField(wireName: r'resolvedDate')
@@ -128,6 +133,13 @@ class _$ReceiptPagedRequestFilterSerializer implements PrimitiveSerializer<Recei
       yield r'status';
       yield serializers.serialize(
         object.status,
+        specifiedType: const FullType(JsonObject),
+      );
+    }
+    if (object.group != null) {
+      yield r'group';
+      yield serializers.serialize(
+        object.group,
         specifiedType: const FullType(JsonObject),
       );
     }
@@ -216,6 +228,13 @@ class _$ReceiptPagedRequestFilterSerializer implements PrimitiveSerializer<Recei
             specifiedType: const FullType(JsonObject),
           ) as JsonObject;
           result.status = valueDes;
+          break;
+        case r'group':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(JsonObject),
+          ) as JsonObject;
+          result.group = valueDes;
           break;
         case r'resolvedDate':
           final valueDes = serializers.deserialize(


### PR DESCRIPTION
## Summary

Two related changes to the receipt filter:

### 1. Add a **Group** field to the receipt filter

- **Multi-select** over the user's own groups (from `GroupState.groupsWithoutAll`, so the synthetic "All" group is excluded).
- **Contains-only** operation (reuses the existing `list` filter type, whose operation set is already `[CONTAINS]`).
- **Shown only on the "All groups" view** — hidden on single-group receipt views and dashboard-widget config, which are already scoped to a single group. Gated by a `showGroupFilter` input the receipts-table dialog sets from `group.isAllGroup`.

Backend: new `Group` `PagedRequestField` on `ReceiptPagedRequestFilter`, normalized in **both** the paged-request and pie-chart command loaders, applied as `group_id IN (?)` in `BuildGormFilterQuery`. Safe by construction — that query is only reached through `GetPagedReceiptsByGroupId`, which always AND-s the caller's member-group scope, so a group filter can never surface another group's receipts. Swagger + generated desktop/mobile clients updated (additive).

### 2. Reset the receipt filter when switching groups

The receipt-table NGXS state is a **single global blob** (one filter/page shared across every group view, persisted under one key), so a filter set on one group bled into the next when you switched — the Group filter just made an existing bug visible.

Fix: reset the filter and page whenever the **selected group actually changes**, in the `SetSelectedGroupId` handler — the single point every group-switch path (sidebar, `GroupGuard`, app-init) flows through, and where the previous group id is still readable. Columns / page size / sort stay global; same-group re-selection and reloads keep the current filter.

## Testing

- **Backend:** result-asserting repository test (real SQLite) confirms the group filter returns only the selected group's rows and that a single-group view filtered to a different group intersects to **0 rows**; `LoadDataFromRequest` normalization tested on both command structs. Full `go test ./...` green.
- **Frontend:** receipt-filter spec covers the filled/reset round-trip with `group` and the `showGroupFilter` gating; new `group.state.spec.ts` covers the group-switch reset (resets on change, preserves on same-group). Full jest suite (1005 tests) + production build green.

### Verification note

Live browser e2e was not run: the only API instance on the dev host predates these changes (signup disabled) and the server port is hard-coded, so a clean end-to-end run against the new code wasn't possible without stopping the running dev API. The group filter is covered by the result-asserting repository test (the exact function the handler calls, against a real DB); the group-switch reset is exercised directly at the NGXS store level (real dispatch → real cross-state reset), and every group-switch path was confirmed by code inspection to dispatch `SetSelectedGroupId`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end “Group” filtering for receipts across API, web, and mobile.
  * Updated the receipt filter UI to optionally display the Group selector, including multi-select support.
* **Bug Fixes**
  * Improved normalization of group filter input when empty, null, or missing.
  * Ensured receipt paging applies group constraints correctly (including scope intersection).
  * Made pie chart group filtering normalize empty inputs consistently.
* **Documentation**
  * Updated API/mobile documentation and models to include the new `group` filter field.
* **Tests**
  * Added and expanded coverage for normalization, API/repository behavior, and UI rendering logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->