### PR TITLE
Reporting engine core

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -643,6 +643,10 @@ A **pure** report engine: `(ReportSpec + FieldCatalog + []Row + MetaInput) → R
 fetches nothing, renders nothing, reads no clock, and consults no global. Renderers (CSV/XLSX/PDF), a
 dashboard widget, template persistence and HTTP delivery all *call* it; none of them are part of it.
 
+**`internal/reporting/README.md`** is the narrative guide for engineers: the pipeline, the type
+vocabulary, and a worked example carried from input rows through the report tree to the rendered
+table. The section below is the rules digest; the README is where the diagrams are.
+
 **The purity rule is enforceable and must stay true:**
 
 ```bash

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -686,6 +686,7 @@ expressible today. Closing it means either derived fields in `receiptsource` (`d
 | Bucket keys | Two values share a bucket key **exactly when `compareValues` finds them equal**. Numbers key on `decimal.String()` (canonical, lossless); dates key on `Unix()` seconds + `Nanosecond()` and **never `UnixNano()`**, which is undefined outside 1678–2262 — a zero `time.Time` and a date in 585 share one. A coarser key merges buckets *and* makes the surviving bucket's value depend on input order. |
 | Bucket **values** | A bucket keeps `Value.canonical()`, not whichever member arrived first. Agreeing with `compareValues` is only half the job: dates compare by instant, so one instant in two zones merges, and `Value.Time()` would otherwise hand a renderer an arbitrary one of them (`2026-05-01T00:00:00Z` vs `2026-04-30T19:00:00-05:00` format as different **calendar days**). **Date buckets are emitted in UTC.** A producer wanting calendar-day grouping in a local zone must truncate before handing rows over. |
 | Unknown enums | `Validate` rejects an `AggFunc` or `DetailMode` outside the known set (`ErrUnknownAggFunc`, `ErrUnknownDetailMode`). Both used to fail silently — an unknown reduction fell through `finalize` and blanked the column; an unknown detail mode skipped the label-column check. Ask "is this aggregate mode?" only through `DetailSpec.isAggregate()`; two spellings of it once disagreed. |
+| Enum switch drift | `AggFunc` is switched on in **four** places (`String`, `valid`, `aggFuncFromName`, `accumulator.finalize`) and Go forces none of them to agree. `enums_test.go` pins them to each other exhaustively over all 256 values. **Adding a reduction means updating all four** — `valid()` alone would let `Validate` accept a column `finalize` blanks. `finalize`'s fallthrough stays `Null()`, not a `panic`: nothing in this package panics, the line is unreachable through `Validate`, and drift is a compile-time mistake caught at `go test` time. |
 | Formula size | `ParseArithmetic`/`ParseAggregate` refuse source over `maxFormulaLength` (1 KB) **before parsing**. expr's 10k-node cap does *not* bound this: a parenthesis builds no node, so nesting is bounded only by the goroutine stack (~640 B/paren; ~1.6M overflows the default 1 GB), and a Go stack overflow is a fatal error `recover` cannot catch. |
 | Field keys | `NewFieldCatalog` rejects a key that is not a plain identifier (`ErrInvalidFieldKey`). `unit-price` would tokenize as a subtraction. |
 | Empty dimension | Explicit `(None)` bucket (`IsNone: true`, `Value` null). Never dropped. |
@@ -753,7 +754,7 @@ only tests the plausible paths — and note the two `12:00` entries look like su
 ### Mutation checking
 
 ```bash
-./internal/reporting/mutation-check.sh          # all 41 mutations, engine + receiptsource
+./internal/reporting/mutation-check.sh          # all 43 mutations, engine + receiptsource
 ./internal/reporting/mutation-check.sh avg      # only those matching "avg"
 ```
 

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -42,6 +42,8 @@ Receipt Wrangler API is a Go-based backend service for a receipt management and 
 - **internal/routers/** - Route definitions and middleware setup
 - **internal/wranglerasynq/** - Background job processing using Asynq
 - **internal/ai/** - AI client implementations (OpenAI, Gemini, Ollama)
+- **internal/permissions/** - Pure permission registry + wildcard matcher (no DB)
+- **internal/reporting/** - Pure report engine (no DB); `receiptsource/` maps receipts into it
 
 ### Database
 - Uses GORM ORM with support for SQLite, MySQL, and PostgreSQL
@@ -634,3 +636,80 @@ a real paid-by and status — neither field is ever null/empty**. This is why th
   and admin-bypass callers are a no-op). This closes a write bypass: the UI picker already limits picks
   to the granted catalog, but a crafted request could otherwise attach a category/tag the caller can't
   see.
+
+## Reporting Engine (`internal/reporting`)
+
+A **pure** report engine: `(ReportSpec + FieldCatalog + []Row + MetaInput) → ReportModel`. It
+fetches nothing, renders nothing, reads no clock, and consults no global. Renderers (CSV/XLSX/PDF), a
+dashboard widget, template persistence and HTTP delivery all *call* it; none of them are part of it.
+
+**The purity rule is enforceable and must stay true:**
+
+```bash
+go list -deps receipt-wrangler/api/internal/reporting | grep -E 'gorm|repositories|internal/models'
+# must print nothing
+```
+
+`internal/reporting/receiptsource/` is the **only** package that imports `models`. It maps
+`[]models.Receipt` + `[]models.CustomField` into `[]reporting.Row`. Item-grain reporting or a
+non-receipt widget adds a *sibling* of it; the engine core never changes.
+
+```go
+source, err := receiptsource.New(customFields)          // needs CustomField.Options loaded
+model, err := reporting.Run(spec, source.Catalog(), source.Rows(receipts), meta)
+```
+
+**Caller must preload** `PaidByUser`, `Group`, `Categories`, `Tags`, `CustomFields`. An unloaded
+association resolves to no value, which surfaces as a `(None)` bucket — not an error.
+
+### Semantics that are easy to get wrong
+
+| Concern | Rule |
+|---|---|
+| Aggregate rollup | A parent **merges its children's accumulators**, never their finalized values. This is what makes `AVG` at a subtotal `sum(all descendants)/count(all descendants)` rather than the average of its children's averages. |
+| Arithmetic rollup | Recomputed from the **same row's** other columns at every level (detail, subtotal, grand total). Never summed. Additive formulas agree either way; ratios and averages do not. |
+| `SUM`/`COUNT` of nothing | `0` — a category with no tax shows `0.00`, not an empty cell. |
+| `AVG`/`MIN`/`MAX` of nothing | `Null` (empty cell). Zero would be a lie. |
+| `COUNT()` | Counts **records**, not values. A row with a null measure still counts. It takes no field. |
+| Nulls | Skipped by `SUM`/`MIN`/`MAX` and excluded from `AVG`'s divisor. Any null operand makes an arithmetic result null. |
+| Division by zero | `Null` cell, **never a panic** — `shopspring` panics on a zero divisor, so `evalBinary` guards `IsZero()` first. |
+| Division precision | `DivRound(x, spec.Config.DivisionScale)`. **Never read or write `decimal.DivisionPrecision`** (a mutable process-wide global). |
+| Multi-value fan-out | A receipt with two tags is attributed to **both** buckets in full, so it double-counts, and that double count propagates to the grand total. Intended — matches `services/pie_chart.go`. Two multi-value levels produce a cross product. |
+| Empty dimension | Explicit `(None)` bucket (`IsNone: true`, `Value` null). Never dropped. |
+| Ordering | Buckets sort by typed value with `(None)` last; records preserve input order. **Never range a Go map to produce output** (`pie_chart.go` has exactly this bug). |
+| Formatting | The engine emits raw typed values. Currency symbols and decimal places are a renderer's job. |
+| `GeneratedAt` | An **input** (`MetaInput`), never `time.Now()`. Determinism depends on it. |
+
+### Columns and formulas
+
+Three column kinds, declared not inferred: `ColumnLabel` (displays a field, blank on subtotal rows),
+`ColumnAggregate` (`SUM(amount)`, `COUNT()` — backed by a mergeable accumulator), and
+`ColumnArithmetic` (`Subtotal + Hst`, `ROUND(Total / Count, 2)`).
+
+`Column.Name` is what formulas reference and must be a plain identifier that is not a reserved word;
+`Column.Label` is the free-text heading. They are separate so renaming a heading (`Avg/Receipt`)
+cannot break a formula (`AvgPerReceipt`).
+
+Formulas are parsed by **`expr-lang/expr` used as a parser front-end only** (`parser.Parse` →
+`ast.Node`); its VM is never run, because it evaluates over `float64` and money must not touch a
+float. The tree is then checked against an allow-list implemented as a **closed type switch whose
+`default` rejects**. Two traps: `??`, `in`, `**` and `%` all parse as `*ast.BinaryNode` (so the
+*operator* is whitelisted too), and expr ships lower-case builtins named `sum`, `min`, `max`,
+`count`, `round`, `len` — so `round(a,2)` arrives as an `*ast.BuiltinNode`, not a `CallNode`.
+
+Arithmetic columns form a **DAG**, topologically sorted with cycle detection, so a column may be
+declared before the aggregate it reads. `ColumnDescriptor.Expr` keeps the parsed tree so the future
+XLSX renderer can translate a column expression into a live `=SUM(...)` cell formula.
+
+### Tests
+
+Both packages are pure — **no `main_test.go`, no DB, no `app.db` cleanup.** The engine suite builds
+synthetic `Row` literals, which is what makes the scenario matrix cheap; `receiptsource` uses real
+`models.Receipt` fixtures. `engine_test.go` reproduces the design's worked example number for number
+as a golden test.
+
+**Compare money with `decimal.Equal`/`StringFixed`, never `reflect.DeepEqual`** — `NewFromInt(200)`
+and `200.00` are equal but carry different internal exponents.
+
+- `internal/reporting/{value,row,field,formula,eval,accumulator,model,validate,engine}_test.go`
+- `internal/reporting/receiptsource/receiptsource_test.go`

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -662,6 +662,13 @@ model, err := reporting.Run(spec, source.Catalog(), source.Rows(receipts), meta)
 **Caller must preload** `PaidByUser`, `Group`, `Categories`, `Tags`, `CustomFields`. An unloaded
 association resolves to no value, which surfaces as a `(None)` bucket — not an error.
 
+**Known gap — no date truncation.** `date`, `resolved_date` and `created_at` are `TypeDate`, hence
+dimensions, hence groupable — but `receiptsource` hands over a raw timestamp, so grouping by `date`
+buckets on the exact instant and yields **one group per receipt**. "Receipts by month" is not
+expressible today. Closing it means either derived fields in `receiptsource` (`date_month`,
+`date_year`) or a `GroupBy` entry carrying a truncation. Decide before `ReportTemplate` persists a
+`GroupBy` shape.
+
 ### Semantics that are easy to get wrong
 
 | Concern | Rule |
@@ -675,8 +682,12 @@ association resolves to no value, which surfaces as a `(None)` bucket — not an
 | Division by zero | `Null` cell, **never a panic** — `shopspring` panics on a zero divisor, so `evalBinary` guards `IsZero()` first. |
 | Division precision | `DivRound(x, spec.Config.DivisionScale)`. **Never read or write `decimal.DivisionPrecision`** (a mutable process-wide global). |
 | Multi-value fan-out | A receipt with two tags is attributed to **both** buckets in full, so it double-counts, and that double count propagates to the grand total. Intended — matches `services/pie_chart.go`. Two multi-value levels produce a cross product. But only **distinct** values fan out: a receipt tagged `"Alex"` twice is attributed once. |
-| Multi-valued measures | Refused (`ErrMeasureIsMultiValued`). Summing a field that resolves to several values would silently read the first and drop the rest. A `Multi` field is still a fine dimension and a fine display label. |
+| Multi-valued measures | Refused (`ErrMeasureIsMultiValued`). Summing a field that resolves to several values would silently read the first and drop the rest. A `Multi` field is still a fine dimension and a fine display label. Note `Multi` is a **producer's declaration**, never checked against the rows: a catalog that lies loses values in `Row.Measure`. |
 | Bucket keys | Two values share a bucket key **exactly when `compareValues` finds them equal**. Numbers key on `decimal.String()` (canonical, lossless); dates key on `Unix()` seconds + `Nanosecond()` and **never `UnixNano()`**, which is undefined outside 1678–2262 — a zero `time.Time` and a date in 585 share one. A coarser key merges buckets *and* makes the surviving bucket's value depend on input order. |
+| Bucket **values** | A bucket keeps `Value.canonical()`, not whichever member arrived first. Agreeing with `compareValues` is only half the job: dates compare by instant, so one instant in two zones merges, and `Value.Time()` would otherwise hand a renderer an arbitrary one of them (`2026-05-01T00:00:00Z` vs `2026-04-30T19:00:00-05:00` format as different **calendar days**). **Date buckets are emitted in UTC.** A producer wanting calendar-day grouping in a local zone must truncate before handing rows over. |
+| Unknown enums | `Validate` rejects an `AggFunc` or `DetailMode` outside the known set (`ErrUnknownAggFunc`, `ErrUnknownDetailMode`). Both used to fail silently — an unknown reduction fell through `finalize` and blanked the column; an unknown detail mode skipped the label-column check. Ask "is this aggregate mode?" only through `DetailSpec.isAggregate()`; two spellings of it once disagreed. |
+| Formula size | `ParseArithmetic`/`ParseAggregate` refuse source over `maxFormulaLength` (1 KB) **before parsing**. expr's 10k-node cap does *not* bound this: a parenthesis builds no node, so nesting is bounded only by the goroutine stack (~640 B/paren; ~1.6M overflows the default 1 GB), and a Go stack overflow is a fatal error `recover` cannot catch. |
+| Field keys | `NewFieldCatalog` rejects a key that is not a plain identifier (`ErrInvalidFieldKey`). `unit-price` would tokenize as a subtraction. |
 | Empty dimension | Explicit `(None)` bucket (`IsNone: true`, `Value` null). Never dropped. |
 | Ordering | Buckets sort by typed value with `(None)` last; records preserve input order. **Never range a Go map to produce output** (`pie_chart.go` has exactly this bug). |
 | Formatting | The engine emits raw typed values. Currency symbols and decimal places are a renderer's job. |
@@ -723,16 +734,26 @@ Four layers, each catching what the one before it cannot:
 | Properties | `property_test.go` | 400 randomized specs + rows from a fixed seed (`REPORTING_SEED` overrides). Conservation, rollup, AVG exactness, arithmetic recompute, bucket cardinality, determinism. |
 | Fuzz | `fuzz_test.go`, `bucketkey_test.go` | Seed corpora run under plain `go test`. `-fuzz` is opt-in. |
 
-**A law must not be derived from the code it judges.** `property_test.go` computes bucket identity
-with `compareValues` and reads rows with `Row.Get`, deliberately *not* `bucketKey`/`dimensionValues`
-— an earlier draft used the engine's own helpers and consequently agreed with the bug it was meant
-to catch. Likewise the random date alphabet contains the two instants that share a `UnixNano`: a
-generator that only produces plausible data only tests the plausible paths.
+**A law must not be derived from the code it judges.** This rule has now been broken twice, in two
+different files, and both times the suite went green over a real defect:
+
+- `property_test.go` computes bucket identity with `compareValues` and reads rows with `Row.Get`,
+  deliberately *not* `bucketKey`/`dimensionValues` — an earlier draft used the engine's own helpers
+  and consequently agreed with the bug it was meant to catch.
+- `invariants_test.go`'s `serializeValue` rendered a date as `bucketKey(value)`, so the determinism
+  and permutation laws agreed that two zones naming one instant were interchangeable — which is the
+  one thing they exist to deny. It now serializes the wall clock and zone offset a **renderer**
+  reads. `Value.String()` normalizes to UTC, so the golden test could not have seen it either.
+
+Likewise the random date alphabet contains both the two instants that share a `UnixNano` **and** one
+instant expressed in two zones that straddle midnight. A generator that only produces plausible data
+only tests the plausible paths — and note the two `12:00` entries look like such a pair and are not
+(one is `12:00Z`, the other `11:00Z`), which is exactly how the gap survived.
 
 ### Mutation checking
 
 ```bash
-./internal/reporting/mutation-check.sh          # all 34 mutations
+./internal/reporting/mutation-check.sh          # all 41 mutations, engine + receiptsource
 ./internal/reporting/mutation-check.sh avg      # only those matching "avg"
 ```
 

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -674,11 +674,14 @@ association resolves to no value, which surfaces as a `(None)` bucket — not an
 | Nulls | Skipped by `SUM`/`MIN`/`MAX` and excluded from `AVG`'s divisor. Any null operand makes an arithmetic result null. |
 | Division by zero | `Null` cell, **never a panic** — `shopspring` panics on a zero divisor, so `evalBinary` guards `IsZero()` first. |
 | Division precision | `DivRound(x, spec.Config.DivisionScale)`. **Never read or write `decimal.DivisionPrecision`** (a mutable process-wide global). |
-| Multi-value fan-out | A receipt with two tags is attributed to **both** buckets in full, so it double-counts, and that double count propagates to the grand total. Intended — matches `services/pie_chart.go`. Two multi-value levels produce a cross product. |
+| Multi-value fan-out | A receipt with two tags is attributed to **both** buckets in full, so it double-counts, and that double count propagates to the grand total. Intended — matches `services/pie_chart.go`. Two multi-value levels produce a cross product. But only **distinct** values fan out: a receipt tagged `"Alex"` twice is attributed once. |
+| Multi-valued measures | Refused (`ErrMeasureIsMultiValued`). Summing a field that resolves to several values would silently read the first and drop the rest. A `Multi` field is still a fine dimension and a fine display label. |
+| Bucket keys | Two values share a bucket key **exactly when `compareValues` finds them equal**. Numbers key on `decimal.String()` (canonical, lossless); dates key on `Unix()` seconds + `Nanosecond()` and **never `UnixNano()`**, which is undefined outside 1678–2262 — a zero `time.Time` and a date in 585 share one. A coarser key merges buckets *and* makes the surviving bucket's value depend on input order. |
 | Empty dimension | Explicit `(None)` bucket (`IsNone: true`, `Value` null). Never dropped. |
 | Ordering | Buckets sort by typed value with `(None)` last; records preserve input order. **Never range a Go map to produce output** (`pie_chart.go` has exactly this bug). |
 | Formatting | The engine emits raw typed values. Currency symbols and decimal places are a renderer's job. |
 | `GeneratedAt` | An **input** (`MetaInput`), never `time.Now()`. Determinism depends on it. |
+| `IsNone` | Equals `Value.IsNull()` for group nodes and **aggregate-mode** detail rows only. The synthetic `Root` and every **records-mode** detail row carry a null `Value` with `IsNone: false`. It is **not** a global biconditional — do not "fix" the engine to make it one. |
 
 ### Columns and formulas
 
@@ -705,11 +708,41 @@ XLSX renderer can translate a column expression into a live `=SUM(...)` cell for
 
 Both packages are pure — **no `main_test.go`, no DB, no `app.db` cleanup.** The engine suite builds
 synthetic `Row` literals, which is what makes the scenario matrix cheap; `receiptsource` uses real
-`models.Receipt` fixtures. `engine_test.go` reproduces the design's worked example number for number
-as a golden test.
+`models.Receipt` fixtures.
 
 **Compare money with `decimal.Equal`/`StringFixed`, never `reflect.DeepEqual`** — `NewFromInt(200)`
-and `200.00` are equal but carry different internal exponents.
+and `200.00` are equal but carry different internal exponents. Determinism is compared through
+`serializeModel` for the same reason.
 
-- `internal/reporting/{value,row,field,formula,eval,accumulator,model,validate,engine}_test.go`
+Four layers, each catching what the one before it cannot:
+
+| Layer | File | What it does |
+|---|---|---|
+| Invariants | `invariants_test.go` | `assertModelInvariants` re-derives the model's structure from the spec. `mustRun` calls it, so **every** engine test checks it. |
+| Golden | `golden_test.go` | Renders a whole report as a text table. One assertion covers grouping, ordering, values, subtotal placement and blank cells. |
+| Properties | `property_test.go` | 400 randomized specs + rows from a fixed seed (`REPORTING_SEED` overrides). Conservation, rollup, AVG exactness, arithmetic recompute, bucket cardinality, determinism. |
+| Fuzz | `fuzz_test.go`, `bucketkey_test.go` | Seed corpora run under plain `go test`. `-fuzz` is opt-in. |
+
+**A law must not be derived from the code it judges.** `property_test.go` computes bucket identity
+with `compareValues` and reads rows with `Row.Get`, deliberately *not* `bucketKey`/`dimensionValues`
+— an earlier draft used the engine's own helpers and consequently agreed with the bug it was meant
+to catch. Likewise the random date alphabet contains the two instants that share a `UnixNano`: a
+generator that only produces plausible data only tests the plausible paths.
+
+### Mutation checking
+
+```bash
+./internal/reporting/mutation-check.sh          # all 34 mutations
+./internal/reporting/mutation-check.sh avg      # only those matching "avg"
+```
+
+Breaks the engine one way at a time and asserts a test objects. Uses `go test -overlay`, so it
+**never writes to the working tree**. Run it before merging any change to the engine; a survivor
+means the engine can be broken that way without a single test noticing.
+
+Its three self-imposed rules, each learned the hard way: a mutation whose search text no longer
+matches is a **failure**, not a pass; a mutant that **does not compile** was never tested, so only
+`--- FAIL` counts as caught; and `-count=1`, or the build cache serves the last verdict.
+
+- `internal/reporting/{value,bucketkey,row,field,formula,eval,accumulator,model,validate,engine,invariants,golden,property,fuzz,passthrough,adversarial}_test.go`
 - `internal/reporting/receiptsource/receiptsource_test.go`

--- a/api/go.mod
+++ b/api/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/auth0/go-jwt-middleware/v2 v2.3.0
 	github.com/chromedp/cdproto v0.0.0-20250403032234-65de8f5d025b
 	github.com/chromedp/chromedp v0.13.7
+	github.com/expr-lang/expr v1.17.8
 	github.com/gabriel-vasile/mimetype v1.4.10
 	github.com/glebarez/sqlite v1.11.0
 	github.com/go-chi/chi/v5 v5.2.3

--- a/api/go.sum
+++ b/api/go.sum
@@ -35,6 +35,8 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/r
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/expr-lang/expr v1.17.8 h1:W1loDTT+0PQf5YteHSTpju2qfUfNoBt4yw9+wOEU9VM=
+github.com/expr-lang/expr v1.17.8/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=

--- a/api/internal/reporting/README.md
+++ b/api/internal/reporting/README.md
@@ -1,0 +1,526 @@
+# The reporting engine
+
+A **pure** function from a report definition and some rows to a format-agnostic tree:
+
+```
+(ReportSpec + FieldCatalog + []Row + MetaInput)  ──▶  ReportModel
+```
+
+It fetches nothing, renders nothing, reads no clock, and consults no global. The same inputs always
+produce byte-identical output. Renderers (CSV/XLSX/PDF), a dashboard widget, template persistence and
+HTTP delivery all *call* it; none of them are part of it.
+
+The purity claim is mechanically checkable, not aspirational:
+
+```bash
+go list -deps receipt-wrangler/api/internal/reporting | grep -E 'gorm|repositories|internal/models'
+# prints nothing
+```
+
+> **Every number in this document is copied from a test assertion.** Where a figure appears, the test
+> that owns it is named. If you change the engine and a number here looks wrong, that test is already
+> red and will tell you so.
+
+---
+
+## 1. The pipeline
+
+`Run` (`engine.go`) is five stages. Rows arrive already resolved — the engine never looks anything up.
+
+```
+   []Row                                                            ReportModel
+     │                                                                   ▲
+     │  ┌───────────────┐   the spec is validated and everything it      │
+     └─▶│  compileSpec  │   needs resolved once: field refs, parsed      │
+        │  validate.go  │   formulas, column types, arithmetic order     │
+        └───────┬───────┘                                                │
+                │                                                        │
+        ┌───────▼───────┐   each row is attributed to every bucket it    │
+        │    insert     │   belongs in. groupPaths() walks the grouping  │
+        │  groupPaths   │   levels; a multi-value dimension fans the row │
+        └───────┬───────┘   out into a cross product of paths            │
+                │                                                        │
+        ┌───────▼───────┐   bottom-up. A parent MERGES its children's    │
+        │    rollUp     │   accumulators — never their finalized values. │
+        │  rollUpLeaf   │   This is the whole point of the accumulator.  │
+        └───────┬───────┘                                                │
+                │                                                        │
+        ┌───────▼───────┐   buckets sort by typed value, (None) last.    │
+        │   emitGroup   │   Arithmetic columns are recomputed per row,   │
+        │   rowCells    │   at every level. Nothing ranges a Go map.     │
+        └───────────────┘───────────────────────────────────────────────▶┘
+```
+
+Validation happens **before any row is touched**: a spec that does not compile is an error, not a
+report full of empty cells.
+
+---
+
+## 2. The vocabulary
+
+| Type | What it is |
+|---|---|
+| `Value` | An immutable typed scalar: null, string, number (`decimal`), date, bool. The zero `Value` is null. |
+| `Row` | `map[FieldKey][]Value` — one source record, fields already resolved. Every field holds a *slice*, so scalar and multi-value fields share one shape. |
+| `FieldRef` | A field a report may reference: key, label, data type, and `Multi`. |
+| `FieldCatalog` | The set of fields a spec may name. A producer builds one alongside the rows it emits. |
+| `ReportSpec` | What to group by, what the bottom rows are, and what the columns compute. |
+| `ReportModel` | The output tree: `Root` → `Children` → `DetailRows` → `Cells`. |
+
+### A field's *role* is derived, never declared
+
+```
+DataType                Role         May be used as
+────────────────────────────────────────────────────────────────
+TypeNumber, TypeCurrency  →  Measure    the input to SUM/AVG/MIN/MAX
+TypeString, TypeDate,     →  Dimension  a groupBy level, or the key
+TypeBool                                of an aggregated detail row
+```
+
+`RoleForDataType` (`field.go`) is the whole rule. A template can therefore never group by a dollar
+amount or sum a status — the spec simply will not compile.
+
+### Three column kinds, declared not inferred
+
+| Kind | Computes | Rolls up by |
+|---|---|---|
+| `ColumnLabel` | displays a field | it doesn't — it is **blank** on a subtotal row |
+| `ColumnAggregate` | `SUM(amount)`, `COUNT()` | **merging accumulators** |
+| `ColumnArithmetic` | `Subtotal + Hst` | **recomputing from the same row** |
+
+The kind is declared rather than inferred from whether summing happens to work. §5 is why.
+
+---
+
+## 3. The output tree
+
+```
+ReportModel
+├── Meta              Title, GeneratedAt, Params, CurrencyFormat, NoneLabel
+├── Columns  []ColumnDescriptor   name, label, kind, data type, format
+├── Root     GroupNode            synthetic: no Dimension, no Subtotals
+│   ├── Dimension  FieldKey       the field this node's siblings were cut by
+│   ├── Value      Value          this bucket's value ((None) ⇒ null + IsNone)
+│   ├── RecordCount int
+│   ├── Children   []GroupNode    ─┐ a node holds one or the other,
+│   ├── DetailRows []DetailRow    ─┘ never both: leaves hold detail
+│   └── Subtotals  []Cell         nil unless the spec asked for them
+└── GrandTotals []Cell            nil unless the spec asked for them
+```
+
+A `Cell` holds `[]Value`. Aggregate and arithmetic cells always hold exactly one value, possibly null.
+A label cell in records mode may hold several, because a record can carry several categories or tags.
+
+---
+
+## 4. A worked example, end to end
+
+Ten rows. Group by payer, then by tag; one summed row per category.
+
+### The input
+
+| paid_by | tag  | category | amount | custom_1 (Hst) |
+|---------|------|----------|--------|----------------|
+| Dana    | Alex | Clothing | 30.00  | 3.90           |
+| Dana    | Alex | Clothing | 30.00  | 3.90           |
+| Dana    | Alex | Clothing | 30.00  | 3.90           |
+| Dana    | Alex | Clothing | 30.00  | 3.90           |
+| Dana    | Alex | Medical  | 50.00  | *(none)*       |
+| Dana    | Alex | Medical  | 30.00  | *(none)*       |
+| Dana    | Sam  | Clothing | 30.00  | 3.90           |
+| Dana    | Sam  | Clothing | 30.00  | 3.90           |
+| Dana    | Sam  | Clothing | 30.00  | 3.90           |
+| Dana    | Sam  | Mileage  | 30.00  | *(none)*       |
+
+### The spec
+
+```go
+sum := func(f FieldKey) Aggregate { return Aggregate{Func: AggSum, Field: f} }
+
+ReportSpec{
+    GroupBy: []FieldKey{"paid_by", "tag"},
+    Detail:  DetailSpec{Mode: DetailAggregate, By: "category"},
+    Columns: []Column{
+        {Name: "Category", Kind: ColumnLabel, Field: "category"},
+        {Name: "Count",    Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}},
+        {Name: "Subtotal", Kind: ColumnAggregate, Agg: sum("amount")},
+        {Name: "Hst",      Kind: ColumnAggregate, Agg: sum("custom_1")},
+        {Name: "Total",    Kind: ColumnArithmetic, Expr: "Subtotal + Hst"},
+        {Name: "AvgPerReceipt", Label: "Avg/Receipt",
+         Kind: ColumnArithmetic, Expr: "Total / Count"},
+    },
+    Subtotals:   true,
+    GrandTotals: true,
+}
+```
+
+`Column.Name` is what formulas reference; `Column.Label` is the heading a reader sees. They are
+separate so that renaming a heading cannot break a formula.
+
+### The tree it becomes
+
+```
+                                    Count  Subtotal    Hst   Total  Avg/Receipt
+Root                        n=10        ·         ·      ·       ·            ·
+└── paid_by "Dana"          n=10       10    320.00  27.30  347.30        34.73
+    ├── tag "Alex"          n=6         6    200.00  15.60  215.60        35.93
+    │   ├── category Clothing  ·        4    120.00  15.60  135.60        33.90
+    │   └── category Medical   ·        2     80.00   0.00   80.00        40.00
+    └── tag "Sam"           n=4         4    120.00  11.70  131.70        32.93
+        ├── category Clothing  ·        3     90.00  11.70  101.70        33.90
+        └── category Mileage   ·        1     30.00   0.00   30.00        30.00
+GrandTotals                            10    320.00  27.30  347.30        34.73
+```
+
+Nodes with an `n=` are `GroupNode`s and the numbers beside them are their `Subtotals`. The indented
+`category` rows are `DetailRow`s. `Root` is synthetic: it has no `Dimension` and never carries
+`Subtotals` — the report-wide figures live in `GrandTotals`.
+
+### The report a renderer draws
+
+Owned by `TestGolden_WorkedExampleRendersAsTheDesignDocument` (`golden_test.go`).
+
+```
+Category      Count  Subtotal    Hst   Total  Avg/Receipt
+Paid By: Dana
+  Tag: Alex
+    Clothing      4    120.00  15.60  135.60        33.90
+    Medical       2     80.00   0.00   80.00        40.00
+    TOTALS        6    200.00  15.60  215.60        35.93
+  Tag: Sam
+    Clothing      3     90.00  11.70  101.70        33.90
+    Mileage       1     30.00   0.00   30.00        30.00
+    TOTALS        4    120.00  11.70  131.70        32.93
+  TOTALS         10    320.00  27.30  347.30        34.73
+GRAND TOTALS     10    320.00  27.30  347.30        34.73
+```
+
+Two things to notice.
+
+**`Hst` for Medical is `0.00`, not blank.** `SUM` and `COUNT` of nothing are zero — a category with no
+tax shows `0.00`. `AVG`, `MIN` and `MAX` of nothing are *null*, and render as an empty cell, because
+there is no value to report and zero would be a lie.
+
+**`Category` is blank on every `TOTALS` row.** A label cuts rather than measures, so it does not roll
+up. The engine emits a cell with **zero values** there. That is a different thing from a `(None)`
+bucket, whose label cell holds **one null value** — see §7.
+
+---
+
+## 5. The two rollups, and why they differ
+
+This is the part that is easy to get wrong, and the reason `ColumnKind` is declared rather than
+guessed.
+
+### Aggregate columns merge accumulators — never finalized values
+
+An `accumulator` (`accumulator.go`) is a monoid. Rows fold into it with `add`; a parent folds its
+children into itself with `merge`; only `finalize` divides. It carries the running `sum`, the count of
+non-null `values`, the count of `records`, and the running `minimum`/`maximum`.
+
+For `SUM` it makes no difference — summing a child's `SUM` gives the parent's `SUM`. For `AVG` it is
+everything. Here is `AVG(amount)` over four receipts of 30 and one of 80 under `Alex`, and one of 120
+under `Sam`. Owned by `TestRun_AvgIsCorrectAtEveryLevel` (`engine_test.go`):
+
+```
+                                   Avg(amount)
+Root                          n=6           ·
+└── paid_by "Dana"            n=6   53.333333   ← not 80, the mean of 40 and 120
+    ├── tag "Alex"            n=5          40   ← not 55, the mean of 30 and 80
+    │   ├── category Clothing              30   (120 / 4)
+    │   └── category Medical               80   ( 80 / 1)
+    └── tag "Sam"             n=1         120
+        └── category Medical              120   (120 / 1)
+GrandTotals                         53.333333
+```
+
+`Alex` is `200 / 5 = 40`, not `(30 + 80) / 2 = 55`. `Dana` is `320 / 6 = 53.333333`, not
+`(40 + 120) / 2 = 80`. Because the parent merged `sum` and `values` and divided once at the end,
+`AVG` at *every* level is `sum(all descendants) / count(all descendants)` — with no special case.
+
+```
+     leaf "Clothing"          leaf "Medical"
+     sum=120  values=4        sum=80   values=1
+              └──────┬────────────┘
+                  merge          (NOT finalize-then-combine)
+                     ▼
+              sum=200  values=5
+                     │ finalize
+                     ▼
+                    40
+```
+
+### Arithmetic columns are recomputed from the row being rendered
+
+At a detail row, a subtotal row and the grand total alike, an arithmetic column is evaluated against
+the *other cells on that same row*. It is never summed and never averaged.
+
+Look at `Avg/Receipt` under `Alex` in the worked example. Three plausible answers:
+
+```
+  sum the column          33.90 + 40.00           = 73.90     ✗ nonsense
+  average the column     (33.90 + 40.00) / 2      = 36.95     ✗ wrong
+  recompute the row       Total / Count
+                          215.60 / 6              = 35.93     ✓ the answer
+```
+
+The same rule covers the additive case for free. `Total = Subtotal + Hst` recomputes to
+`200.00 + 15.60 = 215.60`, which is also what you get by summing `135.60 + 80.00`. An additive formula
+agrees with summing; a ratio does not. **One rule, both correct.**
+
+A zero divisor yields an empty cell, never a panic — `shopspring` panics on division by zero, so a
+report with a zero count would otherwise take down the request that asked for it.
+
+### What each kind shows, where
+
+| | detail row | subtotal row | grand total |
+|---|---|---|---|
+| `ColumnLabel` | the field's value(s) | *blank* (zero values) | *blank* |
+| `ColumnAggregate` | the bucket's `finalize` | merged children's `finalize` | root's `finalize` |
+| `ColumnArithmetic` | recomputed from this row | recomputed from this row | recomputed from this row |
+
+A consequence worth knowing: a **numeric label column reads null on a subtotal row**, so arithmetic
+over it is null there too. That is correct — there is no single record for it to name.
+
+---
+
+## 6. Multi-value fan-out (it double-counts on purpose)
+
+A receipt with two categories is attributed to **both**, in full, and that double count propagates to
+the grand total. This is deliberate: it is the same attribution the dashboard pie chart uses.
+
+One receipt of `100.00` in two categories. Owned by `TestRun_MultiValueDimensionsDoubleCount`:
+
+```
+                              Count   Subtotal
+Root                    n=2
+├── category Clothing             1     100.00
+└── category Medical              1     100.00
+GrandTotals                       2     200.00     ← one receipt, a grand total of 200
+```
+
+Two multi-value levels produce a **cross product**. One receipt of `10.00` with two tags and two
+categories lands in `2 × 2 = 4` buckets and totals `40.00`
+(`TestRun_TwoMultiValueLevelsCrossProduct`).
+
+```
+row: tag=[Alex, Sam]  category=[Clothing, Medical]  amount=10.00
+
+  groupPaths ──▶  [Alex, Clothing]   [Alex, Medical]
+                  [Sam,  Clothing]   [Sam,  Medical]
+```
+
+**Only *distinct* values fan out.** A receipt tagged `"Alex"` twice belongs to the `Alex` bucket once,
+and its amount is counted once (`Row.dimensionValues` deduplicates by bucket key). Fan-out
+double-counts *across* different buckets, never *within* one.
+
+**A multi-valued field cannot be measured.** `SUM` over a field that resolves to several values would
+silently read the first and drop the rest, so `Validate` refuses it with `ErrMeasureIsMultiValued`. A
+`Multi` field remains a perfectly good dimension and a perfectly good display label.
+
+---
+
+## 7. `(None)` — an absent value is a bucket, not a dropped row
+
+A row with no value for a dimension falls into an explicit `(None)` bucket, marked `IsNone: true` with
+a null `Value`. It sorts last. Owned by `TestGolden_NoneBucketsRenderLast`:
+
+```
+Category      Count  Subtotal    Hst   Total  Avg/Receipt
+Paid By: Dana
+  Tag: Alex
+    Clothing      4    120.00  15.60  135.60        33.90
+    Medical       2     80.00   0.00   80.00        40.00
+    (None)        1      7.00   0.00    7.00         7.00
+    TOTALS        7    207.00  15.60  222.60        31.80
+  Tag: Sam
+    Clothing      3     90.00  11.70  101.70        33.90
+    Mileage       1     30.00   0.00   30.00        30.00
+    TOTALS        4    120.00  11.70  131.70        32.93
+  Tag: (None)
+    (None)        1      3.00   0.00    3.00         3.00
+    TOTALS        1      3.00   0.00    3.00         3.00
+  TOTALS         12    330.00  27.30  357.30        29.78
+GRAND TOTALS     12    330.00  27.30  357.30        29.78
+```
+
+Note the difference between a blank `TOTALS` label cell and a `(None)` label cell:
+
+```
+label cell with ZERO values  →  a subtotal row. No bucket named it.  renders ""
+label cell with ONE null     →  the (None) bucket. A bucket like     renders "(None)"
+                                any other, given the report's name.
+```
+
+An empty string is **not** `(None)`. `Str("")` is a bucket of its own and sorts first.
+
+> `IsNone == Value.IsNull()` holds for group nodes and aggregate-mode detail rows **only**. The
+> synthetic `Root` and every records-mode `DetailRow` carry a null `Value` with `IsNone: false`. It is
+> not a global biconditional — do not "fix" the engine to make it one.
+
+---
+
+## 8. Determinism
+
+"The same inputs always produce the same output" is a real guarantee, and five rules hold it up.
+
+**1. The bucket-key law.** Two values share a bucket key *exactly when* `compareValues` finds them
+equal. A key coarser than that merges distinct values; a key finer splits one value across two
+buckets. Numbers key on `decimal.String()` (canonical and lossless); dates key on `Unix()` seconds plus
+`Nanosecond()` — and never `UnixNano()`, which is undefined outside 1678–2262, where a zero `time.Time`
+and a date in 585 share one.
+
+**2. A bucket stores the canonical member of its class.** Agreeing with `compareValues` is only half
+the job. A bucket keeps whichever value created it and drops the rest, so what it reports must depend
+on the *class*, not on which member arrived first. Dates compare by instant, so `2026-05-01T00:00:00Z`
+and `2026-04-30T19:00:00-05:00` merge — and a renderer formatting a calendar day would print a
+different day for each. `Value.canonical()` normalizes a date to UTC, so **date buckets are emitted in
+UTC**.
+
+**3. Buckets are sorted, and no output is ever produced by ranging a Go map.** Siblings sort by typed
+value with `(None)` last. Records preserve input order — ordering them is the caller's query's job.
+
+**4. `GeneratedAt` is an input** (`MetaInput`), never `time.Now()`. A golden test could not exist
+otherwise.
+
+**5. Money is `decimal`, never `float`.** Division goes through `DivRound(x, Config.DivisionScale)`.
+The engine never reads or writes `decimal.DivisionPrecision`, a mutable process-wide global — relying
+on it would make a report's output depend on whatever else the process had done.
+
+---
+
+## 9. Formulas
+
+`expr-lang/expr` is used as a **parser front-end only** (`parser.Parse` → `ast.Node`). Its VM is never
+run, because it evaluates over `float64` and money must not touch a float. The tree is walked by our
+own decimal evaluator (`eval.go`).
+
+The whitelist is a **closed type switch whose `default` rejects**, so it holds by construction rather
+than by remembering to deny each new construct:
+
+```
+allowed:   number literals · column references · + - * / · unary sign · ROUND(x, n)
+rejected:  everything else — property access, comparisons, conditionals, arrays,
+           string and boolean literals, builtins, variable declarations, ...
+```
+
+Two traps, both tested:
+
+- `??`, `in`, `**` and `%` all parse as `*ast.BinaryNode`, so the **operator** is whitelisted too, not
+  just the node type.
+- expr ships lower-case builtins named `sum`, `min`, `max`, `count`, `round`, `len`, so `round(a, 2)`
+  arrives as an `*ast.BuiltinNode` rather than a `CallNode`. Mis-casing produces a helpful error.
+
+Arithmetic columns form a **DAG**, topologically sorted with cycle detection, so a column may be
+declared before the aggregate it reads:
+
+```
+  Avg  ──reads──▶  Total  ──reads──▶  Subtotal  (aggregate)
+                     │                 Hst       (aggregate)
+                     └──reads──────────┘
+
+  Declaration order is irrelevant. A cycle is ErrFormulaCycle, and the
+  error names its members:  A -> B -> C -> A
+```
+
+Source longer than `maxFormulaLength` (1 KB) is refused **before parsing**. expr's ten-thousand-node
+cap does not bound this: a parenthesis builds no node, so nesting is bounded only by the goroutine
+stack, and a Go stack overflow is a fatal error that `recover` cannot catch.
+
+`ColumnDescriptor.Expr` keeps the parsed tree, so a spreadsheet renderer can later translate a column
+into a live `=SUM(...)` cell formula instead of a computed value.
+
+---
+
+## 10. Feeding it data
+
+`internal/reporting/receiptsource` is the **only** package that imports `models`. It maps
+`[]models.Receipt` + `[]models.CustomField` into `[]reporting.Row`.
+
+```go
+source, err := receiptsource.New(customFields)   // needs CustomField.Options loaded
+model,  err := reporting.Run(spec, source.Catalog(), source.Rows(receipts), meta)
+```
+
+It offers `receipt_id`, `name`, `amount`, `date`, `resolved_date`, `created_at`, `status`, `paid_by`,
+`group`, `category`, `tag` (the last two `Multi`), plus one field per custom field, keyed
+`custom_<id>` — **by id, not by name, so renaming a custom field cannot break a saved report**.
+
+The caller must preload `PaidByUser`, `Group`, `Categories`, `Tags`, `CustomFields`. An unloaded
+association resolves to no value, which surfaces as a `(None)` bucket rather than as a crash.
+
+Reporting at item grain, or a widget over something else entirely, adds a **sibling** of this package.
+The engine core never changes.
+
+---
+
+## 11. Extending it
+
+**Adding a reduction** means updating **four** independent switches over `AggFunc`, and Go forces none
+of them to agree:
+
+```
+  aggregate.go   String()            → "MEDIAN"
+  aggregate.go   valid()             → admit it, or Validate rejects the column
+  aggregate.go   aggFuncFromName()   → parse "MEDIAN(amount)"
+  accumulator.go finalize()          → compute it
+```
+
+Wire up three and forget `finalize`, and `Validate` accepts the column while **every cell of it
+renders blank at every level, with no error anywhere**. `enums_test.go` pins the four lists to each
+other exhaustively over all 256 values, so that mistake fails at `go test` time. `DetailMode` is
+pinned the same way.
+
+**Errors are sentinels**, wrapped with `%w` and checked with `errors.Is`. `Validate` is total: whatever
+it is handed, it answers, and it never panics.
+
+---
+
+## 12. How it is tested
+
+Both packages are pure — **no `main_test.go`, no DB, no `app.db` cleanup.** Four layers, each catching
+what the one before it cannot:
+
+| Layer | File | What it does |
+|---|---|---|
+| Invariants | `invariants_test.go` | Re-derives the model's structure from the spec. `mustRun` calls it, so **every** engine test checks it in passing. |
+| Golden | `golden_test.go` | Renders a whole report as a text table. One assertion covers grouping, ordering, values, subtotal placement and blank cells. |
+| Properties | `property_test.go` | 400 randomized specs and rows from a fixed seed (`REPORTING_SEED` overrides). Conservation, rollup, AVG exactness, arithmetic recompute, determinism. |
+| Fuzz | `fuzz_test.go`, `bucketkey_test.go` | Seed corpora run under plain `go test`; `-fuzz` is opt-in. |
+
+**Compare money with `decimal.Equal`/`StringFixed`, never `reflect.DeepEqual`** — `NewFromInt(200)` and
+`200.00` are equal but carry different internal exponents.
+
+**A law must not be derived from the code it judges.** This rule has been broken twice here, and both
+times the suite went green over a real defect: a property test that computed bucket identity with the
+engine's own helpers, and an invariant serializer that rendered dates through `bucketKey`. Both now
+read the model the way a renderer would.
+
+### Mutation checking
+
+```bash
+./internal/reporting/mutation-check.sh          # all 43 mutations
+./internal/reporting/mutation-check.sh avg      # only those matching "avg"
+```
+
+Breaks the engine one way at a time and asserts a test objects. Uses `go test -overlay`, so it never
+writes to the working tree. **Run it before merging any change to the engine** — a survivor means the
+engine can be broken that way without a single test noticing.
+
+Its three self-imposed rules, each learned the hard way: a mutation whose search text no longer matches
+is a **failure**, not a pass; a mutant that **does not compile** was never tested, so only `--- FAIL`
+counts as caught; and `-count=1`, or the build cache serves the last verdict.
+
+---
+
+## 13. Known gaps
+
+**No date truncation.** `date`, `resolved_date` and `created_at` are dimensions, but `receiptsource`
+hands the engine a raw timestamp — so grouping by `date` buckets on the exact instant and yields **one
+group per receipt**. "Receipts by month" is not expressible today. Closing it means either derived
+fields in `receiptsource` (`date_month`, `date_year`) or a `GroupBy` entry carrying a truncation.
+Worth deciding before a persisted template fixes a `GroupBy` shape.
+
+**Per-row allocation.** `rowCells` builds a `map[string]Value` for every rendered row. At 50k rows a
+report costs roughly 165 ms and 39 allocations per row, dominated by `decimal`'s `big.Int` arithmetic
+rather than the map. Fine for a background job; worth revisiting if a synchronous caller ever appears.

--- a/api/internal/reporting/accumulator.go
+++ b/api/internal/reporting/accumulator.go
@@ -129,5 +129,18 @@ func (a accumulator) finalize(divisionScale int32) Value {
 		return Num(a.maximum)
 	}
 
+	// An unrecognized reduction cannot reach here. Validate rejects one with
+	// ErrUnknownAggFunc before a single row is touched, and newAccumulator is
+	// called from exactly one place, with a Func that has already passed that
+	// check.
+	//
+	// It is null rather than a panic on purpose. Nothing in this package panics
+	// — evalArithmetic guards a zero divisor precisely so shopspring cannot —
+	// and a panic here would be a line no test could execute, since every path
+	// to it runs through Validate first. The risk a panic would guard against is
+	// that valid() and this switch drift apart, which is a mistake made at
+	// compile time, not at report time; TestAggFunc_ClosedListsAgree catches it
+	// there, exhaustively, over all 256 values rather than the one someone
+	// forgot.
 	return Null()
 }

--- a/api/internal/reporting/accumulator.go
+++ b/api/internal/reporting/accumulator.go
@@ -1,0 +1,133 @@
+package reporting
+
+import "github.com/shopspring/decimal"
+
+// accumulator backs one aggregate column at one node of the report tree.
+//
+// It is a monoid: rows fold into it with add, and a parent folds its children
+// into itself with merge. A parent therefore combines its children's
+// accumulators, never their finalized values. That distinction is the whole
+// point of the type.
+//
+// Summing a child's SUM gives the parent's SUM, so for SUM the two approaches
+// agree. Averaging a child's AVG does not give the parent's AVG. By carrying
+// the running sum and count and dividing only in finalize, AVG at every level
+// is sum(all descendants) / count(all descendants) — which is the only correct
+// answer, and needs no special case.
+//
+// The zero accumulator is a valid empty SUM. Build others with newAccumulator.
+type accumulator struct {
+	function AggFunc
+
+	// sum totals the non-null values fed to SUM and AVG.
+	sum decimal.Decimal
+
+	// values counts the non-null values fed in, and is AVG's divisor. It is not
+	// the record count: a row whose measure is null contributes to records but
+	// not to values.
+	values int64
+
+	// records counts the rows attributed to this node, and is what COUNT
+	// reports. A row that fans out across two buckets is counted once in each,
+	// so a multi-value dimension double-counts on purpose.
+	records int64
+
+	minimum decimal.Decimal
+	maximum decimal.Decimal
+
+	// seen records whether any non-null value arrived, which distinguishes a
+	// MIN over nothing (null) from a MIN over a single zero.
+	seen bool
+}
+
+func newAccumulator(function AggFunc) accumulator {
+	return accumulator{function: function}
+}
+
+// add folds one row's contribution in. Every row increments the record count,
+// whether or not it carries a value, so COUNT() counts rows. A null or
+// non-numeric value contributes to nothing else: SUM skips it rather than
+// treating it as zero, and AVG excludes it from both its sum and its divisor.
+func (a *accumulator) add(value Value) {
+	a.records++
+
+	number, isNumber := value.Decimal()
+	if !isNumber {
+		return
+	}
+
+	a.sum = a.sum.Add(number)
+	a.values++
+
+	if !a.seen {
+		a.minimum = number
+		a.maximum = number
+		a.seen = true
+		return
+	}
+	if number.LessThan(a.minimum) {
+		a.minimum = number
+	}
+	if number.GreaterThan(a.maximum) {
+		a.maximum = number
+	}
+}
+
+// merge folds a child subtree's accumulator into this one. It is associative
+// and commutative, so the order children are merged in cannot affect the result.
+func (a *accumulator) merge(other accumulator) {
+	a.records += other.records
+	a.values += other.values
+	a.sum = a.sum.Add(other.sum)
+
+	if !other.seen {
+		return
+	}
+	if !a.seen {
+		a.minimum = other.minimum
+		a.maximum = other.maximum
+		a.seen = true
+		return
+	}
+	if other.minimum.LessThan(a.minimum) {
+		a.minimum = other.minimum
+	}
+	if other.maximum.GreaterThan(a.maximum) {
+		a.maximum = other.maximum
+	}
+}
+
+// finalize reduces the accumulator to the value a cell displays.
+//
+// SUM and COUNT of nothing are zero: a category with no HST shows 0.00, not an
+// empty cell. AVG, MIN and MAX of nothing are null, because there is no value
+// to report and zero would be a lie.
+func (a accumulator) finalize(divisionScale int32) Value {
+	switch a.function {
+	case AggSum:
+		return Num(a.sum)
+
+	case AggCount:
+		return Num(decimal.NewFromInt(a.records))
+
+	case AggAvg:
+		if a.values == 0 {
+			return Null()
+		}
+		return Num(a.sum.DivRound(decimal.NewFromInt(a.values), divisionScale))
+
+	case AggMin:
+		if !a.seen {
+			return Null()
+		}
+		return Num(a.minimum)
+
+	case AggMax:
+		if !a.seen {
+			return Null()
+		}
+		return Num(a.maximum)
+	}
+
+	return Null()
+}

--- a/api/internal/reporting/accumulator_test.go
+++ b/api/internal/reporting/accumulator_test.go
@@ -1,0 +1,322 @@
+package reporting
+
+import (
+	"testing"
+	"time"
+)
+
+// addAll folds a list of values into a fresh accumulator.
+func addAll(function AggFunc, values ...Value) accumulator {
+	acc := newAccumulator(function)
+	for _, value := range values {
+		acc.add(value)
+	}
+	return acc
+}
+
+func nums(literals ...string) []Value {
+	values := make([]Value, 0, len(literals))
+	for _, literal := range literals {
+		values = append(values, Num(dec(literal)))
+	}
+	return values
+}
+
+// assertFinalize checks a finalized accumulator against a decimal literal, or
+// against null when want is empty. Money is compared by value, never by
+// reflect.DeepEqual: 200 and 200.00 are equal but hold different internal
+// exponents.
+func assertFinalize(t *testing.T, acc accumulator, want string) {
+	t.Helper()
+
+	got := acc.finalize(testDivisionScale)
+	if want == "" {
+		if !got.IsNull() {
+			t.Errorf("finalize() = %v, want null", got)
+		}
+		return
+	}
+
+	number, isNumber := got.Decimal()
+	if !isNumber {
+		t.Fatalf("finalize() = %v, want the number %s", got, want)
+	}
+	if !number.Equal(dec(want)) {
+		t.Errorf("finalize() = %s, want %s", number, want)
+	}
+}
+
+func TestAccumulator_Sum(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []Value
+		want   string
+	}{
+		{"adds values", nums("120.00", "80.00"), "200.00"},
+		{"a single value", nums("15.60"), "15.60"},
+		// A category with no HST shows 0.00, not an empty cell.
+		{"sum of nothing is zero", nil, "0"},
+		{"sum of only nulls is zero", []Value{Null(), Null()}, "0"},
+		{"nulls are skipped, not treated as zero", []Value{Num(dec("5")), Null(), Num(dec("5"))}, "10"},
+		{"negatives", nums("10", "-4"), "6"},
+		{"no float drift", nums("0.1", "0.2"), "0.3"},
+		{"cents", nums("0.01", "0.01", "0.01"), "0.03"},
+		{"non-numeric values are skipped", []Value{Num(dec("5")), Str("x"), Bool(true)}, "5"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertFinalize(t, addAll(AggSum, test.values...), test.want)
+		})
+	}
+}
+
+// COUNT counts rows, not values. A row whose measure is null still happened.
+func TestAccumulator_Count(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []Value
+		want   string
+	}{
+		{"counts rows", nums("1", "2", "3"), "3"},
+		{"count of nothing is zero", nil, "0"},
+		{"counts rows with null measures", []Value{Null(), Null()}, "2"},
+		{"counts a mix", []Value{Num(dec("1")), Null(), Num(dec("3"))}, "3"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertFinalize(t, addAll(AggCount, test.values...), test.want)
+		})
+	}
+}
+
+func TestAccumulator_Avg(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []Value
+		want   string
+	}{
+		{"averages values", nums("10", "20"), "15"},
+		// The divisor is the count of values, not of rows: a null does not drag
+		// the average down.
+		{"nulls are excluded from the divisor", []Value{Num(dec("10")), Null(), Num(dec("20"))}, "15"},
+		{"avg of nothing is null", nil, ""},
+		{"avg of only nulls is null", []Value{Null()}, ""},
+		// 1 / 3 repeats forever; the division scale bounds it deterministically.
+		{"a repeating quotient is bounded by the division scale", nums("1", "0", "0"), "0.333333"},
+		{"a single zero averages zero, not null", nums("0"), "0"},
+		{"the worked example's grand average", nums("120", "80", "90", "30"), "80"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertFinalize(t, addAll(AggAvg, test.values...), test.want)
+		})
+	}
+}
+
+func TestAccumulator_MinMax(t *testing.T) {
+	tests := []struct {
+		name    string
+		values  []Value
+		wantMin string
+		wantMax string
+	}{
+		{"ordinary range", nums("5", "1", "9"), "1", "9"},
+		{"single value", nums("4.20"), "4.20", "4.20"},
+		{"negatives", nums("-5", "3"), "-5", "3"},
+		// Zero is a value. Null is the absence of one.
+		{"a single zero", nums("0"), "0", "0"},
+		{"of nothing is null", nil, "", ""},
+		{"of only nulls is null", []Value{Null(), Null()}, "", ""},
+		{"nulls are skipped", []Value{Null(), Num(dec("7")), Null()}, "7", "7"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertFinalize(t, addAll(AggMin, test.values...), test.wantMin)
+			assertFinalize(t, addAll(AggMax, test.values...), test.wantMax)
+		})
+	}
+}
+
+// The single most important property in this package. Averaging the children's
+// averages gives the wrong answer; merging their accumulators gives the right
+// one.
+func TestAccumulator_AvgRollupIsNotAvgOfAvgs(t *testing.T) {
+	// Alex: four receipts totalling 120. Sam: one receipt of 80.
+	alex := addAll(AggAvg, nums("30", "30", "30", "30")...)
+	sam := addAll(AggAvg, nums("80")...)
+
+	// Averaging the two child averages would give (30 + 80) / 2 = 55.
+	assertFinalize(t, alex, "30")
+	assertFinalize(t, sam, "80")
+
+	parent := newAccumulator(AggAvg)
+	parent.merge(alex)
+	parent.merge(sam)
+
+	// The truth is 200 / 5 = 40.
+	assertFinalize(t, parent, "40")
+}
+
+func TestAccumulator_Merge(t *testing.T) {
+	tests := []struct {
+		name     string
+		function AggFunc
+		left     []Value
+		right    []Value
+		want     string
+	}{
+		{"sum", AggSum, nums("120.00", "80.00"), nums("90.00", "30.00"), "320.00"},
+		{"count", AggCount, nums("1", "2"), []Value{Null()}, "3"},
+		{"avg", AggAvg, nums("10", "20"), nums("60"), "30"},
+		{"min picks the global minimum", AggMin, nums("5", "9"), nums("1"), "1"},
+		{"max picks the global maximum", AggMax, nums("5", "9"), nums("12"), "12"},
+		{"min ignores an empty child", AggMin, nums("5"), nil, "5"},
+		{"max ignores an empty child", AggMax, nil, nums("5"), "5"},
+		{"min of two empty children is null", AggMin, nil, nil, ""},
+		{"sum of two empty children is zero", AggSum, nil, nil, "0"},
+		{"avg of two empty children is null", AggAvg, nil, nil, ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			parent := newAccumulator(test.function)
+			parent.merge(addAll(test.function, test.left...))
+			parent.merge(addAll(test.function, test.right...))
+			assertFinalize(t, parent, test.want)
+		})
+	}
+}
+
+// Merging must be associative and commutative, otherwise the order the engine
+// walks a subtree in would change the numbers it reports.
+func TestAccumulator_MergeIsAssociativeAndCommutative(t *testing.T) {
+	functions := []AggFunc{AggSum, AggCount, AggAvg, AggMin, AggMax}
+
+	for _, function := range functions {
+		t.Run(function.String(), func(t *testing.T) {
+			a := addAll(function, nums("3", "1")...)
+			b := addAll(function, nums("9")...)
+			c := addAll(function, []Value{Null(), Num(dec("4"))}...)
+
+			// merge(a, merge(b, c))
+			right := newAccumulator(function)
+			right.merge(b)
+			right.merge(c)
+			leftAssociated := newAccumulator(function)
+			leftAssociated.merge(a)
+			leftAssociated.merge(right)
+
+			// merge(merge(a, b), c)
+			left := newAccumulator(function)
+			left.merge(a)
+			left.merge(b)
+			rightAssociated := newAccumulator(function)
+			rightAssociated.merge(left)
+			rightAssociated.merge(c)
+
+			// merge(c, merge(b, a)) — reversed at every step.
+			reversed := newAccumulator(function)
+			reversed.merge(c)
+			reversed.merge(b)
+			reversed.merge(a)
+
+			associatedOne := leftAssociated.finalize(testDivisionScale)
+			associatedTwo := rightAssociated.finalize(testDivisionScale)
+			commuted := reversed.finalize(testDivisionScale)
+
+			if !associatedOne.Equal(associatedTwo) {
+				t.Errorf("merge is not associative: %v vs %v", associatedOne, associatedTwo)
+			}
+			if !associatedOne.Equal(commuted) {
+				t.Errorf("merge is not commutative: %v vs %v", associatedOne, commuted)
+			}
+		})
+	}
+}
+
+// The zero accumulator must behave as an empty one, since a parent starts from
+// it before merging any child.
+func TestAccumulator_MergeWithEmptyIsIdentity(t *testing.T) {
+	functions := []AggFunc{AggSum, AggCount, AggAvg, AggMin, AggMax}
+
+	for _, function := range functions {
+		t.Run(function.String(), func(t *testing.T) {
+			populated := addAll(function, nums("2", "8")...)
+			want := populated.finalize(testDivisionScale)
+
+			mergedAfter := addAll(function, nums("2", "8")...)
+			mergedAfter.merge(newAccumulator(function))
+
+			mergedBefore := newAccumulator(function)
+			mergedBefore.merge(addAll(function, nums("2", "8")...))
+
+			if got := mergedAfter.finalize(testDivisionScale); !got.Equal(want) {
+				t.Errorf("merging an empty child changed the result: %v, want %v", got, want)
+			}
+			if got := mergedBefore.finalize(testDivisionScale); !got.Equal(want) {
+				t.Errorf("merging into an empty parent changed the result: %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+// Deep trees roll up one level at a time, and must land on the same numbers as
+// aggregating every leaf at once.
+func TestAccumulator_DeepRollupMatchesFlatAggregate(t *testing.T) {
+	leaves := [][]Value{
+		nums("10", "20"),
+		nums("30"),
+		{Null(), Num(dec("40"))},
+		nil,
+	}
+
+	functions := []AggFunc{AggSum, AggCount, AggAvg, AggMin, AggMax}
+
+	for _, function := range functions {
+		t.Run(function.String(), func(t *testing.T) {
+			// Roll up through an intermediate level.
+			branchOne := newAccumulator(function)
+			branchOne.merge(addAll(function, leaves[0]...))
+			branchOne.merge(addAll(function, leaves[1]...))
+
+			branchTwo := newAccumulator(function)
+			branchTwo.merge(addAll(function, leaves[2]...))
+			branchTwo.merge(addAll(function, leaves[3]...))
+
+			root := newAccumulator(function)
+			root.merge(branchOne)
+			root.merge(branchTwo)
+
+			// Aggregate every leaf value directly.
+			flat := newAccumulator(function)
+			for _, leaf := range leaves {
+				for _, value := range leaf {
+					flat.add(value)
+				}
+			}
+
+			nested := root.finalize(testDivisionScale)
+			direct := flat.finalize(testDivisionScale)
+			if !nested.Equal(direct) {
+				t.Errorf("rolled up = %v, aggregated flat = %v", nested, direct)
+			}
+		})
+	}
+}
+
+// A record is counted even when its measure is missing, and MIN over a set that
+// contains a zero is that zero rather than null.
+func TestAccumulator_ZeroIsAValueNullIsNot(t *testing.T) {
+	withZero := addAll(AggMin, Num(dec("0")))
+	assertFinalize(t, withZero, "0")
+
+	withNull := addAll(AggMin, Null())
+	assertFinalize(t, withNull, "")
+
+	counted := addAll(AggCount, Null(), Str("ignored"), DateVal(time.Now()))
+	assertFinalize(t, counted, "3")
+}

--- a/api/internal/reporting/adversarial_test.go
+++ b/api/internal/reporting/adversarial_test.go
@@ -1,6 +1,7 @@
 package reporting
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -193,34 +194,81 @@ func TestRun_NullExtremesMergeWithRealOnes(t *testing.T) {
 	assertRow(t, model.GrandTotals, map[string]string{"Least": "4.00", "Total": "4.00"})
 }
 
-// The expression language caps the size of a tree it will build, so a formula
-// cannot be made to exhaust the stack or the heap. Parentheses add no nodes and
-// so parse to a shallow tree however deeply they nest.
+// A formula's source is bounded before it is parsed, which is the only thing
+// that bounds what parsing costs.
+//
+// It is tempting to rely on the expression language's ten-thousand-node cap
+// instead. That cap counts nodes as they are built, and a parenthesis builds
+// none — it only groups — while the parser descends several frames to read it.
+// Nesting is therefore bounded by the goroutine stack alone: about 640 bytes of
+// stack per parenthesis, so Go's default one-gigabyte ceiling falls near 1.6
+// million of them. Reaching it is a fatal stack overflow, which recover cannot
+// catch and which takes the process, not the request.
+//
+// An earlier version of this test asserted that 50,000 nested parentheses parse
+// fine, and read that as proof the cap protected the stack. It proved only that
+// 50,000 frames fit under the ceiling.
 func TestParseArithmetic_SizeLimits(t *testing.T) {
-	t.Run("a very long chain is refused, not fatal", func(t *testing.T) {
-		source := "a" + strings.Repeat("+a", 20000)
+	// One long identifier, so the two cases differ by exactly the one byte the
+	// bound is stated in.
+	t.Run("a formula at exactly the limit is accepted", func(t *testing.T) {
+		source := strings.Repeat("a", maxFormulaLength)
+
+		if _, err := ParseArithmetic(source); err != nil {
+			t.Errorf("a formula of exactly %d bytes was refused: %v", maxFormulaLength, err)
+		}
+	})
+
+	t.Run("one byte past the limit is refused", func(t *testing.T) {
+		source := strings.Repeat("a", maxFormulaLength+1)
 
 		node, err := ParseArithmetic(source)
-		if err == nil {
-			t.Fatalf("a %d-term chain parsed", 20000)
+		if !errors.Is(err, ErrFormulaTooLong) {
+			t.Errorf("error = %v, want ErrFormulaTooLong", err)
 		}
 		if node != nil {
 			t.Errorf("a rejected formula returned a node")
 		}
-		assertFormulaError(t, "long chain", err)
 	})
 
-	t.Run("deeply nested parentheses parse to a shallow tree", func(t *testing.T) {
-		depth := 50000
+	t.Run("a realistic chain well inside the limit is accepted", func(t *testing.T) {
+		source := "a" + strings.Repeat("+a", 100)
+
+		if _, err := ParseArithmetic(source); err != nil {
+			t.Errorf("a %d-byte chain was refused: %v", len(source), err)
+		}
+	})
+
+	t.Run("nesting deep enough to exhaust the stack never reaches the parser", func(t *testing.T) {
+		// Far below the ~1.6M that overflows, and far above the limit: the point
+		// is that the length check answers before the parser is ever called.
+		depth := 100_000
+		source := strings.Repeat("(", depth) + "a" + strings.Repeat(")", depth)
+
+		if _, err := ParseArithmetic(source); !errors.Is(err, ErrFormulaTooLong) {
+			t.Errorf("error = %v, want ErrFormulaTooLong", err)
+		}
+	})
+
+	t.Run("a long chain is refused by length, not by the node cap", func(t *testing.T) {
+		source := "a" + strings.Repeat("+a", 20000)
+
+		if _, err := ParseArithmetic(source); !errors.Is(err, ErrFormulaTooLong) {
+			t.Errorf("error = %v, want ErrFormulaTooLong", err)
+		}
+	})
+
+	t.Run("nesting within the limit still parses to a shallow tree", func(t *testing.T) {
+		// Parentheses group; they do not build nodes. That remains true, and is
+		// why the node cap could never have bounded them.
+		depth := (maxFormulaLength - 1) / 2
 		source := strings.Repeat("(", depth) + "a" + strings.Repeat(")", depth)
 
 		node, err := ParseArithmetic(source)
 		if err != nil {
 			t.Fatalf("ParseArithmetic() error = %v", err)
 		}
-		// Parentheses group; they do not build nodes.
-		refs := columnRefs(node)
-		if len(refs) != 1 || refs[0] != "a" {
+		if refs := columnRefs(node); len(refs) != 1 || refs[0] != "a" {
 			t.Errorf("columnRefs = %v, want [a]", refs)
 		}
 		if got := evalArithmetic(node, map[string]Value{"a": Num(dec("7"))}, 6); got.String() != "7" {
@@ -234,6 +282,14 @@ func TestParseArithmetic_SizeLimits(t *testing.T) {
 
 		if _, err := ParseArithmetic(source); err == nil {
 			t.Fatalf("a %d-deep call chain parsed", depth)
+		}
+	})
+
+	t.Run("an aggregate source is bounded too", func(t *testing.T) {
+		source := "SUM(" + strings.Repeat("a", maxFormulaLength) + ")"
+
+		if _, err := ParseAggregate(source); !errors.Is(err, ErrFormulaTooLong) {
+			t.Errorf("error = %v, want ErrFormulaTooLong", err)
 		}
 	})
 }

--- a/api/internal/reporting/adversarial_test.go
+++ b/api/internal/reporting/adversarial_test.go
@@ -1,0 +1,310 @@
+package reporting
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// Cases at the edges of the engine's semantics: values that look like absences,
+// dimensions that hold more than one type, degenerate specs, and formulas built
+// to exhaust something.
+
+// An empty string is a value. Absence is not. A receipt whose payer is named ""
+// belongs to its own bucket, which sorts before every other string, and is not
+// the (None) bucket.
+func TestRun_EmptyStringIsNotTheNoneBucket(t *testing.T) {
+	spec := ReportSpec{
+		GroupBy: []FieldKey{"paid_by"},
+		Columns: []Column{{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}}},
+	}
+
+	rows := []Row{
+		{"paid_by": {Str("Dana")}},
+		{"paid_by": {Str("")}},
+		{}, // absent
+		{"paid_by": {Null()}},
+	}
+
+	model := mustRun(t, spec, rows)
+
+	if len(model.Root.Children) != 3 {
+		t.Fatalf("got %d buckets, want 3 (empty string, Dana, (None))", len(model.Root.Children))
+	}
+
+	empty, dana, none := model.Root.Children[0], model.Root.Children[1], model.Root.Children[2]
+
+	if text, isText := empty.Value.Text(); !isText || text != "" {
+		t.Errorf("first bucket = %v, want the empty string", empty.Value)
+	}
+	if empty.IsNone {
+		t.Errorf("the empty string was treated as (None)")
+	}
+	if text, _ := dana.Value.Text(); text != "Dana" {
+		t.Errorf("second bucket = %v, want Dana", dana.Value)
+	}
+	// An absent value and an explicit null are the same absence, and share a bucket.
+	if !none.IsNone || none.RecordCount != 2 {
+		t.Errorf("(None) bucket = %+v, want 2 records", none)
+	}
+}
+
+// A dimension normally holds one type. If a producer mixes them, the report
+// must still be totally ordered and stable, because a report that reorders
+// itself is worse than one that looks odd.
+func TestRun_CrossTypeDimensionIsOrderedAndStable(t *testing.T) {
+	catalog, err := NewFieldCatalog(FieldRef{Key: "mixed", DataType: TypeString})
+	if err != nil {
+		t.Fatalf("NewFieldCatalog() error = %v", err)
+	}
+
+	spec := ReportSpec{
+		GroupBy: []FieldKey{"mixed"},
+		Columns: []Column{{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}}},
+	}
+
+	rows := []Row{
+		{"mixed": {Bool(true)}},
+		{"mixed": {DateVal(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))}},
+		{"mixed": {Num(dec("5"))}},
+		{"mixed": {Str("s")}},
+		{},
+	}
+
+	model, err := Run(spec, catalog, rows, MetaInput{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	assertModelInvariants(t, spec, model)
+
+	// Values sort by type, and the (None) bucket is last regardless of type.
+	wantTypes := []ValueType{ValueString, ValueNumber, ValueDate, ValueBool, ValueNull}
+	if len(model.Root.Children) != len(wantTypes) {
+		t.Fatalf("got %d buckets, want %d", len(model.Root.Children), len(wantTypes))
+	}
+	for index, want := range wantTypes {
+		if got := model.Root.Children[index].Value.Type(); got != want {
+			t.Errorf("bucket %d has type %v, want %v", index, got, want)
+		}
+	}
+
+	// And the order does not depend on the order the rows arrived in.
+	reversed := make([]Row, len(rows))
+	for index, row := range rows {
+		reversed[len(rows)-1-index] = row
+	}
+	permuted, err := Run(spec, catalog, reversed, MetaInput{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if serializeModel(permuted) != serializeModel(model) {
+		t.Errorf("reversing the rows reordered a mixed-type dimension")
+	}
+}
+
+// Aggregating the detail by a dimension the report already groups on is
+// degenerate but well defined: every group shows every bucket, because the
+// fan-out applies at both levels independently.
+//
+// Pinned rather than forbidden. It is the cross-product rule applied to itself,
+// and an author who writes it gets an answer that is consistent, if strange.
+func TestRun_DetailDimensionEqualToAGroupByLevel(t *testing.T) {
+	spec := ReportSpec{
+		GroupBy: []FieldKey{"tag"},
+		Detail:  DetailSpec{Mode: DetailAggregate, By: "tag"},
+		Columns: []Column{
+			{Name: "Tag", Kind: ColumnLabel, Field: "tag"},
+			{Name: "Subtotal", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "amount"}},
+		},
+		GrandTotals: true,
+	}
+
+	rows := []Row{{"tag": {Str("Alex"), Str("Sam")}, "amount": {Num(dec("10.00"))}}}
+	model := mustRun(t, spec, rows)
+
+	if len(model.Root.Children) != 2 {
+		t.Fatalf("got %d groups, want 2", len(model.Root.Children))
+	}
+	for _, group := range model.Root.Children {
+		if len(group.DetailRows) != 2 {
+			t.Errorf("group %v has %d detail rows, want 2", group.Value, len(group.DetailRows))
+		}
+	}
+
+	// Two groups times two detail buckets: the row is attributed four times.
+	assertRow(t, model.GrandTotals, map[string]string{"Subtotal": "40.00"})
+}
+
+// MIN and MAX must combine correctly through an internal node, not only within
+// a leaf. Everything else about them is unit-tested on the accumulator.
+func TestRun_MinMaxRollUpThroughTwoLevels(t *testing.T) {
+	spec := ReportSpec{
+		GroupBy: []FieldKey{"paid_by", "tag"},
+		Columns: []Column{
+			{Name: "Least", Kind: ColumnAggregate, Agg: Aggregate{Func: AggMin, Field: "amount"}},
+			{Name: "Most", Kind: ColumnAggregate, Agg: Aggregate{Func: AggMax, Field: "amount"}},
+		},
+		Subtotals:   true,
+		GrandTotals: true,
+	}
+
+	rows := []Row{
+		// Dana's extremes are split across her two children.
+		receiptRow("Dana", "Alex", "", "5.00", ""),
+		receiptRow("Dana", "Alex", "", "9.00", ""),
+		receiptRow("Dana", "Sam", "", "1.00", ""),
+		receiptRow("Dana", "Sam", "", "3.00", ""),
+		// Eve holds the report's maximum, and none of its minimum.
+		receiptRow("Eve", "Kim", "", "50.00", ""),
+	}
+
+	model := mustRun(t, spec, rows)
+	dana, eve := model.Root.Children[0], model.Root.Children[1]
+
+	assertRow(t, dana.Children[0].Subtotals, map[string]string{"Least": "5.00", "Most": "9.00"})
+	assertRow(t, dana.Children[1].Subtotals, map[string]string{"Least": "1.00", "Most": "3.00"})
+	assertRow(t, dana.Subtotals, map[string]string{"Least": "1.00", "Most": "9.00"})
+	assertRow(t, eve.Subtotals, map[string]string{"Least": "50.00", "Most": "50.00"})
+	assertRow(t, model.GrandTotals, map[string]string{"Least": "1.00", "Most": "50.00"})
+}
+
+// A group whose rows all carry a null measure reports null extremes and a zero
+// sum, and that null must survive the merge into a parent that has real values.
+func TestRun_NullExtremesMergeWithRealOnes(t *testing.T) {
+	spec := ReportSpec{
+		GroupBy: []FieldKey{"paid_by"},
+		Columns: []Column{
+			{Name: "Least", Kind: ColumnAggregate, Agg: Aggregate{Func: AggMin, Field: "custom_1"}},
+			{Name: "Total", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "custom_1"}},
+		},
+		Subtotals:   true,
+		GrandTotals: true,
+	}
+
+	rows := []Row{
+		{"paid_by": {Str("Dana")}, "custom_1": {Num(dec("4.00"))}},
+		{"paid_by": {Str("Eve")}}, // no tax recorded at all
+	}
+
+	model := mustRun(t, spec, rows)
+
+	assertRow(t, model.Root.Children[0].Subtotals, map[string]string{"Least": "4.00", "Total": "4.00"})
+	assertRow(t, model.Root.Children[1].Subtotals, map[string]string{"Least": "", "Total": "0"})
+	assertRow(t, model.GrandTotals, map[string]string{"Least": "4.00", "Total": "4.00"})
+}
+
+// The expression language caps the size of a tree it will build, so a formula
+// cannot be made to exhaust the stack or the heap. Parentheses add no nodes and
+// so parse to a shallow tree however deeply they nest.
+func TestParseArithmetic_SizeLimits(t *testing.T) {
+	t.Run("a very long chain is refused, not fatal", func(t *testing.T) {
+		source := "a" + strings.Repeat("+a", 20000)
+
+		node, err := ParseArithmetic(source)
+		if err == nil {
+			t.Fatalf("a %d-term chain parsed", 20000)
+		}
+		if node != nil {
+			t.Errorf("a rejected formula returned a node")
+		}
+		assertFormulaError(t, "long chain", err)
+	})
+
+	t.Run("deeply nested parentheses parse to a shallow tree", func(t *testing.T) {
+		depth := 50000
+		source := strings.Repeat("(", depth) + "a" + strings.Repeat(")", depth)
+
+		node, err := ParseArithmetic(source)
+		if err != nil {
+			t.Fatalf("ParseArithmetic() error = %v", err)
+		}
+		// Parentheses group; they do not build nodes.
+		refs := columnRefs(node)
+		if len(refs) != 1 || refs[0] != "a" {
+			t.Errorf("columnRefs = %v, want [a]", refs)
+		}
+		if got := evalArithmetic(node, map[string]Value{"a": Num(dec("7"))}, 6); got.String() != "7" {
+			t.Errorf("eval = %v, want 7", got)
+		}
+	})
+
+	t.Run("deeply nested calls are refused", func(t *testing.T) {
+		depth := 5000
+		source := strings.Repeat("ROUND(", depth) + "a" + strings.Repeat(", 2)", depth)
+
+		if _, err := ParseArithmetic(source); err == nil {
+			t.Fatalf("a %d-deep call chain parsed", depth)
+		}
+	})
+}
+
+// Validate is total: whatever it is handed, it answers, and it never panics.
+func TestValidate_IsTotal(t *testing.T) {
+	var zeroCatalog FieldCatalog
+
+	specs := []struct {
+		name string
+		spec ReportSpec
+	}{
+		{"zero spec", ReportSpec{}},
+		{"unknown label field", ReportSpec{Columns: []Column{{Name: "A", Kind: ColumnLabel, Field: "nope"}}}},
+		{"out of range kind", ReportSpec{Columns: []Column{{Name: "A", Kind: ColumnKind(200)}}}},
+		{"out of range aggregate", ReportSpec{Columns: []Column{{Name: "A", Kind: ColumnAggregate, Agg: Aggregate{Func: AggFunc(99), Field: "x"}}}}},
+		{"out of range detail mode", ReportSpec{Detail: DetailSpec{Mode: DetailMode(9)}, Columns: []Column{{Name: "A", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}}}}},
+		{"empty groupBy key", ReportSpec{GroupBy: []FieldKey{""}, Columns: []Column{{Name: "A", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}}}}},
+		{"nil columns", ReportSpec{GroupBy: []FieldKey{"tag"}}},
+		{"formula reading itself through a call", ReportSpec{Columns: []Column{{Name: "A", Kind: ColumnArithmetic, Expr: "ROUND(A, 2)"}}}},
+		{"negative scale", ReportSpec{Config: EngineConfig{DivisionScale: -5}, Columns: []Column{{Name: "A", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}}}}},
+	}
+
+	for _, test := range specs {
+		t.Run(test.name, func(t *testing.T) {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					t.Fatalf("Validate panicked: %v", recovered)
+				}
+			}()
+
+			// Against a catalog with no fields, and against a full one.
+			if err := Validate(test.spec, zeroCatalog); err == nil {
+				t.Errorf("Validate() against an empty catalog returned nil")
+			}
+			_ = Validate(test.spec, testCatalog(t))
+		})
+	}
+}
+
+// Run rejects what Validate rejects, before touching a single row.
+func TestRun_RejectsWhatValidateRejects(t *testing.T) {
+	spec := ReportSpec{Columns: []Column{{Name: "Loop", Kind: ColumnArithmetic, Expr: "Loop + 1"}}}
+
+	rows := []Row{{"amount": {Num(dec("1"))}}}
+	if _, err := Run(spec, testCatalog(t), rows, MetaInput{}); err == nil {
+		t.Fatalf("Run() accepted a spec Validate rejects")
+	}
+}
+
+// A row may carry fields the catalog does not know, and may omit fields it
+// does. Neither is an error: the first is ignored, the second is (None).
+func TestRun_RowsNeedNotMatchTheCatalog(t *testing.T) {
+	spec := ReportSpec{
+		GroupBy:     []FieldKey{"tag"},
+		Columns:     []Column{{Name: "Total", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "amount"}}},
+		GrandTotals: true,
+	}
+
+	rows := []Row{
+		{"tag": {Str("Alex")}, "amount": {Num(dec("1.00"))}, "unknown_field": {Str("ignored")}},
+		{"amount": {Num(dec("2.00"))}}, // no tag
+	}
+
+	model := mustRun(t, spec, rows)
+
+	if len(model.Root.Children) != 2 {
+		t.Fatalf("got %d buckets, want 2", len(model.Root.Children))
+	}
+	if !model.Root.Children[1].IsNone {
+		t.Errorf("the row with no tag did not land in (None)")
+	}
+	assertRow(t, model.GrandTotals, map[string]string{"Total": "3.00"})
+}

--- a/api/internal/reporting/aggregate.go
+++ b/api/internal/reporting/aggregate.go
@@ -1,0 +1,67 @@
+package reporting
+
+// AggFunc is a vertical reduction: it collapses many rows into one value.
+type AggFunc uint8
+
+const (
+	AggSum AggFunc = iota
+	AggCount
+	AggAvg
+	AggMin
+	AggMax
+)
+
+func (f AggFunc) String() string {
+	switch f {
+	case AggSum:
+		return "SUM"
+	case AggCount:
+		return "COUNT"
+	case AggAvg:
+		return "AVG"
+	case AggMin:
+		return "MIN"
+	case AggMax:
+		return "MAX"
+	}
+	return "UNKNOWN"
+}
+
+// aggFuncFromName resolves a function name to its reduction. Names are matched
+// exactly, so "sum" is not "SUM".
+func aggFuncFromName(name string) (AggFunc, bool) {
+	switch name {
+	case "SUM":
+		return AggSum, true
+	case "COUNT":
+		return AggCount, true
+	case "AVG":
+		return AggAvg, true
+	case "MIN":
+		return AggMin, true
+	case "MAX":
+		return AggMax, true
+	}
+	return 0, false
+}
+
+// Aggregate defines an aggregate column: exactly one reduction over one measure
+// field. Holding it structurally rather than as a general expression is what
+// lets the engine back each aggregate column with a mergeable accumulator, and
+// therefore roll it up by combining children rather than recomputing from
+// scratch at every level.
+type Aggregate struct {
+	Func AggFunc
+
+	// Field is the measure being reduced. It is empty for AggCount, which
+	// counts records rather than values.
+	Field FieldKey
+}
+
+// String renders the aggregate in the source form ParseAggregate accepts.
+func (a Aggregate) String() string {
+	if a.Func == AggCount {
+		return "COUNT()"
+	}
+	return a.Func.String() + "(" + string(a.Field) + ")"
+}

--- a/api/internal/reporting/aggregate.go
+++ b/api/internal/reporting/aggregate.go
@@ -27,6 +27,20 @@ func (f AggFunc) String() string {
 	return "UNKNOWN"
 }
 
+// valid reports whether the reduction is one the accumulator implements.
+//
+// ParseAggregate can only produce a known reduction, but Aggregate.Func is the
+// canonical form and a persisted template deserializes an integer straight into
+// it. An unknown one would otherwise fall through finalize's switch and render
+// every cell of the column null, at every level, without an error anywhere.
+func (f AggFunc) valid() bool {
+	switch f {
+	case AggSum, AggCount, AggAvg, AggMin, AggMax:
+		return true
+	}
+	return false
+}
+
 // aggFuncFromName resolves a function name to its reduction. Names are matched
 // exactly, so "sum" is not "SUM".
 func aggFuncFromName(name string) (AggFunc, bool) {

--- a/api/internal/reporting/bucketkey_test.go
+++ b/api/internal/reporting/bucketkey_test.go
@@ -182,6 +182,112 @@ func TestBucketKey_DatesAreLocationIndependent(t *testing.T) {
 	}
 }
 
+// Sharing a bucket key is not the same as being interchangeable in the output.
+//
+// A bucket keeps whichever value created it first and discards the rest, so the
+// value it reports must not depend on which arrived. Dates compare by instant,
+// which means two Values naming one instant in two zones are "equal" and merge —
+// yet Value.Time() hands a renderer back the raw time.Time with its location, so
+// a group header formatted as a calendar day would read 2026-05-01 or 2026-04-30
+// depending on the order the rows arrived in.
+//
+// The two instants below straddle midnight precisely so that a date-only format
+// disagrees. This is the same defect class as the UnixNano key above, one layer
+// up: the equivalence class is right, the representative was arbitrary.
+func TestRun_DateBucketIsLocationIndependent(t *testing.T) {
+	catalog, err := NewFieldCatalog(
+		FieldRef{Key: "date", Label: "Date", DataType: TypeDate},
+	)
+	if err != nil {
+		t.Fatalf("NewFieldCatalog() error = %v", err)
+	}
+
+	spec := ReportSpec{
+		GroupBy: []FieldKey{"date"},
+		Columns: []Column{{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}}},
+	}
+
+	utc := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	eastern := time.Date(2026, 4, 30, 19, 0, 0, 0, time.FixedZone("est", -5*3600))
+
+	if !utc.Equal(eastern) {
+		t.Fatalf("the fixture is wrong: these must name one instant")
+	}
+	if utc.Format(time.DateOnly) == eastern.Format(time.DateOnly) {
+		t.Fatalf("the fixture is wrong: these must format as different calendar days")
+	}
+
+	forward := []Row{{"date": {DateVal(utc)}}, {"date": {DateVal(eastern)}}}
+	backward := []Row{{"date": {DateVal(eastern)}}, {"date": {DateVal(utc)}}}
+
+	first, err := Run(spec, catalog, forward, MetaInput{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	second, err := Run(spec, catalog, backward, MetaInput{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if len(first.Root.Children) != 1 {
+		t.Fatalf("one instant produced %d buckets, want 1", len(first.Root.Children))
+	}
+
+	// Not Value.String(), which normalizes to UTC and so cannot see this. A
+	// renderer reads Value.Time() and formats it in the location it carries.
+	forwardTime, _ := first.Root.Children[0].Value.Time()
+	backwardTime, _ := second.Root.Children[0].Value.Time()
+
+	if forwardTime.Format(time.RFC3339Nano) != backwardTime.Format(time.RFC3339Nano) {
+		t.Errorf("reversing the input changed the bucket's date:\n  forward  = %s\n  backward = %s",
+			forwardTime.Format(time.RFC3339Nano), backwardTime.Format(time.RFC3339Nano))
+	}
+	if forwardTime.Format(time.DateOnly) != backwardTime.Format(time.DateOnly) {
+		t.Errorf("reversing the input changed the bucket's calendar day: %s vs %s",
+			forwardTime.Format(time.DateOnly), backwardTime.Format(time.DateOnly))
+	}
+}
+
+// A date bucket's representative is canonical, so a renderer never sees an
+// arbitrary one of the zones the rows happened to carry.
+func TestRun_DateBucketsAreEmittedInUTC(t *testing.T) {
+	catalog, err := NewFieldCatalog(
+		FieldRef{Key: "date", Label: "Date", DataType: TypeDate},
+	)
+	if err != nil {
+		t.Fatalf("NewFieldCatalog() error = %v", err)
+	}
+
+	spec := ReportSpec{
+		GroupBy: []FieldKey{"date"},
+		Detail:  DetailSpec{Mode: DetailAggregate, By: "date"},
+		Columns: []Column{{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}}},
+	}
+
+	eastern := time.Date(2026, 4, 30, 19, 0, 0, 0, time.FixedZone("est", -5*3600))
+	model, err := Run(spec, catalog, []Row{{"date": {DateVal(eastern)}}}, MetaInput{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	group := model.Root.Children[0]
+	groupTime, _ := group.Value.Time()
+	if groupTime.Location() != time.UTC {
+		t.Errorf("group bucket value is in %v, want UTC", groupTime.Location())
+	}
+	if !groupTime.Equal(eastern) {
+		t.Errorf("canonicalizing moved the instant: %v != %v", groupTime, eastern)
+	}
+
+	detailTime, _ := group.DetailRows[0].Value.Time()
+	if detailTime.Location() != time.UTC {
+		t.Errorf("detail bucket value is in %v, want UTC", detailTime.Location())
+	}
+	if !detailTime.Equal(eastern) {
+		t.Errorf("canonicalizing moved the instant: %v != %v", detailTime, eastern)
+	}
+}
+
 // FuzzBucketKeyMatchesCompare searches for any pair of same-typed values whose
 // bucket key disagrees with their ordering. It is the property that both the
 // date and the number defects violated.

--- a/api/internal/reporting/bucketkey_test.go
+++ b/api/internal/reporting/bucketkey_test.go
@@ -1,0 +1,257 @@
+package reporting
+
+import (
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// A bucket key identifies the bucket a value groups into, so two values must
+// share a key exactly when they compare equal. Anything else either merges
+// distinct values into one bucket or splits one value across two.
+//
+// This is the single law the key must obey, and it is fuzzed in
+// FuzzBucketKeyMatchesCompare.
+func assertKeyMatchesCompare(t *testing.T, a, b Value) {
+	t.Helper()
+
+	sameKey := bucketKey(a) == bucketKey(b)
+	equal := compareValues(a, b) == 0
+
+	if sameKey != equal {
+		t.Errorf("bucketKey/compareValues disagree for %v (%v) and %v (%v):\n"+
+			"  bucketKey(a) = %q\n  bucketKey(b) = %q\n  same key = %v, but compareValues says equal = %v",
+			a, a.Type(), b, b.Type(), bucketKey(a), bucketKey(b), sameKey, equal)
+	}
+}
+
+// time.Time.UnixNano is documented as undefined for dates before 1678 or after
+// 2262: the count overflows an int64 and wraps. Keying a date bucket on it
+// silently merges instants exactly 2^64 nanoseconds apart.
+//
+// A receipt whose CreatedAt was never round-tripped through the database holds
+// the zero time, which is one of them.
+func TestBucketKey_DatesOutsideUnixNanoRange(t *testing.T) {
+	zero := time.Time{}                                          // year 1
+	wrapped := zero.Add(math.MaxInt64).Add(math.MaxInt64).Add(2) // year 1 + 2^64ns, mid-585
+
+	if zero.Equal(wrapped) {
+		t.Fatalf("the fixture is wrong: these must be different instants")
+	}
+	if zero.UnixNano() != wrapped.UnixNano() {
+		t.Fatalf("the fixture is wrong: these must share a UnixNano")
+	}
+
+	assertKeyMatchesCompare(t, DateVal(zero), DateVal(wrapped))
+
+	if bucketKey(DateVal(zero)) == bucketKey(DateVal(wrapped)) {
+		t.Errorf("year 1 and year 585 share a bucket key")
+	}
+}
+
+func TestBucketKey_FarFutureDates(t *testing.T) {
+	// Both are outside UnixNano's range and differ by a day.
+	first := time.Date(3000, 1, 1, 0, 0, 0, 0, time.UTC)
+	second := first.AddDate(0, 0, 1)
+
+	assertKeyMatchesCompare(t, DateVal(first), DateVal(second))
+}
+
+// Two rows dated 584 years apart must not merge, and which of them a merged
+// bucket would have displayed must not depend on the order the rows arrived in.
+// This is the engine's determinism guarantee, and the UnixNano key breaks it.
+func TestRun_DistantDatesDoNotMergeOrDependOnInputOrder(t *testing.T) {
+	catalog, err := NewFieldCatalog(
+		FieldRef{Key: "date", Label: "Date", DataType: TypeDate},
+		FieldRef{Key: "amount", Label: "Amount", DataType: TypeCurrency},
+	)
+	if err != nil {
+		t.Fatalf("NewFieldCatalog() error = %v", err)
+	}
+
+	spec := ReportSpec{
+		GroupBy: []FieldKey{"date"},
+		Columns: []Column{{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}}},
+	}
+
+	zero := time.Time{}
+	wrapped := zero.Add(math.MaxInt64).Add(math.MaxInt64).Add(2)
+
+	forward := []Row{{"date": {DateVal(zero)}}, {"date": {DateVal(wrapped)}}}
+	backward := []Row{{"date": {DateVal(wrapped)}}, {"date": {DateVal(zero)}}}
+
+	first, err := Run(spec, catalog, forward, MetaInput{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	second, err := Run(spec, catalog, backward, MetaInput{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if len(first.Root.Children) != 2 {
+		t.Errorf("two distinct dates produced %d bucket(s), want 2", len(first.Root.Children))
+	}
+
+	// Even before the merge is fixed, the report must not change with input order.
+	if first.Root.Children[0].Value.String() != second.Root.Children[0].Value.String() {
+		t.Errorf("reversing the input changed the first bucket: %v vs %v",
+			first.Root.Children[0].Value, second.Root.Children[0].Value)
+	}
+}
+
+// StringFixed(12) truncates, so a value smaller than a picosecond of a cent
+// used to share the zero bucket. decimal.String() is canonical and lossless.
+func TestBucketKey_NumbersBelowTwelveDecimalPlaces(t *testing.T) {
+	tiny := Num(dec("0.0000000000001")) // 13 decimal places
+	zero := Num(dec("0"))
+
+	assertKeyMatchesCompare(t, tiny, zero)
+
+	if bucketKey(tiny) == bucketKey(zero) {
+		t.Errorf("0.0000000000001 shares a bucket key with 0")
+	}
+}
+
+// Scale must not affect the key: 200 and 200.00 are the same number.
+func TestBucketKey_NumbersIgnoreScale(t *testing.T) {
+	pairs := [][2]string{
+		{"200", "200.00"},
+		{"0.1", "0.10"},
+		{"0", "0.000"},
+		{"-1.5", "-1.500"},
+		{"1e3", "1000"},
+	}
+
+	for _, pair := range pairs {
+		t.Run(pair[0]+" vs "+pair[1], func(t *testing.T) {
+			a, b := Num(dec(pair[0])), Num(dec(pair[1]))
+			assertKeyMatchesCompare(t, a, b)
+			if bucketKey(a) != bucketKey(b) {
+				t.Errorf("%s and %s should share a bucket: %q vs %q", pair[0], pair[1], bucketKey(a), bucketKey(b))
+			}
+		})
+	}
+}
+
+// The key law, across every type and every pair, including the pathological
+// instants and magnitudes above.
+func TestBucketKey_MatchesCompareAcrossTypes(t *testing.T) {
+	zero := time.Time{}
+	wrapped := zero.Add(math.MaxInt64).Add(math.MaxInt64).Add(2)
+	utc := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	values := []Value{
+		Null(),
+		Str(""), Str("0"), Str("z"), Str("Clothing"),
+		Num(dec("0")), Num(dec("0.000")), Num(dec("0.0000000000001")),
+		Num(dec("200")), Num(dec("200.00")), Num(dec("-1")),
+		DateVal(zero), DateVal(wrapped), DateVal(utc),
+		DateVal(utc.In(time.FixedZone("plus-one", 3600))),
+		DateVal(utc.Add(time.Nanosecond)),
+		DateVal(time.Date(3000, 1, 1, 0, 0, 0, 0, time.UTC)),
+		Bool(false), Bool(true),
+	}
+
+	for i := range values {
+		for j := range values {
+			assertKeyMatchesCompare(t, values[i], values[j])
+		}
+	}
+}
+
+// A date's key must not depend on the location it was expressed in, only on the
+// instant it names.
+func TestBucketKey_DatesAreLocationIndependent(t *testing.T) {
+	utc := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	for _, offset := range []int{-43200, -3600, 0, 3600, 50400} {
+		zone := time.FixedZone("zone", offset)
+		if bucketKey(DateVal(utc)) != bucketKey(DateVal(utc.In(zone))) {
+			t.Errorf("offset %d changed the bucket key", offset)
+		}
+	}
+
+	// A monotonic clock reading must not leak into the key either.
+	instant := time.Now()
+	if bucketKey(DateVal(instant)) != bucketKey(DateVal(instant.Round(0))) {
+		t.Errorf("a monotonic reading changed the bucket key")
+	}
+}
+
+// FuzzBucketKeyMatchesCompare searches for any pair of same-typed values whose
+// bucket key disagrees with their ordering. It is the property that both the
+// date and the number defects violated.
+func FuzzBucketKeyMatchesCompare(f *testing.F) {
+	// The two known-bad pairs, plus the pairs that must stay equal.
+	f.Add(int64(-62135596800), 0, int64(-43688852727), 709551616, "0", "0", 0, 0)                 // year 1 vs year 585
+	f.Add(int64(0), 0, int64(0), 0, "0", "0.0000000000001", 0, 0)                                 // 0 vs 1e-13
+	f.Add(int64(0), 0, int64(0), 0, "200", "200.00", 0, 0)                                        // scale
+	f.Add(int64(1777978800), 0, int64(1777978800), 0, "1", "1", 3600, -3600)                      // one instant, two zones
+	f.Add(int64(math.MaxInt32), 999999999, int64(math.MinInt32), 1, "-1.5", "1.5", 43200, -43200) // spread
+	f.Add(int64(32503680000), 0, int64(32503766400), 0, "1e30", "1e-30", 0, 0)                    // year 3000 +1d, extremes
+
+	f.Fuzz(func(t *testing.T,
+		secondsA int64, nanosA int, secondsB int64, nanosB int,
+		numberA, numberB string, offsetA, offsetB int,
+	) {
+		dateA := fuzzDate(secondsA, nanosA, offsetA)
+		dateB := fuzzDate(secondsB, nanosB, offsetB)
+		assertKeyMatchesCompare(t, DateVal(dateA), DateVal(dateB))
+
+		decimalA, errA := boundedDecimal(numberA)
+		decimalB, errB := boundedDecimal(numberB)
+		if errA != nil || errB != nil {
+			return
+		}
+		assertKeyMatchesCompare(t, Num(decimalA), Num(decimalB))
+
+		// Cross-type pairs are never equal and must never share a key.
+		assertKeyMatchesCompare(t, DateVal(dateA), Num(decimalA))
+		assertKeyMatchesCompare(t, Str(numberA), Num(decimalA))
+		assertKeyMatchesCompare(t, Null(), DateVal(dateA))
+		assertKeyMatchesCompare(t, Str(numberA), Str(numberB))
+	})
+}
+
+// fuzzDate builds an instant from fuzz input, keeping it inside time.Time's
+// representable range so that formatting it for an error message stays sane.
+// The zone it is expressed in must not affect the key, so the fuzzer varies it.
+func fuzzDate(seconds int64, nanos int, offset int) time.Time {
+	const secondsBound = 200_000_000_000 // roughly the years -4300 to 8300
+
+	seconds %= secondsBound
+	if nanos < 0 {
+		nanos = -nanos
+	}
+	nanos %= 1_000_000_000
+
+	offset %= 14 * 3600
+
+	return time.Unix(seconds, int64(nanos)).In(time.FixedZone("fuzz", offset))
+}
+
+var errDecimalTooLarge = errors.New("decimal is too large to render")
+
+// boundedDecimal parses a fuzzed number, refusing ones whose rendered form
+// would be enormous. bucketKey renders a number through decimal.String(), which
+// expands the exponent, so "1e999999999" would otherwise allocate a string with
+// a billion characters.
+func boundedDecimal(literal string) (decimal.Decimal, error) {
+	if len(literal) > 64 {
+		return decimal.Decimal{}, errDecimalTooLarge
+	}
+
+	value, err := decimal.NewFromString(literal)
+	if err != nil {
+		return decimal.Decimal{}, err
+	}
+	if value.Exponent() < -1000 || value.Exponent() > 1000 {
+		return decimal.Decimal{}, errDecimalTooLarge
+	}
+
+	return value, nil
+}

--- a/api/internal/reporting/column.go
+++ b/api/internal/reporting/column.go
@@ -1,0 +1,81 @@
+package reporting
+
+// ColumnKind decides how a column is computed, and therefore how it rolls up.
+// The kind is declared, not inferred from whether summing happens to work.
+type ColumnKind uint8
+
+const (
+	// ColumnLabel displays a field's value. It cuts rather than measures, so it
+	// never rolls up: a label cell on a subtotal row is empty.
+	ColumnLabel ColumnKind = iota
+
+	// ColumnAggregate reduces rows vertically, and rolls up by merging its
+	// children's accumulators.
+	ColumnAggregate
+
+	// ColumnArithmetic combines other columns horizontally, and is recomputed
+	// from the other columns on the same row at every level. It is never summed.
+	//
+	// For an additive formula such as Total = Subtotal + Hst the two give the
+	// same answer, so a subtotal matches what a spreadsheet's =SUM would show.
+	// For a non-linear one such as Avg = Total / Count, summing or averaging the
+	// computed column is nonsense while recomputing stays correct. One rule
+	// covers both.
+	ColumnArithmetic
+)
+
+func (k ColumnKind) String() string {
+	switch k {
+	case ColumnLabel:
+		return "label"
+	case ColumnAggregate:
+		return "aggregate"
+	case ColumnArithmetic:
+		return "arithmetic"
+	}
+	return "unknown"
+}
+
+// Column is one column of the report.
+type Column struct {
+	// Name identifies the column to arithmetic formulas. It must be a plain
+	// identifier, unique within the spec, and not a reserved word.
+	//
+	// It is deliberately separate from Label so that renaming what a reader sees
+	// cannot break a formula that references it.
+	Name string
+
+	// Label is the heading a renderer draws. It is free text, and defaults to
+	// Name when empty.
+	Label string
+
+	Kind ColumnKind
+
+	// Field is the field a ColumnLabel displays.
+	Field FieldKey
+
+	// Agg is the reduction a ColumnAggregate applies. It is the canonical form;
+	// AggSrc is parsed into it when set.
+	Agg Aggregate
+
+	// AggSrc optionally carries a ColumnAggregate in the source form a persisted
+	// template stores, such as "SUM(amount)". When present it overrides Agg.
+	AggSrc string
+
+	// Expr is a ColumnArithmetic's expression over other column names, such as
+	// "Subtotal + Hst".
+	Expr string
+
+	// Format is an opaque per-column presentation override, such as
+	// "$ #,##0.00". The engine carries it through without interpreting it;
+	// renderers decide what it means.
+	Format string
+}
+
+// heading returns the text a renderer should draw for the column.
+func (c Column) heading() string {
+	if len(c.Label) > 0 {
+		return c.Label
+	}
+	return c.Name
+}

--- a/api/internal/reporting/doc.go
+++ b/api/internal/reporting/doc.go
@@ -39,4 +39,8 @@
 //
 // The engine emits raw typed values. Currency symbols, separators, and decimal
 // places are presentation, and belong to renderers.
+//
+// See README.md in this directory for a worked example carried from input rows
+// through the report tree to the rendered table, and for why aggregate and
+// arithmetic columns roll up by two different mechanisms.
 package reporting

--- a/api/internal/reporting/doc.go
+++ b/api/internal/reporting/doc.go
@@ -1,0 +1,42 @@
+// Package reporting is a pure report engine: it turns a report definition plus
+// already-fetched data into a format-agnostic ReportModel.
+//
+// The engine fetches nothing, renders nothing, and mutates nothing. It imports
+// no database, HTTP, or model packages — the only third-party dependencies are
+// shopspring/decimal and expr-lang/expr. Producers map their own domain objects
+// into Rows before calling Run; see internal/reporting/receiptsource for the
+// receipt mapping. Consumers (CSV/XLSX/PDF renderers, a dashboard widget) read
+// the ReportModel. Because Run is pure, the same inputs always yield the same
+// output.
+//
+// The pipeline is:
+//
+//	rows -> group -> aggregate -> ReportModel
+//
+// Four invariants hold everywhere in this package, and each is covered by tests:
+//
+// Money is decimal, never float. Division goes through DivRound at a configured
+// scale, and a zero divisor yields a null cell rather than a panic. The
+// package-level decimal.DivisionPrecision global is never read or written.
+//
+// Aggregate columns roll up by merging their children's accumulators, never by
+// combining finalized values. This is what makes AVG correct at every level: a
+// subtotal's average is sum(all descendants) / count(all descendants), not the
+// average of its children's averages. Arithmetic columns are recomputed from
+// the other columns on the same row at every level (detail, subtotal, grand
+// total), which keeps non-linear formulas such as ratios and averages correct
+// where summing the computed column would not be.
+//
+// Multi-value dimensions fan out. A row carrying two tags is attributed in full
+// to both tag buckets, so it double-counts, and that double-count propagates to
+// the grand total. This is deliberate and matches the dashboard pie chart's
+// attribution (see services/pie_chart.go). An empty dimension value becomes an
+// explicit (None) bucket and is never silently dropped.
+//
+// Output is deterministic. Buckets sort by their typed value with (None) last,
+// records preserve input order, and no output is ever produced by ranging over
+// a Go map.
+//
+// The engine emits raw typed values. Currency symbols, separators, and decimal
+// places are presentation, and belong to renderers.
+package reporting

--- a/api/internal/reporting/engine.go
+++ b/api/internal/reporting/engine.go
@@ -158,7 +158,7 @@ func (n *buildNode) child(value Value) *buildNode {
 }
 
 func (e engineRun) insertLeaf(leaf *buildNode, row Row) {
-	if e.compiled.spec.Detail.Mode == DetailRecords {
+	if !e.compiled.spec.Detail.isAggregate() {
 		leaf.records = append(leaf.records, row)
 		return
 	}
@@ -209,7 +209,7 @@ func (e engineRun) rollUp(node *buildNode, level int) {
 }
 
 func (e engineRun) rollUpLeaf(leaf *buildNode) {
-	if e.compiled.spec.Detail.Mode == DetailRecords {
+	if !e.compiled.spec.Detail.isAggregate() {
 		for _, record := range leaf.records {
 			e.addRow(leaf.accumulators, record)
 		}
@@ -283,7 +283,7 @@ func (e engineRun) emitGroup(node *buildNode, level int, path []Value) GroupNode
 }
 
 func (e engineRun) emitDetailRows(leaf *buildNode, path []Value) []DetailRow {
-	if e.compiled.spec.Detail.Mode == DetailRecords {
+	if !e.compiled.spec.Detail.isAggregate() {
 		return e.emitRecordRows(leaf)
 	}
 	return e.emitBucketRows(leaf, path)

--- a/api/internal/reporting/engine.go
+++ b/api/internal/reporting/engine.go
@@ -1,0 +1,428 @@
+package reporting
+
+import "sort"
+
+// Run turns a report definition and a set of rows into a ReportModel.
+//
+// It fetches nothing. Rows arrive already resolved — see
+// internal/reporting/receiptsource — and Run neither reads a clock nor consults
+// any global, so the same inputs always produce the same output.
+//
+// The spec is validated first; a spec that does not compile is an error before
+// any row is touched.
+func Run(spec ReportSpec, catalog FieldCatalog, rows []Row, meta MetaInput) (ReportModel, error) {
+	compiled, err := compileSpec(spec, catalog)
+	if err != nil {
+		return ReportModel{}, err
+	}
+
+	run := newEngineRun(compiled)
+
+	root := newBuildNode(Null())
+	for _, row := range rows {
+		run.insert(root, row)
+	}
+	run.rollUp(root, 0)
+
+	model := ReportModel{
+		Meta: Meta{
+			Title:          compiled.spec.Title,
+			GeneratedAt:    meta.GeneratedAt,
+			Params:         copyParams(meta.Params),
+			CurrencyFormat: meta.CurrencyFormat,
+			NoneLabel:      compiled.spec.NoneLabel,
+		},
+		Columns: run.descriptors(),
+		Root:    run.emitGroup(root, 0, nil),
+	}
+
+	if compiled.spec.GrandTotals {
+		model.GrandTotals = run.rowCells(noLabels, root.accumulators)
+	}
+
+	return model, nil
+}
+
+// engineRun carries the compiled spec and the derived lookups the walk needs.
+type engineRun struct {
+	compiled compiledSpec
+	scale    int32
+
+	// aggSlot maps a column's index to its position in a node's accumulator
+	// slice, and is -1 for columns that are not aggregates.
+	aggSlot []int
+}
+
+func newEngineRun(compiled compiledSpec) engineRun {
+	aggSlot := make([]int, len(compiled.columns))
+	for index := range aggSlot {
+		aggSlot[index] = -1
+	}
+	for slot, index := range compiled.aggregateIndexes {
+		aggSlot[index] = slot
+	}
+
+	return engineRun{
+		compiled: compiled,
+		scale:    compiled.spec.Config.DivisionScale,
+		aggSlot:  aggSlot,
+	}
+}
+
+// buildNode is a node of the tree while it is being built. It becomes a
+// GroupNode on the way out.
+type buildNode struct {
+	value Value
+
+	children   []*buildNode
+	childByKey map[string]*buildNode
+
+	// records holds the leaf's rows in records mode, in input order.
+	records []Row
+
+	// buckets holds the leaf's aggregated detail rows in aggregate mode.
+	buckets     []*detailBucket
+	bucketByKey map[string]*detailBucket
+
+	// accumulators and recordCount are filled by rollUp.
+	accumulators []accumulator
+	recordCount  int
+}
+
+// detailBucket is one aggregated detail row: everything attributed to one value
+// of the detail dimension.
+type detailBucket struct {
+	value        Value
+	accumulators []accumulator
+	recordCount  int
+}
+
+func newBuildNode(value Value) *buildNode {
+	return &buildNode{value: value, childByKey: map[string]*buildNode{}}
+}
+
+// insert attributes one row to every bucket it belongs in.
+func (e engineRun) insert(root *buildNode, row Row) {
+	for _, path := range e.groupPaths(row) {
+		node := root
+		for _, value := range path {
+			node = node.child(value)
+		}
+		e.insertLeaf(node, row)
+	}
+}
+
+// groupPaths returns every path through the grouping levels a row is attributed
+// to.
+//
+// A row with two tags is attributed to both tag buckets in full, which
+// double-counts it — the same attribution the dashboard pie chart uses. Two
+// multi-value levels therefore produce a cross product. A level the row has no
+// value for contributes the single (None) bucket, so the row is never dropped.
+//
+// With no grouping levels there is exactly one path, the empty one, and the
+// root is itself the leaf.
+func (e engineRun) groupPaths(row Row) [][]Value {
+	paths := [][]Value{nil}
+
+	for _, field := range e.compiled.groupBy {
+		values := row.dimensionValues(field.Key)
+		extended := make([][]Value, 0, len(paths)*len(values))
+
+		for _, path := range paths {
+			for _, value := range values {
+				next := make([]Value, len(path), len(path)+1)
+				copy(next, path)
+				extended = append(extended, append(next, value))
+			}
+		}
+		paths = extended
+	}
+
+	return paths
+}
+
+func (n *buildNode) child(value Value) *buildNode {
+	key := bucketKey(value)
+	if existing, found := n.childByKey[key]; found {
+		return existing
+	}
+
+	created := newBuildNode(value)
+	n.childByKey[key] = created
+	n.children = append(n.children, created)
+
+	return created
+}
+
+func (e engineRun) insertLeaf(leaf *buildNode, row Row) {
+	if e.compiled.spec.Detail.Mode == DetailRecords {
+		leaf.records = append(leaf.records, row)
+		return
+	}
+
+	for _, value := range row.dimensionValues(e.compiled.detailBy.Key) {
+		bucket := e.bucket(leaf, value)
+		bucket.recordCount++
+		e.addRow(bucket.accumulators, row)
+	}
+}
+
+func (e engineRun) bucket(leaf *buildNode, value Value) *detailBucket {
+	key := bucketKey(value)
+	if leaf.bucketByKey == nil {
+		leaf.bucketByKey = map[string]*detailBucket{}
+	}
+	if existing, found := leaf.bucketByKey[key]; found {
+		return existing
+	}
+
+	created := &detailBucket{value: value, accumulators: e.newAccumulators()}
+	leaf.bucketByKey[key] = created
+	leaf.buckets = append(leaf.buckets, created)
+
+	return created
+}
+
+// rollUp fills every node's accumulators, bottom up.
+//
+// A parent merges its children's accumulators; it never re-reads their rows and
+// never combines their finalized values. That is what makes AVG at a subtotal
+// the average over all of its descendants rather than the average of their
+// averages, and it is why the fan-out's double count propagates to the grand
+// total exactly as the pie chart's does.
+func (e engineRun) rollUp(node *buildNode, level int) {
+	node.accumulators = e.newAccumulators()
+
+	if level == len(e.compiled.groupBy) {
+		e.rollUpLeaf(node)
+		return
+	}
+
+	for _, child := range node.children {
+		e.rollUp(child, level+1)
+		mergeAccumulators(node.accumulators, child.accumulators)
+		node.recordCount += child.recordCount
+	}
+}
+
+func (e engineRun) rollUpLeaf(leaf *buildNode) {
+	if e.compiled.spec.Detail.Mode == DetailRecords {
+		for _, record := range leaf.records {
+			e.addRow(leaf.accumulators, record)
+		}
+		leaf.recordCount = len(leaf.records)
+		return
+	}
+
+	for _, bucket := range leaf.buckets {
+		mergeAccumulators(leaf.accumulators, bucket.accumulators)
+		leaf.recordCount += bucket.recordCount
+	}
+}
+
+func (e engineRun) newAccumulators() []accumulator {
+	accumulators := make([]accumulator, len(e.compiled.aggregateIndexes))
+	for slot, index := range e.compiled.aggregateIndexes {
+		accumulators[slot] = newAccumulator(e.compiled.columns[index].agg.Func)
+	}
+	return accumulators
+}
+
+// addRow folds one row into a set of accumulators. COUNT's field is empty, which
+// reads as null, so it contributes to the record count and nothing else.
+func (e engineRun) addRow(accumulators []accumulator, row Row) {
+	for slot, index := range e.compiled.aggregateIndexes {
+		accumulators[slot].add(row.Measure(e.compiled.columns[index].agg.Field))
+	}
+}
+
+func mergeAccumulators(into []accumulator, from []accumulator) {
+	for slot := range into {
+		into[slot].merge(from[slot])
+	}
+}
+
+// emitGroup converts a built node into the model's GroupNode.
+//
+// path carries the bucket value of each ancestor level, which is what lets a
+// label column on an aggregated detail row show the group it sits under.
+func (e engineRun) emitGroup(node *buildNode, level int, path []Value) GroupNode {
+	group := GroupNode{RecordCount: node.recordCount}
+
+	if level > 0 {
+		group.Dimension = e.compiled.groupBy[level-1].Key
+		group.Value = node.value
+		group.IsNone = node.value.IsNull()
+
+		if e.compiled.spec.Subtotals {
+			group.Subtotals = e.rowCells(noLabels, node.accumulators)
+		}
+	}
+
+	if level == len(e.compiled.groupBy) {
+		group.DetailRows = e.emitDetailRows(node, path)
+		return group
+	}
+
+	sortNodes(node.children)
+	group.Children = make([]GroupNode, 0, len(node.children))
+	for _, child := range node.children {
+		// A fresh slice per child: siblings must not share a backing array,
+		// since each carries its own bucket value down to the detail rows.
+		childPath := make([]Value, len(path), len(path)+1)
+		copy(childPath, path)
+		childPath = append(childPath, child.value)
+
+		group.Children = append(group.Children, e.emitGroup(child, level+1, childPath))
+	}
+
+	return group
+}
+
+func (e engineRun) emitDetailRows(leaf *buildNode, path []Value) []DetailRow {
+	if e.compiled.spec.Detail.Mode == DetailRecords {
+		return e.emitRecordRows(leaf)
+	}
+	return e.emitBucketRows(leaf, path)
+}
+
+// emitRecordRows emits one row per record, in the order the rows arrived. The
+// engine is deterministic given deterministic input; ordering records is the
+// caller's query's job, not the engine's.
+func (e engineRun) emitRecordRows(leaf *buildNode) []DetailRow {
+	rows := make([]DetailRow, 0, len(leaf.records))
+
+	for _, record := range leaf.records {
+		accumulators := e.newAccumulators()
+		e.addRow(accumulators, record)
+
+		labels := func(column compiledColumn) []Value {
+			// Copy, so a renderer holding a cell cannot reach back into the
+			// caller's row.
+			return append([]Value(nil), record.Get(column.field)...)
+		}
+		rows = append(rows, DetailRow{Cells: e.rowCells(labels, accumulators)})
+	}
+
+	return rows
+}
+
+func (e engineRun) emitBucketRows(leaf *buildNode, path []Value) []DetailRow {
+	sortBuckets(leaf.buckets)
+	rows := make([]DetailRow, 0, len(leaf.buckets))
+
+	for _, bucket := range leaf.buckets {
+		labels := func(column compiledColumn) []Value {
+			// An aggregated row sums many records, so the only values it can
+			// show are its own bucket and those of the groups above it.
+			if column.labelLevel == labelFromDetailBucket {
+				return []Value{bucket.value}
+			}
+			return []Value{path[column.labelLevel]}
+		}
+
+		rows = append(rows, DetailRow{
+			Dimension: e.compiled.detailBy.Key,
+			Value:     bucket.value,
+			IsNone:    bucket.value.IsNull(),
+			Cells:     e.rowCells(labels, bucket.accumulators),
+		})
+	}
+
+	return rows
+}
+
+// rowCells assembles one rendered row, whatever level it sits at.
+//
+// Label and aggregate cells are filled first, then arithmetic columns are
+// evaluated in dependency order against the values on this very row. That
+// recomputation is what keeps a non-linear formula correct at a subtotal: an
+// average per receipt is this row's total over this row's count, never the sum
+// or the average of the averages below it.
+func (e engineRun) rowCells(labels func(compiledColumn) []Value, accumulators []accumulator) []Cell {
+	cells := make([]Cell, len(e.compiled.columns))
+	values := make(map[string]Value, len(e.compiled.columns))
+
+	for index, column := range e.compiled.columns {
+		cells[index].Column = column.name
+
+		switch column.kind {
+		case ColumnLabel:
+			cells[index].Values = labels(column)
+			values[column.name] = cells[index].Value()
+
+		case ColumnAggregate:
+			value := accumulators[e.aggSlot[index]].finalize(e.scale)
+			cells[index].Values = []Value{value}
+			values[column.name] = value
+		}
+	}
+
+	for _, index := range e.compiled.arithmeticOrder {
+		column := e.compiled.columns[index]
+		value := evalArithmetic(column.expr, values, e.scale)
+		cells[index].Values = []Value{value}
+		values[column.name] = value
+	}
+
+	return cells
+}
+
+// noLabels leaves label cells empty, which is what a subtotal or grand-total row
+// shows for them.
+func noLabels(compiledColumn) []Value { return nil }
+
+func (e engineRun) descriptors() []ColumnDescriptor {
+	descriptors := make([]ColumnDescriptor, 0, len(e.compiled.columns))
+
+	for _, column := range e.compiled.columns {
+		descriptor := ColumnDescriptor{
+			Name:     column.name,
+			Label:    column.label,
+			Kind:     column.kind,
+			DataType: column.dataType,
+			Format:   column.format,
+		}
+
+		switch column.kind {
+		case ColumnAggregate:
+			aggregate := column.agg
+			descriptor.Agg = &aggregate
+		case ColumnArithmetic:
+			descriptor.Expr = column.expr
+			descriptor.ExprSrc = column.exprSrc
+		}
+
+		descriptors = append(descriptors, descriptor)
+	}
+
+	return descriptors
+}
+
+// sortNodes and sortBuckets order buckets by their value, with (None) last.
+// Nothing in this package emits output by ranging a map.
+func sortNodes(nodes []*buildNode) {
+	sort.SliceStable(nodes, func(i, j int) bool {
+		return compareValues(nodes[i].value, nodes[j].value) < 0
+	})
+}
+
+func sortBuckets(buckets []*detailBucket) {
+	sort.SliceStable(buckets, func(i, j int) bool {
+		return compareValues(buckets[i].value, buckets[j].value) < 0
+	})
+}
+
+func copyParams(params map[string]string) map[string]string {
+	if params == nil {
+		return nil
+	}
+
+	copied := make(map[string]string, len(params))
+	for key, value := range params {
+		copied[key] = value
+	}
+
+	return copied
+}

--- a/api/internal/reporting/engine.go
+++ b/api/internal/reporting/engine.go
@@ -148,7 +148,9 @@ func (n *buildNode) child(value Value) *buildNode {
 		return existing
 	}
 
-	created := newBuildNode(value)
+	// The canonical member of the class the key names, so the bucket's reported
+	// value cannot depend on which member arrived first.
+	created := newBuildNode(value.canonical())
 	n.childByKey[key] = created
 	n.children = append(n.children, created)
 
@@ -177,7 +179,7 @@ func (e engineRun) bucket(leaf *buildNode, value Value) *detailBucket {
 		return existing
 	}
 
-	created := &detailBucket{value: value, accumulators: e.newAccumulators()}
+	created := &detailBucket{value: value.canonical(), accumulators: e.newAccumulators()}
 	leaf.bucketByKey[key] = created
 	leaf.buckets = append(leaf.buckets, created)
 

--- a/api/internal/reporting/engine_test.go
+++ b/api/internal/reporting/engine_test.go
@@ -716,6 +716,28 @@ func TestRun_RecordsMode(t *testing.T) {
 	}
 }
 
+// Measuring a multi-valued field is refused by Validate; displaying one shows
+// every value it holds, and drops nothing.
+func TestRun_MultiValuedLabelShowsEveryValue(t *testing.T) {
+	spec := ReportSpec{
+		Columns: []Column{{Name: "Amounts", Kind: ColumnLabel, Field: "item_amounts"}},
+	}
+
+	rows := []Row{{"item_amounts": {Num(dec("10.00")), Num(dec("90.00"))}}}
+	model := mustRun(t, spec, rows)
+
+	values := model.Root.DetailRows[0].Cells[0].Values
+	if len(values) != 2 {
+		t.Fatalf("label cell holds %d values, want 2", len(values))
+	}
+	for index, want := range []string{"10", "90"} {
+		number, isNumber := values[index].Decimal()
+		if !isNumber || !number.Equal(dec(want)) {
+			t.Errorf("value %d = %v, want %s", index, values[index], want)
+		}
+	}
+}
+
 // A cell must not alias the caller's row.
 func TestRun_RecordsModeDoesNotAliasInputRows(t *testing.T) {
 	spec := ReportSpec{

--- a/api/internal/reporting/engine_test.go
+++ b/api/internal/reporting/engine_test.go
@@ -31,6 +31,8 @@ func receiptRow(paidBy, tag, category, amount, hst string) Row {
 	return row
 }
 
+// mustRun runs a spec and asserts the model's structural invariants, so every
+// engine test below checks them in passing whatever else it is asserting.
 func mustRun(t *testing.T, spec ReportSpec, rows []Row) ReportModel {
 	t.Helper()
 
@@ -38,6 +40,9 @@ func mustRun(t *testing.T, spec ReportSpec, rows []Row) ReportModel {
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
+
+	assertModelInvariants(t, spec, model)
+
 	return model
 }
 

--- a/api/internal/reporting/engine_test.go
+++ b/api/internal/reporting/engine_test.go
@@ -308,6 +308,90 @@ func TestRun_MultiValueDimensionsDoubleCount(t *testing.T) {
 	}
 }
 
+// Distinct values fan out; a repeated one does not. A receipt tagged "Alex"
+// twice belongs to the Alex bucket once, and its amount is counted once.
+//
+// This is the boundary of the rule above: fan-out double-counts across
+// different buckets, never within one.
+func TestRun_RepeatedDimensionValueIsOneAttribution(t *testing.T) {
+	spec := ReportSpec{
+		GroupBy: []FieldKey{"tag"},
+		Columns: []Column{
+			{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}},
+			{Name: "Subtotal", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "amount"}},
+		},
+		Subtotals:   true,
+		GrandTotals: true,
+	}
+
+	rows := []Row{{
+		"tag":    {Str("Alex"), Str("Alex")},
+		"amount": {Num(dec("10.00"))},
+	}}
+
+	model := mustRun(t, spec, rows)
+
+	if len(model.Root.Children) != 1 {
+		t.Fatalf("got %d tag buckets, want 1", len(model.Root.Children))
+	}
+	assertRow(t, model.Root.Children[0].Subtotals, map[string]string{"Count": "1", "Subtotal": "10.00"})
+	assertRow(t, model.GrandTotals, map[string]string{"Count": "1", "Subtotal": "10.00"})
+	if model.Root.RecordCount != 1 {
+		t.Errorf("root RecordCount = %d, want 1", model.Root.RecordCount)
+	}
+}
+
+// The same rule on the detail dimension.
+func TestRun_RepeatedDetailValueIsOneRow(t *testing.T) {
+	spec := ReportSpec{
+		Detail: DetailSpec{Mode: DetailAggregate, By: "category"},
+		Columns: []Column{
+			{Name: "Category", Kind: ColumnLabel, Field: "category"},
+			{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}},
+			{Name: "Subtotal", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "amount"}},
+		},
+		GrandTotals: true,
+	}
+
+	rows := []Row{{
+		"category": {Str("Clothing"), Str("Clothing")},
+		"amount":   {Num(dec("10.00"))},
+	}}
+
+	model := mustRun(t, spec, rows)
+
+	if len(model.Root.DetailRows) != 1 {
+		t.Fatalf("got %d detail rows, want 1", len(model.Root.DetailRows))
+	}
+	assertRow(t, model.Root.DetailRows[0].Cells, map[string]string{"Category": "Clothing", "Count": "1", "Subtotal": "10.00"})
+	assertRow(t, model.GrandTotals, map[string]string{"Count": "1", "Subtotal": "10.00"})
+}
+
+// A repeat mixed in among distinct values collapses only itself.
+func TestRun_RepeatedValueAmongDistinctOnes(t *testing.T) {
+	spec := ReportSpec{
+		GroupBy:     []FieldKey{"tag"},
+		Columns:     []Column{{Name: "Subtotal", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "amount"}}},
+		GrandTotals: true,
+	}
+
+	rows := []Row{{
+		"tag":    {Str("Alex"), Str("Sam"), Str("Alex")},
+		"amount": {Num(dec("10.00"))},
+	}}
+
+	model := mustRun(t, spec, rows)
+
+	if len(model.Root.Children) != 2 {
+		t.Fatalf("got %d tag buckets, want 2", len(model.Root.Children))
+	}
+	// Two distinct buckets, so the amount is attributed twice -- not three times.
+	assertRow(t, model.GrandTotals, map[string]string{"Subtotal": "20.00"})
+	if model.Root.RecordCount != 2 {
+		t.Errorf("root RecordCount = %d, want 2", model.Root.RecordCount)
+	}
+}
+
 // Two multi-value grouping levels produce a cross product.
 func TestRun_TwoMultiValueLevelsCrossProduct(t *testing.T) {
 	spec := ReportSpec{

--- a/api/internal/reporting/engine_test.go
+++ b/api/internal/reporting/engine_test.go
@@ -1,0 +1,945 @@
+package reporting
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+var testGeneratedAt = time.Date(2026, 6, 1, 9, 30, 0, 0, time.UTC)
+
+func testMeta() MetaInput {
+	return MetaInput{
+		GeneratedAt:    testGeneratedAt,
+		Params:         map[string]string{"period": "2026-05-01 TO 2026-05-31"},
+		CurrencyFormat: "$ #,##0.00",
+	}
+}
+
+// receiptRow builds a row shaped like a receipt: one payer, one tag, one
+// category, an amount and a tax amount.
+func receiptRow(paidBy, tag, category, amount, hst string) Row {
+	row := Row{
+		"paid_by":  {Str(paidBy)},
+		"tag":      {Str(tag)},
+		"category": {Str(category)},
+		"amount":   {Num(dec(amount))},
+	}
+	if hst != "" {
+		row["custom_1"] = []Value{Num(dec(hst))}
+	}
+	return row
+}
+
+func mustRun(t *testing.T, spec ReportSpec, rows []Row) ReportModel {
+	t.Helper()
+
+	model, err := Run(spec, testCatalog(t), rows, testMeta())
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	return model
+}
+
+// cell reads a named column out of a row of cells.
+func cell(t *testing.T, cells []Cell, column string) Value {
+	t.Helper()
+
+	for _, candidate := range cells {
+		if candidate.Column == column {
+			return candidate.Value()
+		}
+	}
+	t.Fatalf("no cell for column %q", column)
+	return Null()
+}
+
+// assertRow checks a whole row against decimal literals, where "" means null.
+func assertRow(t *testing.T, cells []Cell, want map[string]string) {
+	t.Helper()
+
+	for column, expected := range want {
+		got := cell(t, cells, column)
+		if expected == "" {
+			if !got.IsNull() {
+				t.Errorf("column %s = %v, want null", column, got)
+			}
+			continue
+		}
+
+		number, isNumber := got.Decimal()
+		if !isNumber {
+			// Fall back to a string comparison for label columns.
+			if text, isText := got.Text(); isText {
+				if text != expected {
+					t.Errorf("column %s = %q, want %q", column, text, expected)
+				}
+				continue
+			}
+			t.Errorf("column %s = %v, want %s", column, got, expected)
+			continue
+		}
+		if !number.Equal(dec(expected)) {
+			t.Errorf("column %s = %s, want %s", column, number, expected)
+		}
+	}
+}
+
+// workedExampleRows is the data behind the design document's worked example:
+//
+//	Foster Parent: Dana
+//	  Child: Alex
+//	                     Count   Subtotal    Hst      Total     Avg/Receipt
+//	    Clothing           4      120.00    15.60    135.60        33.90
+//	    Medical            2       80.00     0.00     80.00        40.00
+//	    TOTALS (Alex)      6      200.00    15.60    215.60        35.93
+//	  Child: Sam
+//	    Clothing           3       90.00    11.70    101.70        33.90
+//	    Mileage            1       30.00     0.00     30.00        30.00
+//	    TOTALS (Sam)       4      120.00    11.70    131.70        32.93
+//	  GRAND TOTALS        10      320.00    27.30    347.30        34.73
+func workedExampleRows() []Row {
+	return []Row{
+		// Alex, Clothing: four receipts totalling 120.00 with 15.60 of tax.
+		receiptRow("Dana", "Alex", "Clothing", "30.00", "3.90"),
+		receiptRow("Dana", "Alex", "Clothing", "30.00", "3.90"),
+		receiptRow("Dana", "Alex", "Clothing", "30.00", "3.90"),
+		receiptRow("Dana", "Alex", "Clothing", "30.00", "3.90"),
+		// Alex, Medical: two receipts totalling 80.00, no tax recorded at all.
+		receiptRow("Dana", "Alex", "Medical", "50.00", ""),
+		receiptRow("Dana", "Alex", "Medical", "30.00", ""),
+		// Sam, Clothing: three receipts totalling 90.00 with 11.70 of tax.
+		receiptRow("Dana", "Sam", "Clothing", "30.00", "3.90"),
+		receiptRow("Dana", "Sam", "Clothing", "30.00", "3.90"),
+		receiptRow("Dana", "Sam", "Clothing", "30.00", "3.90"),
+		// Sam, Mileage: one receipt of 30.00, no tax.
+		receiptRow("Dana", "Sam", "Mileage", "30.00", ""),
+	}
+}
+
+// The golden test. Every number below is read off the design document.
+func TestRun_WorkedExample(t *testing.T) {
+	model := mustRun(t, workedExampleSpec(), workedExampleRows())
+
+	if model.Meta.Title != "Verified Expenses" {
+		t.Errorf("Meta.Title = %q", model.Meta.Title)
+	}
+	if !model.Meta.GeneratedAt.Equal(testGeneratedAt) {
+		t.Errorf("Meta.GeneratedAt = %v, want %v", model.Meta.GeneratedAt, testGeneratedAt)
+	}
+	if model.Meta.Params["period"] != "2026-05-01 TO 2026-05-31" {
+		t.Errorf("Meta.Params = %v", model.Meta.Params)
+	}
+	if model.Meta.NoneLabel != defaultNoneLabel {
+		t.Errorf("Meta.NoneLabel = %q, want %q", model.Meta.NoneLabel, defaultNoneLabel)
+	}
+
+	// One foster parent.
+	if len(model.Root.Children) != 1 {
+		t.Fatalf("root has %d children, want 1", len(model.Root.Children))
+	}
+	dana := model.Root.Children[0]
+	if dana.Dimension != "paid_by" {
+		t.Errorf("level 1 dimension = %q, want paid_by", dana.Dimension)
+	}
+	if text, _ := dana.Value.Text(); text != "Dana" {
+		t.Errorf("level 1 value = %v, want Dana", dana.Value)
+	}
+
+	// Two children, sorted: Alex before Sam.
+	if len(dana.Children) != 2 {
+		t.Fatalf("Dana has %d children, want 2", len(dana.Children))
+	}
+	alex, sam := dana.Children[0], dana.Children[1]
+	if text, _ := alex.Value.Text(); text != "Alex" {
+		t.Errorf("first child = %v, want Alex", alex.Value)
+	}
+	if text, _ := sam.Value.Text(); text != "Sam" {
+		t.Errorf("second child = %v, want Sam", sam.Value)
+	}
+
+	// Alex's detail rows, sorted by category.
+	if len(alex.DetailRows) != 2 {
+		t.Fatalf("Alex has %d detail rows, want 2", len(alex.DetailRows))
+	}
+	assertRow(t, alex.DetailRows[0].Cells, map[string]string{
+		"Category": "Clothing", "Count": "4", "Subtotal": "120.00", "Hst": "15.60",
+		"Total": "135.60", "AvgPerReceipt": "33.9",
+	})
+	// Medical has no tax at all. SUM of nothing is 0.00, not an empty cell.
+	assertRow(t, alex.DetailRows[1].Cells, map[string]string{
+		"Category": "Medical", "Count": "2", "Subtotal": "80.00", "Hst": "0",
+		"Total": "80.00", "AvgPerReceipt": "40",
+	})
+
+	// TOTALS (Alex). Total recomputes to 200 + 15.60, which happens to equal
+	// 135.60 + 80.00 because the formula is additive.
+	assertRow(t, alex.Subtotals, map[string]string{
+		"Count": "6", "Subtotal": "200.00", "Hst": "15.60", "Total": "215.60",
+	})
+	// Avg/Receipt recomputes to 215.60 / 6. Summing the column would give
+	// 73.90 and averaging it 36.95; both are wrong.
+	assertAvg(t, alex.Subtotals, "35.933333")
+	if alex.RecordCount != 6 {
+		t.Errorf("Alex RecordCount = %d, want 6", alex.RecordCount)
+	}
+
+	// Sam's detail rows.
+	assertRow(t, sam.DetailRows[0].Cells, map[string]string{
+		"Category": "Clothing", "Count": "3", "Subtotal": "90.00", "Hst": "11.70",
+		"Total": "101.70", "AvgPerReceipt": "33.9",
+	})
+	assertRow(t, sam.DetailRows[1].Cells, map[string]string{
+		"Category": "Mileage", "Count": "1", "Subtotal": "30.00", "Hst": "0",
+		"Total": "30.00", "AvgPerReceipt": "30",
+	})
+	assertRow(t, sam.Subtotals, map[string]string{
+		"Count": "4", "Subtotal": "120.00", "Hst": "11.70", "Total": "131.70",
+	})
+	assertAvg(t, sam.Subtotals, "32.925")
+
+	// Dana's subtotal is the merge of both children.
+	assertRow(t, dana.Subtotals, map[string]string{
+		"Count": "10", "Subtotal": "320.00", "Hst": "27.30", "Total": "347.30",
+	})
+
+	// GRAND TOTALS.
+	assertRow(t, model.GrandTotals, map[string]string{
+		"Count": "10", "Subtotal": "320.00", "Hst": "27.30", "Total": "347.30",
+	})
+	assertAvg(t, model.GrandTotals, "34.73")
+	if model.Root.RecordCount != 10 {
+		t.Errorf("root RecordCount = %d, want 10", model.Root.RecordCount)
+	}
+
+	// A label column is empty on a subtotal row: no single category summed it.
+	if got := cell(t, alex.Subtotals, "Category"); !got.IsNull() {
+		t.Errorf("subtotal Category = %v, want null", got)
+	}
+	// The root is synthetic: no dimension, no subtotals of its own.
+	if model.Root.Dimension != "" || model.Root.Subtotals != nil || model.Root.IsNone {
+		t.Errorf("root is not synthetic: %+v", model.Root)
+	}
+}
+
+func assertAvg(t *testing.T, cells []Cell, want string) {
+	t.Helper()
+
+	got := cell(t, cells, "AvgPerReceipt")
+	number, isNumber := got.Decimal()
+	if !isNumber {
+		t.Fatalf("AvgPerReceipt = %v, want a number", got)
+	}
+	if !number.Equal(dec(want)) {
+		t.Errorf("AvgPerReceipt = %s, want %s", number, want)
+	}
+}
+
+// The document prints the average rounded to two places. Rounding is a
+// renderer's job, but a template can ask for it with ROUND.
+func TestRun_WorkedExampleRoundedAverage(t *testing.T) {
+	spec := workedExampleSpec()
+	for index, column := range spec.Columns {
+		if column.Name == "AvgPerReceipt" {
+			spec.Columns[index].Expr = "ROUND(Total / Count, 2)"
+		}
+	}
+
+	model := mustRun(t, spec, workedExampleRows())
+	dana := model.Root.Children[0]
+
+	assertAvg(t, dana.Children[0].Subtotals, "35.93")
+	assertAvg(t, dana.Children[1].Subtotals, "32.93")
+	assertAvg(t, model.GrandTotals, "34.73")
+}
+
+// Averaging the children's averages would give 36.95 here; summing the column
+// would give 73.90. Recomputing from the subtotal row's own inputs gives 35.93.
+func TestRun_ArithmeticRecomputesRatherThanRollsUp(t *testing.T) {
+	model := mustRun(t, workedExampleSpec(), workedExampleRows())
+	alex := model.Root.Children[0].Children[0]
+
+	first, _ := cell(t, alex.DetailRows[0].Cells, "AvgPerReceipt").Decimal()
+	second, _ := cell(t, alex.DetailRows[1].Cells, "AvgPerReceipt").Decimal()
+	subtotal, _ := cell(t, alex.Subtotals, "AvgPerReceipt").Decimal()
+
+	if subtotal.Equal(first.Add(second)) {
+		t.Errorf("subtotal average %s is the sum of the detail averages", subtotal)
+	}
+	if subtotal.Equal(first.Add(second).Div(dec("2"))) {
+		t.Errorf("subtotal average %s is the mean of the detail averages", subtotal)
+	}
+	if !subtotal.Equal(dec("35.933333")) {
+		t.Errorf("subtotal average = %s, want 35.933333", subtotal)
+	}
+}
+
+// A receipt in two categories is attributed to both in full, so its amount is
+// counted twice. This matches the dashboard pie chart, and the double count
+// propagates all the way to the grand total. It is intended: do not "fix" it.
+func TestRun_MultiValueDimensionsDoubleCount(t *testing.T) {
+	spec := ReportSpec{
+		Detail: DetailSpec{Mode: DetailAggregate, By: "category"},
+		Columns: []Column{
+			{Name: "Category", Kind: ColumnLabel, Field: "category"},
+			{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}},
+			{Name: "Subtotal", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "amount"}},
+		},
+		GrandTotals: true,
+	}
+
+	rows := []Row{{
+		"category": {Str("Clothing"), Str("Medical")},
+		"amount":   {Num(dec("100.00"))},
+	}}
+
+	model := mustRun(t, spec, rows)
+
+	if len(model.Root.DetailRows) != 2 {
+		t.Fatalf("got %d detail rows, want 2", len(model.Root.DetailRows))
+	}
+	assertRow(t, model.Root.DetailRows[0].Cells, map[string]string{"Category": "Clothing", "Count": "1", "Subtotal": "100.00"})
+	assertRow(t, model.Root.DetailRows[1].Cells, map[string]string{"Category": "Medical", "Count": "1", "Subtotal": "100.00"})
+
+	// One receipt of 100, but a grand total of 200 across two counts.
+	assertRow(t, model.GrandTotals, map[string]string{"Count": "2", "Subtotal": "200.00"})
+	if model.Root.RecordCount != 2 {
+		t.Errorf("root RecordCount = %d, want 2", model.Root.RecordCount)
+	}
+}
+
+// Two multi-value grouping levels produce a cross product.
+func TestRun_TwoMultiValueLevelsCrossProduct(t *testing.T) {
+	spec := ReportSpec{
+		GroupBy:     []FieldKey{"tag", "category"},
+		Columns:     []Column{{Name: "Subtotal", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "amount"}}},
+		Subtotals:   true,
+		GrandTotals: true,
+	}
+
+	rows := []Row{{
+		"tag":      {Str("Alex"), Str("Sam")},
+		"category": {Str("Clothing"), Str("Medical")},
+		"amount":   {Num(dec("10.00"))},
+	}}
+
+	model := mustRun(t, spec, rows)
+
+	if len(model.Root.Children) != 2 {
+		t.Fatalf("got %d tags, want 2", len(model.Root.Children))
+	}
+	for _, tag := range model.Root.Children {
+		if len(tag.Children) != 2 {
+			t.Fatalf("tag %v has %d categories, want 2", tag.Value, len(tag.Children))
+		}
+	}
+
+	// 2 tags x 2 categories = 4 attributions of 10.00.
+	assertRow(t, model.GrandTotals, map[string]string{"Subtotal": "40.00"})
+	if model.Root.RecordCount != 4 {
+		t.Errorf("root RecordCount = %d, want 4", model.Root.RecordCount)
+	}
+}
+
+// A row with no value for a dimension goes into an explicit (None) bucket, and
+// that bucket sorts last.
+func TestRun_NoneBuckets(t *testing.T) {
+	spec := ReportSpec{
+		GroupBy: []FieldKey{"tag"},
+		Detail:  DetailSpec{Mode: DetailAggregate, By: "category"},
+		Columns: []Column{
+			{Name: "Category", Kind: ColumnLabel, Field: "category"},
+			{Name: "Subtotal", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "amount"}},
+		},
+		GrandTotals: true,
+	}
+
+	rows := []Row{
+		{"tag": {Str("Alex")}, "category": {Str("Clothing")}, "amount": {Num(dec("10.00"))}},
+		// No tag and no category at all.
+		{"amount": {Num(dec("5.00"))}},
+		// An empty slice reads the same as an absent key.
+		{"tag": {}, "category": {}, "amount": {Num(dec("2.00"))}},
+	}
+
+	model := mustRun(t, spec, rows)
+
+	if len(model.Root.Children) != 2 {
+		t.Fatalf("got %d tag buckets, want 2", len(model.Root.Children))
+	}
+
+	named, none := model.Root.Children[0], model.Root.Children[1]
+	if text, _ := named.Value.Text(); text != "Alex" {
+		t.Errorf("first bucket = %v, want Alex", named.Value)
+	}
+	if !none.IsNone || !none.Value.IsNull() {
+		t.Errorf("(None) bucket did not sort last: %+v", none)
+	}
+
+	// Both untagged rows landed in the same (None) bucket, and their categories
+	// collapsed into a single (None) detail row.
+	if len(none.DetailRows) != 1 {
+		t.Fatalf("(None) tag has %d detail rows, want 1", len(none.DetailRows))
+	}
+	if !none.DetailRows[0].IsNone {
+		t.Errorf("detail row is not marked (None): %+v", none.DetailRows[0])
+	}
+	assertRow(t, none.DetailRows[0].Cells, map[string]string{"Subtotal": "7.00"})
+
+	// Nothing was dropped.
+	assertRow(t, model.GrandTotals, map[string]string{"Subtotal": "17.00"})
+}
+
+func TestRun_NoneSortsLastAmongManyBuckets(t *testing.T) {
+	spec := ReportSpec{
+		GroupBy: []FieldKey{"category"},
+		Columns: []Column{{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}}},
+	}
+
+	rows := []Row{
+		{"category": {Str("Zebra")}},
+		{},
+		{"category": {Str("Apple")}},
+		{"category": {Str("Mango")}},
+	}
+
+	model := mustRun(t, spec, rows)
+
+	want := []string{"Apple", "Mango", "Zebra"}
+	if len(model.Root.Children) != len(want)+1 {
+		t.Fatalf("got %d buckets, want %d", len(model.Root.Children), len(want)+1)
+	}
+	for index, expected := range want {
+		if text, _ := model.Root.Children[index].Value.Text(); text != expected {
+			t.Errorf("bucket %d = %v, want %s", index, model.Root.Children[index].Value, expected)
+		}
+	}
+	if !model.Root.Children[len(want)].IsNone {
+		t.Errorf("last bucket is not (None)")
+	}
+}
+
+// AVG must be correct at every level: at a leaf that merges detail buckets, at
+// an internal node that merges child groups, and at the grand total.
+//
+// The tree is deliberately two levels deep. With one level the subtotal would
+// come from a leaf, and an implementation that wrongly combined its children's
+// finalized averages would still pass.
+func TestRun_AvgIsCorrectAtEveryLevel(t *testing.T) {
+	spec := ReportSpec{
+		GroupBy:     []FieldKey{"paid_by", "tag"},
+		Detail:      DetailSpec{Mode: DetailAggregate, By: "category"},
+		Columns:     []Column{{Name: "Avg", Kind: ColumnAggregate, Agg: Aggregate{Func: AggAvg, Field: "amount"}}},
+		Subtotals:   true,
+		GrandTotals: true,
+	}
+
+	rows := []Row{
+		// Alex: four receipts of 30 in Clothing and one of 80 in Medical.
+		receiptRow("Dana", "Alex", "Clothing", "30.00", ""),
+		receiptRow("Dana", "Alex", "Clothing", "30.00", ""),
+		receiptRow("Dana", "Alex", "Clothing", "30.00", ""),
+		receiptRow("Dana", "Alex", "Clothing", "30.00", ""),
+		receiptRow("Dana", "Alex", "Medical", "80.00", ""),
+		// Sam: one receipt of 120.
+		receiptRow("Dana", "Sam", "Medical", "120.00", ""),
+	}
+
+	model := mustRun(t, spec, rows)
+	dana := model.Root.Children[0]
+	alex, sam := dana.Children[0], dana.Children[1]
+
+	// Detail buckets: 120/4 and 80/1.
+	assertRow(t, alex.DetailRows[0].Cells, map[string]string{"Avg": "30"})
+	assertRow(t, alex.DetailRows[1].Cells, map[string]string{"Avg": "80"})
+
+	// Leaf, merging its detail buckets. The mean of 30 and 80 is 55; the true
+	// average is 200/5 = 40.
+	assertRow(t, alex.Subtotals, map[string]string{"Avg": "40"})
+	assertRow(t, sam.Subtotals, map[string]string{"Avg": "120"})
+
+	// Internal node, merging its child groups. The mean of 40 and 120 is 80;
+	// the true average is 320/6.
+	assertRow(t, dana.Subtotals, map[string]string{"Avg": "53.333333"})
+	assertRow(t, model.GrandTotals, map[string]string{"Avg": "53.333333"})
+}
+
+// A ratio whose denominator is zero renders as an empty cell rather than
+// crashing the report.
+func TestRun_DivisionByZeroIsAnEmptyCell(t *testing.T) {
+	spec := ReportSpec{
+		Columns: []Column{
+			{Name: "Subtotal", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "amount"}},
+			// custom_1 is null on every row, so this sums to zero.
+			{Name: "Tax", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "custom_1"}},
+			{Name: "Ratio", Kind: ColumnArithmetic, Expr: "Subtotal / Tax"},
+		},
+		GrandTotals: true,
+	}
+
+	rows := []Row{{"amount": {Num(dec("100.00"))}}}
+
+	model := mustRun(t, spec, rows)
+
+	assertRow(t, model.GrandTotals, map[string]string{"Subtotal": "100.00", "Tax": "0", "Ratio": ""})
+}
+
+// SUM of nothing is zero; AVG, MIN and MAX of nothing are null.
+func TestRun_EmptyAndNullAggregates(t *testing.T) {
+	spec := ReportSpec{
+		Columns: []Column{
+			{Name: "Total", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "custom_1"}},
+			{Name: "Mean", Kind: ColumnAggregate, Agg: Aggregate{Func: AggAvg, Field: "custom_1"}},
+			{Name: "Least", Kind: ColumnAggregate, Agg: Aggregate{Func: AggMin, Field: "custom_1"}},
+			{Name: "Most", Kind: ColumnAggregate, Agg: Aggregate{Func: AggMax, Field: "custom_1"}},
+			{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}},
+		},
+		GrandTotals: true,
+	}
+
+	t.Run("rows with no value for the measure", func(t *testing.T) {
+		model := mustRun(t, spec, []Row{{"amount": {Num(dec("1"))}}, {"amount": {Num(dec("2"))}}})
+		assertRow(t, model.GrandTotals, map[string]string{
+			"Total": "0", "Mean": "", "Least": "", "Most": "", "Count": "2",
+		})
+	})
+
+	t.Run("no rows at all", func(t *testing.T) {
+		model := mustRun(t, spec, nil)
+		assertRow(t, model.GrandTotals, map[string]string{
+			"Total": "0", "Mean": "", "Least": "", "Most": "", "Count": "0",
+		})
+		if len(model.Root.Children) != 0 || len(model.Root.DetailRows) != 0 {
+			t.Errorf("empty input produced rows: %+v", model.Root)
+		}
+		if model.Root.RecordCount != 0 {
+			t.Errorf("root RecordCount = %d, want 0", model.Root.RecordCount)
+		}
+	})
+
+	t.Run("no rows with grouping", func(t *testing.T) {
+		grouped := spec
+		grouped.GroupBy = []FieldKey{"tag"}
+		grouped.Subtotals = true
+
+		model := mustRun(t, grouped, nil)
+		if len(model.Root.Children) != 0 {
+			t.Errorf("empty input produced groups: %+v", model.Root.Children)
+		}
+		assertRow(t, model.GrandTotals, map[string]string{"Total": "0", "Count": "0", "Mean": ""})
+	})
+}
+
+func TestRun_DeepNesting(t *testing.T) {
+	spec := ReportSpec{
+		GroupBy: []FieldKey{"paid_by", "tag", "category"},
+		Columns: []Column{
+			{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}},
+			{Name: "Subtotal", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "amount"}},
+		},
+		Subtotals:   true,
+		GrandTotals: true,
+	}
+
+	rows := []Row{
+		receiptRow("Dana", "Alex", "Clothing", "10.00", ""),
+		receiptRow("Dana", "Alex", "Medical", "20.00", ""),
+		receiptRow("Dana", "Sam", "Clothing", "30.00", ""),
+		receiptRow("Eve", "Kim", "Clothing", "40.00", ""),
+	}
+
+	model := mustRun(t, spec, rows)
+
+	if len(model.Root.Children) != 2 {
+		t.Fatalf("got %d payers, want 2", len(model.Root.Children))
+	}
+	dana, eve := model.Root.Children[0], model.Root.Children[1]
+
+	assertRow(t, dana.Subtotals, map[string]string{"Count": "3", "Subtotal": "60.00"})
+	assertRow(t, eve.Subtotals, map[string]string{"Count": "1", "Subtotal": "40.00"})
+
+	alex := dana.Children[0]
+	assertRow(t, alex.Subtotals, map[string]string{"Count": "2", "Subtotal": "30.00"})
+
+	clothing := alex.Children[0]
+	assertRow(t, clothing.Subtotals, map[string]string{"Count": "1", "Subtotal": "10.00"})
+	if len(clothing.DetailRows) != 1 {
+		t.Errorf("deepest level has %d detail rows, want 1", len(clothing.DetailRows))
+	}
+
+	assertRow(t, model.GrandTotals, map[string]string{"Count": "4", "Subtotal": "100.00"})
+}
+
+// Records mode emits one row per record, in the order they arrived.
+func TestRun_RecordsMode(t *testing.T) {
+	spec := ReportSpec{
+		GroupBy: []FieldKey{"paid_by"},
+		Detail:  DetailSpec{Mode: DetailRecords},
+		Columns: []Column{
+			{Name: "Cats", Kind: ColumnLabel, Field: "category"},
+			{Name: "Amount", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "amount"}},
+			{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}},
+			{Name: "Doubled", Kind: ColumnArithmetic, Expr: "Amount * 2"},
+		},
+		Subtotals:   true,
+		GrandTotals: true,
+	}
+
+	rows := []Row{
+		{"paid_by": {Str("Dana")}, "amount": {Num(dec("30.00"))}, "category": {Str("Zebra")}},
+		{"paid_by": {Str("Dana")}, "amount": {Num(dec("10.00"))}, "category": {Str("Apple")}},
+		{"paid_by": {Str("Dana")}, "amount": {Num(dec("20.00"))}, "category": {Str("Mango"), Str("Apple")}},
+	}
+
+	model := mustRun(t, spec, rows)
+	dana := model.Root.Children[0]
+
+	if len(dana.DetailRows) != 3 {
+		t.Fatalf("got %d detail rows, want 3", len(dana.DetailRows))
+	}
+
+	// Input order, not sorted by anything: the caller's query decides.
+	wantAmounts := []string{"30.00", "10.00", "20.00"}
+	for index, want := range wantAmounts {
+		assertRow(t, dana.DetailRows[index].Cells, map[string]string{"Amount": want, "Count": "1"})
+	}
+
+	// An aggregate on a single-record row aggregates that one record.
+	assertRow(t, dana.DetailRows[0].Cells, map[string]string{"Doubled": "60.00"})
+
+	// A label cell keeps every value the record carried.
+	multi := dana.DetailRows[2].Cells
+	for _, candidate := range multi {
+		if candidate.Column != "Cats" {
+			continue
+		}
+		if len(candidate.Values) != 2 {
+			t.Fatalf("multi-value label cell has %d values, want 2", len(candidate.Values))
+		}
+		if first, _ := candidate.Values[0].Text(); first != "Mango" {
+			t.Errorf("label values were reordered: %v", candidate.Values)
+		}
+	}
+
+	// A record contributes once, even when it carries two categories: the
+	// fan-out only applies to dimensions being grouped on.
+	assertRow(t, dana.Subtotals, map[string]string{"Amount": "60.00", "Count": "3", "Doubled": "120.00"})
+	assertRow(t, model.GrandTotals, map[string]string{"Amount": "60.00", "Count": "3"})
+
+	// Detail rows in records mode are not keyed on anything.
+	if dana.DetailRows[0].Dimension != "" || !dana.DetailRows[0].Value.IsNull() {
+		t.Errorf("records-mode detail row is keyed: %+v", dana.DetailRows[0])
+	}
+}
+
+// A cell must not alias the caller's row.
+func TestRun_RecordsModeDoesNotAliasInputRows(t *testing.T) {
+	spec := ReportSpec{
+		Columns: []Column{{Name: "Cats", Kind: ColumnLabel, Field: "category"}},
+	}
+
+	row := Row{"category": {Str("Clothing")}}
+	model := mustRun(t, spec, []Row{row})
+
+	model.Root.DetailRows[0].Cells[0].Values[0] = Str("Tampered")
+
+	if text, _ := row["category"][0].Text(); text != "Clothing" {
+		t.Errorf("mutating a cell changed the caller's row: %v", row)
+	}
+}
+
+// A label column on an aggregated detail row shows the group it sits under.
+func TestRun_LabelColumnReadsAncestorBucket(t *testing.T) {
+	spec := ReportSpec{
+		GroupBy: []FieldKey{"paid_by", "tag"},
+		Detail:  DetailSpec{Mode: DetailAggregate, By: "category"},
+		Columns: []Column{
+			{Name: "PaidBy", Kind: ColumnLabel, Field: "paid_by"},
+			{Name: "Child", Kind: ColumnLabel, Field: "tag"},
+			{Name: "Category", Kind: ColumnLabel, Field: "category"},
+			{Name: "Subtotal", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "amount"}},
+		},
+	}
+
+	rows := []Row{
+		receiptRow("Dana", "Alex", "Clothing", "10.00", ""),
+		receiptRow("Eve", "Kim", "Medical", "20.00", ""),
+	}
+
+	model := mustRun(t, spec, rows)
+
+	dana := model.Root.Children[0].Children[0]
+	assertRow(t, dana.DetailRows[0].Cells, map[string]string{
+		"PaidBy": "Dana", "Child": "Alex", "Category": "Clothing", "Subtotal": "10.00",
+	})
+
+	eve := model.Root.Children[1].Children[0]
+	assertRow(t, eve.DetailRows[0].Cells, map[string]string{
+		"PaidBy": "Eve", "Child": "Kim", "Category": "Medical", "Subtotal": "20.00",
+	})
+}
+
+func TestRun_SingleRecord(t *testing.T) {
+	spec := workedExampleSpec()
+	rows := []Row{receiptRow("Dana", "Alex", "Clothing", "50.00", "6.50")}
+
+	model := mustRun(t, spec, rows)
+	alex := model.Root.Children[0].Children[0]
+
+	want := map[string]string{"Count": "1", "Subtotal": "50.00", "Hst": "6.50", "Total": "56.50", "AvgPerReceipt": "56.50"}
+	assertRow(t, alex.DetailRows[0].Cells, want)
+	assertRow(t, alex.Subtotals, want)
+	assertRow(t, model.GrandTotals, want)
+}
+
+func TestRun_TogglesOffSubtotalsAndGrandTotals(t *testing.T) {
+	spec := workedExampleSpec()
+	spec.Subtotals = false
+	spec.GrandTotals = false
+
+	model := mustRun(t, spec, workedExampleRows())
+
+	if model.GrandTotals != nil {
+		t.Errorf("GrandTotals = %v, want nil", model.GrandTotals)
+	}
+
+	dana := model.Root.Children[0]
+	if dana.Subtotals != nil {
+		t.Errorf("group Subtotals = %v, want nil", dana.Subtotals)
+	}
+	if dana.Children[0].Subtotals != nil {
+		t.Errorf("leaf Subtotals = %v, want nil", dana.Children[0].Subtotals)
+	}
+	// Detail rows are unaffected.
+	if len(dana.Children[0].DetailRows) != 2 {
+		t.Errorf("detail rows were dropped along with the subtotals")
+	}
+}
+
+// The same inputs must always produce the same output, byte for byte.
+func TestRun_IsDeterministic(t *testing.T) {
+	spec := workedExampleSpec()
+	rows := workedExampleRows()
+
+	first := mustRun(t, spec, rows)
+	second := mustRun(t, spec, rows)
+
+	if !reflect.DeepEqual(first.Root, second.Root) {
+		t.Errorf("two runs produced different trees")
+	}
+	if !reflect.DeepEqual(first.GrandTotals, second.GrandTotals) {
+		t.Errorf("two runs produced different grand totals")
+	}
+}
+
+// Aggregated output must not depend on the order rows arrived in, because it is
+// grouped and sorted rather than listed.
+func TestRun_AggregateOutputIsIndependentOfInputOrder(t *testing.T) {
+	spec := workedExampleSpec()
+
+	forward := workedExampleRows()
+	reversed := workedExampleRows()
+	for left, right := 0, len(reversed)-1; left < right; left, right = left+1, right-1 {
+		reversed[left], reversed[right] = reversed[right], reversed[left]
+	}
+
+	if !reflect.DeepEqual(mustRun(t, spec, forward).Root, mustRun(t, spec, reversed).Root) {
+		t.Errorf("shuffling the input changed the report")
+	}
+}
+
+// An arithmetic column may be declared before the aggregate it reads.
+func TestRun_ColumnOrderIsIndependentOfDependencyOrder(t *testing.T) {
+	spec := ReportSpec{
+		Columns: []Column{
+			{Name: "Avg", Kind: ColumnArithmetic, Expr: "Total / Count"},
+			{Name: "Total", Kind: ColumnArithmetic, Expr: "Subtotal + Hst"},
+			{Name: "Subtotal", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "amount"}},
+			{Name: "Hst", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "custom_1"}},
+			{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}},
+		},
+		GrandTotals: true,
+	}
+
+	rows := []Row{
+		receiptRow("Dana", "Alex", "Clothing", "60.00", "6.00"),
+		receiptRow("Dana", "Alex", "Clothing", "40.00", "4.00"),
+	}
+
+	model := mustRun(t, spec, rows)
+
+	// Cells stay in declaration order even though evaluation does not.
+	if model.Columns[0].Name != "Avg" {
+		t.Errorf("columns were reordered: %s", model.Columns[0].Name)
+	}
+	assertRow(t, model.GrandTotals, map[string]string{"Total": "110.00", "Avg": "55", "Count": "2"})
+}
+
+func TestRun_Descriptors(t *testing.T) {
+	model := mustRun(t, workedExampleSpec(), workedExampleRows())
+
+	byName := make(map[string]ColumnDescriptor, len(model.Columns))
+	for _, descriptor := range model.Columns {
+		byName[descriptor.Name] = descriptor
+	}
+
+	if got := byName["AvgPerReceipt"].Label; got != "Avg/Receipt" {
+		t.Errorf("label = %q, want Avg/Receipt", got)
+	}
+	if got := byName["Subtotal"].Label; got != "Subtotal" {
+		t.Errorf("label defaults to the name, got %q", got)
+	}
+
+	// An arithmetic column carries a walkable tree, which is what the
+	// spreadsheet renderer will translate into a live formula.
+	total := byName["Total"]
+	if total.Expr == nil {
+		t.Errorf("arithmetic column has no parsed expression")
+	}
+	if total.ExprSrc != "Subtotal + Hst" {
+		t.Errorf("ExprSrc = %q", total.ExprSrc)
+	}
+	if total.Agg != nil {
+		t.Errorf("arithmetic column carries an aggregate")
+	}
+	if refs := columnRefs(total.Expr); len(refs) != 2 {
+		t.Errorf("columnRefs(Total) = %v, want two references", refs)
+	}
+
+	// An aggregate column carries its reduction.
+	subtotal := byName["Subtotal"]
+	if subtotal.Agg == nil || subtotal.Agg.Func != AggSum || subtotal.Agg.Field != "amount" {
+		t.Errorf("Subtotal.Agg = %+v, want SUM(amount)", subtotal.Agg)
+	}
+	if subtotal.Expr != nil {
+		t.Errorf("aggregate column carries an expression")
+	}
+
+	// Money combined with a count is still money.
+	if byName["AvgPerReceipt"].DataType != TypeCurrency {
+		t.Errorf("AvgPerReceipt is not currency")
+	}
+	if byName["Count"].DataType != TypeNumber {
+		t.Errorf("Count is not a plain number")
+	}
+	if byName["Category"].DataType != TypeString {
+		t.Errorf("Category is not a string")
+	}
+}
+
+// Money keeps every cent through grouping and rollup.
+func TestRun_NoFloatDriftThroughTheTree(t *testing.T) {
+	spec := ReportSpec{
+		GroupBy:     []FieldKey{"tag"},
+		Columns:     []Column{{Name: "Subtotal", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "amount"}}},
+		Subtotals:   true,
+		GrandTotals: true,
+	}
+
+	rows := make([]Row, 0, 300)
+	for index := 0; index < 300; index++ {
+		tag := "Alex"
+		if index%2 == 0 {
+			tag = "Sam"
+		}
+		rows = append(rows, Row{"tag": {Str(tag)}, "amount": {Num(dec("0.01"))}})
+	}
+
+	model := mustRun(t, spec, rows)
+	assertRow(t, model.GrandTotals, map[string]string{"Subtotal": "3.00"})
+	for _, child := range model.Root.Children {
+		assertRow(t, child.Subtotals, map[string]string{"Subtotal": "1.50"})
+	}
+}
+
+func TestRun_RejectsAnInvalidSpec(t *testing.T) {
+	_, err := Run(ReportSpec{}, testCatalog(t), nil, testMeta())
+	if err == nil {
+		t.Fatalf("Run() with no columns did not error")
+	}
+}
+
+func TestRun_MetaParamsAreCopied(t *testing.T) {
+	params := map[string]string{"period": "May"}
+	model, err := Run(
+		ReportSpec{Columns: []Column{{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}}}},
+		testCatalog(t), nil, MetaInput{GeneratedAt: testGeneratedAt, Params: params},
+	)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	params["period"] = "June"
+	if model.Meta.Params["period"] != "May" {
+		t.Errorf("Meta.Params aliases the caller's map")
+	}
+}
+
+// Grouping on a date must not split one instant across two buckets because the
+// caller happened to hand it over in a different time zone.
+func TestRun_DateBucketsNormalizeAcrossZones(t *testing.T) {
+	spec := ReportSpec{
+		GroupBy: []FieldKey{"date"},
+		Columns: []Column{{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}}},
+	}
+
+	utc := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	elsewhere := utc.In(time.FixedZone("plus-one", 3600))
+
+	model := mustRun(t, spec, []Row{
+		{"date": {DateVal(utc)}},
+		{"date": {DateVal(elsewhere)}},
+	})
+
+	if len(model.Root.Children) != 1 {
+		t.Fatalf("got %d date buckets, want 1", len(model.Root.Children))
+	}
+	if model.Root.Children[0].RecordCount != 2 {
+		t.Errorf("RecordCount = %d, want 2", model.Root.Children[0].RecordCount)
+	}
+}
+
+// false sorts before true, and both are their own bucket.
+func TestRun_BooleanBucketing(t *testing.T) {
+	spec := ReportSpec{
+		GroupBy: []FieldKey{"resolved"},
+		Columns: []Column{{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}}},
+	}
+
+	model := mustRun(t, spec, []Row{
+		{"resolved": {Bool(true)}},
+		{"resolved": {Bool(false)}},
+		{"resolved": {Bool(true)}},
+	})
+
+	if len(model.Root.Children) != 2 {
+		t.Fatalf("got %d buckets, want 2", len(model.Root.Children))
+	}
+	if value, _ := model.Root.Children[0].Value.Boolean(); value {
+		t.Errorf("true sorted before false")
+	}
+	if model.Root.Children[0].RecordCount != 1 {
+		t.Errorf("false bucket RecordCount = %d, want 1", model.Root.Children[0].RecordCount)
+	}
+	if model.Root.Children[1].RecordCount != 2 {
+		t.Errorf("true bucket RecordCount = %d, want 2", model.Root.Children[1].RecordCount)
+	}
+}
+
+// Two amounts that differ only in scale are the same number, and grouping is
+// keyed on the number rather than on how it was written.
+func TestRun_NumbersDifferingOnlyInScaleShareABucket(t *testing.T) {
+	spec := ReportSpec{
+		GroupBy: []FieldKey{"category"},
+		Columns: []Column{{Name: "Total", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "amount"}}},
+	}
+
+	// bucketKey normalizes numbers even though a measure can never be grouped
+	// on; this checks the normalization directly.
+	if bucketKey(Num(dec("200"))) != bucketKey(Num(dec("200.00"))) {
+		t.Errorf("200 and 200.00 landed in different buckets")
+	}
+
+	model := mustRun(t, spec, []Row{{"category": {Str("Clothing")}, "amount": {Num(dec("200.00"))}}})
+	assertRow(t, model.Root.Children[0].DetailRows[0].Cells, map[string]string{"Total": "200"})
+}

--- a/api/internal/reporting/enums_test.go
+++ b/api/internal/reporting/enums_test.go
@@ -1,0 +1,87 @@
+package reporting
+
+import "testing"
+
+// An enum the engine switches on in more than one place is only as sound as the
+// agreement between those switches, and Go enforces none of it: a switch that
+// forgets a value compiles, runs, and returns whatever its fallthrough says.
+//
+// That is not hypothetical here. Validate once accepted an AggFunc the
+// accumulator did not implement, and every cell of the column rendered blank at
+// every level with no error anywhere — the switch in finalize simply fell
+// through to null. The fix was to add valid(), which closed the hole but created
+// a second closed list that can drift from the first.
+//
+// So the lists are pinned to each other, exhaustively over the whole domain
+// rather than over the five values someone remembered. These tests are what make
+// the fallthrough in accumulator.finalize safe to leave as null instead of a
+// panic: drift is caught here, at `go test` time, rather than in a report
+// somebody is waiting on.
+
+// TestAggFunc_ClosedListsAgree pins the four independent switches over AggFunc:
+// String, valid, aggFuncFromName, and accumulator.finalize.
+func TestAggFunc_ClosedListsAgree(t *testing.T) {
+	for candidate := 0; candidate <= 255; candidate++ {
+		function := AggFunc(candidate)
+		valid := function.valid()
+
+		// String and valid must admit the same set.
+		if named := function.String() != "UNKNOWN"; named != valid {
+			t.Errorf("AggFunc(%d): valid() = %v but String() = %q", candidate, valid, function.String())
+		}
+
+		// finalize must implement exactly the set valid() admits. A populated
+		// accumulator finalizes to a number under every known reduction — AVG's
+		// empty-divisor guard and MIN/MAX's unseen guard are both satisfied by
+		// the single value below — so only the fallthrough can yield null.
+		accumulator := newAccumulator(function)
+		accumulator.add(Num(dec("1")))
+
+		if implemented := !accumulator.finalize(testDivisionScale).IsNull(); implemented != valid {
+			t.Errorf("AggFunc(%d) (%s): valid() = %v but finalize implements it = %v — "+
+				"a reduction Validate accepts and the accumulator does not implement renders every cell blank",
+				candidate, function, valid, implemented)
+		}
+
+		// Only round-trip the valid ones: aggFuncFromName reports failure as
+		// (0, false), and 0 is AggSum, so an unknown value would appear to
+		// round-trip to SUM.
+		if !valid {
+			continue
+		}
+		parsed, known := aggFuncFromName(function.String())
+		if !known || parsed != function {
+			t.Errorf("AggFunc(%d) (%s): aggFuncFromName(%q) = (%v, %v), want (%v, true)",
+				candidate, function, function.String(), parsed, known, function)
+		}
+	}
+}
+
+// TestDetailMode_ClosedListsAgree pins valid against String, the same way.
+func TestDetailMode_ClosedListsAgree(t *testing.T) {
+	for candidate := 0; candidate <= 255; candidate++ {
+		mode := DetailMode(candidate)
+		valid := mode.valid()
+
+		if named := mode.String() != "unknown"; named != valid {
+			t.Errorf("DetailMode(%d): valid() = %v but String() = %q", candidate, valid, mode.String())
+		}
+	}
+}
+
+// isAggregate is the single spelling of "are the bottom rows summed buckets?",
+// and every valid mode must answer it one way or the other. The engine reads it
+// as a biconditional — insertLeaf, rollUpLeaf and emitDetailRows all branch on
+// its negation — so a mode that is neither records nor aggregate would take the
+// records path everywhere while compileDetail called it something else.
+func TestDetailMode_IsAggregatePartitionsTheValidModes(t *testing.T) {
+	if !DetailAggregate.valid() || !DetailRecords.valid() {
+		t.Fatal("the two known modes must be valid")
+	}
+	if !(DetailSpec{Mode: DetailAggregate}).isAggregate() {
+		t.Error("DetailAggregate is not aggregate")
+	}
+	if (DetailSpec{Mode: DetailRecords}).isAggregate() {
+		t.Error("DetailRecords is aggregate")
+	}
+}

--- a/api/internal/reporting/eval.go
+++ b/api/internal/reporting/eval.go
@@ -1,0 +1,110 @@
+package reporting
+
+import (
+	"github.com/expr-lang/expr/ast"
+	"github.com/shopspring/decimal"
+)
+
+// evalArithmetic evaluates an arithmetic column against the values already
+// computed for the other columns on the same row. It is called once per column
+// per rendered row — detail rows, subtotal rows, and the grand total alike —
+// which is what keeps a non-linear formula such as an average or a ratio
+// correct at every level.
+//
+// Evaluation never fails and never panics. Anything undefined yields a null
+// value, which a renderer draws as an empty cell:
+//
+//   - a null operand propagates, so ROUND(null, 2) and null + 5 are both null
+//   - a non-numeric operand is null, though Validate rejects those up front
+//   - division by a zero divisor is null rather than a panic, which is what
+//     shopspring's Div would otherwise do
+//
+// All arithmetic is decimal. Division rounds to divisionScale places, chosen by
+// the caller, rather than consulting decimal.DivisionPrecision — that global is
+// mutable and shared process-wide, so relying on it would make the engine's
+// output depend on whatever else the process had done.
+func evalArithmetic(node ast.Node, columns map[string]Value, divisionScale int32) Value {
+	switch n := node.(type) {
+	case *ast.IntegerNode:
+		return Num(decimal.NewFromInt(int64(n.Value)))
+
+	case *ast.FloatNode:
+		// NewFromFloat takes the shortest decimal that round-trips the float, so
+		// a literal a human wrote as 0.1 stays exactly 0.1. Literals carrying
+		// more precision than a float64 holds cannot survive the parser, which
+		// bounds how exact a literal can be.
+		return Num(decimal.NewFromFloat(n.Value))
+
+	case *ast.IdentifierNode:
+		return columns[n.Value]
+
+	case *ast.UnaryNode:
+		return evalUnary(n, columns, divisionScale)
+
+	case *ast.BinaryNode:
+		left := evalArithmetic(n.Left, columns, divisionScale)
+		right := evalArithmetic(n.Right, columns, divisionScale)
+		return evalBinary(n.Operator, left, right, divisionScale)
+
+	case *ast.CallNode:
+		return evalRound(n, columns, divisionScale)
+	}
+
+	return Null()
+}
+
+func evalUnary(node *ast.UnaryNode, columns map[string]Value, divisionScale int32) Value {
+	operand, isNumber := evalArithmetic(node.Node, columns, divisionScale).Decimal()
+	if !isNumber {
+		return Null()
+	}
+	if node.Operator == "-" {
+		return Num(operand.Neg())
+	}
+	return Num(operand)
+}
+
+func evalBinary(operator string, left, right Value, divisionScale int32) Value {
+	leftNumber, leftIsNumber := left.Decimal()
+	rightNumber, rightIsNumber := right.Decimal()
+	if !leftIsNumber || !rightIsNumber {
+		return Null()
+	}
+
+	switch operator {
+	case "+":
+		return Num(leftNumber.Add(rightNumber))
+	case "-":
+		return Num(leftNumber.Sub(rightNumber))
+	case "*":
+		return Num(leftNumber.Mul(rightNumber))
+	case "/":
+		if rightNumber.IsZero() {
+			return Null()
+		}
+		return Num(leftNumber.DivRound(rightNumber, divisionScale))
+	}
+
+	return Null()
+}
+
+// evalRound applies ROUND, which rounds half away from zero to match the
+// spreadsheet function of the same name. Negative places round to tens,
+// hundreds, and so on.
+func evalRound(call *ast.CallNode, columns map[string]Value, divisionScale int32) Value {
+	if len(call.Arguments) != 2 {
+		return Null()
+	}
+
+	operand, isNumber := evalArithmetic(call.Arguments[0], columns, divisionScale).Decimal()
+	if !isNumber {
+		return Null()
+	}
+
+	places, err := integerLiteral(call.Arguments[1])
+	if err != nil {
+		return Null()
+	}
+
+	return Num(operand.Round(places))
+}

--- a/api/internal/reporting/eval_test.go
+++ b/api/internal/reporting/eval_test.go
@@ -1,0 +1,287 @@
+package reporting
+
+import (
+	"testing"
+	"time"
+
+	"github.com/expr-lang/expr/ast"
+)
+
+const testDivisionScale = 6
+
+func mustParseArithmetic(t *testing.T, src string) ast.Node {
+	t.Helper()
+	node, err := ParseArithmetic(src)
+	if err != nil {
+		t.Fatalf("ParseArithmetic(%q) error = %v", src, err)
+	}
+	return node
+}
+
+// evalSrc parses and evaluates in one step, which is how every eval case below
+// reads.
+func evalSrc(t *testing.T, src string, columns map[string]Value) Value {
+	t.Helper()
+	return evalArithmetic(mustParseArithmetic(t, src), columns, testDivisionScale)
+}
+
+func TestEvalArithmetic_Numbers(t *testing.T) {
+	columns := map[string]Value{
+		"Subtotal": Num(dec("200.00")),
+		"Hst":      Num(dec("15.60")),
+		"Count":    Num(dec("6")),
+		"Zero":     Num(dec("0")),
+		"Negative": Num(dec("-4.50")),
+	}
+
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{"integer literal", "2", "2"},
+		{"float literal", "1.05", "1.05"},
+		{"column reference", "Subtotal", "200"},
+		{"addition", "Subtotal + Hst", "215.6"},
+		{"subtraction", "Subtotal - Hst", "184.4"},
+		{"multiplication", "Hst * 2", "31.2"},
+		{"division", "Subtotal / 4", "50"},
+		{"precedence", "Subtotal + Hst * 2", "231.2"},
+		{"parentheses override precedence", "(Subtotal + Hst) * 2", "431.2"},
+		{"left associative subtraction", "Subtotal - Hst - Hst", "168.8"},
+		{"unary minus on a column", "-Subtotal", "-200"},
+		{"unary minus on a literal", "-2 + Subtotal", "198"},
+		{"double sign parses as unary plus", "Subtotal ++ Hst", "215.6"},
+		{"subtracting a negative", "Subtotal - Negative", "204.5"},
+		{"negative column", "Negative * 2", "-9"},
+		{"zero is a legal operand", "Subtotal + Zero", "200"},
+		{"zero numerator", "Zero / Count", "0"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := evalSrc(t, test.src, columns)
+			number, isNumber := got.Decimal()
+			if !isNumber {
+				t.Fatalf("eval(%q) = %v, want a number", test.src, got)
+			}
+			if number.String() != test.want {
+				t.Errorf("eval(%q) = %s, want %s", test.src, number, test.want)
+			}
+		})
+	}
+}
+
+// Division rounds to the configured scale rather than consulting the mutable
+// decimal.DivisionPrecision global.
+func TestEvalArithmetic_DivisionScale(t *testing.T) {
+	columns := map[string]Value{
+		"Total": Num(dec("215.60")),
+		"Count": Num(dec("6")),
+	}
+
+	tests := []struct {
+		scale int32
+		want  string
+	}{
+		{0, "36"},
+		{2, "35.93"},
+		{6, "35.933333"},
+		{10, "35.9333333333"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.want, func(t *testing.T) {
+			got := evalArithmetic(mustParseArithmetic(t, "Total / Count"), columns, test.scale)
+			number, _ := got.Decimal()
+			if number.String() != test.want {
+				t.Errorf("Total / Count at scale %d = %s, want %s", test.scale, number, test.want)
+			}
+		})
+	}
+}
+
+// A zero divisor must yield an empty cell. shopspring panics on this, so the
+// guard is the only thing standing between a report with a zero count and a
+// crashed request.
+func TestEvalArithmetic_DivisionByZeroIsNullNotPanic(t *testing.T) {
+	columns := map[string]Value{
+		"Total":     Num(dec("215.60")),
+		"Count":     Num(dec("0")),
+		"ZeroScale": Num(dec("0.00")),
+	}
+
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{"column divisor", "Total / Count"},
+		{"zero with a scale", "Total / ZeroScale"},
+		{"literal divisor", "Total / 0"},
+		{"nested in a sum", "1 + Total / Count"},
+		{"inside round", "ROUND(Total / Count, 2)"},
+		{"zero over zero", "Count / Count"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					t.Fatalf("eval(%q) panicked: %v", test.src, recovered)
+				}
+			}()
+
+			if got := evalSrc(t, test.src, columns); !got.IsNull() {
+				t.Errorf("eval(%q) = %v, want null", test.src, got)
+			}
+		})
+	}
+}
+
+// Null propagates through every operator, so a subtotal built on an empty
+// aggregate renders as an empty cell rather than as zero.
+func TestEvalArithmetic_NullPropagates(t *testing.T) {
+	columns := map[string]Value{
+		"Subtotal": Num(dec("200.00")),
+		"Missing":  Null(),
+		"Label":    Str("Clothing"),
+		"When":     DateVal(time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)),
+		"Flag":     Bool(true),
+	}
+
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{"null on the left", "Missing + Subtotal"},
+		{"null on the right", "Subtotal + Missing"},
+		{"null subtraction", "Subtotal - Missing"},
+		{"null multiplication", "Subtotal * Missing"},
+		{"null numerator", "Missing / Subtotal"},
+		{"null divisor", "Subtotal / Missing"},
+		{"null under unary minus", "-Missing"},
+		{"null inside round", "ROUND(Missing, 2)"},
+		{"null nested deep", "ROUND((Subtotal + Missing) * 2, 2)"},
+		{"undeclared column is null", "Subtotal + Nonexistent"},
+
+		// Validate rejects these up front; eval must still not misread them.
+		{"string operand", "Subtotal + Label"},
+		{"date operand", "Subtotal + When"},
+		{"bool operand", "Subtotal + Flag"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := evalSrc(t, test.src, columns); !got.IsNull() {
+				t.Errorf("eval(%q) = %v, want null", test.src, got)
+			}
+		})
+	}
+}
+
+func TestEvalArithmetic_Round(t *testing.T) {
+	columns := map[string]Value{
+		"Half":     Num(dec("32.925")),
+		"Long":     Num(dec("35.93333")),
+		"Negative": Num(dec("-2.345")),
+		"Thousand": Num(dec("1234")),
+	}
+
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{"rounds half away from zero", "ROUND(Half, 2)", "32.93"},
+		{"truncates a long tail", "ROUND(Long, 2)", "35.93"},
+		{"rounds negative away from zero", "ROUND(Negative, 2)", "-2.35"},
+		{"rounds to zero places", "ROUND(Long, 0)", "36"},
+		{"negative places round to hundreds", "ROUND(Thousand, -2)", "1200"},
+		{"rounds an expression", "ROUND(Half * 2, 1)", "65.9"},
+		{"round is composable", "ROUND(Half, 2) + ROUND(Long, 2)", "68.86"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := evalSrc(t, test.src, columns)
+			number, isNumber := got.Decimal()
+			if !isNumber {
+				t.Fatalf("eval(%q) = %v, want a number", test.src, got)
+			}
+			if number.String() != test.want {
+				t.Errorf("eval(%q) = %s, want %s", test.src, number, test.want)
+			}
+		})
+	}
+}
+
+// Money never touches a float. These are the sums that would drift if it did.
+func TestEvalArithmetic_NoFloatDrift(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		columns map[string]Value
+		want    string
+	}{
+		{
+			name:    "0.1 + 0.2 is exactly 0.3",
+			src:     "A + B",
+			columns: map[string]Value{"A": Num(dec("0.1")), "B": Num(dec("0.2"))},
+			want:    "0.3",
+		},
+		{
+			name: "float literals are exact",
+			src:  "0.1 + 0.2",
+			want: "0.3",
+		},
+		{
+			name: "a literal keeps every digit it was written with",
+			src:  "1.05",
+			want: "1.05",
+		},
+		{
+			name:    "33.33 times 3",
+			src:     "A * 3",
+			columns: map[string]Value{"A": Num(dec("33.33"))},
+			want:    "99.99",
+		},
+		{
+			name:    "a hundred cents make a dollar",
+			src:     "A * 100",
+			columns: map[string]Value{"A": Num(dec("0.01"))},
+			want:    "1",
+		},
+		{
+			name:    "the worked example's grand total",
+			src:     "Subtotal + Hst",
+			columns: map[string]Value{"Subtotal": Num(dec("320.00")), "Hst": Num(dec("27.30"))},
+			want:    "347.3",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := evalSrc(t, test.src, test.columns)
+			number, isNumber := got.Decimal()
+			if !isNumber {
+				t.Fatalf("eval(%q) = %v, want a number", test.src, got)
+			}
+			if !number.Equal(dec(test.want)) {
+				t.Errorf("eval(%q) = %s, want %s", test.src, number, test.want)
+			}
+		})
+	}
+}
+
+// The engine must not read the process-wide division precision, because another
+// package could have changed it.
+func TestEvalArithmetic_IgnoresDivisionPrecisionGlobal(t *testing.T) {
+	columns := map[string]Value{"A": Num(dec("1")), "B": Num(dec("3"))}
+
+	got := evalArithmetic(mustParseArithmetic(t, "A / B"), columns, 4)
+	number, _ := got.Decimal()
+
+	if number.String() != "0.3333" {
+		t.Errorf("A / B at scale 4 = %s, want 0.3333", number)
+	}
+}

--- a/api/internal/reporting/field.go
+++ b/api/internal/reporting/field.go
@@ -1,0 +1,133 @@
+package reporting
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrEmptyFieldKey is returned when a catalog is built with a keyless field.
+	ErrEmptyFieldKey = errors.New("field key must not be empty")
+
+	// ErrDuplicateField is returned when a catalog is built with two fields
+	// sharing a key.
+	ErrDuplicateField = errors.New("duplicate field key in catalog")
+)
+
+// DataType is the type of value a field resolves to. It determines the field's
+// role, and travels onto a column descriptor so renderers know how to format.
+type DataType uint8
+
+const (
+	TypeString DataType = iota
+	TypeNumber
+	TypeCurrency
+	TypeDate
+	TypeBool
+)
+
+func (d DataType) String() string {
+	switch d {
+	case TypeString:
+		return "string"
+	case TypeNumber:
+		return "number"
+	case TypeCurrency:
+		return "currency"
+	case TypeDate:
+		return "date"
+	case TypeBool:
+		return "bool"
+	}
+	return "unknown"
+}
+
+// IsNumeric reports whether values of this type can be summed and can take part
+// in arithmetic. Currency is a number that renderers format differently.
+func (d DataType) IsNumeric() bool {
+	return d == TypeNumber || d == TypeCurrency
+}
+
+// Role is what a field may be used for. It is derived from the data type rather
+// than declared, so a template can never group by a dollar amount or sum a
+// status.
+type Role uint8
+
+const (
+	// RoleDimension is a way to cut the data: a groupBy level, or the dimension
+	// an aggregated detail row is keyed on.
+	RoleDimension Role = iota
+
+	// RoleMeasure is a thing to measure: the input to an aggregate column.
+	RoleMeasure
+)
+
+func (r Role) String() string {
+	switch r {
+	case RoleDimension:
+		return "dimension"
+	case RoleMeasure:
+		return "measure"
+	}
+	return "unknown"
+}
+
+// RoleForDataType derives a field's role from its type. Numbers measure;
+// everything else cuts.
+func RoleForDataType(dataType DataType) Role {
+	if dataType.IsNumeric() {
+		return RoleMeasure
+	}
+	return RoleDimension
+}
+
+// FieldKey identifies a field within a catalog. Keys must be valid expression
+// identifiers so that a formula can name one without quoting.
+type FieldKey string
+
+// FieldRef describes one field a report may reference. Built-in fields and
+// custom fields are the same abstraction, which is what makes a custom field
+// usable anywhere a built-in is.
+type FieldRef struct {
+	Key      FieldKey
+	Label    string
+	DataType DataType
+
+	// Multi marks a field that can resolve to several values at once, such as a
+	// receipt's categories or tags. Grouping on one fans the row out into every
+	// bucket, so the row double-counts.
+	Multi bool
+}
+
+// Role reports whether the field cuts the data or measures it.
+func (f FieldRef) Role() Role { return RoleForDataType(f.DataType) }
+
+// FieldCatalog is the set of fields a report may reference. A producer builds
+// one alongside the rows it emits, so a spec can be validated against exactly
+// the fields the rows carry.
+type FieldCatalog struct {
+	fields map[FieldKey]FieldRef
+}
+
+// NewFieldCatalog builds a catalog, rejecting keyless and duplicated fields.
+func NewFieldCatalog(fields ...FieldRef) (FieldCatalog, error) {
+	catalog := FieldCatalog{fields: make(map[FieldKey]FieldRef, len(fields))}
+
+	for _, field := range fields {
+		if len(field.Key) == 0 {
+			return FieldCatalog{}, fmt.Errorf("%w: %q", ErrEmptyFieldKey, field.Label)
+		}
+		if _, exists := catalog.fields[field.Key]; exists {
+			return FieldCatalog{}, fmt.Errorf("%w: %s", ErrDuplicateField, field.Key)
+		}
+		catalog.fields[field.Key] = field
+	}
+
+	return catalog, nil
+}
+
+// Get returns the field with the given key.
+func (c FieldCatalog) Get(key FieldKey) (FieldRef, bool) {
+	field, exists := c.fields[key]
+	return field, exists
+}

--- a/api/internal/reporting/field.go
+++ b/api/internal/reporting/field.go
@@ -12,6 +12,10 @@ var (
 	// ErrDuplicateField is returned when a catalog is built with two fields
 	// sharing a key.
 	ErrDuplicateField = errors.New("duplicate field key in catalog")
+
+	// ErrInvalidFieldKey is returned when a catalog is built with a key a
+	// formula could not name.
+	ErrInvalidFieldKey = errors.New("field key must be a plain identifier")
 )
 
 // DataType is the type of value a field resolves to. It determines the field's
@@ -82,7 +86,9 @@ func RoleForDataType(dataType DataType) Role {
 }
 
 // FieldKey identifies a field within a catalog. Keys must be valid expression
-// identifiers so that a formula can name one without quoting.
+// identifiers so that a formula can name one without quoting, which
+// NewFieldCatalog enforces: a key such as "unit-price" would tokenize as a
+// subtraction rather than as the field an author meant.
 type FieldKey string
 
 // FieldRef describes one field a report may reference. Built-in fields and
@@ -109,13 +115,17 @@ type FieldCatalog struct {
 	fields map[FieldKey]FieldRef
 }
 
-// NewFieldCatalog builds a catalog, rejecting keyless and duplicated fields.
+// NewFieldCatalog builds a catalog, rejecting keyless, unnameable and duplicated
+// fields.
 func NewFieldCatalog(fields ...FieldRef) (FieldCatalog, error) {
 	catalog := FieldCatalog{fields: make(map[FieldKey]FieldRef, len(fields))}
 
 	for _, field := range fields {
 		if len(field.Key) == 0 {
 			return FieldCatalog{}, fmt.Errorf("%w: %q", ErrEmptyFieldKey, field.Label)
+		}
+		if !isIdentifier(string(field.Key)) {
+			return FieldCatalog{}, fmt.Errorf("%w: %q", ErrInvalidFieldKey, field.Key)
 		}
 		if _, exists := catalog.fields[field.Key]; exists {
 			return FieldCatalog{}, fmt.Errorf("%w: %s", ErrDuplicateField, field.Key)

--- a/api/internal/reporting/field_test.go
+++ b/api/internal/reporting/field_test.go
@@ -1,0 +1,125 @@
+package reporting
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestDataType_IsNumeric(t *testing.T) {
+	tests := []struct {
+		dataType DataType
+		want     bool
+	}{
+		{TypeString, false},
+		{TypeNumber, true},
+		{TypeCurrency, true},
+		{TypeDate, false},
+		{TypeBool, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.dataType.String(), func(t *testing.T) {
+			if got := test.dataType.IsNumeric(); got != test.want {
+				t.Errorf("%v.IsNumeric() = %v, want %v", test.dataType, got, test.want)
+			}
+		})
+	}
+}
+
+// You group by a tag; you sum a dollar amount. The role falls out of the type so
+// a template can never do the reverse.
+func TestRoleForDataType(t *testing.T) {
+	tests := []struct {
+		dataType DataType
+		want     Role
+	}{
+		{TypeString, RoleDimension},
+		{TypeDate, RoleDimension},
+		{TypeBool, RoleDimension},
+		{TypeNumber, RoleMeasure},
+		{TypeCurrency, RoleMeasure},
+	}
+
+	for _, test := range tests {
+		t.Run(test.dataType.String(), func(t *testing.T) {
+			if got := RoleForDataType(test.dataType); got != test.want {
+				t.Errorf("RoleForDataType(%v) = %v, want %v", test.dataType, got, test.want)
+			}
+		})
+	}
+}
+
+func TestFieldRef_Role(t *testing.T) {
+	currency := FieldRef{Key: "custom_1", Label: "HST", DataType: TypeCurrency}
+	if got := currency.Role(); got != RoleMeasure {
+		t.Errorf("currency custom field role = %v, want %v", got, RoleMeasure)
+	}
+
+	selectField := FieldRef{Key: "custom_2", Label: "Child", DataType: TypeString}
+	if got := selectField.Role(); got != RoleDimension {
+		t.Errorf("select custom field role = %v, want %v", got, RoleDimension)
+	}
+}
+
+func TestNewFieldCatalog(t *testing.T) {
+	amount := FieldRef{Key: "amount", Label: "Amount", DataType: TypeCurrency}
+	tag := FieldRef{Key: "tag", Label: "Tag", DataType: TypeString, Multi: true}
+
+	t.Run("builds and looks up fields", func(t *testing.T) {
+		catalog, err := NewFieldCatalog(amount, tag)
+		if err != nil {
+			t.Fatalf("NewFieldCatalog() error = %v, want nil", err)
+		}
+
+		got, exists := catalog.Get("amount")
+		if !exists {
+			t.Fatalf("Get(\"amount\") not found")
+		}
+		if got.Label != "Amount" || got.DataType != TypeCurrency || got.Multi {
+			t.Errorf("Get(\"amount\") = %+v, want the amount field", got)
+		}
+
+		multi, exists := catalog.Get("tag")
+		if !exists || !multi.Multi {
+			t.Errorf("Get(\"tag\") = %+v, %v; want a multi-value field", multi, exists)
+		}
+	})
+
+	t.Run("empty catalog", func(t *testing.T) {
+		catalog, err := NewFieldCatalog()
+		if err != nil {
+			t.Fatalf("NewFieldCatalog() error = %v, want nil", err)
+		}
+		if _, exists := catalog.Get("amount"); exists {
+			t.Errorf("empty catalog returned a field")
+		}
+	})
+
+	t.Run("missing key", func(t *testing.T) {
+		catalog, _ := NewFieldCatalog(amount)
+		if _, exists := catalog.Get("nope"); exists {
+			t.Errorf("Get(\"nope\") found a field")
+		}
+	})
+
+	t.Run("zero catalog does not panic", func(t *testing.T) {
+		var catalog FieldCatalog
+		if _, exists := catalog.Get("amount"); exists {
+			t.Errorf("zero catalog returned a field")
+		}
+	})
+
+	t.Run("rejects an empty key", func(t *testing.T) {
+		_, err := NewFieldCatalog(FieldRef{Label: "Nameless", DataType: TypeString})
+		if !errors.Is(err, ErrEmptyFieldKey) {
+			t.Errorf("NewFieldCatalog() error = %v, want %v", err, ErrEmptyFieldKey)
+		}
+	})
+
+	t.Run("rejects a duplicate key", func(t *testing.T) {
+		_, err := NewFieldCatalog(amount, FieldRef{Key: "amount", Label: "Other", DataType: TypeNumber})
+		if !errors.Is(err, ErrDuplicateField) {
+			t.Errorf("NewFieldCatalog() error = %v, want %v", err, ErrDuplicateField)
+		}
+	})
+}

--- a/api/internal/reporting/field_test.go
+++ b/api/internal/reporting/field_test.go
@@ -122,4 +122,31 @@ func TestNewFieldCatalog(t *testing.T) {
 			t.Errorf("NewFieldCatalog() error = %v, want %v", err, ErrDuplicateField)
 		}
 	})
+
+	// A key a formula cannot name is not a key. "unit-price" would tokenize as a
+	// subtraction of two identifiers, and "2nd" as a number followed by one.
+	t.Run("rejects a key that is not a plain identifier", func(t *testing.T) {
+		keys := []FieldKey{"unit-price", "unit price", "unit.price", "2nd", "montée", "sum(x)", "$env"}
+
+		for _, key := range keys {
+			t.Run(string(key), func(t *testing.T) {
+				_, err := NewFieldCatalog(FieldRef{Key: key, Label: "Whatever", DataType: TypeString})
+				if !errors.Is(err, ErrInvalidFieldKey) {
+					t.Errorf("NewFieldCatalog(%q) error = %v, want %v", key, err, ErrInvalidFieldKey)
+				}
+			})
+		}
+	})
+
+	t.Run("accepts the keys a receipt source produces", func(t *testing.T) {
+		keys := []FieldKey{"amount", "paid_by", "created_at", "custom_1", "custom_42", "_private"}
+
+		for _, key := range keys {
+			t.Run(string(key), func(t *testing.T) {
+				if _, err := NewFieldCatalog(FieldRef{Key: key, DataType: TypeString}); err != nil {
+					t.Errorf("NewFieldCatalog(%q) error = %v, want nil", key, err)
+				}
+			})
+		}
+	})
 }

--- a/api/internal/reporting/formula.go
+++ b/api/internal/reporting/formula.go
@@ -1,0 +1,367 @@
+package reporting
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/expr-lang/expr/ast"
+	"github.com/expr-lang/expr/parser"
+)
+
+var (
+	// ErrFormulaSyntax is returned when an expression does not parse.
+	ErrFormulaSyntax = errors.New("formula syntax error")
+
+	// ErrFormulaUnsupported is returned when an expression parses but uses a
+	// construct outside the whitelist.
+	ErrFormulaUnsupported = errors.New("formula uses an unsupported construct")
+
+	// ErrUnknownFunction is returned when an expression calls a function that
+	// is not allowed in that position.
+	ErrUnknownFunction = errors.New("unknown or disallowed function in formula")
+
+	// ErrBadCallArity is returned when a function is called with the wrong
+	// number of arguments.
+	ErrBadCallArity = errors.New("wrong number of arguments to function")
+
+	// ErrBadRoundPlaces is returned when ROUND's second argument is not a small
+	// integer literal.
+	ErrBadRoundPlaces = errors.New("ROUND places must be an integer literal")
+)
+
+// roundFunction is the only function an arithmetic expression may call. The
+// vertical reducers (SUM, COUNT, AVG, MIN, MAX) define aggregate columns
+// instead, and are rejected here.
+const roundFunction = "ROUND"
+
+// roundPlacesLimit bounds ROUND's second argument. Rescaling a decimal to an
+// arbitrary number of places would let a user-authored formula allocate without
+// bound, and no report needs more than a handful of digits either way.
+const roundPlacesLimit = 30
+
+// reservedWords are identifiers the expression language treats as operators or
+// keywords. A column may not be named one of these, since a formula referencing
+// it would not parse as a column reference.
+var reservedWords = map[string]struct{}{
+	"and": {}, "or": {}, "not": {}, "in": {},
+	"matches": {}, "contains": {}, "startsWith": {}, "endsWith": {},
+	"let": {}, "if": {}, "else": {},
+	"nil": {}, "true": {}, "false": {},
+}
+
+// isReservedWord reports whether a name collides with the expression language's
+// grammar or with a function the engine defines.
+func isReservedWord(name string) bool {
+	if _, reserved := reservedWords[name]; reserved {
+		return true
+	}
+	if name == roundFunction {
+		return true
+	}
+	_, isAggregate := aggFuncFromName(name)
+	return isAggregate
+}
+
+// ParseArithmetic parses an arithmetic column expression such as
+// "Subtotal + Hst" or "ROUND(Total / Count, 2)" and returns its syntax tree.
+//
+// Parsing is delegated to the expression language, but the resulting tree is
+// then checked against an allow-list: numeric literals, column references, the
+// operators + - * /, unary sign, and ROUND. Everything else the language can
+// express — property access, comparisons, conditionals, arrays, string and
+// boolean literals, builtins, variable declarations — is rejected. The check is
+// a closed type switch whose default rejects, so the whitelist holds by
+// construction rather than by remembering to deny each new construct.
+//
+// Identifiers are not resolved here; Validate checks them against the spec's
+// columns. The returned tree is exported so a renderer can walk it, which is
+// how the XLSX renderer translates a column expression into a live spreadsheet
+// formula.
+func ParseArithmetic(src string) (ast.Node, error) {
+	tree, err := parser.Parse(src)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrFormulaSyntax, err)
+	}
+	if err := checkArithmetic(tree.Node); err != nil {
+		return nil, err
+	}
+	return tree.Node, nil
+}
+
+// ParseAggregate parses an aggregate column expression such as "SUM(amount)" or
+// "COUNT()" into its structural form. An aggregate column is exactly one
+// reduction over one field; composing reductions is done with an arithmetic
+// column over the aggregate columns.
+//
+// Field names are not resolved here; Validate checks them against the catalog.
+func ParseAggregate(src string) (Aggregate, error) {
+	tree, err := parser.Parse(src)
+	if err != nil {
+		return Aggregate{}, fmt.Errorf("%w: %s", ErrFormulaSyntax, err)
+	}
+
+	// A mis-cased reducer such as sum(amount) collides with one of the
+	// expression language's own builtins, so it parses as a builtin rather than
+	// as a call.
+	if builtin, isBuiltin := tree.Node.(*ast.BuiltinNode); isBuiltin {
+		return Aggregate{}, aggregateFunctionError(builtin.Name)
+	}
+
+	call, isCall := tree.Node.(*ast.CallNode)
+	if !isCall {
+		return Aggregate{}, fmt.Errorf(
+			"%w: an aggregate column must be a single call such as SUM(amount), got %s",
+			ErrFormulaUnsupported, nodeKind(tree.Node))
+	}
+
+	name, named := calleeName(call)
+	if !named {
+		return Aggregate{}, fmt.Errorf("%w: computed function call", ErrFormulaUnsupported)
+	}
+
+	aggFunc, known := aggFuncFromName(name)
+	if !known {
+		return Aggregate{}, aggregateFunctionError(name)
+	}
+
+	if aggFunc == AggCount {
+		if len(call.Arguments) != 0 {
+			return Aggregate{}, fmt.Errorf("%w: COUNT takes no arguments, got %d",
+				ErrBadCallArity, len(call.Arguments))
+		}
+		return Aggregate{Func: AggCount}, nil
+	}
+
+	if len(call.Arguments) != 1 {
+		return Aggregate{}, fmt.Errorf("%w: %s takes 1 argument, got %d",
+			ErrBadCallArity, name, len(call.Arguments))
+	}
+
+	field, isIdentifier := call.Arguments[0].(*ast.IdentifierNode)
+	if !isIdentifier {
+		return Aggregate{}, fmt.Errorf("%w: %s must be given a field name, got %s",
+			ErrFormulaUnsupported, name, nodeKind(call.Arguments[0]))
+	}
+
+	return Aggregate{Func: aggFunc, Field: FieldKey(field.Value)}, nil
+}
+
+// columnRefs returns the distinct column names an arithmetic expression
+// references, in order of first appearance so error messages stay stable. A
+// function's name is not a column reference.
+func columnRefs(node ast.Node) []string {
+	var refs []string
+	seen := make(map[string]struct{})
+
+	var walk func(ast.Node)
+	walk = func(node ast.Node) {
+		switch n := node.(type) {
+		case *ast.IdentifierNode:
+			if _, exists := seen[n.Value]; !exists {
+				seen[n.Value] = struct{}{}
+				refs = append(refs, n.Value)
+			}
+		case *ast.UnaryNode:
+			walk(n.Node)
+		case *ast.BinaryNode:
+			walk(n.Left)
+			walk(n.Right)
+		case *ast.CallNode:
+			// Skip the callee: ROUND is a function, not a column.
+			for _, argument := range n.Arguments {
+				walk(argument)
+			}
+		}
+	}
+	walk(node)
+
+	return refs
+}
+
+// checkArithmetic enforces the arithmetic whitelist over a parsed tree.
+func checkArithmetic(node ast.Node) error {
+	switch n := node.(type) {
+	case *ast.IntegerNode, *ast.FloatNode:
+		return nil
+
+	case *ast.IdentifierNode:
+		return nil
+
+	case *ast.UnaryNode:
+		if n.Operator != "-" && n.Operator != "+" {
+			return fmt.Errorf("%w: unary operator %q", ErrFormulaUnsupported, n.Operator)
+		}
+		return checkArithmetic(n.Node)
+
+	case *ast.BinaryNode:
+		if !isArithmeticOperator(n.Operator) {
+			return fmt.Errorf("%w: operator %q", ErrFormulaUnsupported, n.Operator)
+		}
+		if err := checkArithmetic(n.Left); err != nil {
+			return err
+		}
+		return checkArithmetic(n.Right)
+
+	case *ast.CallNode:
+		return checkCall(n)
+
+	case *ast.BuiltinNode:
+		// The expression language defines lower-case builtins of its own —
+		// sum, min, max, count, round, len — so a mis-cased function name
+		// arrives here rather than as a call.
+		return arithmeticFunctionError(n.Name)
+	}
+
+	return fmt.Errorf("%w: %s", ErrFormulaUnsupported, nodeKind(node))
+}
+
+// checkCall allows ROUND and nothing else.
+func checkCall(call *ast.CallNode) error {
+	name, named := calleeName(call)
+	if !named {
+		return fmt.Errorf("%w: computed function call", ErrFormulaUnsupported)
+	}
+
+	if name != roundFunction {
+		return arithmeticFunctionError(name)
+	}
+
+	if len(call.Arguments) != 2 {
+		return fmt.Errorf("%w: ROUND takes 2 arguments, got %d", ErrBadCallArity, len(call.Arguments))
+	}
+	if err := checkArithmetic(call.Arguments[0]); err != nil {
+		return err
+	}
+	if _, err := integerLiteral(call.Arguments[1]); err != nil {
+		return err
+	}
+	return nil
+}
+
+// integerLiteral reads ROUND's places argument. The parser represents a
+// negative literal as unary minus applied to a positive one, so sign nodes are
+// unwrapped here.
+func integerLiteral(node ast.Node) (int32, error) {
+	switch n := node.(type) {
+	case *ast.IntegerNode:
+		if n.Value > roundPlacesLimit || n.Value < -roundPlacesLimit {
+			return 0, fmt.Errorf("%w: %d is outside [-%d, %d]",
+				ErrBadRoundPlaces, n.Value, roundPlacesLimit, roundPlacesLimit)
+		}
+		return int32(n.Value), nil
+
+	case *ast.UnaryNode:
+		if n.Operator != "-" && n.Operator != "+" {
+			break
+		}
+		inner, err := integerLiteral(n.Node)
+		if err != nil {
+			return 0, err
+		}
+		if n.Operator == "-" {
+			return -inner, nil
+		}
+		return inner, nil
+	}
+
+	return 0, fmt.Errorf("%w: got %s", ErrBadRoundPlaces, nodeKind(node))
+}
+
+// arithmeticFunctionError explains why a function is not allowed in an
+// arithmetic column. Naming a vertical reducer, or mis-casing ROUND, are the two
+// mistakes worth their own message.
+func arithmeticFunctionError(name string) error {
+	upper := strings.ToUpper(name)
+
+	if _, isAggregate := aggFuncFromName(upper); isAggregate {
+		return fmt.Errorf("%w: %s reduces rows and may only define an aggregate column",
+			ErrUnknownFunction, name)
+	}
+	if upper == roundFunction && name != roundFunction {
+		return fmt.Errorf("%w: %s (function names are upper case: did you mean %s?)",
+			ErrUnknownFunction, name, roundFunction)
+	}
+	return fmt.Errorf("%w: %s", ErrUnknownFunction, name)
+}
+
+// aggregateFunctionError explains why a function cannot define an aggregate
+// column.
+func aggregateFunctionError(name string) error {
+	upper := strings.ToUpper(name)
+
+	if _, isAggregate := aggFuncFromName(upper); isAggregate && upper != name {
+		return fmt.Errorf("%w: %s (function names are upper case: did you mean %s?)",
+			ErrUnknownFunction, name, upper)
+	}
+	if upper == roundFunction {
+		return fmt.Errorf("%w: %s does not reduce rows; round an arithmetic column instead",
+			ErrUnknownFunction, name)
+	}
+	return fmt.Errorf("%w: %s", ErrUnknownFunction, name)
+}
+
+func isArithmeticOperator(operator string) bool {
+	switch operator {
+	case "+", "-", "*", "/":
+		return true
+	}
+	return false
+}
+
+func calleeName(call *ast.CallNode) (string, bool) {
+	identifier, isIdentifier := call.Callee.(*ast.IdentifierNode)
+	if !isIdentifier {
+		return "", false
+	}
+	return identifier.Value, true
+}
+
+// nodeKind names a syntax node for an error message.
+func nodeKind(node ast.Node) string {
+	switch node.(type) {
+	case *ast.IntegerNode, *ast.FloatNode:
+		return "number literal"
+	case *ast.IdentifierNode:
+		return "column reference"
+	case *ast.StringNode:
+		return "string literal"
+	case *ast.BoolNode:
+		return "boolean literal"
+	case *ast.NilNode:
+		return "nil"
+	case *ast.BytesNode:
+		return "bytes literal"
+	case *ast.ConstantNode:
+		return "constant"
+	case *ast.ArrayNode:
+		return "array literal"
+	case *ast.MapNode, *ast.PairNode:
+		return "map literal"
+	case *ast.MemberNode:
+		return "property access"
+	case *ast.SliceNode:
+		return "slice"
+	case *ast.BuiltinNode:
+		return "builtin function"
+	case *ast.ConditionalNode:
+		return "conditional expression"
+	case *ast.ChainNode:
+		return "optional chaining"
+	case *ast.PredicateNode:
+		return "predicate"
+	case *ast.PointerNode:
+		return "pointer"
+	case *ast.VariableDeclaratorNode:
+		return "variable declaration"
+	case *ast.SequenceNode:
+		return "expression sequence"
+	case *ast.CallNode:
+		return "function call"
+	case *ast.UnaryNode:
+		return "unary expression"
+	case *ast.BinaryNode:
+		return "binary expression"
+	}
+	return fmt.Sprintf("%T", node)
+}

--- a/api/internal/reporting/formula.go
+++ b/api/internal/reporting/formula.go
@@ -28,6 +28,10 @@ var (
 	// ErrBadRoundPlaces is returned when ROUND's second argument is not a small
 	// integer literal.
 	ErrBadRoundPlaces = errors.New("ROUND places must be an integer literal")
+
+	// ErrFormulaTooLong is returned when an expression is longer than any real
+	// formula needs and long enough to be dangerous.
+	ErrFormulaTooLong = errors.New("formula is too long")
 )
 
 // roundFunction is the only function an arithmetic expression may call. The
@@ -39,6 +43,23 @@ const roundFunction = "ROUND"
 // arbitrary number of places would let a user-authored formula allocate without
 // bound, and no report needs more than a handful of digits either way.
 const roundPlacesLimit = 30
+
+// maxFormulaLength bounds the source an expression may be parsed from.
+//
+// The expression language caps the tree it will build at ten thousand nodes, and
+// that cap is often mistaken for a bound on the work parsing costs. It is not.
+// Parentheses group without producing a node, so they are never counted, and the
+// parser descends through several frames for each one. Nesting is therefore
+// bounded only by the goroutine stack: measured at roughly 640 bytes of stack
+// per parenthesis, Go's default one-gigabyte ceiling falls at about 1.6 million
+// of them — a few megabytes of source. A Go stack overflow is a fatal error that
+// recover cannot catch, so it takes the process down rather than the request.
+//
+// Bounding the input is the fix, for the same reason roundPlacesLimit and
+// maxDivisionScale are bounded: a template a user authored must not be able to
+// ask for unbounded work. A kilobyte is far longer than any real formula and
+// leaves the parser at most a few hundred frames deep.
+const maxFormulaLength = 1024
 
 // reservedWords are identifiers the expression language treats as operators or
 // keywords. A column may not be named one of these, since a formula referencing
@@ -79,6 +100,10 @@ func isReservedWord(name string) bool {
 // how the XLSX renderer translates a column expression into a live spreadsheet
 // formula.
 func ParseArithmetic(src string) (ast.Node, error) {
+	if err := checkFormulaLength(src); err != nil {
+		return nil, err
+	}
+
 	tree, err := parser.Parse(src)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", ErrFormulaSyntax, err)
@@ -96,6 +121,10 @@ func ParseArithmetic(src string) (ast.Node, error) {
 //
 // Field names are not resolved here; Validate checks them against the catalog.
 func ParseAggregate(src string) (Aggregate, error) {
+	if err := checkFormulaLength(src); err != nil {
+		return Aggregate{}, err
+	}
+
 	tree, err := parser.Parse(src)
 	if err != nil {
 		return Aggregate{}, fmt.Errorf("%w: %s", ErrFormulaSyntax, err)
@@ -145,6 +174,16 @@ func ParseAggregate(src string) (Aggregate, error) {
 	}
 
 	return Aggregate{Func: aggFunc, Field: FieldKey(field.Value)}, nil
+}
+
+// checkFormulaLength refuses source long enough to make parsing it expensive.
+// It runs before the parser, because the parser is what would be made to do the
+// work.
+func checkFormulaLength(src string) error {
+	if len(src) > maxFormulaLength {
+		return fmt.Errorf("%w: %d bytes, limit is %d", ErrFormulaTooLong, len(src), maxFormulaLength)
+	}
+	return nil
 }
 
 // columnRefs returns the distinct column names an arithmetic expression

--- a/api/internal/reporting/formula_test.go
+++ b/api/internal/reporting/formula_test.go
@@ -1,0 +1,271 @@
+package reporting
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestParseArithmetic_Accepts(t *testing.T) {
+	sources := []struct {
+		name string
+		src  string
+	}{
+		{"column reference", "Subtotal"},
+		{"integer literal", "2"},
+		{"float literal", "1.05"},
+		{"addition", "Subtotal + Hst"},
+		{"subtraction", "Total - Hst"},
+		{"multiplication", "Subtotal * 2"},
+		{"division", "Total / Count"},
+		{"precedence", "a + b * c"},
+		{"parentheses", "(a + b) * c"},
+		{"left associative subtraction", "a - b - c"},
+		{"left associative division", "a / b / c"},
+		{"unary minus", "-Subtotal"},
+		{"unary plus", "+Subtotal"},
+		{"subtract a negated column", "a - -b"},
+		// The parser reads this as a + (+b), not as a syntax error. Harmless.
+		{"doubled sign is a unary plus", "a ++ b"},
+		{"round", "ROUND(Total / Count, 2)"},
+		{"round to zero places", "ROUND(Total, 0)"},
+		{"round to tens", "ROUND(Total, -2)"},
+		{"nested round", "ROUND(a, 2) + ROUND(b, 2)"},
+		{"leading and trailing whitespace", "   a  +  b   "},
+	}
+
+	for _, test := range sources {
+		t.Run(test.name, func(t *testing.T) {
+			node, err := ParseArithmetic(test.src)
+			if err != nil {
+				t.Fatalf("ParseArithmetic(%q) error = %v, want nil", test.src, err)
+			}
+			if node == nil {
+				t.Errorf("ParseArithmetic(%q) returned a nil node", test.src)
+			}
+		})
+	}
+}
+
+func TestParseArithmetic_Rejects(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		wantErr error
+	}{
+		// Does not parse at all.
+		{"empty", "", ErrFormulaSyntax},
+		{"whitespace only", "   ", ErrFormulaSyntax},
+		{"trailing operator", "a +", ErrFormulaSyntax},
+		{"unbalanced parenthesis", "(a + b", ErrFormulaSyntax},
+		{"adjacent identifiers", "a b", ErrFormulaSyntax},
+		{"unknown operator", "a & b", ErrFormulaSyntax},
+		{"stray symbol", "#", ErrFormulaSyntax},
+
+		// Parses, but the operator is outside the whitelist. These are the
+		// dangerous ones: the expression language returns a BinaryNode for all
+		// of them, so a node-type check alone would let them through.
+		{"nil coalescing", "a ?? b", ErrFormulaUnsupported},
+		{"membership", "a in b", ErrFormulaUnsupported},
+		{"exponent", "a ** b", ErrFormulaUnsupported},
+		{"modulo", "a % b", ErrFormulaUnsupported},
+		{"comparison", "a > b", ErrFormulaUnsupported},
+		{"equality", "a == b", ErrFormulaUnsupported},
+		{"logical and", "a and b", ErrFormulaUnsupported},
+		{"string match", `a matches "x"`, ErrFormulaUnsupported},
+		{"logical not is a unary node", "not a", ErrFormulaUnsupported},
+
+		// Parses, but the node type is outside the whitelist.
+		{"property access", "a.b", ErrFormulaUnsupported},
+		{"array literal", "[1, 2]", ErrFormulaUnsupported},
+		{"map literal", "{a: 1}", ErrFormulaUnsupported},
+		{"string literal", `"s"`, ErrFormulaUnsupported},
+		{"boolean literal", "true", ErrFormulaUnsupported},
+		{"nil literal", "nil", ErrFormulaUnsupported},
+		{"conditional", "a > b ? 1 : 2", ErrFormulaUnsupported},
+		{"variable declaration", "let x = 1; x", ErrFormulaUnsupported},
+
+		// Functions. The expression language ships lower-case builtins named
+		// sum, min, max, count, round and len, so a mis-cased function name
+		// parses as a builtin rather than as a call. Both paths must land on
+		// the same sentinel.
+		{"unknown function", "FOO(a)", ErrUnknownFunction},
+		{"sum is aggregate only", "SUM(a)", ErrUnknownFunction},
+		{"count is aggregate only", "COUNT()", ErrUnknownFunction},
+		{"avg is aggregate only", "AVG(a)", ErrUnknownFunction},
+		{"lowercase sum is a builtin", "sum(a)", ErrUnknownFunction},
+		{"lowercase avg is a call", "avg(a)", ErrUnknownFunction},
+		{"lowercase round is a builtin", "round(a, 2)", ErrUnknownFunction},
+		{"unrelated builtin", "len(a)", ErrUnknownFunction},
+		{"builtin nested in a sum", "a + len(b)", ErrUnknownFunction},
+
+		// ROUND's shape.
+		{"round with one argument", "ROUND(a)", ErrBadCallArity},
+		{"round with three arguments", "ROUND(a, 2, 3)", ErrBadCallArity},
+		{"round places is a column", "ROUND(a, b)", ErrBadRoundPlaces},
+		{"round places is a float", "ROUND(a, 1.5)", ErrBadRoundPlaces},
+		{"round places is an expression", "ROUND(a, 1 + 1)", ErrBadRoundPlaces},
+		{"round places exceeds the limit", "ROUND(a, 999)", ErrBadRoundPlaces},
+		{"round places below the limit", "ROUND(a, -999)", ErrBadRoundPlaces},
+
+		// The whitelist is recursive, not just applied to the root.
+		{"unsupported operator nested in a sum", "a + (b % c)", ErrFormulaUnsupported},
+		{"unsupported node nested under round", "ROUND(a.b, 2)", ErrFormulaUnsupported},
+		{"unsupported node nested under unary", "-[1]", ErrFormulaUnsupported},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			node, err := ParseArithmetic(test.src)
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("ParseArithmetic(%q) error = %v, want %v", test.src, err, test.wantErr)
+			}
+			if node != nil {
+				t.Errorf("ParseArithmetic(%q) returned a node alongside an error", test.src)
+			}
+		})
+	}
+}
+
+func TestParseAggregate_Accepts(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want Aggregate
+	}{
+		{"sum", "SUM(amount)", Aggregate{Func: AggSum, Field: "amount"}},
+		{"sum of a custom field", "SUM(custom_1)", Aggregate{Func: AggSum, Field: "custom_1"}},
+		{"count", "COUNT()", Aggregate{Func: AggCount}},
+		{"avg", "AVG(amount)", Aggregate{Func: AggAvg, Field: "amount"}},
+		{"min", "MIN(amount)", Aggregate{Func: AggMin, Field: "amount"}},
+		{"max", "MAX(amount)", Aggregate{Func: AggMax, Field: "amount"}},
+		{"whitespace", "  SUM( amount )  ", Aggregate{Func: AggSum, Field: "amount"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ParseAggregate(test.src)
+			if err != nil {
+				t.Fatalf("ParseAggregate(%q) error = %v, want nil", test.src, err)
+			}
+			if got != test.want {
+				t.Errorf("ParseAggregate(%q) = %+v, want %+v", test.src, got, test.want)
+			}
+		})
+	}
+}
+
+func TestParseAggregate_Rejects(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		wantErr error
+	}{
+		{"empty", "", ErrFormulaSyntax},
+		{"not a call", "amount", ErrFormulaUnsupported},
+		{"a call plus something", "SUM(amount) + 1", ErrFormulaUnsupported},
+		{"two aggregates", "SUM(a) + SUM(b)", ErrFormulaUnsupported},
+		{"unknown function", "TOTAL(amount)", ErrUnknownFunction},
+		{"round is arithmetic only", "ROUND(amount, 2)", ErrUnknownFunction},
+		{"lowercase sum is a builtin", "sum(amount)", ErrUnknownFunction},
+		{"lowercase avg is a call", "avg(amount)", ErrUnknownFunction},
+		{"lowercase round is a builtin", "round(amount, 2)", ErrUnknownFunction},
+		{"unrelated builtin", "len(a)", ErrUnknownFunction},
+		{"count takes no arguments", "COUNT(amount)", ErrBadCallArity},
+		{"sum needs an argument", "SUM()", ErrBadCallArity},
+		{"sum takes one argument", "SUM(a, b)", ErrBadCallArity},
+		{"argument must be a field name", "SUM(a + b)", ErrFormulaUnsupported},
+		{"argument must not be a literal", "SUM(1)", ErrFormulaUnsupported},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ParseAggregate(test.src)
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("ParseAggregate(%q) error = %v, want %v", test.src, err, test.wantErr)
+			}
+			if got != (Aggregate{}) {
+				t.Errorf("ParseAggregate(%q) returned %+v alongside an error", test.src, got)
+			}
+		})
+	}
+}
+
+// Round-tripping keeps the persisted template form and the structural form in
+// step.
+func TestAggregate_String(t *testing.T) {
+	sources := []string{"SUM(amount)", "COUNT()", "AVG(custom_1)", "MIN(amount)", "MAX(amount)"}
+
+	for _, src := range sources {
+		t.Run(src, func(t *testing.T) {
+			aggregate, err := ParseAggregate(src)
+			if err != nil {
+				t.Fatalf("ParseAggregate(%q) error = %v", src, err)
+			}
+			if got := aggregate.String(); got != src {
+				t.Errorf("Aggregate.String() = %q, want %q", got, src)
+			}
+		})
+	}
+}
+
+func TestColumnRefs(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{"single reference", "Subtotal", []string{"Subtotal"}},
+		{"binary", "Subtotal + Hst", []string{"Subtotal", "Hst"}},
+		{"first appearance order", "Hst + Subtotal", []string{"Hst", "Subtotal"}},
+		{"deduplicated", "a + a * a", []string{"a"}},
+		{"no references", "1 + 2", nil},
+		{"unary", "-Subtotal", []string{"Subtotal"}},
+		{"nested parentheses", "(a + b) * (c - a)", []string{"a", "b", "c"}},
+		// The function's name must not be mistaken for a column.
+		{"round callee is not a column", "ROUND(Total / Count, 2)", []string{"Total", "Count"}},
+		{"round of a constant", "ROUND(1.5, 0)", nil},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			node, err := ParseArithmetic(test.src)
+			if err != nil {
+				t.Fatalf("ParseArithmetic(%q) error = %v", test.src, err)
+			}
+
+			got := columnRefs(node)
+			if len(got) != len(test.want) {
+				t.Fatalf("columnRefs(%q) = %v, want %v", test.src, got, test.want)
+			}
+			for i := range got {
+				if got[i] != test.want[i] {
+					t.Errorf("columnRefs(%q)[%d] = %q, want %q", test.src, i, got[i], test.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestIsReservedWord(t *testing.T) {
+	reserved := []string{
+		"and", "or", "not", "in", "matches", "contains", "startsWith", "endsWith",
+		"let", "if", "else", "nil", "true", "false",
+		"SUM", "COUNT", "AVG", "MIN", "MAX", "ROUND",
+	}
+	for _, name := range reserved {
+		t.Run("reserved "+name, func(t *testing.T) {
+			if !isReservedWord(name) {
+				t.Errorf("isReservedWord(%q) = false, want true", name)
+			}
+		})
+	}
+
+	allowed := []string{"Subtotal", "Hst", "Total", "Count", "AvgPerReceipt", "sum", "Round", "In"}
+	for _, name := range allowed {
+		t.Run("allowed "+name, func(t *testing.T) {
+			if isReservedWord(name) {
+				t.Errorf("isReservedWord(%q) = true, want false", name)
+			}
+		})
+	}
+}

--- a/api/internal/reporting/fuzz_test.go
+++ b/api/internal/reporting/fuzz_test.go
@@ -1,0 +1,351 @@
+package reporting
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/expr-lang/expr/ast"
+	"github.com/shopspring/decimal"
+)
+
+// Formulas are authored by people and stored in templates, so the parser is an
+// untrusted-input boundary even though the author is trusted. These targets
+// assert that whatever it is handed, it either refuses it or produces something
+// the evaluator can safely run.
+//
+// The seed corpora carry every accepted and rejected expression from
+// formula_test.go, so a plain `go test` run already exercises them.
+
+var fuzzFormulaSeeds = []string{
+	// Accepted.
+	"Subtotal", "2", "1.05", "Subtotal + Hst", "Total - Hst", "Subtotal * 2",
+	"Total / Count", "a + b * c", "(a + b) * c", "a - b - c", "a / b / c",
+	"-Subtotal", "+Subtotal", "a - -b", "a ++ b", "ROUND(Total / Count, 2)",
+	"ROUND(Total, 0)", "ROUND(Total, -2)", "ROUND(a, --2)", "ROUND(a, 2) + ROUND(b, 2)",
+	"   a  +  b   ",
+
+	// Rejected: unparsable.
+	"", "   ", "a +", "(a + b", "a b", "a & b", "#",
+
+	// Rejected: parses, but outside the whitelist.
+	"a ?? b", "a in b", "a ** b", "a % b", "a > b", "a == b", "a and b",
+	`a matches "x"`, "not a", "a.b", "[1, 2]", "{a: 1}", `"s"`, "true", "nil",
+	"a > b ? 1 : 2", "let x = 1; x", "len(a)", "sum(a)", "round(a, 2)",
+
+	// Rejected: functions and arity.
+	"FOO(a)", "SUM(a)", "COUNT()", "AVG(a)", "ROUND(a)", "ROUND(a, 2, 3)",
+	"ROUND(a, b)", "ROUND(a, 1.5)", "ROUND(a, 1 + 1)", "ROUND(a, 999)", "ROUND(a, -999)",
+
+	// Numeric edges.
+	"9223372036854775807", "9223372036854775808", "0.1 + 0.2", "1e30", "0/0", "1/0",
+}
+
+// FuzzParseArithmetic asserts the parser is total and that whatever it accepts,
+// the evaluator can run without panicking.
+//
+// Anything accepted must also survive a second whitelist check and be walkable
+// for its column references, since a renderer will later walk the same tree.
+func FuzzParseArithmetic(f *testing.F) {
+	for _, seed := range fuzzFormulaSeeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, source string) {
+		node, err := ParseArithmetic(source)
+
+		if (err == nil) != (node != nil) {
+			t.Fatalf("ParseArithmetic(%q) returned node=%v and err=%v", source, node != nil, err)
+		}
+		if err != nil {
+			assertFormulaError(t, source, err)
+			return
+		}
+
+		// An accepted tree stays accepted, and its references are walkable.
+		if again := checkArithmetic(node); again != nil {
+			t.Fatalf("ParseArithmetic(%q) accepted a tree that checkArithmetic rejects: %v", source, again)
+		}
+
+		columns := map[string]Value{}
+		for _, ref := range columnRefs(node) {
+			columns[ref] = Num(dec("2"))
+		}
+
+		// Evaluation must be total, and must yield a number or nothing.
+		value := evalArithmetic(node, columns, 6)
+		if value.Type() != ValueNumber && value.Type() != ValueNull {
+			t.Fatalf("eval(%q) = %v, want a number or null", source, value)
+		}
+
+		if len(columns) == 0 {
+			// A constant expression reads nothing; the two cases below are about
+			// what happens to the values it would have read.
+			return
+		}
+
+		// Every column zero: this is where division by zero lives, and it must
+		// produce a value rather than a panic.
+		for name := range columns {
+			columns[name] = Num(dec("0"))
+		}
+		_ = evalArithmetic(node, columns, 6)
+
+		// Every column null: an expression that reads one is null.
+		for name := range columns {
+			columns[name] = Null()
+		}
+		if got := evalArithmetic(node, columns, 6); !got.IsNull() {
+			t.Fatalf("eval(%q) over null columns = %v, want null", source, got)
+		}
+	})
+}
+
+// assertFormulaError: a rejection always carries one of the package's sentinels,
+// so a caller can tell a typo from a forbidden construct.
+func assertFormulaError(t *testing.T, source string, err error) {
+	t.Helper()
+
+	sentinels := []error{
+		ErrFormulaSyntax, ErrFormulaUnsupported, ErrUnknownFunction,
+		ErrBadCallArity, ErrBadRoundPlaces,
+	}
+	for _, sentinel := range sentinels {
+		if errors.Is(err, sentinel) {
+			return
+		}
+	}
+	t.Fatalf("ParseArithmetic(%q) failed with an unclassified error: %v", source, err)
+}
+
+// FuzzParseAggregate asserts the aggregate front door is total: it returns a
+// well-formed aggregate or an error, never both and never a panic.
+func FuzzParseAggregate(f *testing.F) {
+	seeds := []string{
+		"SUM(amount)", "SUM(custom_1)", "COUNT()", "AVG(amount)", "MIN(amount)", "MAX(amount)",
+		"  SUM( amount )  ", "", "amount", "SUM(amount) + 1", "SUM(a) + SUM(b)",
+		"TOTAL(amount)", "ROUND(amount, 2)", "sum(amount)", "avg(amount)", "round(amount, 2)",
+		"len(a)", "COUNT(amount)", "SUM()", "SUM(a, b)", "SUM(a + b)", "SUM(1)", "SUM(",
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, source string) {
+		aggregate, err := ParseAggregate(source)
+
+		if err != nil {
+			if aggregate != (Aggregate{}) {
+				t.Fatalf("ParseAggregate(%q) returned %+v alongside %v", source, aggregate, err)
+			}
+			assertFormulaError(t, source, err)
+			return
+		}
+
+		switch aggregate.Func {
+		case AggSum, AggAvg, AggMin, AggMax:
+			if aggregate.Field == "" {
+				t.Fatalf("ParseAggregate(%q) = %s with no field", source, aggregate.Func)
+			}
+		case AggCount:
+			if aggregate.Field != "" {
+				t.Fatalf("ParseAggregate(%q) = COUNT over %s", source, aggregate.Field)
+			}
+		default:
+			t.Fatalf("ParseAggregate(%q) produced an unknown function %d", source, aggregate.Func)
+		}
+
+		// The structural form renders back to something that parses the same.
+		reparsed, err := ParseAggregate(aggregate.String())
+		if err != nil || reparsed != aggregate {
+			t.Fatalf("ParseAggregate(%q).String() = %q, which reparses to %+v (%v)",
+				source, aggregate.String(), reparsed, err)
+		}
+	})
+}
+
+// FuzzEvalArithmetic asserts the evaluator is total over arbitrary column
+// values, and — the guarantee that matters most — that its answer never depends
+// on decimal's mutable, process-wide DivisionPrecision.
+func FuzzEvalArithmetic(f *testing.F) {
+	f.Add("Total / Count", "215.60", "0", int32(6))
+	f.Add("Total / Count", "215.60", "6", int32(2))
+	f.Add("Total + Count", "0.1", "0.2", int32(6))
+	f.Add("ROUND(Total / Count, 2)", "1", "3", int32(6))
+	f.Add("Total * Count - Total / Count", "-5.5", "0.001", int32(0))
+	f.Add("ROUND(Total, -2)", "1234", "1", int32(30))
+
+	f.Fuzz(func(t *testing.T, source, left, right string, scale int32) {
+		if scale < 0 || scale > maxDivisionScale {
+			t.Skip()
+		}
+
+		node, err := ParseArithmetic(source)
+		if err != nil {
+			t.Skip()
+		}
+
+		leftValue, leftErr := boundedDecimal(left)
+		rightValue, rightErr := boundedDecimal(right)
+		if leftErr != nil || rightErr != nil {
+			t.Skip()
+		}
+
+		columns := map[string]Value{"Total": Num(leftValue), "Count": Num(rightValue)}
+		for _, ref := range columnRefs(node) {
+			if _, known := columns[ref]; !known {
+				columns[ref] = Null()
+			}
+		}
+
+		got := evalArithmetic(node, columns, scale)
+		if got.Type() != ValueNumber && got.Type() != ValueNull {
+			t.Fatalf("eval(%q) = %v, want a number or null", source, got)
+		}
+
+		// Dividing by zero is an empty cell, never a panic and never an error.
+		if rightValue.IsZero() && dividesByCount(node) && !got.IsNull() {
+			t.Fatalf("eval(%q) with Count=0 = %v, want null", source, got)
+		}
+
+		// Another package mutating decimal.DivisionPrecision must not move the
+		// answer. The engine rounds explicitly and never reads the global.
+		original := decimal.DivisionPrecision
+		defer func() { decimal.DivisionPrecision = original }()
+
+		decimal.DivisionPrecision = 1
+		low := evalArithmetic(node, columns, scale)
+		decimal.DivisionPrecision = 60
+		high := evalArithmetic(node, columns, scale)
+
+		if !low.Equal(got) || !high.Equal(got) {
+			t.Fatalf("eval(%q) changed with decimal.DivisionPrecision: %v / %v / %v", source, got, low, high)
+		}
+	})
+}
+
+// dividesByCount reports whether the expression's top level divides by Count,
+// which is the only shape the zero-divisor assertion above can predict.
+func dividesByCount(node ast.Node) bool {
+	binary, isBinary := node.(*ast.BinaryNode)
+	if !isBinary || binary.Operator != "/" {
+		return false
+	}
+	identifier, isIdentifier := binary.Right.(*ast.IdentifierNode)
+	return isIdentifier && identifier.Value == "Count"
+}
+
+// FuzzRunIsTotal drives the whole engine from fuzz bytes: a bounded spec over a
+// fixed catalog, and a handful of rows. Whatever comes out, if Validate
+// accepted the spec then Run must not panic and the model must obey its
+// structural laws.
+func FuzzRunIsTotal(f *testing.F) {
+	f.Add(uint8(0), uint8(0), uint8(3), uint8(7), true, true, int32(6))
+	f.Add(uint8(2), uint8(1), uint8(5), uint8(0), false, true, int32(2))
+	f.Add(uint8(3), uint8(4), uint8(0), uint8(255), true, false, int32(0))
+	f.Add(uint8(255), uint8(255), uint8(255), uint8(255), false, false, int32(31))
+
+	f.Fuzz(func(t *testing.T, levels, detailBy, rowCount, shape uint8, subtotals, grandTotals bool, scale int32) {
+		catalog := fuzzCatalog(t)
+
+		dimensions := []FieldKey{"category", "tag", "paid_by", "date", "resolved"}
+		groupBy := make([]FieldKey, 0, 3)
+		for index := 0; index < int(levels)%4; index++ {
+			groupBy = append(groupBy, dimensions[(int(shape)+index)%len(dimensions)])
+		}
+
+		detail := DetailSpec{Mode: DetailRecords}
+		if detailBy%2 == 0 {
+			detail = DetailSpec{Mode: DetailAggregate, By: dimensions[int(detailBy)%len(dimensions)]}
+		}
+
+		spec := ReportSpec{
+			GroupBy: groupBy,
+			Detail:  detail,
+			Columns: []Column{
+				{Name: "Cnt", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}},
+				{Name: "Total", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "amount"}},
+				{Name: "Mean", Kind: ColumnAggregate, Agg: Aggregate{Func: AggAvg, Field: "amount"}},
+				{Name: "Ratio", Kind: ColumnArithmetic, Expr: "Total / Cnt"},
+			},
+			Subtotals:   subtotals,
+			GrandTotals: grandTotals,
+			Config:      EngineConfig{DivisionScale: scale},
+		}
+
+		// A spec Validate rejects is not the engine's problem; that it rejects
+		// rather than panicking is, and it already has by the time we get here.
+		if err := Validate(spec, catalog); err != nil {
+			return
+		}
+
+		rows := make([]Row, int(rowCount)%9)
+		for index := range rows {
+			rows[index] = fuzzRow(index, int(shape))
+		}
+
+		model, err := Run(spec, catalog, rows, MetaInput{})
+		if err != nil {
+			t.Fatalf("Validate accepted a spec that Run rejects: %v", err)
+		}
+
+		assertModelInvariants(t, spec, model)
+
+		// Determinism, over whatever shape the fuzzer found.
+		again, err := Run(spec, catalog, rows, MetaInput{})
+		if err != nil {
+			t.Fatalf("Run() error on the second run = %v", err)
+		}
+		if serializeModel(again) != serializeModel(model) {
+			t.Fatalf("two runs over the same input disagree")
+		}
+	})
+}
+
+func fuzzCatalog(t *testing.T) FieldCatalog {
+	t.Helper()
+
+	catalog, err := NewFieldCatalog(
+		FieldRef{Key: "amount", DataType: TypeCurrency},
+		FieldRef{Key: "category", DataType: TypeString, Multi: true},
+		FieldRef{Key: "tag", DataType: TypeString, Multi: true},
+		FieldRef{Key: "paid_by", DataType: TypeString},
+		FieldRef{Key: "date", DataType: TypeDate},
+		FieldRef{Key: "resolved", DataType: TypeBool},
+	)
+	if err != nil {
+		t.Fatalf("NewFieldCatalog() error = %v", err)
+	}
+	return catalog
+}
+
+// fuzzRow builds a row whose shape varies with the fuzzed bytes: absent fields,
+// explicit nulls, repeated values, and the colliding dates.
+func fuzzRow(index, shape int) Row {
+	row := Row{}
+	mix := (index + shape) % 6
+
+	switch mix {
+	case 0:
+		// Everything absent: the row lands in every (None) bucket.
+	case 1:
+		row["category"] = []Value{Str("a"), Str("a")} // a repeat, not a fan-out
+		row["amount"] = []Value{Num(dec("10.00"))}
+	case 2:
+		row["tag"] = []Value{Str("x"), Str("y")} // a genuine fan-out
+		row["amount"] = []Value{Num(dec("-1.50"))}
+	case 3:
+		row["date"] = []Value{DateVal(propertyDates[index%len(propertyDates)])}
+		row["amount"] = []Value{Null()} // counted, but contributes no amount
+	case 4:
+		row["paid_by"] = []Value{Str("")} // the empty string is its own bucket
+		row["resolved"] = []Value{Bool(index%2 == 0)}
+		row["amount"] = []Value{Num(dec("0"))}
+	default:
+		row["category"] = []Value{Str("b")}
+		row["tag"] = []Value{Str("z")}
+		row["paid_by"] = []Value{Str("p")}
+		row["amount"] = []Value{Num(dec("3.33"))}
+	}
+
+	return row
+}

--- a/api/internal/reporting/fuzz_test.go
+++ b/api/internal/reporting/fuzz_test.go
@@ -107,7 +107,7 @@ func assertFormulaError(t *testing.T, source string, err error) {
 
 	sentinels := []error{
 		ErrFormulaSyntax, ErrFormulaUnsupported, ErrUnknownFunction,
-		ErrBadCallArity, ErrBadRoundPlaces,
+		ErrBadCallArity, ErrBadRoundPlaces, ErrFormulaTooLong,
 	}
 	for _, sentinel := range sentinels {
 		if errors.Is(err, sentinel) {

--- a/api/internal/reporting/golden_test.go
+++ b/api/internal/reporting/golden_test.go
@@ -1,0 +1,215 @@
+package reporting
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// renderTextTable lays a report out as a fixed-width table, the way a human
+// reads one. It exists so that a single assertion covers the shape of a whole
+// report at once: the grouping, the ordering, the values, where subtotals sit,
+// and which cells are blank.
+//
+// It is a test helper, not a renderer. It assumes the report's first column is
+// the one naming each detail row, which is how the design's report is built.
+func renderTextTable(model ReportModel, labels map[FieldKey]string) string {
+	type line struct {
+		cells   []string
+		heading bool
+	}
+
+	var lines []line
+
+	header := make([]string, 0, len(model.Columns))
+	for _, column := range model.Columns {
+		header = append(header, column.Label)
+	}
+	lines = append(lines, line{cells: header})
+
+	format := func(cells []Cell, leading string, indent int) []string {
+		rendered := make([]string, len(cells))
+		for index, cell := range cells {
+			rendered[index] = formatCell(model.Columns[index], cell, model.Meta.NoneLabel)
+		}
+		if leading != "" {
+			rendered[0] = leading
+		}
+		rendered[0] = strings.Repeat("  ", indent) + rendered[0]
+		return rendered
+	}
+
+	var walk func(node GroupNode, depth int)
+	walk = func(node GroupNode, depth int) {
+		if depth > 0 {
+			name := labels[node.Dimension]
+			value := node.Value.String()
+			if node.IsNone {
+				value = model.Meta.NoneLabel
+			}
+			lines = append(lines, line{
+				cells:   []string{strings.Repeat("  ", depth-1) + name + ": " + value},
+				heading: true,
+			})
+		}
+
+		for _, row := range node.DetailRows {
+			lines = append(lines, line{cells: format(row.Cells, "", depth)})
+		}
+		for _, child := range node.Children {
+			walk(child, depth+1)
+		}
+		if node.Subtotals != nil {
+			lines = append(lines, line{cells: format(node.Subtotals, "TOTALS", depth)})
+		}
+	}
+	walk(model.Root, 0)
+
+	if model.GrandTotals != nil {
+		lines = append(lines, line{cells: format(model.GrandTotals, "GRAND TOTALS", 0)})
+	}
+
+	widths := make([]int, len(model.Columns))
+	for _, current := range lines {
+		if current.heading {
+			continue
+		}
+		for index, cell := range current.cells {
+			if len(cell) > widths[index] {
+				widths[index] = len(cell)
+			}
+		}
+	}
+
+	var out strings.Builder
+	for _, current := range lines {
+		if current.heading {
+			out.WriteString(current.cells[0] + "\n")
+			continue
+		}
+		parts := make([]string, len(current.cells))
+		for index, cell := range current.cells {
+			if index == 0 {
+				parts[index] = fmt.Sprintf("%-*s", widths[index], cell)
+			} else {
+				parts[index] = fmt.Sprintf("%*s", widths[index], cell)
+			}
+		}
+		out.WriteString(strings.TrimRight(strings.Join(parts, "  "), " ") + "\n")
+	}
+
+	return out.String()
+}
+
+// formatCell renders one cell the way a report would present it: money to two
+// places, counts as whole numbers, labels as text, and an undefined value as an
+// empty cell.
+//
+// A label cell holding no values is blank — that is a subtotal row, which no
+// single bucket named. A label cell holding one null value is the (None)
+// bucket, which is a bucket like any other and gets the report's name for it.
+// The two are different things and the model keeps them apart.
+func formatCell(column ColumnDescriptor, cell Cell, noneLabel string) string {
+	if len(cell.Values) == 0 {
+		return ""
+	}
+
+	if column.Kind == ColumnLabel {
+		parts := make([]string, 0, len(cell.Values))
+		for _, value := range cell.Values {
+			if value.IsNull() {
+				parts = append(parts, noneLabel)
+				continue
+			}
+			parts = append(parts, value.String())
+		}
+		return strings.Join(parts, ", ")
+	}
+
+	value := cell.Value()
+	if value.IsNull() {
+		return ""
+	}
+
+	number, isNumber := value.Decimal()
+	if !isNumber {
+		return value.String()
+	}
+	if column.DataType == TypeCurrency {
+		return number.StringFixed(2)
+	}
+	return number.String()
+}
+
+// The golden report. Every number, every row and every position below is read
+// off the design document's worked example.
+//
+// Money is shown to two places, which is presentation rather than data: the
+// engine's Avg/Receipt for Alex is 35.933333, and it is the renderer that shows
+// 35.93. The grouping labels come from the catalog, not from the engine, which
+// only names the dimension each level was cut by.
+func TestGolden_WorkedExampleRendersAsTheDesignDocument(t *testing.T) {
+	model := mustRun(t, workedExampleSpec(), workedExampleRows())
+
+	labels := map[FieldKey]string{"paid_by": "Paid By", "tag": "Tag"}
+
+	want := strings.TrimPrefix(`
+Category      Count  Subtotal    Hst   Total  Avg/Receipt
+Paid By: Dana
+  Tag: Alex
+    Clothing      4    120.00  15.60  135.60        33.90
+    Medical       2     80.00   0.00   80.00        40.00
+    TOTALS        6    200.00  15.60  215.60        35.93
+  Tag: Sam
+    Clothing      3     90.00  11.70  101.70        33.90
+    Mileage       1     30.00   0.00   30.00        30.00
+    TOTALS        4    120.00  11.70  131.70        32.93
+  TOTALS         10    320.00  27.30  347.30        34.73
+GRAND TOTALS     10    320.00  27.30  347.30        34.73
+`, "\n")
+
+	if got := renderTextTable(model, labels); got != want {
+		t.Errorf("report does not match the design document.\n\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+// The same report with the (None) bucket in it, so the empty-value case has a
+// golden shape too. A receipt with no tag and one with no category are both
+// kept, and both sort last within their level.
+func TestGolden_NoneBucketsRenderLast(t *testing.T) {
+	spec := workedExampleSpec()
+	spec.NoneLabel = "(None)"
+
+	rows := append(workedExampleRows(),
+		// Tagged, but uncategorized.
+		Row{"paid_by": {Str("Dana")}, "tag": {Str("Alex")}, "amount": {Num(dec("7.00"))}},
+		// Untagged and uncategorized.
+		Row{"paid_by": {Str("Dana")}, "amount": {Num(dec("3.00"))}},
+	)
+
+	model := mustRun(t, spec, rows)
+	labels := map[FieldKey]string{"paid_by": "Paid By", "tag": "Tag"}
+
+	want := strings.TrimPrefix(`
+Category      Count  Subtotal    Hst   Total  Avg/Receipt
+Paid By: Dana
+  Tag: Alex
+    Clothing      4    120.00  15.60  135.60        33.90
+    Medical       2     80.00   0.00   80.00        40.00
+    (None)        1      7.00   0.00    7.00         7.00
+    TOTALS        7    207.00  15.60  222.60        31.80
+  Tag: Sam
+    Clothing      3     90.00  11.70  101.70        33.90
+    Mileage       1     30.00   0.00   30.00        30.00
+    TOTALS        4    120.00  11.70  131.70        32.93
+  Tag: (None)
+    (None)        1      3.00   0.00    3.00         3.00
+    TOTALS        1      3.00   0.00    3.00         3.00
+  TOTALS         12    330.00  27.30  357.30        29.78
+GRAND TOTALS     12    330.00  27.30  357.30        29.78
+`, "\n")
+
+	if got := renderTextTable(model, labels); got != want {
+		t.Errorf("report does not match.\n\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}

--- a/api/internal/reporting/invariants_test.go
+++ b/api/internal/reporting/invariants_test.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 )
 
 // This file holds the laws every ReportModel obeys, whatever the spec and
@@ -282,9 +283,16 @@ func serializeCells(cells []Cell) string {
 	return strings.Join(parts, " ")
 }
 
-// serializeValue renders a value canonically. A number renders through the
-// decimal's own normalization, so 200 and 200.00 serialize alike, and a date
-// through its absolute instant.
+// serializeValue renders everything about a value that a renderer can observe.
+//
+// A number renders through the decimal's own normalization, so 200 and 200.00
+// serialize alike. A date renders as its wall clock and zone offset — not
+// through bucketKey, and not normalized to UTC, because both of those erase the
+// location, and the location is exactly what a renderer formats a group header
+// from. A law must not be derived from the code it judges: an earlier draft
+// serialized dates with bucketKey and so agreed that two zones naming one
+// instant were interchangeable, which is the one thing the determinism laws
+// exist to deny.
 func serializeValue(value Value) string {
 	switch value.Type() {
 	case ValueNull:
@@ -299,7 +307,8 @@ func serializeValue(value Value) string {
 		flag, _ := value.Boolean()
 		return fmt.Sprintf("b%v", flag)
 	case ValueDate:
-		return "d" + bucketKey(value)
+		instant, _ := value.Time()
+		return "d" + instant.Format(time.RFC3339Nano)
 	}
 	return "?"
 }

--- a/api/internal/reporting/invariants_test.go
+++ b/api/internal/reporting/invariants_test.go
@@ -172,13 +172,21 @@ func assertCellCardinality(t *testing.T, model ReportModel, cells []Cell, path s
 	}
 }
 
-// assertSortedByValue: siblings ascend by value, and the (None) bucket is last.
+// assertSortedByValue: siblings ascend by value, are pairwise distinct, and the
+// (None) bucket is last.
+//
+// Distinctness matters as much as order. Two siblings that compare equal are
+// one value split across two buckets, which is what a bucket key finer than
+// equality produces. Since the siblings are sorted, equals are adjacent.
 func assertSortedByValue(t *testing.T, values []Value, path string) {
 	t.Helper()
 
 	for index := 1; index < len(values); index++ {
-		if compareValues(values[index-1], values[index]) > 0 {
+		switch compareValues(values[index-1], values[index]) {
+		case 1:
 			t.Errorf("%s: %v sorts after %v", path, values[index-1], values[index])
+		case 0:
+			t.Errorf("%s: %v appears as two buckets", path, values[index])
 		}
 	}
 	for index, value := range values {

--- a/api/internal/reporting/invariants_test.go
+++ b/api/internal/reporting/invariants_test.go
@@ -1,0 +1,297 @@
+package reporting
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// This file holds the laws every ReportModel obeys, whatever the spec and
+// whatever the rows. Engine tests assert them alongside their own expectations,
+// and the property tests assert them over randomly generated reports, so a
+// regression in any one of them trips almost everywhere at once.
+
+// assertModelInvariants checks the structural laws of a report model. It is
+// deliberately independent of the engine's implementation: it walks the output
+// and re-derives what must be true of it from the spec alone.
+func assertModelInvariants(t *testing.T, spec ReportSpec, model ReportModel) {
+	t.Helper()
+
+	filled := spec.withDefaults()
+
+	assertColumnAlignment(t, model, model.GrandTotals, "grand totals")
+	if filled.GrandTotals != (model.GrandTotals != nil) {
+		t.Errorf("GrandTotals present = %v, want %v", model.GrandTotals != nil, filled.GrandTotals)
+	}
+	assertCellCardinality(t, model, model.GrandTotals, "grand totals", false)
+
+	// The root is synthetic. It names no dimension, carries no subtotals of its
+	// own, and is never the (None) bucket even though its value is null.
+	if model.Root.Dimension != "" {
+		t.Errorf("root Dimension = %q, want empty", model.Root.Dimension)
+	}
+	if model.Root.Subtotals != nil {
+		t.Errorf("root carries subtotals; grand totals are the report-wide ones")
+	}
+	if model.Root.IsNone {
+		t.Errorf("root is marked as the (None) bucket")
+	}
+	if !model.Root.Value.IsNull() {
+		t.Errorf("root Value = %v, want null", model.Root.Value)
+	}
+
+	assertGroupNode(t, filled, model, model.Root, 0, "root")
+}
+
+func assertGroupNode(t *testing.T, spec ReportSpec, model ReportModel, node GroupNode, depth int, path string) {
+	t.Helper()
+
+	isLeaf := depth == len(spec.GroupBy)
+
+	// A node holds children or detail rows, never both. Assert nil-ness rather
+	// than length, so an empty-but-present slice is still a violation.
+	if isLeaf {
+		if node.Children != nil {
+			t.Errorf("%s: leaf at depth %d has children", path, depth)
+		}
+		if node.DetailRows == nil {
+			t.Errorf("%s: leaf at depth %d has no detail rows", path, depth)
+		}
+	} else {
+		if node.DetailRows != nil {
+			t.Errorf("%s: internal node at depth %d has detail rows", path, depth)
+		}
+		if node.Children == nil {
+			t.Errorf("%s: internal node at depth %d has no children slice", path, depth)
+		}
+	}
+
+	if depth > 0 {
+		// A non-root node names the dimension its siblings were bucketed by, and
+		// is the (None) bucket exactly when its value is null.
+		if want := spec.GroupBy[depth-1]; node.Dimension != want {
+			t.Errorf("%s: Dimension = %q, want %q", path, node.Dimension, want)
+		}
+		if node.IsNone != node.Value.IsNull() {
+			t.Errorf("%s: IsNone = %v but Value.IsNull() = %v", path, node.IsNone, node.Value.IsNull())
+		}
+
+		wantSubtotals := spec.Subtotals
+		if (node.Subtotals != nil) != wantSubtotals {
+			t.Errorf("%s: Subtotals present = %v, want %v", path, node.Subtotals != nil, wantSubtotals)
+		}
+		assertColumnAlignment(t, model, node.Subtotals, path+" subtotals")
+		assertCellCardinality(t, model, node.Subtotals, path+" subtotals", false)
+	}
+
+	assertSortedByValue(t, nodeValues(node.Children), path+" children")
+
+	childRecords := 0
+	for _, child := range node.Children {
+		childPath := fmt.Sprintf("%s/%s", path, child.Value)
+		assertGroupNode(t, spec, model, child, depth+1, childPath)
+		childRecords += child.RecordCount
+	}
+	if len(node.Children) > 0 && node.RecordCount != childRecords {
+		t.Errorf("%s: RecordCount = %d, but children sum to %d", path, node.RecordCount, childRecords)
+	}
+
+	if !isLeaf {
+		return
+	}
+
+	records := spec.Detail.Mode == DetailRecords
+	if records && node.RecordCount != len(node.DetailRows) {
+		t.Errorf("%s: RecordCount = %d, but there are %d records", path, node.RecordCount, len(node.DetailRows))
+	}
+
+	if !records {
+		assertSortedByValue(t, detailValues(node.DetailRows), path+" detail rows")
+	}
+
+	for index, row := range node.DetailRows {
+		rowPath := fmt.Sprintf("%s[%d]", path, index)
+		assertColumnAlignment(t, model, row.Cells, rowPath)
+		assertCellCardinality(t, model, row.Cells, rowPath, records)
+
+		if records {
+			// A record row is one source record; nothing keys it.
+			if row.Dimension != "" || row.IsNone || !row.Value.IsNull() {
+				t.Errorf("%s: a records-mode detail row is keyed: %+v", rowPath, row)
+			}
+			continue
+		}
+
+		if row.Dimension != spec.Detail.By {
+			t.Errorf("%s: Dimension = %q, want %q", rowPath, row.Dimension, spec.Detail.By)
+		}
+		if row.IsNone != row.Value.IsNull() {
+			t.Errorf("%s: IsNone = %v but Value.IsNull() = %v", rowPath, row.IsNone, row.Value.IsNull())
+		}
+	}
+}
+
+// assertColumnAlignment: a rendered row carries one cell per column, in the
+// column order, named after it. A renderer reads cells positionally.
+func assertColumnAlignment(t *testing.T, model ReportModel, cells []Cell, path string) {
+	t.Helper()
+
+	if cells == nil {
+		return
+	}
+	if len(cells) != len(model.Columns) {
+		t.Fatalf("%s: %d cells for %d columns", path, len(cells), len(model.Columns))
+	}
+	for index, cell := range cells {
+		if cell.Column != model.Columns[index].Name {
+			t.Errorf("%s: cell %d is %q, want %q", path, index, cell.Column, model.Columns[index].Name)
+		}
+	}
+}
+
+// assertCellCardinality: aggregate and arithmetic cells hold exactly one value.
+// Only a label cell on a records-mode detail row may hold several, because only
+// a source record can carry several categories.
+func assertCellCardinality(t *testing.T, model ReportModel, cells []Cell, path string, recordsDetailRow bool) {
+	t.Helper()
+
+	for index, cell := range cells {
+		column := model.Columns[index]
+
+		switch column.Kind {
+		case ColumnAggregate, ColumnArithmetic:
+			if len(cell.Values) != 1 {
+				t.Errorf("%s: %s cell %q holds %d values, want 1", path, column.Kind, cell.Column, len(cell.Values))
+			}
+		case ColumnLabel:
+			if !recordsDetailRow && len(cell.Values) > 1 {
+				t.Errorf("%s: label cell %q holds %d values outside records mode", path, cell.Column, len(cell.Values))
+			}
+		}
+	}
+}
+
+// assertSortedByValue: siblings ascend by value, and the (None) bucket is last.
+func assertSortedByValue(t *testing.T, values []Value, path string) {
+	t.Helper()
+
+	for index := 1; index < len(values); index++ {
+		if compareValues(values[index-1], values[index]) > 0 {
+			t.Errorf("%s: %v sorts after %v", path, values[index-1], values[index])
+		}
+	}
+	for index, value := range values {
+		if value.IsNull() && index != len(values)-1 {
+			t.Errorf("%s: the (None) bucket is at %d of %d, want last", path, index, len(values))
+		}
+	}
+}
+
+func nodeValues(nodes []GroupNode) []Value {
+	values := make([]Value, 0, len(nodes))
+	for _, node := range nodes {
+		values = append(values, node.Value)
+	}
+	return values
+}
+
+func detailValues(rows []DetailRow) []Value {
+	values := make([]Value, 0, len(rows))
+	for _, row := range rows {
+		values = append(values, row.Value)
+	}
+	return values
+}
+
+// serializeModel renders a model to a stable string.
+//
+// Determinism is compared through this rather than through reflect.DeepEqual,
+// which inspects a decimal's internal exponent and would call 200 and 200.00
+// different. It also makes a failing comparison readable.
+func serializeModel(model ReportModel) string {
+	var out strings.Builder
+
+	fmt.Fprintf(&out, "title=%q generatedAt=%s currency=%q none=%q\n",
+		model.Meta.Title, model.Meta.GeneratedAt.UTC().Format("2006-01-02T15:04:05.999999999Z07:00"),
+		model.Meta.CurrencyFormat, model.Meta.NoneLabel)
+
+	keys := make([]string, 0, len(model.Meta.Params))
+	for key := range model.Meta.Params {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		fmt.Fprintf(&out, "param %s=%q\n", key, model.Meta.Params[key])
+	}
+
+	for _, column := range model.Columns {
+		fmt.Fprintf(&out, "column %s label=%q kind=%s type=%s format=%q expr=%q\n",
+			column.Name, column.Label, column.Kind, column.DataType, column.Format, column.ExprSrc)
+		if column.Agg != nil {
+			fmt.Fprintf(&out, "  agg=%s\n", column.Agg)
+		}
+	}
+
+	serializeGroup(&out, model.Root, 0)
+	fmt.Fprintf(&out, "grand %s\n", serializeCells(model.GrandTotals))
+
+	return out.String()
+}
+
+func serializeGroup(out *strings.Builder, node GroupNode, depth int) {
+	indent := strings.Repeat("  ", depth)
+
+	fmt.Fprintf(out, "%sgroup dim=%s value=%s none=%v records=%d\n",
+		indent, node.Dimension, serializeValue(node.Value), node.IsNone, node.RecordCount)
+
+	for _, row := range node.DetailRows {
+		fmt.Fprintf(out, "%s  row dim=%s value=%s none=%v %s\n",
+			indent, row.Dimension, serializeValue(row.Value), row.IsNone, serializeCells(row.Cells))
+	}
+	for _, child := range node.Children {
+		serializeGroup(out, child, depth+1)
+	}
+	if node.Subtotals != nil {
+		fmt.Fprintf(out, "%s  subtotal %s\n", indent, serializeCells(node.Subtotals))
+	}
+}
+
+func serializeCells(cells []Cell) string {
+	if cells == nil {
+		return "<none>"
+	}
+
+	parts := make([]string, 0, len(cells))
+	for _, cell := range cells {
+		values := make([]string, 0, len(cell.Values))
+		for _, value := range cell.Values {
+			values = append(values, serializeValue(value))
+		}
+		parts = append(parts, cell.Column+"=["+strings.Join(values, ",")+"]")
+	}
+
+	return strings.Join(parts, " ")
+}
+
+// serializeValue renders a value canonically. A number renders through the
+// decimal's own normalization, so 200 and 200.00 serialize alike, and a date
+// through its absolute instant.
+func serializeValue(value Value) string {
+	switch value.Type() {
+	case ValueNull:
+		return "null"
+	case ValueNumber:
+		number, _ := value.Decimal()
+		return "n" + number.String()
+	case ValueString:
+		text, _ := value.Text()
+		return fmt.Sprintf("s%q", text)
+	case ValueBool:
+		flag, _ := value.Boolean()
+		return fmt.Sprintf("b%v", flag)
+	case ValueDate:
+		return "d" + bucketKey(value)
+	}
+	return "?"
+}

--- a/api/internal/reporting/model.go
+++ b/api/internal/reporting/model.go
@@ -1,0 +1,116 @@
+package reporting
+
+import (
+	"time"
+
+	"github.com/expr-lang/expr/ast"
+)
+
+// ReportModel is the engine's output: a format-agnostic tree of data.
+//
+// It carries no layout, coordinates, or styling. There is enough structure for
+// a renderer to lay out group headers, detail rows, subtotal rows and grand
+// totals, and nothing about how any of them should look.
+type ReportModel struct {
+	Meta    Meta
+	Columns []ColumnDescriptor
+
+	// Root is a synthetic node holding the top level of the report. Its
+	// Dimension is empty and its Subtotals are nil; the report-wide totals are
+	// GrandTotals.
+	Root GroupNode
+
+	// GrandTotals is non-nil only when the spec asked for them.
+	GrandTotals []Cell
+}
+
+// Meta is report-scope context a renderer draws around the table.
+type Meta struct {
+	Title       string
+	GeneratedAt time.Time
+	Params      map[string]string
+
+	CurrencyFormat string
+	NoneLabel      string
+}
+
+// ColumnDescriptor tells a renderer what a column is.
+type ColumnDescriptor struct {
+	Name  string
+	Label string
+	Kind  ColumnKind
+
+	// DataType is the type of the column's cells. For an aggregate it follows
+	// the measure being reduced, except COUNT which is always a plain number.
+	// For arithmetic it is currency when any column it reads is currency, since
+	// money combined with a count is still money.
+	DataType DataType
+
+	Format string
+
+	// Agg is set for an aggregate column.
+	Agg *Aggregate
+
+	// Expr is set for an arithmetic column: the parsed, whitelisted syntax tree
+	// of ExprSrc. It is exported so a renderer can walk it — the spreadsheet
+	// renderer translates it into a live cell formula rather than emitting the
+	// computed value.
+	Expr    ast.Node
+	ExprSrc string
+}
+
+// GroupNode is one bucket of the report tree.
+//
+// A node holds either Children or DetailRows, never both: the leaves of the
+// grouping are where detail lives.
+type GroupNode struct {
+	// Dimension is the field this node's siblings were bucketed by. It is empty
+	// on the synthetic root.
+	Dimension FieldKey
+
+	// Value is the bucket's value. It is null exactly when IsNone is set.
+	Value  Value
+	IsNone bool
+
+	// RecordCount is how many rows were attributed to this node. A row carrying
+	// two tags is attributed to both tag buckets, so counts double up on
+	// purpose.
+	RecordCount int
+
+	Children   []GroupNode
+	DetailRows []DetailRow
+
+	// Subtotals is non-nil only when the spec asked for them.
+	Subtotals []Cell
+}
+
+// DetailRow is one of the report's bottom rows.
+type DetailRow struct {
+	// Dimension and Value identify the bucket an aggregated detail row sums.
+	// Both are zero in records mode, where the row is a single source record and
+	// nothing keys it.
+	Dimension FieldKey
+	Value     Value
+	IsNone    bool
+
+	Cells []Cell
+}
+
+// Cell is one column's contribution to one row.
+//
+// Aggregate and arithmetic cells always hold exactly one value, which may be
+// null. A label cell in records mode may hold several, because a record can
+// carry several categories or tags; a renderer decides how to join them.
+type Cell struct {
+	Column string
+	Values []Value
+}
+
+// Value returns a cell's single value, or null when it has none. Use Values
+// directly to read a multi-value label cell.
+func (c Cell) Value() Value {
+	if len(c.Values) == 0 {
+		return Null()
+	}
+	return c.Values[0]
+}

--- a/api/internal/reporting/model_test.go
+++ b/api/internal/reporting/model_test.go
@@ -1,0 +1,123 @@
+package reporting
+
+import "testing"
+
+func TestCell_Value(t *testing.T) {
+	tests := []struct {
+		name string
+		cell Cell
+		want Value
+	}{
+		{"single value", Cell{Column: "Subtotal", Values: []Value{Num(dec("200"))}}, Num(dec("200"))},
+		{"explicit null", Cell{Column: "Avg", Values: []Value{Null()}}, Null()},
+		{"no values is null", Cell{Column: "Category"}, Null()},
+		{"empty slice is null", Cell{Column: "Category", Values: []Value{}}, Null()},
+		{"multi value takes the first", Cell{Column: "Tags", Values: []Value{Str("Alex"), Str("Sam")}}, Str("Alex")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.cell.Value(); !got.Equal(test.want) {
+				t.Errorf("Cell.Value() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestColumn_Heading(t *testing.T) {
+	tests := []struct {
+		name   string
+		column Column
+		want   string
+	}{
+		{"label wins", Column{Name: "AvgPerReceipt", Label: "Avg/Receipt"}, "Avg/Receipt"},
+		{"name is the fallback", Column{Name: "Subtotal"}, "Subtotal"},
+		{"empty label is not a heading", Column{Name: "Hst", Label: ""}, "Hst"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.column.heading(); got != test.want {
+				t.Errorf("heading() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestReportSpec_WithDefaults(t *testing.T) {
+	t.Run("fills a zero spec", func(t *testing.T) {
+		spec := ReportSpec{}.withDefaults()
+
+		if spec.NoneLabel != defaultNoneLabel {
+			t.Errorf("NoneLabel = %q, want %q", spec.NoneLabel, defaultNoneLabel)
+		}
+		if spec.Config.DivisionScale != defaultDivisionScale {
+			t.Errorf("DivisionScale = %d, want %d", spec.Config.DivisionScale, defaultDivisionScale)
+		}
+	})
+
+	t.Run("keeps what the caller set", func(t *testing.T) {
+		spec := ReportSpec{
+			NoneLabel: "Uncategorized",
+			Config:    EngineConfig{DivisionScale: 2},
+		}.withDefaults()
+
+		if spec.NoneLabel != "Uncategorized" {
+			t.Errorf("NoneLabel = %q, want %q", spec.NoneLabel, "Uncategorized")
+		}
+		if spec.Config.DivisionScale != 2 {
+			t.Errorf("DivisionScale = %d, want 2", spec.Config.DivisionScale)
+		}
+	})
+
+	t.Run("does not mutate the receiver", func(t *testing.T) {
+		original := ReportSpec{}
+		_ = original.withDefaults()
+
+		if original.NoneLabel != "" || original.Config.DivisionScale != 0 {
+			t.Errorf("withDefaults mutated its receiver: %+v", original)
+		}
+	})
+}
+
+func TestDefaultConfig(t *testing.T) {
+	if got := DefaultConfig().DivisionScale; got != defaultDivisionScale {
+		t.Errorf("DefaultConfig().DivisionScale = %d, want %d", got, defaultDivisionScale)
+	}
+}
+
+func TestStringers(t *testing.T) {
+	kinds := map[ColumnKind]string{
+		ColumnLabel:      "label",
+		ColumnAggregate:  "aggregate",
+		ColumnArithmetic: "arithmetic",
+	}
+	for kind, want := range kinds {
+		if got := kind.String(); got != want {
+			t.Errorf("ColumnKind(%d).String() = %q, want %q", kind, got, want)
+		}
+	}
+
+	modes := map[DetailMode]string{
+		DetailRecords:   "records",
+		DetailAggregate: "aggregate",
+	}
+	for mode, want := range modes {
+		if got := mode.String(); got != want {
+			t.Errorf("DetailMode(%d).String() = %q, want %q", mode, got, want)
+		}
+	}
+
+	functions := map[AggFunc]string{
+		AggSum:   "SUM",
+		AggCount: "COUNT",
+		AggAvg:   "AVG",
+		AggMin:   "MIN",
+		AggMax:   "MAX",
+	}
+	for function, want := range functions {
+		if got := function.String(); got != want {
+			t.Errorf("AggFunc(%d).String() = %q, want %q", function, got, want)
+		}
+	}
+}

--- a/api/internal/reporting/mutation-check.sh
+++ b/api/internal/reporting/mutation-check.sh
@@ -62,6 +62,26 @@ add() {
     replaces+=("$4")
 }
 
+# --- enums: the closed lists must agree with each other ----------------------
+
+# TestAggFunc_ClosedListsAgree — AggFunc is covered by four independent switches
+# (String, valid, aggFuncFromName, accumulator.finalize) and nothing but this
+# test forces them to agree. Admitting a reduction finalize does not implement is
+# how the blank-column defect comes back. 201 collides with no test fixture, so
+# only the drift test can object.
+add 'agg-func-valid-list-drifts' 'aggregate.go' \
+'	case AggSum, AggCount, AggAvg, AggMin, AggMax:
+		return true' \
+'	case AggSum, AggCount, AggAvg, AggMin, AggMax, AggFunc(201):
+		return true'
+
+# TestDetailMode_ClosedListsAgree — the same drift, one enum over.
+add 'detail-mode-valid-list-drifts' 'spec.go' \
+'	case DetailRecords, DetailAggregate:
+		return true' \
+'	case DetailRecords, DetailAggregate, DetailMode(201):
+		return true'
+
 # --- accumulator: the monoid ------------------------------------------------
 
 # TestAccumulator_Avg — AVG divides by the count of values, not of records.

--- a/api/internal/reporting/mutation-check.sh
+++ b/api/internal/reporting/mutation-check.sh
@@ -256,6 +256,15 @@ add 'null-sorts-first' 'value.go' \
 '		case a.IsNull():
 			return -1'
 
+# TestRun_DateBucketIsLocationIndependent — a bucket must report the canonical
+# member of its class, not whichever member arrived first.
+add 'date-bucket-keeps-an-arbitrary-zone' 'value.go' \
+'	if v.valueType == ValueDate {
+		return DateVal(v.date.UTC())
+	}
+	return v' \
+'	return v'
+
 # --- eval: decimal discipline -----------------------------------------------
 
 # TestEvalArithmetic_DivisionByZeroIsNullNotPanic — shopspring panics on a zero

--- a/api/internal/reporting/mutation-check.sh
+++ b/api/internal/reporting/mutation-check.sh
@@ -181,9 +181,9 @@ add 'leaf-depth-off-by-one' 'engine.go' \
 # TestRun_RecordsMode
 add 'records-and-aggregate-swapped' 'engine.go' \
 'func (e engineRun) emitDetailRows(leaf *buildNode, path []Value) []DetailRow {
-	if e.compiled.spec.Detail.Mode == DetailRecords {' \
+	if !e.compiled.spec.Detail.isAggregate() {' \
 'func (e engineRun) emitDetailRows(leaf *buildNode, path []Value) []DetailRow {
-	if e.compiled.spec.Detail.Mode != DetailRecords {'
+	if e.compiled.spec.Detail.isAggregate() {'
 
 # TestRun_ColumnOrderIsIndependentOfDependencyOrder — arithmetic is evaluated in
 # dependency order, not declaration order.
@@ -370,6 +370,17 @@ add 'arithmetic-type-never-currency' 'validate.go' \
 '		if columns[index].dataType == TypeCurrency {
 			return TypeNumber
 		}'
+
+# --- field: the catalog -----------------------------------------------------
+
+# TestNewFieldCatalog/rejects a key that is not a plain identifier — a key a
+# formula cannot name is not a key.
+add 'catalog-accepts-any-key' 'field.go' \
+'		if !isIdentifier(string(field.Key)) {
+			return FieldCatalog{}, fmt.Errorf("%w: %q", ErrInvalidFieldKey, field.Key)
+		}
+' \
+''
 
 # --- receiptsource: the receipt mapping -------------------------------------
 

--- a/api/internal/reporting/mutation-check.sh
+++ b/api/internal/reporting/mutation-check.sh
@@ -326,6 +326,30 @@ add 'multi-valued-measure-accepted' 'validate.go' \
 ' \
 ''
 
+# TestValidate_Rejects/aggregate with a reduction the accumulator does not know —
+# an unknown reduction renders the whole column null rather than erroring.
+add 'unknown-agg-func-accepted' 'validate.go' \
+'	if !aggregate.Func.valid() {
+		return compiledColumn{}, fmt.Errorf("%w: column %s applies reduction %d",
+			ErrUnknownAggFunc, column.Name, aggregate.Func)
+	}
+' \
+''
+
+# TestValidate_Rejects/detail mode the engine does not know
+add 'unknown-detail-mode-accepted' 'validate.go' \
+'	if !detail.Mode.valid() {
+		return FieldRef{}, fmt.Errorf("%w: %d", ErrUnknownDetailMode, detail.Mode)
+	}
+' \
+''
+
+# No mutation swaps isAggregate() back for `Mode != DetailRecords`. With the mode
+# validated the two spellings agree on every spec that compiles, so the swap is
+# semantically equivalent and would survive by being correct. The predicate earns
+# its place by keeping a third mode from reintroducing the divergence, not by
+# changing today's behaviour — and a mutation nothing can catch teaches nothing.
+
 # TestCompileSpec_DataTypes — money combined with a count is still money.
 add 'arithmetic-type-never-currency' 'validate.go' \
 '		if columns[index].dataType == TypeCurrency {

--- a/api/internal/reporting/mutation-check.sh
+++ b/api/internal/reporting/mutation-check.sh
@@ -1,0 +1,433 @@
+#!/usr/bin/env bash
+#
+# mutation-check.sh — prove the reporting engine's tests still have teeth.
+#
+# Coverage says which lines ran. It does not say whether anything would have
+# noticed had those lines been wrong. This script breaks the engine one way at a
+# time and checks that the suite objects. A mutation nothing catches is a hole
+# in the tests, not in the code.
+#
+# It never writes to the working tree. Each mutation is applied to a copy in a
+# temporary directory and compiled through `go test -overlay`, so an interrupted
+# run leaves nothing behind.
+#
+# Three rules, each learned by getting it wrong:
+#
+#   1. Assert the mutation applied. A search string that matches nothing yields
+#      an unmutated build that passes, and the harness reports "the tests caught
+#      it" having changed nothing at all.
+#
+#   2. A mutant that does not compile was never tested. A build error is not a
+#      failing test, and counting it as one is the same lie in a different coat.
+#      A mutation is caught only when a test says `--- FAIL`.
+#
+#   3. Pass -count=1. The build cache will otherwise serve the previous
+#      mutation's result.
+#
+# Usage:
+#   ./internal/reporting/mutation-check.sh          # every mutation
+#   ./internal/reporting/mutation-check.sh avg      # only those matching "avg"
+#
+# Exits non-zero if any mutation survives or fails to apply.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+package_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+module_dir="$(cd "${package_dir}/../.." && pwd)"
+
+filter="${1:-}"
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf "${work_dir}"' EXIT
+
+# Mutations are held in four parallel arrays rather than in delimited records,
+# because most of them span several lines and bash's `read` stops at the first
+# newline — which silently truncates the search text, breaks the build, and (see
+# rule 2) used to be reported as a pass.
+names=()
+files=()
+searches=()
+replaces=()
+
+# add <name> <file> <search> <replace>
+#
+# The comment above each names the test that must catch it. Where several do,
+# the first speaks to the mutation most directly.
+add() {
+    names+=("$1")
+    files+=("$2")
+    searches+=("$3")
+    replaces+=("$4")
+}
+
+# --- accumulator: the monoid ------------------------------------------------
+
+# TestAccumulator_Avg — AVG divides by the count of values, not of records.
+add 'avg-divides-by-records' 'accumulator.go' \
+'return Num(a.sum.DivRound(decimal.NewFromInt(a.values), divisionScale))' \
+'return Num(a.sum.DivRound(decimal.NewFromInt(a.records), divisionScale))'
+
+# TestAccumulator_Count — COUNT counts rows, including rows with a null measure.
+add 'count-skips-null-rows' 'accumulator.go' \
+'	a.records++
+
+	number, isNumber := value.Decimal()
+	if !isNumber {
+		return
+	}' \
+'	number, isNumber := value.Decimal()
+	if !isNumber {
+		return
+	}
+	a.records++'
+
+# TestAccumulator_Sum — SUM of nothing is zero, not null.
+add 'sum-of-nothing-is-null' 'accumulator.go' \
+'	case AggSum:
+		return Num(a.sum)' \
+'	case AggSum:
+		if !a.seen {
+			return Null()
+		}
+		return Num(a.sum)'
+
+# TestAccumulator_Merge — MIN keeps the smaller of the two.
+add 'min-merge-picks-max' 'accumulator.go' \
+'	if other.minimum.LessThan(a.minimum) {' \
+'	if other.minimum.GreaterThan(a.minimum) {'
+
+# TestAccumulator_MergeIsAssociativeAndCommutative
+add 'merge-drops-child-sum' 'accumulator.go' \
+'	a.sum = a.sum.Add(other.sum)
+' \
+''
+
+# --- engine: rollup, fan-out, ordering --------------------------------------
+
+# TestRun_AvgIsCorrectAtEveryLevel — a parent merges its children's
+# accumulators, and never combines their finalized values.
+add 'parent-combines-finalized-values' 'engine.go' \
+'		mergeAccumulators(node.accumulators, child.accumulators)' \
+'		for slot := range node.accumulators {
+			node.accumulators[slot].add(child.accumulators[slot].finalize(e.scale))
+		}'
+
+# TestRun_TwoMultiValueLevelsCrossProduct — a row fans out into every bucket.
+add 'drop-group-fan-out' 'engine.go' \
+'		for _, path := range paths {
+			for _, value := range values {' \
+'		for _, path := range paths {
+			for _, value := range values[:1] {'
+
+# TestRun_MultiValueDimensionsDoubleCount
+add 'drop-detail-fan-out' 'engine.go' \
+'	for _, value := range row.dimensionValues(e.compiled.detailBy.Key) {' \
+'	for _, value := range row.dimensionValues(e.compiled.detailBy.Key)[:1] {'
+
+# TestRun_NoneBuckets — an absent value is a bucket, not a dropped row.
+add 'no-none-bucket' 'row.go' \
+'	switch len(values) {
+	case 0:
+		return []Value{Null()}
+	case 1:
+		return values
+	}' \
+'	switch len(values) {
+	case 0:
+		return nil
+	case 1:
+		return values
+	}'
+
+# TestRun_RepeatedDimensionValueIsOneAttribution
+add 'no-dedupe-of-repeated-values' 'row.go' \
+'	distinct := make([]Value, 0, len(values))
+	seen := make(map[string]struct{}, len(values))' \
+'	if true {
+		return values
+	}
+
+	distinct := make([]Value, 0, len(values))
+	seen := make(map[string]struct{}, len(values))'
+
+# TestRun_NoneBuckets
+add 'isnone-always-false' 'engine.go' \
+'		group.IsNone = node.value.IsNull()' \
+'		group.IsNone = false'
+
+# TestRun_NoneSortsLastAmongManyBuckets
+add 'buckets-sort-descending' 'engine.go' \
+'		return compareValues(nodes[i].value, nodes[j].value) < 0' \
+'		return compareValues(nodes[i].value, nodes[j].value) > 0'
+
+# TestGolden_WorkedExampleRendersAsTheDesignDocument
+add 'detail-rows-sort-descending' 'engine.go' \
+'		return compareValues(buckets[i].value, buckets[j].value) < 0' \
+'		return compareValues(buckets[i].value, buckets[j].value) > 0'
+
+# TestRun_DeepNesting — the leaf sits at the last grouping level.
+add 'leaf-depth-off-by-one' 'engine.go' \
+'	if level == len(e.compiled.groupBy) {
+		e.rollUpLeaf(node)
+		return
+	}' \
+'	if level >= len(e.compiled.groupBy)-1 {
+		e.rollUpLeaf(node)
+		return
+	}'
+
+# TestRun_RecordsMode
+add 'records-and-aggregate-swapped' 'engine.go' \
+'func (e engineRun) emitDetailRows(leaf *buildNode, path []Value) []DetailRow {
+	if e.compiled.spec.Detail.Mode == DetailRecords {' \
+'func (e engineRun) emitDetailRows(leaf *buildNode, path []Value) []DetailRow {
+	if e.compiled.spec.Detail.Mode != DetailRecords {'
+
+# TestRun_ColumnOrderIsIndependentOfDependencyOrder — arithmetic is evaluated in
+# dependency order, not declaration order.
+add 'arithmetic-in-declaration-order' 'engine.go' \
+'	for _, index := range e.compiled.arithmeticOrder {
+		column := e.compiled.columns[index]
+		value := evalArithmetic(column.expr, values, e.scale)' \
+'	for index := range e.compiled.columns {
+		column := e.compiled.columns[index]
+		if column.kind != ColumnArithmetic {
+			continue
+		}
+		value := evalArithmetic(column.expr, values, e.scale)'
+
+# TestRun_LabelColumnReadsAncestorBucket
+add 'label-reads-the-wrong-level' 'engine.go' \
+'			return []Value{path[column.labelLevel]}' \
+'			return []Value{path[0]}'
+
+# TestRun_TogglesOffSubtotalsAndGrandTotals
+add 'subtotals-toggle-ignored' 'engine.go' \
+'		if e.compiled.spec.Subtotals {
+			group.Subtotals = e.rowCells(noLabels, node.accumulators)
+		}' \
+'		group.Subtotals = e.rowCells(noLabels, node.accumulators)'
+
+# TestRun_DivisionScaleIsHonoured — the caller's scale reaches AVG and division.
+add 'division-scale-hardcoded' 'engine.go' \
+'		scale:    compiled.spec.Config.DivisionScale,' \
+'		scale:    defaultDivisionScale,'
+
+# TestRun_MetaAndFormatsPassThrough
+add 'column-format-dropped' 'engine.go' \
+'			Format:   column.format,' \
+'			Format:   "",'
+
+# TestRun_MetaParamsAreCopied
+add 'meta-params-aliased' 'engine.go' \
+'			Params:         copyParams(meta.Params),' \
+'			Params:         meta.Params,'
+
+# TestRun_RecordsModeDoesNotAliasInputRows
+add 'records-label-cell-aliases-the-row' 'engine.go' \
+'			return append([]Value(nil), record.Get(column.field)...)' \
+'			return record.Get(column.field)'
+
+# TestRun_DescriptorsDoNotAlias — every descriptor would point at one aggregate.
+add 'descriptors-share-an-aggregate' 'engine.go' \
+'			aggregate := column.agg
+			descriptor.Agg = &aggregate' \
+'			descriptor.Agg = &e.compiled.columns[0].agg'
+
+# --- value: the bucket key --------------------------------------------------
+
+# TestBucketKey_DatesOutsideUnixNanoRange — UnixNano is undefined outside
+# 1678..2262, so it merges distinct instants.
+add 'date-key-uses-unixnano' 'value.go' \
+'		return "d:" + strconv.FormatInt(v.date.Unix(), 10) + ":" + strconv.Itoa(v.date.Nanosecond())' \
+'		return "d:" + strconv.FormatInt(v.date.UnixNano(), 10)'
+
+# TestBucketKey_NumbersBelowTwelveDecimalPlaces
+add 'number-key-truncates' 'value.go' \
+'		return "n:" + v.num.String()' \
+'		return "n:" + v.num.StringFixed(12)'
+
+# TestCompareValues_NullSortsLast
+add 'null-sorts-first' 'value.go' \
+'		case a.IsNull():
+			return 1' \
+'		case a.IsNull():
+			return -1'
+
+# --- eval: decimal discipline -----------------------------------------------
+
+# TestEvalArithmetic_DivisionByZeroIsNullNotPanic — shopspring panics on a zero
+# divisor, so removing the guard crashes the report rather than emptying a cell.
+add 'division-guard-removed' 'eval.go' \
+'		if rightNumber.IsZero() {
+			return Null()
+		}
+		return Num(leftNumber.DivRound(rightNumber, divisionScale))' \
+'		return Num(leftNumber.DivRound(rightNumber, divisionScale))'
+
+# TestEvalArithmetic_IgnoresDivisionPrecisionGlobal
+add 'division-reads-the-global' 'eval.go' \
+'		return Num(leftNumber.DivRound(rightNumber, divisionScale))' \
+'		return Num(leftNumber.Div(rightNumber))'
+
+# TestEvalArithmetic_NullPropagates
+add 'null-operand-reads-as-zero' 'eval.go' \
+'	leftNumber, leftIsNumber := left.Decimal()
+	rightNumber, rightIsNumber := right.Decimal()
+	if !leftIsNumber || !rightIsNumber {
+		return Null()
+	}' \
+'	leftNumber, _ := left.Decimal()
+	rightNumber, _ := right.Decimal()'
+
+# --- validate: the rules ----------------------------------------------------
+
+# TestValidate_Rejects/arithmetic references itself
+#
+# The discarded Join keeps "strings" used, so the mutant compiles. A mutation
+# that does not build tests nothing.
+add 'cycle-detection-removed' 'validate.go' \
+'		case visiting:
+			return fmt.Errorf("%w: %s", ErrFormulaCycle, strings.Join(append(path, columns[index].name), " -> "))' \
+'		case visiting:
+			_ = strings.Join(path, " -> ")
+			return nil'
+
+# TestValidate_CycleMessageNamesTheCycle
+add 'cycle-path-truncated' 'validate.go' \
+'strings.Join(append(path, columns[index].name), " -> ")' \
+'strings.Join(path, " -> ")'
+
+# TestValidate_Rejects/groupBy a measure
+add 'groupby-accepts-a-measure' 'validate.go' \
+'		if field.Role() != RoleDimension {
+			return nil, fmt.Errorf("%w: %s is a %s", ErrGroupByNotDimension, key, field.DataType)
+		}
+' \
+''
+
+# TestValidate_Rejects/sum a multi-valued measure
+add 'multi-valued-measure-accepted' 'validate.go' \
+'	if field.Multi {
+		return compiledColumn{}, fmt.Errorf("%w: column %s applies %s to %s",
+			ErrMeasureIsMultiValued, column.Name, aggregate.Func, aggregate.Field)
+	}
+' \
+''
+
+# TestCompileSpec_DataTypes — money combined with a count is still money.
+add 'arithmetic-type-never-currency' 'validate.go' \
+'		if columns[index].dataType == TypeCurrency {
+			return TypeCurrency
+		}' \
+'		if columns[index].dataType == TypeCurrency {
+			return TypeNumber
+		}'
+
+# ----------------------------------------------------------------------------
+
+green() { printf '\033[32m%s\033[0m' "$1"; }
+red()   { printf '\033[31m%s\033[0m' "$1"; }
+
+echo "mutation-check: ${#names[@]} mutations against internal/reporting"
+echo
+
+survivors=()
+broken=()
+ran=0
+skipped=0
+
+for index in "${!names[@]}"; do
+    name="${names[$index]}"
+    file="${files[$index]}"
+
+    if [[ -n "${filter}" && "${name}" != *"${filter}"* ]]; then
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    source_file="${package_dir}/${file}"
+    mutant="${work_dir}/${file}"
+    overlay="${work_dir}/overlay.json"
+
+    # Rule 1: refuse to run a mutation that changed nothing.
+    if ! SEARCH="${searches[$index]}" REPLACE="${replaces[$index]}" \
+        python3 - "${source_file}" "${mutant}" "${overlay}" <<'PY'
+import json, os, sys
+
+source_file, mutant, overlay = sys.argv[1], sys.argv[2], sys.argv[3]
+search, replace = os.environ["SEARCH"], os.environ["REPLACE"]
+
+original = open(source_file).read()
+if search not in original:
+    sys.stderr.write("search text not found\n")
+    sys.exit(1)
+
+mutated = original.replace(search, replace, 1)
+if mutated == original:
+    sys.stderr.write("replacement changed nothing\n")
+    sys.exit(1)
+
+open(mutant, "w").write(mutated)
+open(overlay, "w").write(json.dumps({"Replace": {source_file: mutant}}))
+PY
+    then
+        printf '  %s  %-36s the mutation no longer matches %s\n' "$(red 'STALE   ')" "${name}" "${file}"
+        broken+=("${name} (stale)")
+        continue
+    fi
+
+    ran=$((ran + 1))
+
+    # Rule 3: -count=1, or the cache serves the previous mutation's verdict.
+    exit_code=0
+    output="$(cd "${module_dir}" && go test -count=1 -overlay="${overlay}" ./internal/reporting/ 2>&1)" || exit_code=$?
+
+    # One awk, not `grep | head`: under `set -o pipefail`, head closing the pipe
+    # hands grep a SIGPIPE and the failed pipeline takes the script down.
+    caught="$(awk '/^--- FAIL: / { sub(/^--- FAIL: /, ""); sub(/ .*/, ""); if (++found <= 3) printf "%s ", $0 }' <<< "${output}")"
+
+    if (( exit_code == 0 )); then
+        printf '  %s  %s\n' "$(red 'SURVIVED')" "${name}"
+        survivors+=("${name}")
+    elif [[ -z "${caught}" ]]; then
+        # Rule 2: it failed, but no test said so. The mutant did not build, so
+        # nothing was tested and nothing was proved.
+        printf '  %s  %-36s the mutant does not compile\n' "$(red 'BROKEN  ')" "${name}"
+        printf '%s\n' "${output}" | head -5 | sed 's/^/            /'
+        broken+=("${name} (does not compile)")
+    else
+        printf '  %s  %-36s %s\n' "$(green 'caught  ')" "${name}" "${caught}"
+    fi
+done
+
+echo
+if (( skipped > 0 )); then
+    echo "${ran} run, ${skipped} skipped by filter '${filter}'"
+    echo
+fi
+
+if (( ${#survivors[@]} > 0 )); then
+    printf '%s: %d of %d mutations survived:\n' "$(red 'FAIL')" "${#survivors[@]}" "${ran}"
+    printf '  - %s\n' "${survivors[@]}"
+    echo
+    echo "A surviving mutation means the engine can be broken that way without a"
+    echo "single test objecting. Either add the test, or delete the mutation and"
+    echo "say why the behaviour does not matter."
+fi
+
+if (( ${#broken[@]} > 0 )); then
+    printf '%s: %d mutations could not be evaluated:\n' "$(red 'FAIL')" "${#broken[@]}"
+    printf '  - %s\n' "${broken[@]}"
+    echo
+    echo "A mutation that does not apply, or does not compile, proves nothing."
+    echo "Re-anchor it against the code as it stands now."
+fi
+
+if (( ${#survivors[@]} > 0 || ${#broken[@]} > 0 )); then
+    exit 1
+fi
+
+printf '%s: all %d mutations caught by a failing test.\n' "$(green 'PASS')" "${ran}"

--- a/api/internal/reporting/mutation-check.sh
+++ b/api/internal/reporting/mutation-check.sh
@@ -371,6 +371,32 @@ add 'arithmetic-type-never-currency' 'validate.go' \
 			return TypeNumber
 		}'
 
+# --- receiptsource: the receipt mapping -------------------------------------
+
+# TestSource_DuplicateCustomFieldValuesResolveByLowestId — position cannot decide
+# which of two values for one field wins, because the association is loaded
+# without an ORDER BY.
+add 'custom-field-first-in-slice-wins' 'receiptsource/receiptsource.go' \
+'		if incumbent, held := winners[key]; held && incumbent <= customFieldValue.ID {
+			continue
+		}' \
+'		if _, held := winners[key]; held {
+			continue
+		}'
+
+# TestSource_UnresolvableCustomFieldValueNeverWins — an empty value must not
+# claim the field and lock out a real one.
+add 'unresolvable-custom-field-value-wins' 'receiptsource/receiptsource.go' \
+'		value, ok := s.customFieldValue(customFieldValue)
+		if !ok {
+			continue
+		}
+
+		winners[key] = customFieldValue.ID' \
+'		value, _ := s.customFieldValue(customFieldValue)
+
+		winners[key] = customFieldValue.ID'
+
 # ----------------------------------------------------------------------------
 
 green() { printf '\033[32m%s\033[0m' "$1"; }
@@ -415,6 +441,7 @@ if mutated == original:
     sys.stderr.write("replacement changed nothing\n")
     sys.exit(1)
 
+os.makedirs(os.path.dirname(mutant), exist_ok=True)
 open(mutant, "w").write(mutated)
 open(overlay, "w").write(json.dumps({"Replace": {source_file: mutant}}))
 PY
@@ -427,8 +454,9 @@ PY
     ran=$((ran + 1))
 
     # Rule 3: -count=1, or the cache serves the previous mutation's verdict.
+    # The ... matters: receiptsource is mutated too, and its tests live with it.
     exit_code=0
-    output="$(cd "${module_dir}" && go test -count=1 -overlay="${overlay}" ./internal/reporting/ 2>&1)" || exit_code=$?
+    output="$(cd "${module_dir}" && go test -count=1 -overlay="${overlay}" ./internal/reporting/... 2>&1)" || exit_code=$?
 
     # One awk, not `grep | head`: under `set -o pipefail`, head closing the pipe
     # hands grep a SIGPIPE and the failed pipeline takes the script down.

--- a/api/internal/reporting/mutation-check.sh
+++ b/api/internal/reporting/mutation-check.sh
@@ -265,6 +265,18 @@ add 'date-bucket-keeps-an-arbitrary-zone' 'value.go' \
 	return v' \
 '	return v'
 
+# --- formula: the allow-list and the bounds ---------------------------------
+
+# TestParseArithmetic_SizeLimits — the node cap does not bound parenthesis
+# nesting, because a parenthesis builds no node. Only the length check does.
+add 'formula-length-unbounded' 'formula.go' \
+'	if len(src) > maxFormulaLength {
+		return fmt.Errorf("%w: %d bytes, limit is %d", ErrFormulaTooLong, len(src), maxFormulaLength)
+	}
+	return nil' \
+'	_ = src
+	return nil'
+
 # --- eval: decimal discipline -----------------------------------------------
 
 # TestEvalArithmetic_DivisionByZeroIsNullNotPanic — shopspring panics on a zero

--- a/api/internal/reporting/passthrough_test.go
+++ b/api/internal/reporting/passthrough_test.go
@@ -1,0 +1,348 @@
+package reporting
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// A value the caller supplies and the engine merely carries is easy to get
+// right and easy to leave untested: it works, so nothing notices when it stops.
+//
+// Every test here was written because mutation testing showed the suite could
+// not tell the difference. Hardcoding the division scale, dropping a column's
+// format, and truncating the cycle error's path all passed the entire suite.
+
+// The division scale reaches AVG and reaches arithmetic division. A template
+// that asks for two decimal places must not silently receive six.
+func TestRun_DivisionScaleIsHonoured(t *testing.T) {
+	spec := ReportSpec{
+		Columns: []Column{
+			{Name: "Cnt", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}},
+			{Name: "Total", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "amount"}},
+			{Name: "Mean", Kind: ColumnAggregate, Agg: Aggregate{Func: AggAvg, Field: "amount"}},
+			{Name: "Ratio", Kind: ColumnArithmetic, Expr: "Total / Cnt"},
+		},
+		GrandTotals: true,
+	}
+
+	// Three receipts of 1.00, 0.00 and 0.00 average to a third of a dollar,
+	// which no scale renders exactly.
+	rows := []Row{
+		{"amount": {Num(dec("1.00"))}},
+		{"amount": {Num(dec("0.00"))}},
+		{"amount": {Num(dec("0.00"))}},
+	}
+
+	tests := []struct {
+		scale int32
+		want  string
+	}{
+		{1, "0.3"},
+		{2, "0.33"},
+		{6, "0.333333"},
+		{10, "0.3333333333"},
+		{maxDivisionScale, "0.333333333333333333333333333333"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.want, func(t *testing.T) {
+			scaled := spec
+			scaled.Config = EngineConfig{DivisionScale: test.scale}
+
+			model := mustRun(t, scaled, rows)
+
+			// Both the aggregate and the arithmetic division use the scale.
+			assertRow(t, model.GrandTotals, map[string]string{"Mean": test.want, "Ratio": test.want})
+		})
+	}
+}
+
+// Zero means unset, and takes the default rather than asking for integer
+// division. A column wanting whole numbers asks with ROUND.
+func TestRun_ZeroDivisionScaleTakesTheDefault(t *testing.T) {
+	spec := ReportSpec{
+		Columns: []Column{
+			{Name: "Cnt", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}},
+			{Name: "Total", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "amount"}},
+			{Name: "Ratio", Kind: ColumnArithmetic, Expr: "Total / Cnt"},
+			{Name: "Whole", Kind: ColumnArithmetic, Expr: "ROUND(Total / Cnt, 0)"},
+		},
+		Config:      EngineConfig{DivisionScale: 0},
+		GrandTotals: true,
+	}
+
+	rows := []Row{{"amount": {Num(dec("1.00"))}}, {"amount": {Num(dec("0.00"))}}, {"amount": {Num(dec("0.00"))}}}
+	model := mustRun(t, spec, rows)
+
+	assertRow(t, model.GrandTotals, map[string]string{"Ratio": "0.333333", "Whole": "0"})
+}
+
+// Everything the caller hands the engine to carry, it carries.
+func TestRun_MetaAndFormatsPassThrough(t *testing.T) {
+	spec := ReportSpec{
+		Title:     "Quarterly",
+		NoneLabel: "Uncategorized",
+		Columns: []Column{
+			{Name: "Category", Kind: ColumnLabel, Field: "category", Format: "text"},
+			{Name: "Total", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "amount"}, Format: "$ #,##0.00"},
+			{Name: "Doubled", Kind: ColumnArithmetic, Expr: "Total * 2", Format: "0.000"},
+		},
+	}
+
+	generatedAt := time.Date(2026, 6, 1, 9, 30, 0, 0, time.UTC)
+	meta := MetaInput{
+		GeneratedAt:    generatedAt,
+		Params:         map[string]string{"period": "May", "group": "Household"},
+		CurrencyFormat: "€ #.##0,00",
+	}
+
+	model, err := Run(spec, testCatalog(t), []Row{{"amount": {Num(dec("1.00"))}}}, meta)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if model.Meta.Title != "Quarterly" {
+		t.Errorf("Title = %q", model.Meta.Title)
+	}
+	if !model.Meta.GeneratedAt.Equal(generatedAt) {
+		t.Errorf("GeneratedAt = %v", model.Meta.GeneratedAt)
+	}
+	if model.Meta.CurrencyFormat != "€ #.##0,00" {
+		t.Errorf("CurrencyFormat = %q", model.Meta.CurrencyFormat)
+	}
+	if model.Meta.NoneLabel != "Uncategorized" {
+		t.Errorf("NoneLabel = %q", model.Meta.NoneLabel)
+	}
+	if model.Meta.Params["period"] != "May" || model.Meta.Params["group"] != "Household" {
+		t.Errorf("Params = %v", model.Meta.Params)
+	}
+
+	wantFormats := map[string]string{"Category": "text", "Total": "$ #,##0.00", "Doubled": "0.000"}
+	for _, descriptor := range model.Columns {
+		if got := descriptor.Format; got != wantFormats[descriptor.Name] {
+			t.Errorf("column %s Format = %q, want %q", descriptor.Name, got, wantFormats[descriptor.Name])
+		}
+	}
+}
+
+// A nil parameter map stays nil rather than becoming an empty one. A renderer
+// can then tell "no parameters" from "parameters, none of them set".
+func TestRun_NilParamsStayNil(t *testing.T) {
+	spec := ReportSpec{Columns: []Column{{Name: "Cnt", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}}}}
+
+	model, err := Run(spec, testCatalog(t), nil, MetaInput{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if model.Meta.Params != nil {
+		t.Errorf("Meta.Params = %v, want nil", model.Meta.Params)
+	}
+}
+
+// A cycle's error must name the columns that form it, not merely announce that
+// one exists. Someone has to fix the template.
+func TestValidate_CycleMessageNamesTheCycle(t *testing.T) {
+	tests := []struct {
+		name    string
+		columns []Column
+		want    string
+	}{
+		{
+			name:    "self reference",
+			columns: []Column{{Name: "Loop", Kind: ColumnArithmetic, Expr: "Loop + 1"}},
+			want:    "Loop -> Loop",
+		},
+		{
+			name: "a pair",
+			columns: []Column{
+				{Name: "A", Kind: ColumnArithmetic, Expr: "B + 1"},
+				{Name: "B", Kind: ColumnArithmetic, Expr: "A + 1"},
+			},
+			want: "A -> B -> A",
+		},
+		{
+			name: "a longer chain",
+			columns: []Column{
+				{Name: "A", Kind: ColumnArithmetic, Expr: "B"},
+				{Name: "B", Kind: ColumnArithmetic, Expr: "C"},
+				{Name: "C", Kind: ColumnArithmetic, Expr: "A"},
+			},
+			want: "A -> B -> C -> A",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := Validate(ReportSpec{Columns: test.columns}, testCatalog(t))
+			if !errors.Is(err, ErrFormulaCycle) {
+				t.Fatalf("Validate() error = %v, want %v", err, ErrFormulaCycle)
+			}
+			if !strings.Contains(err.Error(), test.want) {
+				t.Errorf("error %q does not name the cycle %q", err, test.want)
+			}
+		})
+	}
+}
+
+// Run reads its arguments and writes to none of them.
+func TestRun_DoesNotMutateItsArguments(t *testing.T) {
+	spec := workedExampleSpec()
+	rows := workedExampleRows()
+
+	specBefore := deepCopySpec(spec)
+	rowsBefore := deepCopyRows(rows)
+
+	if _, err := Run(spec, testCatalog(t), rows, testMeta()); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	// withDefaults fills NoneLabel and DivisionScale on a copy, and compileSpec
+	// infers column types on a copy. Neither may reach the caller's spec.
+	if !reflect.DeepEqual(spec, specBefore) {
+		t.Errorf("Run mutated the spec:\n got %+v\nwant %+v", spec, specBefore)
+	}
+	if !reflect.DeepEqual(rows, rowsBefore) {
+		t.Errorf("Run mutated the rows")
+	}
+}
+
+// No cell in the returned model may alias a row the caller still holds.
+func TestRun_ModelDoesNotAliasInputRows(t *testing.T) {
+	tests := []struct {
+		name string
+		spec ReportSpec
+	}{
+		{
+			name: "records mode label cell",
+			spec: ReportSpec{Columns: []Column{{Name: "Cats", Kind: ColumnLabel, Field: "category"}}},
+		},
+		{
+			name: "aggregated detail bucket label cell",
+			spec: ReportSpec{
+				Detail:  DetailSpec{Mode: DetailAggregate, By: "category"},
+				Columns: []Column{{Name: "Cats", Kind: ColumnLabel, Field: "category"}},
+			},
+		},
+		{
+			name: "label reading an ancestor bucket",
+			spec: ReportSpec{
+				GroupBy: []FieldKey{"tag"},
+				Detail:  DetailSpec{Mode: DetailAggregate, By: "category"},
+				Columns: []Column{{Name: "Tag", Kind: ColumnLabel, Field: "tag"}},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rows := []Row{{"category": {Str("Clothing")}, "tag": {Str("Alex")}, "amount": {Num(dec("1.00"))}}}
+			model := mustRun(t, test.spec, rows)
+
+			var cells []Cell
+			node := model.Root
+			for len(node.Children) > 0 {
+				node = node.Children[0]
+			}
+			cells = node.DetailRows[0].Cells
+
+			for index := range cells {
+				for value := range cells[index].Values {
+					cells[index].Values[value] = Str("tampered")
+				}
+			}
+
+			for key, values := range rows[0] {
+				for _, value := range values {
+					if text, isText := value.Text(); isText && text == "tampered" {
+						t.Errorf("mutating a cell reached the caller's row at %s", key)
+					}
+				}
+			}
+		})
+	}
+}
+
+// Two aggregate columns must not share an Agg pointer, nor share one with a
+// second run's model.
+func TestRun_DescriptorsDoNotAlias(t *testing.T) {
+	spec := ReportSpec{Columns: []Column{
+		{Name: "Total", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "amount"}},
+		{Name: "Most", Kind: ColumnAggregate, Agg: Aggregate{Func: AggMax, Field: "amount"}},
+	}}
+
+	first := mustRun(t, spec, nil)
+	second := mustRun(t, spec, nil)
+
+	if first.Columns[0].Agg == first.Columns[1].Agg {
+		t.Fatalf("two columns share an Agg pointer")
+	}
+	if first.Columns[0].Agg == second.Columns[0].Agg {
+		t.Fatalf("two runs share an Agg pointer")
+	}
+
+	first.Columns[0].Agg.Func = AggMin
+	if first.Columns[1].Agg.Func != AggMax {
+		t.Errorf("mutating one column's aggregate changed another")
+	}
+	if second.Columns[0].Agg.Func != AggSum {
+		t.Errorf("mutating one run's aggregate changed another run")
+	}
+}
+
+// Run is pure, so concurrent calls over a shared spec and catalog must neither
+// race nor disagree. Only meaningful under -race.
+func TestRun_ConcurrentRunsAreRaceFreeAndAgree(t *testing.T) {
+	spec := workedExampleSpec()
+	catalog := testCatalog(t)
+	rows := workedExampleRows()
+
+	want := serializeModel(mustRun(t, spec, rows))
+
+	const goroutines = 16
+	results := make([]string, goroutines)
+
+	var group sync.WaitGroup
+	for index := 0; index < goroutines; index++ {
+		group.Add(1)
+		go func(slot int) {
+			defer group.Done()
+
+			model, err := Run(spec, catalog, rows, testMeta())
+			if err != nil {
+				t.Errorf("Run() error = %v", err)
+				return
+			}
+			results[slot] = serializeModel(model)
+		}(index)
+	}
+	group.Wait()
+
+	for index, got := range results {
+		if got != want {
+			t.Errorf("goroutine %d produced a different report", index)
+		}
+	}
+}
+
+func deepCopySpec(spec ReportSpec) ReportSpec {
+	copied := spec
+	copied.GroupBy = append([]FieldKey(nil), spec.GroupBy...)
+	copied.Columns = append([]Column(nil), spec.Columns...)
+	return copied
+}
+
+func deepCopyRows(rows []Row) []Row {
+	copied := make([]Row, len(rows))
+	for index, row := range rows {
+		duplicate := make(Row, len(row))
+		for key, values := range row {
+			duplicate[key] = append([]Value(nil), values...)
+		}
+		copied[index] = duplicate
+	}
+	return copied
+}

--- a/api/internal/reporting/property_test.go
+++ b/api/internal/reporting/property_test.go
@@ -168,10 +168,17 @@ func randomDimensionValues(random *rand.Rand, dimension FieldKey) []Value {
 }
 
 // propertyDates deliberately includes the pathological instants, not merely a
-// spread of ordinary ones. The first two are distinct moments that share a
-// UnixNano, so a report grouping on them merges two buckets into one unless the
-// key is faithful. A generator that only produces plausible data only tests the
-// plausible paths.
+// spread of ordinary ones. A generator that only produces plausible data only
+// tests the plausible paths.
+//
+// Two pairs earn their place. The first two entries are distinct moments that
+// share a UnixNano, so a report grouping on them merges two buckets into one
+// unless the key is faithful. The last two are one instant expressed in two
+// zones, straddling midnight so they format as different calendar days: they
+// must merge into a single bucket whose reported value is the same whichever
+// arrived first. Note that the two 12:00 entries are *not* such a pair — one is
+// 12:00Z and the other 11:00Z — which is why the colliding pair had to be added
+// explicitly rather than assumed.
 var propertyDates = []time.Time{
 	time.Time{}, // year 1
 	time.Time{}.Add(math.MaxInt64).Add(math.MaxInt64).Add(2), // year 585, same UnixNano
@@ -179,6 +186,8 @@ var propertyDates = []time.Time{
 	time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
 	time.Date(2026, 5, 1, 12, 0, 0, 0, time.FixedZone("plus-one", 3600)),
 	time.Date(3000, 1, 1, 0, 0, 0, 1, time.UTC),
+	time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),                               // one instant,
+	time.Date(2026, 4, 30, 19, 0, 0, 0, time.FixedZone("minus-five", -18000)), // two zones, two days
 }
 
 func randomDimensionValue(random *rand.Rand, dimension FieldKey) Value {

--- a/api/internal/reporting/property_test.go
+++ b/api/internal/reporting/property_test.go
@@ -1,0 +1,635 @@
+package reporting
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// The laws in this file hold for every spec and every row set, so they are
+// checked against randomly generated reports rather than against fixtures. A
+// fixture proves the engine right about one report; a law proves it right about
+// the shape of every report, and catches the special case an implementation
+// quietly got away with.
+//
+// Everything here is seeded and reproducible. A failure prints the seed and the
+// case that broke, and REPORTING_SEED re-runs it.
+
+const propertyCases = 400
+
+// propertySeed is fixed so the suite is deterministic, and overridable so a
+// soak run can explore further.
+func propertySeed(t *testing.T) int64 {
+	t.Helper()
+
+	if raw := os.Getenv("REPORTING_SEED"); raw != "" {
+		seed, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil {
+			t.Fatalf("REPORTING_SEED=%q is not an integer", raw)
+		}
+		return seed
+	}
+	return 20260709
+}
+
+// propertyCatalog is the field vocabulary random specs are drawn from: two
+// currency measures, a plain numeric measure, two multi-value dimensions, and
+// one dimension of each remaining type.
+func propertyCatalog(t *testing.T) FieldCatalog {
+	t.Helper()
+
+	catalog, err := NewFieldCatalog(
+		FieldRef{Key: "amount", Label: "Amount", DataType: TypeCurrency},
+		FieldRef{Key: "hst", Label: "Hst", DataType: TypeCurrency},
+		FieldRef{Key: "quantity", Label: "Quantity", DataType: TypeNumber},
+		FieldRef{Key: "category", Label: "Category", DataType: TypeString, Multi: true},
+		FieldRef{Key: "tag", Label: "Tag", DataType: TypeString, Multi: true},
+		FieldRef{Key: "paid_by", Label: "Paid By", DataType: TypeString},
+		FieldRef{Key: "date", Label: "Date", DataType: TypeDate},
+		FieldRef{Key: "resolved", Label: "Resolved", DataType: TypeBool},
+	)
+	if err != nil {
+		t.Fatalf("NewFieldCatalog() error = %v", err)
+	}
+	return catalog
+}
+
+var (
+	propertyDimensions = []FieldKey{"category", "tag", "paid_by", "date", "resolved"}
+	propertyMeasures   = []FieldKey{"amount", "hst", "quantity"}
+	propertyMultiValue = map[FieldKey]bool{"category": true, "tag": true}
+)
+
+// randomCase is one generated report: a spec, the rows it runs over, and the
+// seed that produced them.
+type randomCase struct {
+	seed int64
+	spec ReportSpec
+	rows []Row
+}
+
+func (c randomCase) String() string {
+	return fmt.Sprintf("seed=%d groupBy=%v detail=%s/%s columns=%d rows=%d subtotals=%v grand=%v scale=%d",
+		c.seed, c.spec.GroupBy, c.spec.Detail.Mode, c.spec.Detail.By,
+		len(c.spec.Columns), len(c.rows), c.spec.Subtotals, c.spec.GrandTotals, c.spec.Config.DivisionScale)
+}
+
+// generateCase builds a random but valid report. The column set always carries
+// SUM, COUNT, AVG, MIN and MAX over one measure plus the arithmetic that reads
+// them, because those are the columns the laws below are stated over.
+func generateCase(random *rand.Rand, seed int64) randomCase {
+	levels := random.Intn(4) // 0..3 grouping levels
+	shuffled := append([]FieldKey(nil), propertyDimensions...)
+	random.Shuffle(len(shuffled), func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })
+	groupBy := shuffled[:levels]
+
+	detail := DetailSpec{Mode: DetailRecords}
+	remaining := shuffled[levels:]
+	if len(remaining) > 0 && random.Intn(2) == 0 {
+		detail = DetailSpec{Mode: DetailAggregate, By: remaining[random.Intn(len(remaining))]}
+	}
+
+	measure := propertyMeasures[random.Intn(len(propertyMeasures))]
+
+	columns := []Column{
+		{Name: "Cnt", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}},
+		{Name: "Total", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: measure}},
+		{Name: "Mean", Kind: ColumnAggregate, Agg: Aggregate{Func: AggAvg, Field: measure}},
+		{Name: "Least", Kind: ColumnAggregate, Agg: Aggregate{Func: AggMin, Field: measure}},
+		{Name: "Most", Kind: ColumnAggregate, Agg: Aggregate{Func: AggMax, Field: measure}},
+		// Additive, and non-linear: the second is the one that must be recomputed.
+		{Name: "Doubled", Kind: ColumnArithmetic, Expr: "Total + Total"},
+		{Name: "Ratio", Kind: ColumnArithmetic, Expr: "Total / Cnt"},
+		{Name: "Chained", Kind: ColumnArithmetic, Expr: "ROUND(Ratio * 2, 3)"},
+	}
+	if detail.Mode == DetailAggregate {
+		columns = append(columns, Column{Name: "Bucket", Kind: ColumnLabel, Field: detail.By})
+	}
+
+	spec := ReportSpec{
+		Title:       "property",
+		GroupBy:     groupBy,
+		Detail:      detail,
+		Columns:     columns,
+		Subtotals:   random.Intn(2) == 0,
+		GrandTotals: random.Intn(2) == 0,
+		Config:      EngineConfig{DivisionScale: int32(1 + random.Intn(8))},
+	}
+
+	rows := make([]Row, random.Intn(12))
+	for index := range rows {
+		rows[index] = generateRow(random, measure)
+	}
+
+	return randomCase{seed: seed, spec: spec, rows: rows}
+}
+
+func generateRow(random *rand.Rand, measure FieldKey) Row {
+	row := Row{}
+
+	for _, dimension := range propertyDimensions {
+		switch random.Intn(6) {
+		case 0:
+			// Absent: the row falls into the (None) bucket.
+			continue
+		case 1:
+			row[dimension] = []Value{Null()}
+		default:
+			row[dimension] = randomDimensionValues(random, dimension)
+		}
+	}
+
+	// The measure is null on some rows, which SUM skips and AVG excludes from
+	// its divisor, while COUNT still counts the row.
+	if random.Intn(5) > 0 {
+		row[measure] = []Value{Num(randomDecimal(random))}
+	}
+
+	return row
+}
+
+func randomDimensionValues(random *rand.Rand, dimension FieldKey) []Value {
+	count := 1
+	if propertyMultiValue[dimension] {
+		count = 1 + random.Intn(3)
+	}
+
+	values := make([]Value, 0, count)
+	for i := 0; i < count; i++ {
+		values = append(values, randomDimensionValue(random, dimension))
+	}
+	return values
+}
+
+// propertyDates deliberately includes the pathological instants, not merely a
+// spread of ordinary ones. The first two are distinct moments that share a
+// UnixNano, so a report grouping on them merges two buckets into one unless the
+// key is faithful. A generator that only produces plausible data only tests the
+// plausible paths.
+var propertyDates = []time.Time{
+	time.Time{}, // year 1
+	time.Time{}.Add(math.MaxInt64).Add(math.MaxInt64).Add(2), // year 585, same UnixNano
+	time.Date(1700, 3, 4, 0, 0, 0, 0, time.UTC),
+	time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+	time.Date(2026, 5, 1, 12, 0, 0, 0, time.FixedZone("plus-one", 3600)),
+	time.Date(3000, 1, 1, 0, 0, 0, 1, time.UTC),
+}
+
+func randomDimensionValue(random *rand.Rand, dimension FieldKey) Value {
+	switch dimension {
+	case "date":
+		return DateVal(propertyDates[random.Intn(len(propertyDates))])
+	case "resolved":
+		return Bool(random.Intn(2) == 0)
+	default:
+		// A small alphabet, so buckets collide often. The empty string is a
+		// bucket of its own, distinct from (None).
+		names := []string{"", "a", "b", "c"}
+		return Str(names[random.Intn(len(names))])
+	}
+}
+
+func randomDecimal(random *rand.Rand) decimal.Decimal {
+	// Two decimal places, positive and negative, including zero.
+	return decimal.New(int64(random.Intn(20001)-10000), -2)
+}
+
+// TestProperty_Laws generates reports and checks every law against each.
+func TestProperty_Laws(t *testing.T) {
+	seed := propertySeed(t)
+	catalog := propertyCatalog(t)
+	random := rand.New(rand.NewSource(seed))
+
+	skipped := 0
+	for index := 0; index < propertyCases; index++ {
+		testCase := generateCase(random, seed)
+
+		if err := Validate(testCase.spec, catalog); err != nil {
+			skipped++
+			continue
+		}
+
+		model, err := Run(testCase.spec, catalog, testCase.rows, MetaInput{})
+		if err != nil {
+			t.Fatalf("case %d: Run() error = %v\n%s", index, err, testCase)
+		}
+
+		t.Run(fmt.Sprintf("case%03d", index), func(t *testing.T) {
+			defer func() {
+				if t.Failed() {
+					t.Logf("reproduce with REPORTING_SEED=%d; case: %s", seed, testCase)
+				}
+			}()
+
+			assertModelInvariants(t, testCase.spec, model)
+			assertBucketCardinality(t, testCase, model)
+			assertConservation(t, testCase, model)
+			assertRollup(t, testCase, model, model.Root, 0)
+			assertArithmeticRecomputed(t, testCase, model)
+			assertDeterminism(t, testCase, catalog, model)
+		})
+	}
+
+	if skipped == propertyCases {
+		t.Fatalf("every generated case was rejected by Validate; the generator is broken")
+	}
+	t.Logf("%d cases, %d rejected by Validate", propertyCases, skipped)
+}
+
+// distinctValues returns the values of a field that are pairwise unequal.
+//
+// It compares with compareValues and deliberately not with bucketKey, and it
+// reads the row directly rather than through dimensionValues. Both are the
+// point: a law derived from the code it judges cannot catch that code being
+// wrong. An earlier draft of this file used the engine's own helper here, and
+// consequently agreed with the engine that a receipt tagged "Alex" twice
+// belonged to the Alex bucket twice.
+//
+// A field with no values is one bucket: (None).
+func distinctValues(values []Value) []Value {
+	if len(values) == 0 {
+		return []Value{Null()}
+	}
+
+	distinct := make([]Value, 0, len(values))
+	for _, value := range values {
+		duplicate := false
+		for _, kept := range distinct {
+			if compareValues(value, kept) == 0 {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			distinct = append(distinct, value)
+		}
+	}
+	return distinct
+}
+
+// attributions is the number of buckets a row is counted into: the product of
+// the distinct values it holds at each grouping level, times the distinct
+// values of the detail dimension. An absent level contributes exactly one, the
+// (None) bucket.
+//
+// Computed from the rows alone, so it is an independent prediction rather than
+// a restatement of what the engine did.
+func attributions(spec ReportSpec, row Row) int {
+	count := 1
+	for _, level := range spec.GroupBy {
+		count *= len(distinctValues(row.Get(level)))
+	}
+	if spec.Detail.Mode == DetailAggregate {
+		count *= len(distinctValues(row.Get(spec.Detail.By)))
+	}
+	return count
+}
+
+// A11: the buckets at a level are exactly the distinct values the rows hold
+// there — no fewer, which would mean two values merged, and no more, which
+// would mean one value split.
+//
+// This is the law the date bucket key broke: two instants that compareValues
+// called different shared a UnixNano and collapsed into one bucket.
+func assertBucketCardinality(t *testing.T, testCase randomCase, model ReportModel) {
+	t.Helper()
+
+	if len(testCase.rows) == 0 {
+		return
+	}
+
+	if len(testCase.spec.GroupBy) > 0 {
+		var all []Value
+		for _, row := range testCase.rows {
+			all = append(all, distinctValues(row.Get(testCase.spec.GroupBy[0]))...)
+		}
+		if want := len(distinctValues(all)); len(model.Root.Children) != want {
+			t.Errorf("A11: the top level has %d buckets, but the rows hold %d distinct values",
+				len(model.Root.Children), want)
+		}
+		return
+	}
+
+	if testCase.spec.Detail.Mode == DetailAggregate {
+		var all []Value
+		for _, row := range testCase.rows {
+			all = append(all, distinctValues(row.Get(testCase.spec.Detail.By))...)
+		}
+		if want := len(distinctValues(all)); len(model.Root.DetailRows) != want {
+			t.Errorf("A11: there are %d detail rows, but the rows hold %d distinct values",
+				len(model.Root.DetailRows), want)
+		}
+	}
+}
+
+// A1, A2: the grand total counts every attribution, and sums every attributed
+// amount. A row that fans into two buckets contributes twice, on purpose.
+func assertConservation(t *testing.T, testCase randomCase, model ReportModel) {
+	t.Helper()
+
+	if !testCase.spec.GrandTotals {
+		return
+	}
+
+	measure := measureOf(testCase.spec, "Total")
+
+	wantCount := 0
+	wantSum := decimal.Zero
+	for _, row := range testCase.rows {
+		times := attributions(testCase.spec, row)
+		wantCount += times
+
+		if value, isNumber := row.Measure(measure).Decimal(); isNumber {
+			wantSum = wantSum.Add(value.Mul(decimal.NewFromInt(int64(times))))
+		}
+	}
+
+	if got := cellNumber(t, model.GrandTotals, "Cnt"); !got.Equal(decimal.NewFromInt(int64(wantCount))) {
+		t.Errorf("A1: grand COUNT = %s, want %d", got, wantCount)
+	}
+	if model.Root.RecordCount != wantCount {
+		t.Errorf("A1: root RecordCount = %d, want %d", model.Root.RecordCount, wantCount)
+	}
+	if got := cellNumber(t, model.GrandTotals, "Total"); !got.Equal(wantSum) {
+		t.Errorf("A2: grand SUM = %s, want %s", got, wantSum)
+	}
+}
+
+// A3, A4, A5, A6: how a node relates to the rows beneath it.
+func assertRollup(t *testing.T, testCase randomCase, model ReportModel, node GroupNode, depth int) {
+	t.Helper()
+
+	for _, child := range node.Children {
+		assertRollup(t, testCase, model, child, depth+1)
+	}
+
+	cells := node.Subtotals
+	if depth == 0 {
+		cells = model.GrandTotals
+	}
+	if cells == nil {
+		return
+	}
+
+	// The rows immediately beneath this node: its children's own totals, or its
+	// detail rows.
+	var children [][]Cell
+	for _, child := range node.Children {
+		if child.Subtotals == nil {
+			return // subtotals are switched off; nothing to compare against
+		}
+		children = append(children, child.Subtotals)
+	}
+	if len(node.Children) == 0 {
+		for _, row := range node.DetailRows {
+			children = append(children, row.Cells)
+		}
+	}
+
+	// A4: SUM and COUNT are the sum of their children. Nothing else is.
+	for _, column := range []string{"Cnt", "Total"} {
+		want := decimal.Zero
+		for _, child := range children {
+			want = want.Add(cellNumber(t, child, column))
+		}
+		if got := cellNumber(t, cells, column); !got.Equal(want) {
+			t.Errorf("A4: %s at depth %d = %s, want %s (the sum of %d children)", column, depth, got, want, len(children))
+		}
+	}
+
+	// A5: MIN and MAX are the extremes of their children, and null only when
+	// every child is null.
+	assertExtremum(t, cells, children, "Least", depth, func(candidate, best decimal.Decimal) bool {
+		return candidate.LessThan(best)
+	})
+	assertExtremum(t, cells, children, "Most", depth, func(candidate, best decimal.Decimal) bool {
+		return candidate.GreaterThan(best)
+	})
+
+	// A6: AVG is the average over every descendant, never the average of the
+	// children's averages. With SUM and COUNT on the same row, that is exactly
+	// AVG * COUNT == SUM.
+	mean := cellValue(t, cells, "Mean")
+	total := cellNumber(t, cells, "Total")
+	count := cellNumber(t, cells, "Cnt")
+
+	if mean.IsNull() {
+		// AVG is null only when no row beneath carried a value, in which case
+		// SUM is zero.
+		if !total.IsZero() {
+			t.Errorf("A6: AVG at depth %d is null but SUM is %s", depth, total)
+		}
+		return
+	}
+
+	average, _ := mean.Decimal()
+	scale := testCase.spec.Config.DivisionScale
+
+	// AVG is rounded to the division scale, so every comparison below allows one
+	// unit at that scale. A single value of 1.07 averaged at scale 1 is 1.1,
+	// which is genuinely outside [MIN, MAX].
+	epsilon := decimal.New(1, -scale)
+
+	// AVG divides by the count of non-null values, which is at most the record
+	// count. The exact divisor cannot be recovered from the model, so assert the
+	// relation that always holds -- AVG lies between MIN and MAX -- and, when
+	// every row carried a value so the divisor is the record count, that
+	// AVG * COUNT reconstructs SUM.
+	assertBetweenExtremes(t, cells, average, epsilon, depth)
+
+	if everyRowHasAMeasure(testCase) && !count.IsZero() {
+		reconstructed := average.Mul(count)
+		tolerance := epsilon.Mul(count)
+		if reconstructed.Sub(total).Abs().GreaterThan(tolerance) {
+			t.Errorf("A6: AVG*COUNT at depth %d = %s, want %s (within %s)", depth, reconstructed, total, tolerance)
+		}
+	}
+}
+
+func assertExtremum(t *testing.T, cells []Cell, children [][]Cell, column string, depth int, better func(a, b decimal.Decimal) bool) {
+	t.Helper()
+
+	var want decimal.Decimal
+	seen := false
+	for _, child := range children {
+		value := cellValue(t, child, column)
+		if value.IsNull() {
+			continue
+		}
+		number, _ := value.Decimal()
+		if !seen || better(number, want) {
+			want = number
+			seen = true
+		}
+	}
+
+	got := cellValue(t, cells, column)
+	if !seen {
+		if !got.IsNull() {
+			t.Errorf("A5: %s at depth %d = %v, want null (every child is null)", column, depth, got)
+		}
+		return
+	}
+	number, isNumber := got.Decimal()
+	if !isNumber || !number.Equal(want) {
+		t.Errorf("A5: %s at depth %d = %v, want %s", column, depth, got, want)
+	}
+}
+
+func assertBetweenExtremes(t *testing.T, cells []Cell, average, epsilon decimal.Decimal, depth int) {
+	t.Helper()
+
+	least := cellValue(t, cells, "Least")
+	most := cellValue(t, cells, "Most")
+	if least.IsNull() || most.IsNull() {
+		return
+	}
+
+	low, _ := least.Decimal()
+	high, _ := most.Decimal()
+	if average.LessThan(low.Sub(epsilon)) || average.GreaterThan(high.Add(epsilon)) {
+		t.Errorf("A6: AVG %s at depth %d is outside [%s, %s] by more than %s", average, depth, low, high, epsilon)
+	}
+}
+
+// everyRowHasAMeasure reports whether every row carried a value for the
+// measure. When they all did, AVG's divisor is the record count, and AVG times
+// COUNT reconstructs SUM. When some are null, the divisor is smaller and the
+// model does not expose it.
+func everyRowHasAMeasure(testCase randomCase) bool {
+	measure := measureOf(testCase.spec, "Total")
+	for _, row := range testCase.rows {
+		if row.Measure(measure).IsNull() {
+			return false
+		}
+	}
+	return true
+}
+
+// A7, A8: an arithmetic column is recomputed from the other cells on its own
+// row, at every level. Re-evaluating its expression against that row's cells
+// must reproduce the cell exactly.
+func assertArithmeticRecomputed(t *testing.T, testCase randomCase, model ReportModel) {
+	t.Helper()
+
+	compiled, err := compileSpec(testCase.spec, propertyCatalog(t))
+	if err != nil {
+		t.Fatalf("compileSpec() error = %v", err)
+	}
+	scale := compiled.spec.Config.DivisionScale
+
+	check := func(cells []Cell, where string) {
+		if cells == nil {
+			return
+		}
+
+		values := make(map[string]Value, len(cells))
+		for _, cell := range cells {
+			values[cell.Column] = cell.Value()
+		}
+
+		for _, column := range compiled.columns {
+			if column.kind != ColumnArithmetic {
+				continue
+			}
+			want := evalArithmetic(column.expr, values, scale)
+			got := values[column.name]
+
+			if want.IsNull() != got.IsNull() {
+				t.Errorf("A7: %s at %s = %v, recomputes to %v", column.name, where, got, want)
+				continue
+			}
+			if want.IsNull() {
+				continue
+			}
+			wantNumber, _ := want.Decimal()
+			gotNumber, _ := got.Decimal()
+			if !gotNumber.Equal(wantNumber) {
+				t.Errorf("A7: %s at %s = %s, recomputes to %s", column.name, where, gotNumber, wantNumber)
+			}
+		}
+	}
+
+	var walk func(node GroupNode, path string)
+	walk = func(node GroupNode, path string) {
+		check(node.Subtotals, path+" subtotal")
+		for index, row := range node.DetailRows {
+			check(row.Cells, fmt.Sprintf("%s row %d", path, index))
+		}
+		for index, child := range node.Children {
+			walk(child, fmt.Sprintf("%s/%d", path, index))
+		}
+	}
+	walk(model.Root, "root")
+	check(model.GrandTotals, "grand totals")
+}
+
+// A9: identical inputs give identical output, and an aggregated report does not
+// depend on the order its rows arrived in.
+func assertDeterminism(t *testing.T, testCase randomCase, catalog FieldCatalog, model ReportModel) {
+	t.Helper()
+
+	again, err := Run(testCase.spec, catalog, testCase.rows, MetaInput{})
+	if err != nil {
+		t.Fatalf("Run() error on the second run = %v", err)
+	}
+	if serializeModel(again) != serializeModel(model) {
+		t.Errorf("A9: two runs over the same input disagree")
+	}
+
+	if testCase.spec.Detail.Mode == DetailRecords {
+		// Records keep their input order, so a permutation legitimately changes
+		// the report. The totals must not move.
+		return
+	}
+
+	reversed := make([]Row, len(testCase.rows))
+	for index, row := range testCase.rows {
+		reversed[len(testCase.rows)-1-index] = row
+	}
+
+	permuted, err := Run(testCase.spec, catalog, reversed, MetaInput{})
+	if err != nil {
+		t.Fatalf("Run() error on the permuted input = %v", err)
+	}
+	if serializeModel(permuted) != serializeModel(model) {
+		t.Errorf("A9: reversing the rows changed an aggregated report")
+	}
+}
+
+func measureOf(spec ReportSpec, column string) FieldKey {
+	for _, candidate := range spec.Columns {
+		if candidate.Name == column {
+			return candidate.Agg.Field
+		}
+	}
+	return ""
+}
+
+func cellValue(t *testing.T, cells []Cell, column string) Value {
+	t.Helper()
+
+	for _, cell := range cells {
+		if cell.Column == column {
+			return cell.Value()
+		}
+	}
+	t.Fatalf("no cell for column %q", column)
+	return Null()
+}
+
+func cellNumber(t *testing.T, cells []Cell, column string) decimal.Decimal {
+	t.Helper()
+
+	number, isNumber := cellValue(t, cells, column).Decimal()
+	if !isNumber {
+		t.Fatalf("column %q is not a number", column)
+	}
+	return number
+}

--- a/api/internal/reporting/receiptsource/receiptsource.go
+++ b/api/internal/reporting/receiptsource/receiptsource.go
@@ -196,12 +196,27 @@ func (s Source) row(receipt *models.Receipt) reporting.Row {
 
 // addCustomFields resolves each of a receipt's custom field values against its
 // definition. A field the receipt carries no value for simply has no entry,
-// which reads as null when measured and as (None) when grouped. Where a receipt
-// holds several values for one field, the first that resolves wins.
+// which reads as null when measured and as (None) when grouped.
+//
+// Where a receipt holds several values for one field, the one with the lowest id
+// wins. Nothing stops it holding several: custom_field_values carries no unique
+// index on (receipt_id, custom_field_id), and a receipt update replaces the
+// association with whatever the request contained. Preferring whichever came
+// back first would hand the answer to the database, since the association is
+// loaded without an ORDER BY — and a report whose numbers depend on row order is
+// the one thing this package must not produce.
+//
+// A value that does not resolve never wins, so an empty low-id row cannot hide a
+// real one. Ties are only possible between rows that were never persisted, since
+// a saved row has a distinct id; among those the first still wins.
 func (s Source) addCustomFields(row reporting.Row, receipt *models.Receipt) {
+	// The id of the value currently holding each field.
+	winners := make(map[reporting.FieldKey]uint, len(receipt.CustomFields))
+
 	for _, customFieldValue := range receipt.CustomFields {
 		key := CustomFieldKey(customFieldValue.CustomFieldId)
-		if _, resolved := row[key]; resolved {
+
+		if incumbent, held := winners[key]; held && incumbent <= customFieldValue.ID {
 			continue
 		}
 
@@ -209,6 +224,8 @@ func (s Source) addCustomFields(row reporting.Row, receipt *models.Receipt) {
 		if !ok {
 			continue
 		}
+
+		winners[key] = customFieldValue.ID
 		row[key] = []reporting.Value{value}
 	}
 }

--- a/api/internal/reporting/receiptsource/receiptsource.go
+++ b/api/internal/reporting/receiptsource/receiptsource.go
@@ -1,0 +1,292 @@
+// Package receiptsource maps receipts onto the rows the reporting engine
+// consumes.
+//
+// It is the only part of the reporting system that knows what a receipt is.
+// Everything downstream — grouping, aggregation, formulas, the report model —
+// works on typed values and would serve any other source just as well. Reporting
+// at item grain, or a dashboard widget over something else entirely, adds a
+// sibling of this package rather than changing the engine.
+//
+// It fetches nothing either. Receipts arrive already loaded, and the caller is
+// responsible for having preloaded the associations the report reads.
+package receiptsource
+
+import (
+	"sort"
+	"strconv"
+
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/reporting"
+
+	"github.com/shopspring/decimal"
+)
+
+// The built-in fields a report may reference. Keys are plain identifiers so a
+// formula can name one without quoting, as in SUM(amount).
+const (
+	KeyReceiptID    reporting.FieldKey = "receipt_id"
+	KeyName         reporting.FieldKey = "name"
+	KeyAmount       reporting.FieldKey = "amount"
+	KeyDate         reporting.FieldKey = "date"
+	KeyResolvedDate reporting.FieldKey = "resolved_date"
+	KeyCreatedAt    reporting.FieldKey = "created_at"
+	KeyStatus       reporting.FieldKey = "status"
+	KeyPaidBy       reporting.FieldKey = "paid_by"
+	KeyGroup        reporting.FieldKey = "group"
+	KeyCategory     reporting.FieldKey = "category"
+	KeyTag          reporting.FieldKey = "tag"
+)
+
+// customFieldKeyPrefix builds a custom field's key from its id rather than its
+// name, so that renaming a custom field cannot break a saved report.
+const customFieldKeyPrefix = "custom_"
+
+// CustomFieldKey returns the field key a custom field is referenced by.
+func CustomFieldKey(customFieldID uint) reporting.FieldKey {
+	return reporting.FieldKey(customFieldKeyPrefix + strconv.FormatUint(uint64(customFieldID), 10))
+}
+
+// builtinFields returns the fields every receipt report may reference.
+//
+// Categories and tags are multi-valued: grouping on one fans a receipt out into
+// every bucket it belongs to, attributing the whole amount to each, exactly as
+// the dashboard pie chart does.
+func builtinFields() []reporting.FieldRef {
+	return []reporting.FieldRef{
+		{Key: KeyReceiptID, Label: "Receipt Id", DataType: reporting.TypeNumber},
+		{Key: KeyName, Label: "Name", DataType: reporting.TypeString},
+		{Key: KeyAmount, Label: "Amount", DataType: reporting.TypeCurrency},
+		{Key: KeyDate, Label: "Date", DataType: reporting.TypeDate},
+		{Key: KeyResolvedDate, Label: "Resolved Date", DataType: reporting.TypeDate},
+		{Key: KeyCreatedAt, Label: "Added At", DataType: reporting.TypeDate},
+		{Key: KeyStatus, Label: "Status", DataType: reporting.TypeString},
+		{Key: KeyPaidBy, Label: "Paid By", DataType: reporting.TypeString},
+		{Key: KeyGroup, Label: "Group", DataType: reporting.TypeString},
+		{Key: KeyCategory, Label: "Category", DataType: reporting.TypeString, Multi: true},
+		{Key: KeyTag, Label: "Tag", DataType: reporting.TypeString, Multi: true},
+	}
+}
+
+// Source maps receipts to engine rows against a fixed set of custom fields.
+//
+// It resolves the custom field definitions once, so the catalog it offers and
+// the rows it builds cannot disagree about a field's type or about what a
+// select option's value is.
+type Source struct {
+	catalog reporting.FieldCatalog
+
+	// types maps a custom field's id to its type, which decides which of the
+	// five value columns on a CustomFieldValue holds the answer.
+	types map[uint]models.CustomFieldType
+
+	// options maps a select field's id to its option values by option id, which
+	// is how a stored option id becomes the text a reader sees.
+	options map[uint]map[uint]string
+}
+
+// New builds a Source over the custom fields a report may reference. Pass them
+// with their Options loaded; a select field whose options are missing resolves
+// to no value rather than to a bare option id.
+//
+// Two custom fields sharing an id are rejected, since they would claim the same
+// field key.
+func New(customFields []models.CustomField) (Source, error) {
+	// Sort by id so the catalog does not depend on the order the definitions
+	// arrived in.
+	sorted := make([]models.CustomField, len(customFields))
+	copy(sorted, customFields)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].ID < sorted[j].ID })
+
+	source := Source{
+		types:   make(map[uint]models.CustomFieldType, len(sorted)),
+		options: make(map[uint]map[uint]string),
+	}
+
+	fields := builtinFields()
+	for _, customField := range sorted {
+		source.types[customField.ID] = customField.Type
+
+		if customField.Type == models.SELECT {
+			values := make(map[uint]string, len(customField.Options))
+			for _, option := range customField.Options {
+				values[option.ID] = option.Value
+			}
+			source.options[customField.ID] = values
+		}
+
+		fields = append(fields, reporting.FieldRef{
+			Key:      CustomFieldKey(customField.ID),
+			Label:    customField.Name,
+			DataType: dataTypeFor(customField.Type),
+		})
+	}
+
+	catalog, err := reporting.NewFieldCatalog(fields...)
+	if err != nil {
+		return Source{}, err
+	}
+	source.catalog = catalog
+
+	return source, nil
+}
+
+// Catalog returns the fields a report run against this source may reference:
+// every built-in, plus one per custom field.
+func (s Source) Catalog() reporting.FieldCatalog { return s.catalog }
+
+// dataTypeFor maps a custom field's type onto the engine's. A currency custom
+// field is a measure and every other kind is a dimension, which is why a tax
+// field needs no special case: it is summable because it is currency.
+func dataTypeFor(customFieldType models.CustomFieldType) reporting.DataType {
+	switch customFieldType {
+	case models.CURRENCY:
+		return reporting.TypeCurrency
+	case models.DATE:
+		return reporting.TypeDate
+	case models.BOOLEAN:
+		return reporting.TypeBool
+	}
+	// TEXT and SELECT both read as text.
+	return reporting.TypeString
+}
+
+// Rows resolves receipts into engine rows, one row per receipt, in the order
+// they were given. The engine preserves that order for a records-mode report,
+// so the caller's query decides how those rows are sorted.
+//
+// The caller must have preloaded whatever the report reads: Categories, Tags
+// and CustomFields on the receipt, plus PaidByUser and Group for their display
+// names. An association that was not loaded resolves to no value, which the
+// engine reports as a (None) bucket. A missing preload therefore shows up as an
+// empty group rather than as a crash.
+func (s Source) Rows(receipts []models.Receipt) []reporting.Row {
+	rows := make([]reporting.Row, 0, len(receipts))
+	for index := range receipts {
+		rows = append(rows, s.row(&receipts[index]))
+	}
+	return rows
+}
+
+func (s Source) row(receipt *models.Receipt) reporting.Row {
+	row := reporting.Row{
+		KeyReceiptID: {reporting.Num(decimal.NewFromInt(int64(receipt.ID)))},
+		KeyName:      {reporting.Str(receipt.Name)},
+		KeyAmount:    {reporting.Num(receipt.Amount)},
+		KeyDate:      {reporting.DateVal(receipt.Date)},
+		KeyCreatedAt: {reporting.DateVal(receipt.CreatedAt)},
+		KeyStatus:    {reporting.Str(string(receipt.Status))},
+		KeyCategory:  categoryValues(receipt.Categories),
+		KeyTag:       tagValues(receipt.Tags),
+	}
+
+	if receipt.ResolvedDate != nil {
+		row[KeyResolvedDate] = []reporting.Value{reporting.DateVal(*receipt.ResolvedDate)}
+	}
+	if displayName := userDisplayName(receipt.PaidByUser); len(displayName) > 0 {
+		row[KeyPaidBy] = []reporting.Value{reporting.Str(displayName)}
+	}
+	if len(receipt.Group.Name) > 0 {
+		row[KeyGroup] = []reporting.Value{reporting.Str(receipt.Group.Name)}
+	}
+
+	s.addCustomFields(row, receipt)
+
+	return row
+}
+
+// addCustomFields resolves each of a receipt's custom field values against its
+// definition. A field the receipt carries no value for simply has no entry,
+// which reads as null when measured and as (None) when grouped. Where a receipt
+// holds several values for one field, the first that resolves wins.
+func (s Source) addCustomFields(row reporting.Row, receipt *models.Receipt) {
+	for _, customFieldValue := range receipt.CustomFields {
+		key := CustomFieldKey(customFieldValue.CustomFieldId)
+		if _, resolved := row[key]; resolved {
+			continue
+		}
+
+		value, ok := s.customFieldValue(customFieldValue)
+		if !ok {
+			continue
+		}
+		row[key] = []reporting.Value{value}
+	}
+}
+
+// customFieldValue reads the one column of a value row that its field's type
+// says is populated.
+//
+// The type comes from this source's definitions rather than from the value's
+// own embedded CustomField, which the caller need not have preloaded. A value
+// whose field is not in the catalog is skipped: the engine could not reference
+// it anyway.
+func (s Source) customFieldValue(customFieldValue models.CustomFieldValue) (reporting.Value, bool) {
+	customFieldType, known := s.types[customFieldValue.CustomFieldId]
+	if !known {
+		return reporting.Null(), false
+	}
+
+	switch customFieldType {
+	case models.CURRENCY:
+		if customFieldValue.CurrencyValue == nil {
+			return reporting.Null(), false
+		}
+		return reporting.Num(*customFieldValue.CurrencyValue), true
+
+	case models.TEXT:
+		if customFieldValue.StringValue == nil {
+			return reporting.Null(), false
+		}
+		return reporting.Str(*customFieldValue.StringValue), true
+
+	case models.SELECT:
+		// A select stores an option id, not the text a reader sees.
+		if customFieldValue.SelectValue == nil {
+			return reporting.Null(), false
+		}
+		text, found := s.options[customFieldValue.CustomFieldId][*customFieldValue.SelectValue]
+		if !found {
+			return reporting.Null(), false
+		}
+		return reporting.Str(text), true
+
+	case models.DATE:
+		if customFieldValue.DateValue == nil {
+			return reporting.Null(), false
+		}
+		return reporting.DateVal(*customFieldValue.DateValue), true
+
+	case models.BOOLEAN:
+		if customFieldValue.BooleanValue == nil {
+			return reporting.Null(), false
+		}
+		return reporting.Bool(*customFieldValue.BooleanValue), true
+	}
+
+	return reporting.Null(), false
+}
+
+// userDisplayName prefers what a user chose to be called, falling back to the
+// name they log in with, which is how the dashboard names a payer.
+func userDisplayName(user models.User) string {
+	if len(user.DisplayName) > 0 {
+		return user.DisplayName
+	}
+	return user.Username
+}
+
+func categoryValues(categories []models.Category) []reporting.Value {
+	values := make([]reporting.Value, 0, len(categories))
+	for _, category := range categories {
+		values = append(values, reporting.Str(category.Name))
+	}
+	return values
+}
+
+func tagValues(tags []models.Tag) []reporting.Value {
+	values := make([]reporting.Value, 0, len(tags))
+	for _, tag := range tags {
+		values = append(values, reporting.Str(tag.Name))
+	}
+	return values
+}

--- a/api/internal/reporting/receiptsource/receiptsource_test.go
+++ b/api/internal/reporting/receiptsource/receiptsource_test.go
@@ -2,6 +2,7 @@ package receiptsource
 
 import (
 	"errors"
+	"math"
 	"testing"
 	"time"
 
@@ -559,5 +560,172 @@ func TestSource_FeedsTheEngine(t *testing.T) {
 	// cell.
 	if got := find(alex.DetailRows[1].Cells, "Hst"); got != "0" {
 		t.Errorf("Medical HST = %s, want 0", got)
+	}
+}
+
+// A receipt that never round-tripped through the database holds the zero time.
+// Grouping on it must be stable, which it was not while date buckets were keyed
+// on UnixNano: the zero time and an instant in 585 shared a key.
+func TestSource_ZeroCreatedAtGroupsStably(t *testing.T) {
+	source := mustNew(t)
+
+	// The zero time, and the instant exactly 2^64 nanoseconds later.
+	zero := time.Time{}
+	wrapped := zero.Add(math.MaxInt64).Add(math.MaxInt64).Add(2)
+
+	receipts := []models.Receipt{
+		{BaseModel: models.BaseModel{ID: 1, CreatedAt: zero}, Amount: dec("1.00")},
+		{BaseModel: models.BaseModel{ID: 2, CreatedAt: wrapped}, Amount: dec("2.00")},
+	}
+
+	spec := reporting.ReportSpec{
+		GroupBy:     []reporting.FieldKey{KeyCreatedAt},
+		Columns:     []reporting.Column{{Name: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"}},
+		GrandTotals: true,
+	}
+
+	model, err := reporting.Run(spec, source.Catalog(), source.Rows(receipts), reporting.MetaInput{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if len(model.Root.Children) != 2 {
+		t.Errorf("two distinct created-at instants produced %d bucket(s), want 2", len(model.Root.Children))
+	}
+
+	// And reversing the receipts must not change the report.
+	reversed := []models.Receipt{receipts[1], receipts[0]}
+	permuted, err := reporting.Run(spec, source.Catalog(), source.Rows(reversed), reporting.MetaInput{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if permuted.Root.Children[0].Value.String() != model.Root.Children[0].Value.String() {
+		t.Errorf("reversing the receipts changed the first bucket")
+	}
+}
+
+// A receipt amount that was never set is the zero decimal, whose internal
+// coefficient is a nil big.Int. It must sum like any other zero.
+func TestSource_ZeroValueAmountSums(t *testing.T) {
+	source := mustNew(t)
+
+	receipts := []models.Receipt{
+		{BaseModel: models.BaseModel{ID: 1}}, // Amount is the zero decimal.Decimal
+		{BaseModel: models.BaseModel{ID: 2}, Amount: dec("5.00")},
+	}
+
+	spec := reporting.ReportSpec{
+		Columns:     []reporting.Column{{Name: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"}},
+		GrandTotals: true,
+	}
+
+	model, err := reporting.Run(spec, source.Catalog(), source.Rows(receipts), reporting.MetaInput{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	total := model.GrandTotals[0].Value()
+	number, isNumber := total.Decimal()
+	if !isNumber || !number.Equal(dec("5.00")) {
+		t.Errorf("grand total = %v, want 5.00", total)
+	}
+}
+
+// A receipt with no status resolves to the empty string, which is a bucket of
+// its own. It is not the same as having no status field at all, and the report
+// must not quietly file it under (None).
+func TestSource_EmptyStatusIsTheEmptyString(t *testing.T) {
+	row := mustNew(t).Rows([]models.Receipt{{Name: "Bare"}})[0]
+
+	values := row.Get(KeyStatus)
+	if len(values) != 1 {
+		t.Fatalf("status resolved to %d values, want 1", len(values))
+	}
+	text, isText := values[0].Text()
+	if !isText || text != "" {
+		t.Errorf("status = %v, want the empty string", values[0])
+	}
+}
+
+// A custom field whose type is not one the engine knows takes a place in the
+// catalog, so a saved report referencing it still validates, but resolves to no
+// value rather than guessing which column holds the answer.
+func TestSource_UnknownCustomFieldType(t *testing.T) {
+	source, err := New([]models.CustomField{
+		{BaseModel: models.BaseModel{ID: 9}, Name: "Mystery", Type: models.CustomFieldType("SOMETHING_NEW")},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	field, exists := source.Catalog().Get("custom_9")
+	if !exists {
+		t.Fatalf("catalog is missing custom_9")
+	}
+	if field.DataType != reporting.TypeString {
+		t.Errorf("dataType = %v, want %v", field.DataType, reporting.TypeString)
+	}
+
+	note := "anything"
+	row := source.Rows([]models.Receipt{{
+		CustomFields: []models.CustomFieldValue{{CustomFieldId: 9, StringValue: &note}},
+	}})[0]
+
+	if len(row.Get("custom_9")) != 0 {
+		t.Errorf("custom_9 = %v, want no value", row.Get("custom_9"))
+	}
+}
+
+// Options belong to select fields. Loading them onto another kind changes
+// nothing, and must not make its values resolve through them.
+func TestSource_OptionsOnANonSelectFieldAreIgnored(t *testing.T) {
+	source, err := New([]models.CustomField{{
+		BaseModel: models.BaseModel{ID: 1},
+		Name:      "HST",
+		Type:      models.CURRENCY,
+		Options:   []models.CustomFieldOption{{BaseModel: models.BaseModel{ID: 10}, Value: "Alex"}},
+	}})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	amount := dec("15.60")
+	row := source.Rows([]models.Receipt{{
+		CustomFields: []models.CustomFieldValue{{CustomFieldId: 1, CurrencyValue: &amount}},
+	}})[0]
+
+	number, isNumber := row.Measure("custom_1").Decimal()
+	if !isNumber || !number.Equal(dec("15.60")) {
+		t.Errorf("custom_1 = %v, want 15.60", row.Measure("custom_1"))
+	}
+}
+
+// A receipt carrying the same category twice belongs to that bucket once.
+// receipt_categories cannot express it, but a row built by hand can.
+func TestSource_DuplicateCategoriesAreOneBucket(t *testing.T) {
+	source := mustNew(t)
+
+	receipts := []models.Receipt{{
+		Amount:     dec("10.00"),
+		Categories: []models.Category{{Name: "Clothing"}, {Name: "Clothing"}},
+	}}
+
+	spec := reporting.ReportSpec{
+		GroupBy:     []reporting.FieldKey{KeyCategory},
+		Columns:     []reporting.Column{{Name: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"}},
+		GrandTotals: true,
+	}
+
+	model, err := reporting.Run(spec, source.Catalog(), source.Rows(receipts), reporting.MetaInput{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if len(model.Root.Children) != 1 {
+		t.Fatalf("got %d buckets, want 1", len(model.Root.Children))
+	}
+	number, _ := model.GrandTotals[0].Value().Decimal()
+	if !number.Equal(dec("10.00")) {
+		t.Errorf("grand total = %s, want 10.00", number)
 	}
 }

--- a/api/internal/reporting/receiptsource/receiptsource_test.go
+++ b/api/internal/reporting/receiptsource/receiptsource_test.go
@@ -1,0 +1,563 @@
+package receiptsource
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/reporting"
+
+	"github.com/shopspring/decimal"
+)
+
+const (
+	hstFieldID      uint = 1
+	noteFieldID     uint = 2
+	childFieldID    uint = 3
+	dueDateFieldID  uint = 4
+	reimbursedField uint = 5
+)
+
+func dec(literal string) decimal.Decimal {
+	return decimal.RequireFromString(literal)
+}
+
+func testCustomFields() []models.CustomField {
+	return []models.CustomField{
+		{BaseModel: models.BaseModel{ID: hstFieldID}, Name: "HST", Type: models.CURRENCY},
+		{BaseModel: models.BaseModel{ID: noteFieldID}, Name: "Note", Type: models.TEXT},
+		{
+			BaseModel: models.BaseModel{ID: childFieldID},
+			Name:      "Child",
+			Type:      models.SELECT,
+			Options: []models.CustomFieldOption{
+				{BaseModel: models.BaseModel{ID: 10}, Value: "Alex", CustomFieldId: childFieldID},
+				{BaseModel: models.BaseModel{ID: 11}, Value: "Sam", CustomFieldId: childFieldID},
+			},
+		},
+		{BaseModel: models.BaseModel{ID: dueDateFieldID}, Name: "Due Date", Type: models.DATE},
+		{BaseModel: models.BaseModel{ID: reimbursedField}, Name: "Reimbursed", Type: models.BOOLEAN},
+	}
+}
+
+func mustNew(t *testing.T) Source {
+	t.Helper()
+
+	source, err := New(testCustomFields())
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	return source
+}
+
+func TestCustomFieldKey(t *testing.T) {
+	tests := []struct {
+		id   uint
+		want reporting.FieldKey
+	}{
+		{1, "custom_1"},
+		{0, "custom_0"},
+		{4294967295, "custom_4294967295"},
+	}
+
+	for _, test := range tests {
+		if got := CustomFieldKey(test.id); got != test.want {
+			t.Errorf("CustomFieldKey(%d) = %q, want %q", test.id, got, test.want)
+		}
+	}
+}
+
+// A currency custom field is a measure, so a tax field is summable without any
+// special case. Everything else cuts the data.
+func TestSource_CatalogTypesCustomFields(t *testing.T) {
+	catalog := mustNew(t).Catalog()
+
+	tests := []struct {
+		key      reporting.FieldKey
+		label    string
+		dataType reporting.DataType
+		role     reporting.Role
+	}{
+		{"custom_1", "HST", reporting.TypeCurrency, reporting.RoleMeasure},
+		{"custom_2", "Note", reporting.TypeString, reporting.RoleDimension},
+		{"custom_3", "Child", reporting.TypeString, reporting.RoleDimension},
+		{"custom_4", "Due Date", reporting.TypeDate, reporting.RoleDimension},
+		{"custom_5", "Reimbursed", reporting.TypeBool, reporting.RoleDimension},
+	}
+
+	for _, test := range tests {
+		t.Run(test.label, func(t *testing.T) {
+			field, exists := catalog.Get(test.key)
+			if !exists {
+				t.Fatalf("catalog is missing %s", test.key)
+			}
+			if field.Label != test.label {
+				t.Errorf("label = %q, want %q", field.Label, test.label)
+			}
+			if field.DataType != test.dataType {
+				t.Errorf("dataType = %v, want %v", field.DataType, test.dataType)
+			}
+			if field.Role() != test.role {
+				t.Errorf("role = %v, want %v", field.Role(), test.role)
+			}
+			if field.Multi {
+				t.Errorf("custom fields are single-valued")
+			}
+		})
+	}
+}
+
+func TestSource_CatalogBuiltins(t *testing.T) {
+	catalog := mustNew(t).Catalog()
+
+	tests := []struct {
+		key      reporting.FieldKey
+		dataType reporting.DataType
+		multi    bool
+	}{
+		{KeyReceiptID, reporting.TypeNumber, false},
+		{KeyName, reporting.TypeString, false},
+		{KeyAmount, reporting.TypeCurrency, false},
+		{KeyDate, reporting.TypeDate, false},
+		{KeyResolvedDate, reporting.TypeDate, false},
+		{KeyCreatedAt, reporting.TypeDate, false},
+		{KeyStatus, reporting.TypeString, false},
+		{KeyPaidBy, reporting.TypeString, false},
+		{KeyGroup, reporting.TypeString, false},
+		{KeyCategory, reporting.TypeString, true},
+		{KeyTag, reporting.TypeString, true},
+	}
+
+	for _, test := range tests {
+		t.Run(string(test.key), func(t *testing.T) {
+			field, exists := catalog.Get(test.key)
+			if !exists {
+				t.Fatalf("catalog is missing %s", test.key)
+			}
+			if field.DataType != test.dataType {
+				t.Errorf("dataType = %v, want %v", field.DataType, test.dataType)
+			}
+			if field.Multi != test.multi {
+				t.Errorf("multi = %v, want %v", field.Multi, test.multi)
+			}
+		})
+	}
+}
+
+func TestNew_RejectsDuplicateCustomFieldIds(t *testing.T) {
+	_, err := New([]models.CustomField{
+		{BaseModel: models.BaseModel{ID: 1}, Name: "HST", Type: models.CURRENCY},
+		{BaseModel: models.BaseModel{ID: 1}, Name: "GST", Type: models.CURRENCY},
+	})
+
+	if !errors.Is(err, reporting.ErrDuplicateField) {
+		t.Errorf("New() error = %v, want %v", err, reporting.ErrDuplicateField)
+	}
+}
+
+func TestNew_NoCustomFields(t *testing.T) {
+	source, err := New(nil)
+	if err != nil {
+		t.Fatalf("New(nil) error = %v", err)
+	}
+	if _, exists := source.Catalog().Get(KeyAmount); !exists {
+		t.Errorf("builtins are missing from a catalog with no custom fields")
+	}
+	if _, exists := source.Catalog().Get("custom_1"); exists {
+		t.Errorf("catalog invented a custom field")
+	}
+}
+
+// The catalog must not depend on the order the definitions arrived in.
+func TestNew_CatalogIsIndependentOfDefinitionOrder(t *testing.T) {
+	forward := testCustomFields()
+	reversed := testCustomFields()
+	for left, right := 0, len(reversed)-1; left < right; left, right = left+1, right-1 {
+		reversed[left], reversed[right] = reversed[right], reversed[left]
+	}
+
+	first, err := New(forward)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	second, err := New(reversed)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	for _, key := range []reporting.FieldKey{"custom_1", "custom_3", "custom_5"} {
+		one, _ := first.Catalog().Get(key)
+		two, _ := second.Catalog().Get(key)
+		if one != two {
+			t.Errorf("%s resolved differently: %+v vs %+v", key, one, two)
+		}
+	}
+}
+
+func fullReceipt() models.Receipt {
+	resolved := time.Date(2026, 5, 20, 0, 0, 0, 0, time.UTC)
+	hst := dec("15.60")
+	note := "office supplies"
+	option := uint(11)
+	due := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	reimbursed := true
+
+	return models.Receipt{
+		BaseModel:    models.BaseModel{ID: 7, CreatedAt: time.Date(2026, 5, 1, 8, 0, 0, 0, time.UTC)},
+		Name:         "Staples",
+		Amount:       dec("120.00"),
+		Date:         time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC),
+		ResolvedDate: &resolved,
+		Status:       models.RESOLVED,
+		PaidByUser:   models.User{DisplayName: "Dana"},
+		Group:        models.Group{Name: "Household"},
+		Categories:   []models.Category{{Name: "Clothing"}, {Name: "Medical"}},
+		Tags:         []models.Tag{{Name: "Alex"}},
+		CustomFields: []models.CustomFieldValue{
+			{CustomFieldId: hstFieldID, CurrencyValue: &hst},
+			{CustomFieldId: noteFieldID, StringValue: &note},
+			{CustomFieldId: childFieldID, SelectValue: &option},
+			{CustomFieldId: dueDateFieldID, DateValue: &due},
+			{CustomFieldId: reimbursedField, BooleanValue: &reimbursed},
+		},
+	}
+}
+
+func TestSource_RowsResolvesEveryField(t *testing.T) {
+	rows := mustNew(t).Rows([]models.Receipt{fullReceipt()})
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	row := rows[0]
+
+	t.Run("receipt id", func(t *testing.T) {
+		number, isNumber := row.Measure(KeyReceiptID).Decimal()
+		if !isNumber || !number.Equal(dec("7")) {
+			t.Errorf("receipt_id = %v", row.Measure(KeyReceiptID))
+		}
+	})
+
+	t.Run("amount", func(t *testing.T) {
+		number, isNumber := row.Measure(KeyAmount).Decimal()
+		if !isNumber || !number.Equal(dec("120.00")) {
+			t.Errorf("amount = %v", row.Measure(KeyAmount))
+		}
+	})
+
+	t.Run("currency custom field", func(t *testing.T) {
+		number, isNumber := row.Measure("custom_1").Decimal()
+		if !isNumber || !number.Equal(dec("15.60")) {
+			t.Errorf("custom_1 = %v", row.Measure("custom_1"))
+		}
+	})
+
+	strings := []struct {
+		key  reporting.FieldKey
+		want string
+	}{
+		{KeyName, "Staples"},
+		{KeyStatus, "RESOLVED"},
+		{KeyPaidBy, "Dana"},
+		{KeyGroup, "Household"},
+		{KeyTag, "Alex"},
+		{"custom_2", "office supplies"},
+		// A select stores an option id; the row carries the text.
+		{"custom_3", "Sam"},
+	}
+	for _, test := range strings {
+		t.Run(string(test.key), func(t *testing.T) {
+			text, isText := row.Measure(test.key).Text()
+			if !isText || text != test.want {
+				t.Errorf("%s = %v, want %q", test.key, row.Measure(test.key), test.want)
+			}
+		})
+	}
+
+	dates := []struct {
+		key  reporting.FieldKey
+		want time.Time
+	}{
+		{KeyDate, time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC)},
+		{KeyResolvedDate, time.Date(2026, 5, 20, 0, 0, 0, 0, time.UTC)},
+		{KeyCreatedAt, time.Date(2026, 5, 1, 8, 0, 0, 0, time.UTC)},
+		{"custom_4", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)},
+	}
+	for _, test := range dates {
+		t.Run(string(test.key), func(t *testing.T) {
+			instant, isDate := row.Measure(test.key).Time()
+			if !isDate || !instant.Equal(test.want) {
+				t.Errorf("%s = %v, want %v", test.key, row.Measure(test.key), test.want)
+			}
+		})
+	}
+
+	t.Run("boolean custom field", func(t *testing.T) {
+		value, isBool := row.Measure("custom_5").Boolean()
+		if !isBool || !value {
+			t.Errorf("custom_5 = %v, want true", row.Measure("custom_5"))
+		}
+	})
+
+	// Categories are multi-valued, and keep the order the receipt carried them.
+	t.Run("categories fan out", func(t *testing.T) {
+		values := row.Get(KeyCategory)
+		if len(values) != 2 {
+			t.Fatalf("got %d categories, want 2", len(values))
+		}
+		first, _ := values[0].Text()
+		second, _ := values[1].Text()
+		if first != "Clothing" || second != "Medical" {
+			t.Errorf("categories = %v, %v", first, second)
+		}
+	})
+}
+
+// A payer without a display name falls back to the name they log in with.
+func TestSource_PaidByFallsBackToUsername(t *testing.T) {
+	receipt := models.Receipt{PaidByUser: models.User{Username: "dana.smith"}}
+	row := mustNew(t).Rows([]models.Receipt{receipt})[0]
+
+	text, isText := row.Measure(KeyPaidBy).Text()
+	if !isText || text != "dana.smith" {
+		t.Errorf("paid_by = %v, want dana.smith", row.Measure(KeyPaidBy))
+	}
+}
+
+// An association the caller did not preload resolves to no value, which the
+// engine reports as (None) rather than as an error.
+func TestSource_UnloadedAssociationsBecomeNone(t *testing.T) {
+	row := mustNew(t).Rows([]models.Receipt{{Name: "Bare", Amount: dec("1.00")}})[0]
+
+	absent := []reporting.FieldKey{KeyPaidBy, KeyGroup, KeyResolvedDate, KeyCategory, KeyTag, "custom_1"}
+	for _, key := range absent {
+		t.Run(string(key), func(t *testing.T) {
+			if len(row.Get(key)) != 0 {
+				t.Errorf("%s resolved to %v, want no value", key, row.Get(key))
+			}
+			if !row.Measure(key).IsNull() {
+				t.Errorf("%s measures as %v, want null", key, row.Measure(key))
+			}
+		})
+	}
+}
+
+func TestSource_MissingCustomFieldValues(t *testing.T) {
+	receipt := models.Receipt{
+		CustomFields: []models.CustomFieldValue{
+			// The right field, but its column is empty.
+			{CustomFieldId: hstFieldID},
+			{CustomFieldId: noteFieldID},
+			{CustomFieldId: childFieldID},
+			{CustomFieldId: dueDateFieldID},
+			{CustomFieldId: reimbursedField},
+		},
+	}
+
+	row := mustNew(t).Rows([]models.Receipt{receipt})[0]
+
+	for _, key := range []reporting.FieldKey{"custom_1", "custom_2", "custom_3", "custom_4", "custom_5"} {
+		if len(row.Get(key)) != 0 {
+			t.Errorf("%s resolved to %v, want no value", key, row.Get(key))
+		}
+	}
+}
+
+// A select value pointing at an option that was not loaded, or that no longer
+// exists, resolves to nothing rather than to a bare id.
+func TestSource_SelectWithUnknownOption(t *testing.T) {
+	missing := uint(99)
+	receipt := models.Receipt{CustomFields: []models.CustomFieldValue{
+		{CustomFieldId: childFieldID, SelectValue: &missing},
+	}}
+
+	row := mustNew(t).Rows([]models.Receipt{receipt})[0]
+	if len(row.Get("custom_3")) != 0 {
+		t.Errorf("custom_3 = %v, want no value", row.Get("custom_3"))
+	}
+}
+
+func TestSource_SelectWithUnloadedOptions(t *testing.T) {
+	source, err := New([]models.CustomField{
+		{BaseModel: models.BaseModel{ID: childFieldID}, Name: "Child", Type: models.SELECT},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	option := uint(10)
+	receipt := models.Receipt{CustomFields: []models.CustomFieldValue{
+		{CustomFieldId: childFieldID, SelectValue: &option},
+	}}
+
+	row := source.Rows([]models.Receipt{receipt})[0]
+	if len(row.Get("custom_3")) != 0 {
+		t.Errorf("custom_3 = %v, want no value", row.Get("custom_3"))
+	}
+}
+
+// A value for a field the source does not know about is skipped: the engine
+// could not reference it anyway.
+func TestSource_UnknownCustomFieldValueIsSkipped(t *testing.T) {
+	amount := dec("5.00")
+	receipt := models.Receipt{CustomFields: []models.CustomFieldValue{
+		{CustomFieldId: 404, CurrencyValue: &amount},
+	}}
+
+	row := mustNew(t).Rows([]models.Receipt{receipt})[0]
+	if len(row.Get("custom_404")) != 0 {
+		t.Errorf("custom_404 = %v, want no value", row.Get("custom_404"))
+	}
+}
+
+// Where a receipt somehow carries two values for one field, the first that
+// resolves wins, so the row is deterministic.
+func TestSource_DuplicateCustomFieldValues(t *testing.T) {
+	first, second := dec("1.00"), dec("2.00")
+	receipt := models.Receipt{CustomFields: []models.CustomFieldValue{
+		{CustomFieldId: hstFieldID, CurrencyValue: &first},
+		{CustomFieldId: hstFieldID, CurrencyValue: &second},
+	}}
+
+	row := mustNew(t).Rows([]models.Receipt{receipt})[0]
+
+	values := row.Get("custom_1")
+	if len(values) != 1 {
+		t.Fatalf("got %d values, want 1", len(values))
+	}
+	number, _ := values[0].Decimal()
+	if !number.Equal(dec("1.00")) {
+		t.Errorf("custom_1 = %s, want 1.00", number)
+	}
+}
+
+// An empty first value must not hide a real second one.
+func TestSource_FirstResolvableCustomFieldValueWins(t *testing.T) {
+	amount := dec("2.00")
+	receipt := models.Receipt{CustomFields: []models.CustomFieldValue{
+		{CustomFieldId: hstFieldID},
+		{CustomFieldId: hstFieldID, CurrencyValue: &amount},
+	}}
+
+	row := mustNew(t).Rows([]models.Receipt{receipt})[0]
+
+	number, isNumber := row.Measure("custom_1").Decimal()
+	if !isNumber || !number.Equal(dec("2.00")) {
+		t.Errorf("custom_1 = %v, want 2.00", row.Measure("custom_1"))
+	}
+}
+
+func TestSource_RowsPreservesOrder(t *testing.T) {
+	receipts := []models.Receipt{
+		{BaseModel: models.BaseModel{ID: 3}},
+		{BaseModel: models.BaseModel{ID: 1}},
+		{BaseModel: models.BaseModel{ID: 2}},
+	}
+
+	rows := mustNew(t).Rows(receipts)
+
+	want := []string{"3", "1", "2"}
+	for index, expected := range want {
+		number, _ := rows[index].Measure(KeyReceiptID).Decimal()
+		if number.String() != expected {
+			t.Errorf("row %d receipt_id = %s, want %s", index, number, expected)
+		}
+	}
+}
+
+func TestSource_RowsOnNoReceipts(t *testing.T) {
+	if rows := mustNew(t).Rows(nil); len(rows) != 0 {
+		t.Errorf("Rows(nil) = %v, want empty", rows)
+	}
+}
+
+// The end-to-end shape: real receipts through the source into the engine,
+// reproducing the design document's worked example.
+func TestSource_FeedsTheEngine(t *testing.T) {
+	source := mustNew(t)
+
+	hst := func(literal string) *decimal.Decimal {
+		value := dec(literal)
+		return &value
+	}
+	receipt := func(payer, tag, category, amount string, tax *decimal.Decimal) models.Receipt {
+		built := models.Receipt{
+			Amount:     dec(amount),
+			PaidByUser: models.User{DisplayName: payer},
+			Tags:       []models.Tag{{Name: tag}},
+			Categories: []models.Category{{Name: category}},
+		}
+		if tax != nil {
+			built.CustomFields = []models.CustomFieldValue{{CustomFieldId: hstFieldID, CurrencyValue: tax}}
+		}
+		return built
+	}
+
+	receipts := []models.Receipt{
+		receipt("Dana", "Alex", "Clothing", "30.00", hst("3.90")),
+		receipt("Dana", "Alex", "Clothing", "30.00", hst("3.90")),
+		receipt("Dana", "Alex", "Clothing", "30.00", hst("3.90")),
+		receipt("Dana", "Alex", "Clothing", "30.00", hst("3.90")),
+		receipt("Dana", "Alex", "Medical", "50.00", nil),
+		receipt("Dana", "Alex", "Medical", "30.00", nil),
+		receipt("Dana", "Sam", "Clothing", "30.00", hst("3.90")),
+		receipt("Dana", "Sam", "Clothing", "30.00", hst("3.90")),
+		receipt("Dana", "Sam", "Clothing", "30.00", hst("3.90")),
+		receipt("Dana", "Sam", "Mileage", "30.00", nil),
+	}
+
+	spec := reporting.ReportSpec{
+		GroupBy: []reporting.FieldKey{KeyPaidBy, KeyTag},
+		Detail:  reporting.DetailSpec{Mode: reporting.DetailAggregate, By: KeyCategory},
+		Columns: []reporting.Column{
+			{Name: "Category", Kind: reporting.ColumnLabel, Field: KeyCategory},
+			{Name: "Count", Kind: reporting.ColumnAggregate, AggSrc: "COUNT()"},
+			{Name: "Subtotal", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+			{Name: "Hst", Kind: reporting.ColumnAggregate, AggSrc: "SUM(custom_1)"},
+			{Name: "Total", Kind: reporting.ColumnArithmetic, Expr: "Subtotal + Hst"},
+			{Name: "AvgPerReceipt", Label: "Avg/Receipt", Kind: reporting.ColumnArithmetic, Expr: "ROUND(Total / Count, 2)"},
+		},
+		Subtotals:   true,
+		GrandTotals: true,
+	}
+
+	model, err := reporting.Run(spec, source.Catalog(), source.Rows(receipts), reporting.MetaInput{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	find := func(cells []reporting.Cell, column string) string {
+		for _, candidate := range cells {
+			if candidate.Column == column {
+				return candidate.Value().String()
+			}
+		}
+		t.Fatalf("no cell for %s", column)
+		return ""
+	}
+
+	dana := model.Root.Children[0]
+	alex, sam := dana.Children[0], dana.Children[1]
+
+	if got := find(alex.Subtotals, "Subtotal"); got != "200" {
+		t.Errorf("Alex subtotal = %s, want 200", got)
+	}
+	if got := find(alex.Subtotals, "AvgPerReceipt"); got != "35.93" {
+		t.Errorf("Alex average = %s, want 35.93", got)
+	}
+	if got := find(sam.Subtotals, "AvgPerReceipt"); got != "32.93" {
+		t.Errorf("Sam average = %s, want 32.93", got)
+	}
+	if got := find(model.GrandTotals, "Total"); got != "347.3" {
+		t.Errorf("grand total = %s, want 347.3", got)
+	}
+	if got := find(model.GrandTotals, "AvgPerReceipt"); got != "34.73" {
+		t.Errorf("grand average = %s, want 34.73", got)
+	}
+
+	// Medical carried no tax at all, and sums to zero rather than to an empty
+	// cell.
+	if got := find(alex.DetailRows[1].Cells, "Hst"); got != "0" {
+		t.Errorf("Medical HST = %s, want 0", got)
+	}
+}

--- a/api/internal/reporting/receiptsource/receiptsource_test.go
+++ b/api/internal/reporting/receiptsource/receiptsource_test.go
@@ -411,40 +411,62 @@ func TestSource_UnknownCustomFieldValueIsSkipped(t *testing.T) {
 	}
 }
 
-// Where a receipt somehow carries two values for one field, the first that
-// resolves wins, so the row is deterministic.
-func TestSource_DuplicateCustomFieldValues(t *testing.T) {
-	first, second := dec("1.00"), dec("2.00")
-	receipt := models.Receipt{CustomFields: []models.CustomFieldValue{
-		{CustomFieldId: hstFieldID, CurrencyValue: &first},
-		{CustomFieldId: hstFieldID, CurrencyValue: &second},
+// Where a receipt carries two values for one field, the lowest id wins — and it
+// wins whichever order the association came back in.
+//
+// Position cannot decide this. The association is loaded without an ORDER BY, so
+// "the first one" is whatever the database felt like returning, and a report
+// whose numbers depend on that is not deterministic.
+func TestSource_DuplicateCustomFieldValuesResolveByLowestId(t *testing.T) {
+	lower, higher := dec("1.00"), dec("2.00")
+
+	ascending := models.Receipt{CustomFields: []models.CustomFieldValue{
+		{BaseModel: models.BaseModel{ID: 10}, CustomFieldId: hstFieldID, CurrencyValue: &lower},
+		{BaseModel: models.BaseModel{ID: 20}, CustomFieldId: hstFieldID, CurrencyValue: &higher},
+	}}
+	descending := models.Receipt{CustomFields: []models.CustomFieldValue{
+		{BaseModel: models.BaseModel{ID: 20}, CustomFieldId: hstFieldID, CurrencyValue: &higher},
+		{BaseModel: models.BaseModel{ID: 10}, CustomFieldId: hstFieldID, CurrencyValue: &lower},
 	}}
 
-	row := mustNew(t).Rows([]models.Receipt{receipt})[0]
+	source := mustNew(t)
+	for name, receipt := range map[string]models.Receipt{"ascending": ascending, "descending": descending} {
+		t.Run(name, func(t *testing.T) {
+			row := source.Rows([]models.Receipt{receipt})[0]
 
-	values := row.Get("custom_1")
-	if len(values) != 1 {
-		t.Fatalf("got %d values, want 1", len(values))
-	}
-	number, _ := values[0].Decimal()
-	if !number.Equal(dec("1.00")) {
-		t.Errorf("custom_1 = %s, want 1.00", number)
+			values := row.Get("custom_1")
+			if len(values) != 1 {
+				t.Fatalf("got %d values, want 1", len(values))
+			}
+			number, _ := values[0].Decimal()
+			if !number.Equal(dec("1.00")) {
+				t.Errorf("custom_1 = %s, want 1.00 (the value with the lowest id)", number)
+			}
+		})
 	}
 }
 
-// An empty first value must not hide a real second one.
-func TestSource_FirstResolvableCustomFieldValueWins(t *testing.T) {
+// A value that resolves to nothing never wins, so an empty low-id row cannot
+// hide a real one — in either order.
+func TestSource_UnresolvableCustomFieldValueNeverWins(t *testing.T) {
 	amount := dec("2.00")
-	receipt := models.Receipt{CustomFields: []models.CustomFieldValue{
-		{CustomFieldId: hstFieldID},
-		{CustomFieldId: hstFieldID, CurrencyValue: &amount},
-	}}
 
-	row := mustNew(t).Rows([]models.Receipt{receipt})[0]
+	empty := models.CustomFieldValue{BaseModel: models.BaseModel{ID: 10}, CustomFieldId: hstFieldID}
+	real := models.CustomFieldValue{BaseModel: models.BaseModel{ID: 20}, CustomFieldId: hstFieldID, CurrencyValue: &amount}
 
-	number, isNumber := row.Measure("custom_1").Decimal()
-	if !isNumber || !number.Equal(dec("2.00")) {
-		t.Errorf("custom_1 = %v, want 2.00", row.Measure("custom_1"))
+	source := mustNew(t)
+	for name, values := range map[string][]models.CustomFieldValue{
+		"empty first": {empty, real},
+		"empty last":  {real, empty},
+	} {
+		t.Run(name, func(t *testing.T) {
+			row := source.Rows([]models.Receipt{{CustomFields: values}})[0]
+
+			number, isNumber := row.Measure("custom_1").Decimal()
+			if !isNumber || !number.Equal(dec("2.00")) {
+				t.Errorf("custom_1 = %v, want 2.00", row.Measure("custom_1"))
+			}
+		})
 	}
 }
 

--- a/api/internal/reporting/row.go
+++ b/api/internal/reporting/row.go
@@ -19,10 +19,16 @@ func (r Row) Get(key FieldKey) []Value {
 // Measure returns the single value a measure field contributes, or null when
 // the field is absent or empty.
 //
-// Measures are single-valued: Validate refuses to aggregate a multi-valued
-// field, precisely so that no value is ever silently discarded here. The
-// first-value fallback below is therefore unreachable through Run, and exists
-// only so that a direct caller cannot make this panic.
+// Measures are single-valued, and Validate refuses to aggregate a field the
+// catalog marks Multi, so that no value is ever silently discarded here. That
+// rests on the catalog telling the truth: Multi is a producer's declaration
+// about its own rows, and the engine never checks a row against it. A producer
+// that declares a field scalar and then resolves it to two values still loses
+// the second, here, quietly.
+//
+// The first-value fallback is therefore unreachable through Run over an honest
+// catalog, and exists so that neither a direct caller nor a dishonest one can
+// make this panic.
 func (r Row) Measure(key FieldKey) Value {
 	values := r[key]
 	if len(values) == 0 {

--- a/api/internal/reporting/row.go
+++ b/api/internal/reporting/row.go
@@ -27,16 +27,39 @@ func (r Row) Measure(key FieldKey) Value {
 	return values[0]
 }
 
-// dimensionValues returns the buckets a row is attributed to for a dimension.
+// dimensionValues returns the distinct buckets a row is attributed to for a
+// dimension.
 //
 // A row with several values fans out into all of them, which double-counts it —
 // that is the pie chart's attribution and is deliberate. A row with no value
 // falls into the single (None) bucket, represented by a null Value, rather than
 // being dropped.
+//
+// Values are deduplicated, so a row is attributed once per distinct bucket.
+// A receipt tagged "Alex" twice belongs to the Alex bucket once; only distinct
+// values fan out. The database cannot express a duplicate — the join tables key
+// on the pair — but a producer over some other source could, and counting one
+// row's amount twice into one bucket is never what a report means.
 func (r Row) dimensionValues(key FieldKey) []Value {
 	values := r[key]
-	if len(values) == 0 {
+
+	switch len(values) {
+	case 0:
 		return []Value{Null()}
+	case 1:
+		return values
 	}
-	return values
+
+	distinct := make([]Value, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		bucket := bucketKey(value)
+		if _, exists := seen[bucket]; exists {
+			continue
+		}
+		seen[bucket] = struct{}{}
+		distinct = append(distinct, value)
+	}
+
+	return distinct
 }

--- a/api/internal/reporting/row.go
+++ b/api/internal/reporting/row.go
@@ -1,0 +1,42 @@
+package reporting
+
+// Row is one source record with its fields already resolved to typed values.
+//
+// Every field holds a slice so that scalar and multi-value fields share one
+// shape: a scalar field carries zero or one value, a multi-value field such as
+// categories or tags carries zero or more. Producers build Rows — see
+// internal/reporting/receiptsource — and the engine never resolves anything
+// itself.
+//
+// A Row may be nil or may omit a key entirely; both read as an absent value.
+type Row map[FieldKey][]Value
+
+// Get returns the values resolved for a field, or nil when the field is absent.
+func (r Row) Get(key FieldKey) []Value {
+	return r[key]
+}
+
+// Measure returns the single value a measure field contributes, or null when
+// the field is absent or empty. Measures are single-valued by definition, so a
+// field that somehow resolved to several values contributes only its first.
+func (r Row) Measure(key FieldKey) Value {
+	values := r[key]
+	if len(values) == 0 {
+		return Null()
+	}
+	return values[0]
+}
+
+// dimensionValues returns the buckets a row is attributed to for a dimension.
+//
+// A row with several values fans out into all of them, which double-counts it —
+// that is the pie chart's attribution and is deliberate. A row with no value
+// falls into the single (None) bucket, represented by a null Value, rather than
+// being dropped.
+func (r Row) dimensionValues(key FieldKey) []Value {
+	values := r[key]
+	if len(values) == 0 {
+		return []Value{Null()}
+	}
+	return values
+}

--- a/api/internal/reporting/row.go
+++ b/api/internal/reporting/row.go
@@ -17,8 +17,12 @@ func (r Row) Get(key FieldKey) []Value {
 }
 
 // Measure returns the single value a measure field contributes, or null when
-// the field is absent or empty. Measures are single-valued by definition, so a
-// field that somehow resolved to several values contributes only its first.
+// the field is absent or empty.
+//
+// Measures are single-valued: Validate refuses to aggregate a multi-valued
+// field, precisely so that no value is ever silently discarded here. The
+// first-value fallback below is therefore unreachable through Run, and exists
+// only so that a direct caller cannot make this panic.
 func (r Row) Measure(key FieldKey) Value {
 	values := r[key]
 	if len(values) == 0 {

--- a/api/internal/reporting/row_test.go
+++ b/api/internal/reporting/row_test.go
@@ -1,0 +1,106 @@
+package reporting
+
+import "testing"
+
+func TestRow_Get(t *testing.T) {
+	row := Row{
+		"amount": {Num(dec("120.00"))},
+		"tag":    {Str("Alex"), Str("Sam")},
+		"name":   {},
+	}
+
+	tests := []struct {
+		name  string
+		row   Row
+		key   FieldKey
+		want  int
+		first Value
+	}{
+		{"present scalar", row, "amount", 1, Num(dec("120.00"))},
+		{"present multi value", row, "tag", 2, Str("Alex")},
+		{"present but empty", row, "name", 0, Null()},
+		{"absent key", row, "status", 0, Null()},
+		{"nil row", nil, "amount", 0, Null()},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.row.Get(test.key)
+			if len(got) != test.want {
+				t.Fatalf("Get(%q) returned %d values, want %d", test.key, len(got), test.want)
+			}
+			if test.want > 0 && !got[0].Equal(test.first) {
+				t.Errorf("Get(%q)[0] = %v, want %v", test.key, got[0], test.first)
+			}
+		})
+	}
+}
+
+// A measure with no value is null, never a zero amount — the two mean different
+// things once they reach an aggregate.
+func TestRow_Measure(t *testing.T) {
+	row := Row{
+		"amount":   {Num(dec("120.00"))},
+		"hst":      {},
+		"multi":    {Num(dec("1")), Num(dec("2"))},
+		"nullable": {Null()},
+	}
+
+	tests := []struct {
+		name string
+		row  Row
+		key  FieldKey
+		want Value
+	}{
+		{"present", row, "amount", Num(dec("120.00"))},
+		{"empty slice is null", row, "hst", Null()},
+		{"absent key is null", row, "missing", Null()},
+		{"nil row is null", nil, "amount", Null()},
+		{"explicit null stays null", row, "nullable", Null()},
+		{"multi valued measure takes the first", row, "multi", Num(dec("1"))},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.row.Measure(test.key); !got.Equal(test.want) {
+				t.Errorf("Measure(%q) = %v, want %v", test.key, got, test.want)
+			}
+		})
+	}
+}
+
+// An absent dimension is never dropped: it becomes exactly one (None) bucket.
+func TestRow_DimensionValues(t *testing.T) {
+	row := Row{
+		"category": {Str("Clothing"), Str("Medical")},
+		"tag":      {Str("Alex")},
+		"empty":    {},
+	}
+
+	tests := []struct {
+		name string
+		row  Row
+		key  FieldKey
+		want []Value
+	}{
+		{"multi value fans out", row, "category", []Value{Str("Clothing"), Str("Medical")}},
+		{"single value", row, "tag", []Value{Str("Alex")}},
+		{"empty slice is one none bucket", row, "empty", []Value{Null()}},
+		{"absent key is one none bucket", row, "missing", []Value{Null()}},
+		{"nil row is one none bucket", nil, "category", []Value{Null()}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.row.dimensionValues(test.key)
+			if len(got) != len(test.want) {
+				t.Fatalf("dimensionValues(%q) returned %d values, want %d", test.key, len(got), len(test.want))
+			}
+			for i := range got {
+				if !got[i].Equal(test.want[i]) {
+					t.Errorf("dimensionValues(%q)[%d] = %v, want %v", test.key, i, got[i], test.want[i])
+				}
+			}
+		})
+	}
+}

--- a/api/internal/reporting/row_test.go
+++ b/api/internal/reporting/row_test.go
@@ -70,11 +70,17 @@ func TestRow_Measure(t *testing.T) {
 }
 
 // An absent dimension is never dropped: it becomes exactly one (None) bucket.
+// A repeated one is not counted twice: only distinct values fan out.
 func TestRow_DimensionValues(t *testing.T) {
 	row := Row{
-		"category": {Str("Clothing"), Str("Medical")},
-		"tag":      {Str("Alex")},
-		"empty":    {},
+		"category":  {Str("Clothing"), Str("Medical")},
+		"tag":       {Str("Alex")},
+		"empty":     {},
+		"repeated":  {Str("Alex"), Str("Alex")},
+		"mixed":     {Str("Alex"), Str("Sam"), Str("Alex")},
+		"rescaled":  {Num(dec("200")), Num(dec("200.00"))},
+		"allNull":   {Null(), Null()},
+		"nullFirst": {Null(), Str("Alex")},
 	}
 
 	tests := []struct {
@@ -88,6 +94,13 @@ func TestRow_DimensionValues(t *testing.T) {
 		{"empty slice is one none bucket", row, "empty", []Value{Null()}},
 		{"absent key is one none bucket", row, "missing", []Value{Null()}},
 		{"nil row is one none bucket", nil, "category", []Value{Null()}},
+		{"a repeated value is one bucket", row, "repeated", []Value{Str("Alex")}},
+		{"deduplication keeps first-seen order", row, "mixed", []Value{Str("Alex"), Str("Sam")}},
+		// Deduplication is by bucket, so it agrees with grouping: 200 and 200.00
+		// are the same number and therefore the same bucket.
+		{"values differing only in scale are one bucket", row, "rescaled", []Value{Num(dec("200"))}},
+		{"repeated nulls are one none bucket", row, "allNull", []Value{Null()}},
+		{"an explicit null is its own bucket", row, "nullFirst", []Value{Null(), Str("Alex")}},
 	}
 
 	for _, test := range tests {

--- a/api/internal/reporting/spec.go
+++ b/api/internal/reporting/spec.go
@@ -32,6 +32,15 @@ func (m DetailMode) String() string {
 	return "unknown"
 }
 
+// valid reports whether the mode is one the engine implements.
+func (m DetailMode) valid() bool {
+	switch m {
+	case DetailRecords, DetailAggregate:
+		return true
+	}
+	return false
+}
+
 // DetailSpec chooses what the bottom rows of the report are.
 type DetailSpec struct {
 	Mode DetailMode
@@ -40,6 +49,17 @@ type DetailSpec struct {
 	// for DetailRecords.
 	By FieldKey
 }
+
+// isAggregate reports whether the bottom rows are summed buckets rather than
+// source records.
+//
+// It exists to be the single spelling of that question. Asking it as "the mode
+// is not DetailRecords" in one place and "the mode is exactly DetailAggregate"
+// in another agreed on every valid spec and disagreed on every invalid one, so
+// an unknown mode took the aggregate path everywhere but the label-column check,
+// which it skipped. Validate now rejects an unknown mode outright, and this
+// predicate keeps the two readings from drifting apart again.
+func (d DetailSpec) isAggregate() bool { return d.Mode == DetailAggregate }
 
 // EngineConfig tunes numeric behavior.
 type EngineConfig struct {

--- a/api/internal/reporting/spec.go
+++ b/api/internal/reporting/spec.go
@@ -1,0 +1,117 @@
+package reporting
+
+import "time"
+
+// defaultNoneLabel is what a renderer draws for the bucket holding rows with no
+// value for a dimension.
+const defaultNoneLabel = "(None)"
+
+// defaultDivisionScale bounds division to a scale far finer than any currency
+// needs, so a quotient carries enough precision for a renderer to round it for
+// display.
+const defaultDivisionScale = 6
+
+// DetailMode is the shape of the innermost rows of the report.
+type DetailMode uint8
+
+const (
+	// DetailRecords emits one row per source record.
+	DetailRecords DetailMode = iota
+
+	// DetailAggregate emits one summed row per distinct value of a dimension.
+	DetailAggregate
+)
+
+func (m DetailMode) String() string {
+	switch m {
+	case DetailRecords:
+		return "records"
+	case DetailAggregate:
+		return "aggregate"
+	}
+	return "unknown"
+}
+
+// DetailSpec chooses what the bottom rows of the report are.
+type DetailSpec struct {
+	Mode DetailMode
+
+	// By is the dimension a DetailAggregate keys its rows on. It must be empty
+	// for DetailRecords.
+	By FieldKey
+}
+
+// EngineConfig tunes numeric behavior.
+type EngineConfig struct {
+	// DivisionScale is the number of decimal places division and AVG round to.
+	//
+	// It exists because shopspring's Div consults decimal.DivisionPrecision, a
+	// mutable process-wide global. Reading it would make a report's output
+	// depend on whatever else the process had done, so the engine never touches
+	// it and rounds explicitly instead.
+	//
+	// Zero means unset, and becomes the default. A column that should show whole
+	// numbers asks for them with ROUND(x, 0) rather than by dividing coarsely.
+	DivisionScale int32
+}
+
+// DefaultConfig returns the configuration a caller gets when it leaves
+// EngineConfig zero.
+func DefaultConfig() EngineConfig {
+	return EngineConfig{DivisionScale: defaultDivisionScale}
+}
+
+// ReportSpec is a runnable report definition: what to group by, what the bottom
+// rows are, and what the columns compute.
+//
+// It says nothing about how the result looks. Slots, branding, page size and
+// currency symbols belong to whatever renders the ReportModel.
+type ReportSpec struct {
+	Title string
+
+	// GroupBy is the ordered list of dimensions to nest the report by. It may
+	// be empty, in which case the detail rows hang directly off the root.
+	GroupBy []FieldKey
+
+	Detail  DetailSpec
+	Columns []Column
+
+	Subtotals   bool
+	GrandTotals bool
+
+	// NoneLabel names the bucket holding rows with no value for a dimension. It
+	// defaults to "(None)" and is carried to the model for renderers; the data
+	// itself marks those buckets with IsNone.
+	NoneLabel string
+
+	Config EngineConfig
+}
+
+// withDefaults fills in the values a caller may leave zero. It does not
+// validate; Validate does that.
+func (s ReportSpec) withDefaults() ReportSpec {
+	if len(s.NoneLabel) == 0 {
+		s.NoneLabel = defaultNoneLabel
+	}
+	if s.Config.DivisionScale == 0 {
+		s.Config.DivisionScale = defaultDivisionScale
+	}
+	return s
+}
+
+// MetaInput is the report-scope context a caller supplies at run time.
+type MetaInput struct {
+	// GeneratedAt is an input rather than something the engine reads from the
+	// clock, so that the same inputs always produce the same output. A golden
+	// test could not exist otherwise.
+	GeneratedAt time.Time
+
+	// Params are the resolved run-time parameter values, such as the period a
+	// report covers. The engine carries them through to the model for a
+	// renderer to substitute into its copy.
+	Params map[string]string
+
+	// CurrencyFormat is an opaque default presentation hint, overridable per
+	// column. The engine does not interpret it.
+	CurrencyFormat string
+}

--- a/api/internal/reporting/validate.go
+++ b/api/internal/reporting/validate.go
@@ -1,0 +1,493 @@
+package reporting
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/expr-lang/expr/ast"
+)
+
+var (
+	ErrNoColumns          = errors.New("report spec has no columns")
+	ErrEmptyColumnName    = errors.New("column name must not be empty")
+	ErrInvalidColumnName  = errors.New("column name must be a plain identifier")
+	ErrReservedColumnName = errors.New("column name is a reserved word")
+	ErrDuplicateColumn    = errors.New("duplicate column name")
+	ErrUnknownColumnKind  = errors.New("unknown column kind")
+
+	ErrUnknownField        = errors.New("field not found in catalog")
+	ErrGroupByNotDimension = errors.New("groupBy field is not a dimension")
+	ErrDuplicateGroupBy    = errors.New("duplicate groupBy field")
+
+	ErrDetailByRequired     = errors.New("aggregate detail mode requires a dimension")
+	ErrDetailByOnRecords    = errors.New("records detail mode must not set a dimension")
+	ErrDetailByNotDimension = errors.New("detail field is not a dimension")
+
+	ErrLabelFieldRequired      = errors.New("label column requires a field")
+	ErrLabelColumnUnresolvable = errors.New("label column has no value on an aggregated detail row")
+
+	ErrAggregateFieldRequired = errors.New("aggregate requires a field")
+	ErrAggregateNotMeasure    = errors.New("aggregate field is not a measure")
+	ErrCountTakesNoField      = errors.New("COUNT counts records and takes no field")
+
+	ErrUnknownColumnRef        = errors.New("formula references an unknown column")
+	ErrArithmeticNonNumericRef = errors.New("formula references a non-numeric column")
+	ErrFormulaCycle            = errors.New("arithmetic columns form a cycle")
+
+	ErrInvalidConfig = errors.New("invalid engine config")
+)
+
+// maxDivisionScale bounds the precision division may be carried to, for the same
+// reason ROUND's places are bounded: rescaling a decimal without limit lets a
+// saved template allocate without limit.
+const maxDivisionScale = 30
+
+// labelFromDetailBucket marks a label column that reads the aggregated detail
+// row's own bucket value rather than an ancestor group's.
+const labelFromDetailBucket = -1
+
+// compiledColumn is a validated column with everything the engine needs already
+// resolved: its data type, its parsed expression, and where a label reads from.
+type compiledColumn struct {
+	name     string
+	label    string
+	kind     ColumnKind
+	dataType DataType
+	format   string
+
+	// field and fieldRef describe a label column's source.
+	field    FieldKey
+	fieldRef FieldRef
+
+	// labelLevel says where a label column reads from when detail rows are
+	// aggregated: labelFromDetailBucket for the row's own bucket, otherwise the
+	// index of the groupBy level whose bucket value it shows. It is unused in
+	// records mode, where a label reads straight off the record.
+	labelLevel int
+
+	// agg is an aggregate column's reduction.
+	agg Aggregate
+
+	// expr is an arithmetic column's parsed expression, and refs the column
+	// names it reads.
+	expr    ast.Node
+	exprSrc string
+	refs    []string
+}
+
+// compiledSpec is a ReportSpec that has been validated against a catalog.
+type compiledSpec struct {
+	spec    ReportSpec
+	catalog FieldCatalog
+
+	columns []compiledColumn
+
+	// groupBy is the resolved dimension of each nesting level.
+	groupBy []FieldRef
+
+	// detailBy is the dimension aggregated detail rows are keyed on.
+	detailBy FieldRef
+
+	// aggregateIndexes lists the aggregate columns, and arithmeticOrder lists
+	// the arithmetic columns in an order where a column's dependencies always
+	// come first.
+	aggregateIndexes []int
+	arithmeticOrder  []int
+}
+
+// Validate reports whether a spec can run against a catalog. Run calls it, so
+// callers only need it to check a template as it is being authored.
+func Validate(spec ReportSpec, catalog FieldCatalog) error {
+	_, err := compileSpec(spec, catalog)
+	return err
+}
+
+// compileSpec validates a spec and resolves everything the engine would
+// otherwise have to work out per row: field references, parsed expressions,
+// column data types, and the order arithmetic columns must be evaluated in.
+func compileSpec(spec ReportSpec, catalog FieldCatalog) (compiledSpec, error) {
+	if err := validateConfig(spec.Config); err != nil {
+		return compiledSpec{}, err
+	}
+	if len(spec.Columns) == 0 {
+		return compiledSpec{}, ErrNoColumns
+	}
+
+	compiled := compiledSpec{spec: spec.withDefaults(), catalog: catalog}
+
+	groupBy, err := compileGroupBy(spec.GroupBy, catalog)
+	if err != nil {
+		return compiledSpec{}, err
+	}
+	compiled.groupBy = groupBy
+
+	detailBy, err := compileDetail(spec.Detail, catalog)
+	if err != nil {
+		return compiledSpec{}, err
+	}
+	compiled.detailBy = detailBy
+
+	columns, byName, err := compileColumns(spec, catalog)
+	if err != nil {
+		return compiledSpec{}, err
+	}
+	compiled.columns = columns
+
+	for index, column := range compiled.columns {
+		if column.kind == ColumnAggregate {
+			compiled.aggregateIndexes = append(compiled.aggregateIndexes, index)
+		}
+	}
+
+	// Arithmetic columns may read each other, so they are checked and ordered
+	// as a graph rather than in the order they were declared.
+	order, err := orderArithmetic(compiled.columns, byName)
+	if err != nil {
+		return compiledSpec{}, err
+	}
+	compiled.arithmeticOrder = order
+
+	// A column's type can depend on the columns it reads, so arithmetic types
+	// are inferred in dependency order.
+	for _, index := range order {
+		compiled.columns[index].dataType = arithmeticDataType(compiled.columns[index], compiled.columns, byName)
+	}
+
+	return compiled, nil
+}
+
+func validateConfig(config EngineConfig) error {
+	if config.DivisionScale < 0 || config.DivisionScale > maxDivisionScale {
+		return fmt.Errorf("%w: division scale %d is outside [0, %d]",
+			ErrInvalidConfig, config.DivisionScale, maxDivisionScale)
+	}
+	return nil
+}
+
+func compileGroupBy(keys []FieldKey, catalog FieldCatalog) ([]FieldRef, error) {
+	seen := make(map[FieldKey]struct{}, len(keys))
+	refs := make([]FieldRef, 0, len(keys))
+
+	for _, key := range keys {
+		field, exists := catalog.Get(key)
+		if !exists {
+			return nil, fmt.Errorf("%w: groupBy %s", ErrUnknownField, key)
+		}
+		if field.Role() != RoleDimension {
+			return nil, fmt.Errorf("%w: %s is a %s", ErrGroupByNotDimension, key, field.DataType)
+		}
+		if _, duplicate := seen[key]; duplicate {
+			return nil, fmt.Errorf("%w: %s", ErrDuplicateGroupBy, key)
+		}
+		seen[key] = struct{}{}
+		refs = append(refs, field)
+	}
+
+	return refs, nil
+}
+
+func compileDetail(detail DetailSpec, catalog FieldCatalog) (FieldRef, error) {
+	if detail.Mode == DetailRecords {
+		if len(detail.By) > 0 {
+			return FieldRef{}, fmt.Errorf("%w: %s", ErrDetailByOnRecords, detail.By)
+		}
+		return FieldRef{}, nil
+	}
+
+	if len(detail.By) == 0 {
+		return FieldRef{}, ErrDetailByRequired
+	}
+
+	field, exists := catalog.Get(detail.By)
+	if !exists {
+		return FieldRef{}, fmt.Errorf("%w: detail %s", ErrUnknownField, detail.By)
+	}
+	if field.Role() != RoleDimension {
+		return FieldRef{}, fmt.Errorf("%w: %s is a %s", ErrDetailByNotDimension, detail.By, field.DataType)
+	}
+
+	return field, nil
+}
+
+func compileColumns(spec ReportSpec, catalog FieldCatalog) ([]compiledColumn, map[string]int, error) {
+	columns := make([]compiledColumn, 0, len(spec.Columns))
+	byName := make(map[string]int, len(spec.Columns))
+
+	for _, column := range spec.Columns {
+		if err := validateColumnName(column.Name); err != nil {
+			return nil, nil, err
+		}
+		if _, duplicate := byName[column.Name]; duplicate {
+			return nil, nil, fmt.Errorf("%w: %s", ErrDuplicateColumn, column.Name)
+		}
+
+		compiled, err := compileColumn(column, spec, catalog)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		byName[column.Name] = len(columns)
+		columns = append(columns, compiled)
+	}
+
+	// Resolving arithmetic references needs every column to be known, so it
+	// happens once the whole set is compiled.
+	for _, column := range columns {
+		if column.kind != ColumnArithmetic {
+			continue
+		}
+		if err := validateArithmeticRefs(column, columns, byName); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return columns, byName, nil
+}
+
+func compileColumn(column Column, spec ReportSpec, catalog FieldCatalog) (compiledColumn, error) {
+	compiled := compiledColumn{
+		name:   column.Name,
+		label:  column.heading(),
+		kind:   column.Kind,
+		format: column.Format,
+	}
+
+	switch column.Kind {
+	case ColumnLabel:
+		return compileLabelColumn(compiled, column, spec, catalog)
+	case ColumnAggregate:
+		return compileAggregateColumn(compiled, column, catalog)
+	case ColumnArithmetic:
+		return compileArithmeticColumn(compiled, column)
+	}
+
+	return compiledColumn{}, fmt.Errorf("%w: column %s has kind %d", ErrUnknownColumnKind, column.Name, column.Kind)
+}
+
+func compileLabelColumn(compiled compiledColumn, column Column, spec ReportSpec, catalog FieldCatalog) (compiledColumn, error) {
+	if len(column.Field) == 0 {
+		return compiledColumn{}, fmt.Errorf("%w: column %s", ErrLabelFieldRequired, column.Name)
+	}
+
+	field, exists := catalog.Get(column.Field)
+	if !exists {
+		return compiledColumn{}, fmt.Errorf("%w: column %s reads %s", ErrUnknownField, column.Name, column.Field)
+	}
+
+	compiled.field = column.Field
+	compiled.fieldRef = field
+	compiled.dataType = field.DataType
+	compiled.labelLevel = labelFromDetailBucket
+
+	// In records mode a label reads straight off the record, so any field will
+	// do. Aggregated detail rows have no single record to read from: the only
+	// values that exist are the row's own bucket and the buckets of the groups
+	// above it.
+	if spec.Detail.Mode == DetailAggregate && column.Field != spec.Detail.By {
+		level := groupByLevel(spec.GroupBy, column.Field)
+		if level < 0 {
+			return compiledColumn{}, fmt.Errorf(
+				"%w: column %s reads %s, which is neither the detail dimension nor a groupBy level",
+				ErrLabelColumnUnresolvable, column.Name, column.Field)
+		}
+		compiled.labelLevel = level
+	}
+
+	return compiled, nil
+}
+
+func compileAggregateColumn(compiled compiledColumn, column Column, catalog FieldCatalog) (compiledColumn, error) {
+	aggregate := column.Agg
+	if len(column.AggSrc) > 0 {
+		parsed, err := ParseAggregate(column.AggSrc)
+		if err != nil {
+			return compiledColumn{}, fmt.Errorf("column %s: %w", column.Name, err)
+		}
+		aggregate = parsed
+	}
+
+	if aggregate.Func == AggCount {
+		if len(aggregate.Field) > 0 {
+			return compiledColumn{}, fmt.Errorf("%w: column %s counts %s",
+				ErrCountTakesNoField, column.Name, aggregate.Field)
+		}
+		compiled.agg = aggregate
+		compiled.dataType = TypeNumber
+		return compiled, nil
+	}
+
+	if len(aggregate.Field) == 0 {
+		return compiledColumn{}, fmt.Errorf("%w: column %s applies %s",
+			ErrAggregateFieldRequired, column.Name, aggregate.Func)
+	}
+
+	field, exists := catalog.Get(aggregate.Field)
+	if !exists {
+		return compiledColumn{}, fmt.Errorf("%w: column %s reduces %s",
+			ErrUnknownField, column.Name, aggregate.Field)
+	}
+	if field.Role() != RoleMeasure {
+		return compiledColumn{}, fmt.Errorf("%w: column %s applies %s to %s, which is a %s",
+			ErrAggregateNotMeasure, column.Name, aggregate.Func, aggregate.Field, field.DataType)
+	}
+
+	compiled.agg = aggregate
+	compiled.dataType = field.DataType
+
+	return compiled, nil
+}
+
+func compileArithmeticColumn(compiled compiledColumn, column Column) (compiledColumn, error) {
+	expr, err := ParseArithmetic(column.Expr)
+	if err != nil {
+		return compiledColumn{}, fmt.Errorf("column %s: %w", column.Name, err)
+	}
+
+	compiled.expr = expr
+	compiled.exprSrc = column.Expr
+	compiled.refs = columnRefs(expr)
+	// A placeholder until the dependency order is known; see compileSpec.
+	compiled.dataType = TypeNumber
+
+	return compiled, nil
+}
+
+// validateArithmeticRefs checks that a formula reads only declared columns that
+// actually produce numbers.
+func validateArithmeticRefs(column compiledColumn, columns []compiledColumn, byName map[string]int) error {
+	for _, ref := range column.refs {
+		index, declared := byName[ref]
+		if !declared {
+			return fmt.Errorf("%w: column %s reads %s", ErrUnknownColumnRef, column.name, ref)
+		}
+
+		referenced := columns[index]
+		if referenced.kind == ColumnLabel && !referenced.fieldRef.DataType.IsNumeric() {
+			return fmt.Errorf("%w: column %s reads %s, which shows a %s",
+				ErrArithmeticNonNumericRef, column.name, ref, referenced.fieldRef.DataType)
+		}
+	}
+	return nil
+}
+
+// orderArithmetic topologically sorts the arithmetic columns so that a column's
+// dependencies are always evaluated before it, and rejects cycles.
+//
+// Columns are visited in declaration order and dependencies depth-first, which
+// makes the resulting order deterministic. A column may therefore be declared
+// before the aggregate it reads.
+func orderArithmetic(columns []compiledColumn, byName map[string]int) ([]int, error) {
+	const (
+		unvisited = iota
+		visiting
+		visited
+	)
+
+	state := make([]int, len(columns))
+	order := make([]int, 0, len(columns))
+
+	// path tracks the columns currently being visited, so a cycle can name its
+	// members rather than merely announcing that one exists.
+	var path []string
+
+	var visit func(index int) error
+	visit = func(index int) error {
+		switch state[index] {
+		case visited:
+			return nil
+		case visiting:
+			return fmt.Errorf("%w: %s", ErrFormulaCycle, strings.Join(append(path, columns[index].name), " -> "))
+		}
+
+		state[index] = visiting
+		path = append(path, columns[index].name)
+
+		for _, ref := range columns[index].refs {
+			dependency, declared := byName[ref]
+			if !declared {
+				// validateArithmeticRefs already rejected this.
+				continue
+			}
+			if columns[dependency].kind != ColumnArithmetic {
+				continue
+			}
+			if err := visit(dependency); err != nil {
+				return err
+			}
+		}
+
+		path = path[:len(path)-1]
+		state[index] = visited
+		order = append(order, index)
+
+		return nil
+	}
+
+	for index, column := range columns {
+		if column.kind != ColumnArithmetic {
+			continue
+		}
+		if err := visit(index); err != nil {
+			return nil, err
+		}
+	}
+
+	return order, nil
+}
+
+// arithmeticDataType infers what an arithmetic column holds. Money combined
+// with anything is still money, so the column is currency when any column it
+// reads is. Dependencies are already typed, because this runs in dependency
+// order.
+func arithmeticDataType(column compiledColumn, columns []compiledColumn, byName map[string]int) DataType {
+	for _, ref := range column.refs {
+		index, declared := byName[ref]
+		if !declared {
+			continue
+		}
+		if columns[index].dataType == TypeCurrency {
+			return TypeCurrency
+		}
+	}
+	return TypeNumber
+}
+
+func validateColumnName(name string) error {
+	if len(name) == 0 {
+		return ErrEmptyColumnName
+	}
+	if !isIdentifier(name) {
+		return fmt.Errorf("%w: %q", ErrInvalidColumnName, name)
+	}
+	if isReservedWord(name) {
+		return fmt.Errorf("%w: %q", ErrReservedColumnName, name)
+	}
+	return nil
+}
+
+// isIdentifier reports whether a name matches [A-Za-z_][A-Za-z0-9_]*, which is
+// what a formula can reference without quoting.
+func isIdentifier(name string) bool {
+	for index, symbol := range name {
+		switch {
+		case symbol == '_':
+		case symbol >= 'a' && symbol <= 'z':
+		case symbol >= 'A' && symbol <= 'Z':
+		case symbol >= '0' && symbol <= '9' && index > 0:
+		default:
+			return false
+		}
+	}
+	return len(name) > 0
+}
+
+// groupByLevel returns the nesting level a dimension is grouped at, or -1.
+func groupByLevel(groupBy []FieldKey, key FieldKey) int {
+	for level, candidate := range groupBy {
+		if candidate == key {
+			return level
+		}
+	}
+	return -1
+}

--- a/api/internal/reporting/validate.go
+++ b/api/internal/reporting/validate.go
@@ -20,6 +20,7 @@ var (
 	ErrGroupByNotDimension = errors.New("groupBy field is not a dimension")
 	ErrDuplicateGroupBy    = errors.New("duplicate groupBy field")
 
+	ErrUnknownDetailMode    = errors.New("unknown detail mode")
 	ErrDetailByRequired     = errors.New("aggregate detail mode requires a dimension")
 	ErrDetailByOnRecords    = errors.New("records detail mode must not set a dimension")
 	ErrDetailByNotDimension = errors.New("detail field is not a dimension")
@@ -27,6 +28,7 @@ var (
 	ErrLabelFieldRequired      = errors.New("label column requires a field")
 	ErrLabelColumnUnresolvable = errors.New("label column has no value on an aggregated detail row")
 
+	ErrUnknownAggFunc         = errors.New("unknown aggregate function")
 	ErrAggregateFieldRequired = errors.New("aggregate requires a field")
 	ErrAggregateNotMeasure    = errors.New("aggregate field is not a measure")
 	ErrCountTakesNoField      = errors.New("COUNT counts records and takes no field")
@@ -189,7 +191,11 @@ func compileGroupBy(keys []FieldKey, catalog FieldCatalog) ([]FieldRef, error) {
 }
 
 func compileDetail(detail DetailSpec, catalog FieldCatalog) (FieldRef, error) {
-	if detail.Mode == DetailRecords {
+	if !detail.Mode.valid() {
+		return FieldRef{}, fmt.Errorf("%w: %d", ErrUnknownDetailMode, detail.Mode)
+	}
+
+	if !detail.isAggregate() {
 		if len(detail.By) > 0 {
 			return FieldRef{}, fmt.Errorf("%w: %s", ErrDetailByOnRecords, detail.By)
 		}
@@ -285,7 +291,7 @@ func compileLabelColumn(compiled compiledColumn, column Column, spec ReportSpec,
 	// do. Aggregated detail rows have no single record to read from: the only
 	// values that exist are the row's own bucket and the buckets of the groups
 	// above it.
-	if spec.Detail.Mode == DetailAggregate && column.Field != spec.Detail.By {
+	if spec.Detail.isAggregate() && column.Field != spec.Detail.By {
 		level := groupByLevel(spec.GroupBy, column.Field)
 		if level < 0 {
 			return compiledColumn{}, fmt.Errorf(
@@ -306,6 +312,11 @@ func compileAggregateColumn(compiled compiledColumn, column Column, catalog Fiel
 			return compiledColumn{}, fmt.Errorf("column %s: %w", column.Name, err)
 		}
 		aggregate = parsed
+	}
+
+	if !aggregate.Func.valid() {
+		return compiledColumn{}, fmt.Errorf("%w: column %s applies reduction %d",
+			ErrUnknownAggFunc, column.Name, aggregate.Func)
 	}
 
 	if aggregate.Func == AggCount {

--- a/api/internal/reporting/validate.go
+++ b/api/internal/reporting/validate.go
@@ -30,6 +30,7 @@ var (
 	ErrAggregateFieldRequired = errors.New("aggregate requires a field")
 	ErrAggregateNotMeasure    = errors.New("aggregate field is not a measure")
 	ErrCountTakesNoField      = errors.New("COUNT counts records and takes no field")
+	ErrMeasureIsMultiValued   = errors.New("a multi-valued field cannot be measured")
 
 	ErrUnknownColumnRef        = errors.New("formula references an unknown column")
 	ErrArithmeticNonNumericRef = errors.New("formula references a non-numeric column")
@@ -332,6 +333,15 @@ func compileAggregateColumn(compiled compiledColumn, column Column, catalog Fiel
 			ErrAggregateNotMeasure, column.Name, aggregate.Func, aggregate.Field, field.DataType)
 	}
 
+	// A row resolves a multi-valued field to several values, and a measure reads
+	// one. Rather than silently reading the first and discarding the rest, refuse
+	// the column: whichever answer the author wanted, this is not how to ask for
+	// it. Grouping on such a field, or displaying it, remains fine.
+	if field.Multi {
+		return compiledColumn{}, fmt.Errorf("%w: column %s applies %s to %s",
+			ErrMeasureIsMultiValued, column.Name, aggregate.Func, aggregate.Field)
+	}
+
 	compiled.agg = aggregate
 	compiled.dataType = field.DataType
 
@@ -354,7 +364,7 @@ func compileArithmeticColumn(compiled compiledColumn, column Column) (compiledCo
 }
 
 // validateArithmeticRefs checks that a formula reads only declared columns that
-// actually produce numbers.
+// produce exactly one number.
 func validateArithmeticRefs(column compiledColumn, columns []compiledColumn, byName map[string]int) error {
 	for _, ref := range column.refs {
 		index, declared := byName[ref]
@@ -363,9 +373,21 @@ func validateArithmeticRefs(column compiledColumn, columns []compiledColumn, byN
 		}
 
 		referenced := columns[index]
-		if referenced.kind == ColumnLabel && !referenced.fieldRef.DataType.IsNumeric() {
+		if referenced.kind != ColumnLabel {
+			// Aggregate and arithmetic columns always produce one number.
+			continue
+		}
+
+		if !referenced.fieldRef.DataType.IsNumeric() {
 			return fmt.Errorf("%w: column %s reads %s, which shows a %s",
 				ErrArithmeticNonNumericRef, column.name, ref, referenced.fieldRef.DataType)
+		}
+
+		// A label column over a multi-valued field shows every value, and a
+		// formula cannot silently pick one of them.
+		if referenced.fieldRef.Multi {
+			return fmt.Errorf("%w: column %s reads %s, which shows every value of %s",
+				ErrMeasureIsMultiValued, column.name, ref, referenced.field)
 		}
 	}
 	return nil

--- a/api/internal/reporting/validate_test.go
+++ b/api/internal/reporting/validate_test.go
@@ -1,0 +1,614 @@
+package reporting
+
+import (
+	"errors"
+	"testing"
+)
+
+// testCatalog mirrors the shape a receipt source produces: currency measures, a
+// plain numeric measure, multi-value and single-value string dimensions, a date
+// and a boolean.
+func testCatalog(t *testing.T) FieldCatalog {
+	t.Helper()
+
+	catalog, err := NewFieldCatalog(
+		FieldRef{Key: "amount", Label: "Amount", DataType: TypeCurrency},
+		FieldRef{Key: "custom_1", Label: "HST", DataType: TypeCurrency},
+		FieldRef{Key: "quantity", Label: "Quantity", DataType: TypeNumber},
+		FieldRef{Key: "category", Label: "Category", DataType: TypeString, Multi: true},
+		FieldRef{Key: "tag", Label: "Tag", DataType: TypeString, Multi: true},
+		FieldRef{Key: "paid_by", Label: "Paid By", DataType: TypeString},
+		FieldRef{Key: "date", Label: "Date", DataType: TypeDate},
+		FieldRef{Key: "resolved", Label: "Resolved", DataType: TypeBool},
+	)
+	if err != nil {
+		t.Fatalf("NewFieldCatalog() error = %v", err)
+	}
+	return catalog
+}
+
+// workedExampleSpec is the design document's report: foster parent, then child,
+// with one summed row per category.
+func workedExampleSpec() ReportSpec {
+	return ReportSpec{
+		Title:   "Verified Expenses",
+		GroupBy: []FieldKey{"paid_by", "tag"},
+		Detail:  DetailSpec{Mode: DetailAggregate, By: "category"},
+		Columns: []Column{
+			{Name: "Category", Kind: ColumnLabel, Field: "category"},
+			{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}},
+			{Name: "Subtotal", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "amount"}},
+			{Name: "Hst", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "custom_1"}},
+			{Name: "Total", Kind: ColumnArithmetic, Expr: "Subtotal + Hst"},
+			{Name: "AvgPerReceipt", Label: "Avg/Receipt", Kind: ColumnArithmetic, Expr: "Total / Count"},
+		},
+		Subtotals:   true,
+		GrandTotals: true,
+	}
+}
+
+func TestValidate_AcceptsTheWorkedExample(t *testing.T) {
+	if err := Validate(workedExampleSpec(), testCatalog(t)); err != nil {
+		t.Fatalf("Validate() error = %v, want nil", err)
+	}
+}
+
+func TestValidate_AcceptsVariations(t *testing.T) {
+	tests := []struct {
+		name string
+		spec ReportSpec
+	}{
+		{
+			name: "records mode with no grouping",
+			spec: ReportSpec{
+				Columns: []Column{{Name: "Name", Kind: ColumnLabel, Field: "paid_by"}},
+			},
+		},
+		{
+			name: "records mode may label any field",
+			spec: ReportSpec{
+				GroupBy: []FieldKey{"paid_by"},
+				Columns: []Column{
+					{Name: "When", Kind: ColumnLabel, Field: "date"},
+					{Name: "Cats", Kind: ColumnLabel, Field: "category"},
+					{Name: "Amount", Kind: ColumnLabel, Field: "amount"},
+				},
+			},
+		},
+		{
+			name: "aggregate detail may label a groupBy level",
+			spec: ReportSpec{
+				GroupBy: []FieldKey{"paid_by"},
+				Detail:  DetailSpec{Mode: DetailAggregate, By: "category"},
+				Columns: []Column{
+					{Name: "PaidBy", Kind: ColumnLabel, Field: "paid_by"},
+					{Name: "Category", Kind: ColumnLabel, Field: "category"},
+					{Name: "Subtotal", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "amount"}},
+				},
+			},
+		},
+		{
+			name: "aggregate source form",
+			spec: ReportSpec{
+				Columns: []Column{
+					{Name: "Count", Kind: ColumnAggregate, AggSrc: "COUNT()"},
+					{Name: "Subtotal", Kind: ColumnAggregate, AggSrc: "SUM(amount)"},
+					{Name: "Biggest", Kind: ColumnAggregate, AggSrc: "MAX(amount)"},
+				},
+			},
+		},
+		{
+			name: "arithmetic may be declared before what it reads",
+			spec: ReportSpec{
+				Columns: []Column{
+					{Name: "Avg", Kind: ColumnArithmetic, Expr: "Total / Count"},
+					{Name: "Total", Kind: ColumnArithmetic, Expr: "Subtotal + Hst"},
+					{Name: "Subtotal", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "amount"}},
+					{Name: "Hst", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "custom_1"}},
+					{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}},
+				},
+			},
+		},
+		{
+			name: "arithmetic may read a numeric label column",
+			spec: ReportSpec{
+				Columns: []Column{
+					{Name: "Qty", Kind: ColumnLabel, Field: "quantity"},
+					{Name: "Doubled", Kind: ColumnArithmetic, Expr: "Qty * 2"},
+				},
+			},
+		},
+		{
+			name: "constant arithmetic reads nothing",
+			spec: ReportSpec{
+				Columns: []Column{{Name: "Fixed", Kind: ColumnArithmetic, Expr: "1 + 1"}},
+			},
+		},
+		{
+			name: "division scale at the bounds",
+			spec: ReportSpec{
+				Config:  EngineConfig{DivisionScale: maxDivisionScale},
+				Columns: []Column{{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}}},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := Validate(test.spec, testCatalog(t)); err != nil {
+				t.Errorf("Validate() error = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestValidate_Rejects(t *testing.T) {
+	countColumn := Column{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}}
+
+	tests := []struct {
+		name    string
+		spec    ReportSpec
+		wantErr error
+	}{
+		{
+			name:    "no columns",
+			spec:    ReportSpec{},
+			wantErr: ErrNoColumns,
+		},
+		{
+			name:    "negative division scale",
+			spec:    ReportSpec{Config: EngineConfig{DivisionScale: -1}, Columns: []Column{countColumn}},
+			wantErr: ErrInvalidConfig,
+		},
+		{
+			name:    "division scale beyond the limit",
+			spec:    ReportSpec{Config: EngineConfig{DivisionScale: maxDivisionScale + 1}, Columns: []Column{countColumn}},
+			wantErr: ErrInvalidConfig,
+		},
+		{
+			name:    "empty column name",
+			spec:    ReportSpec{Columns: []Column{{Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}}}},
+			wantErr: ErrEmptyColumnName,
+		},
+		{
+			name:    "column name with a slash",
+			spec:    ReportSpec{Columns: []Column{{Name: "Avg/Receipt", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}}}},
+			wantErr: ErrInvalidColumnName,
+		},
+		{
+			name:    "column name starting with a digit",
+			spec:    ReportSpec{Columns: []Column{{Name: "1st", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}}}},
+			wantErr: ErrInvalidColumnName,
+		},
+		{
+			name:    "column name with a space",
+			spec:    ReportSpec{Columns: []Column{{Name: "Paid By", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}}}},
+			wantErr: ErrInvalidColumnName,
+		},
+		{
+			name:    "column name with an accent",
+			spec:    ReportSpec{Columns: []Column{{Name: "Montée", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}}}},
+			wantErr: ErrInvalidColumnName,
+		},
+		{
+			// "in" is an operator in the expression language, so a formula could
+			// never reference a column of that name.
+			name:    "column named after an operator",
+			spec:    ReportSpec{Columns: []Column{{Name: "in", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}}}},
+			wantErr: ErrReservedColumnName,
+		},
+		{
+			name:    "column named after an aggregate function",
+			spec:    ReportSpec{Columns: []Column{{Name: "SUM", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}}}},
+			wantErr: ErrReservedColumnName,
+		},
+		{
+			name:    "column named ROUND",
+			spec:    ReportSpec{Columns: []Column{{Name: "ROUND", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}}}},
+			wantErr: ErrReservedColumnName,
+		},
+		{
+			name: "duplicate column name",
+			spec: ReportSpec{Columns: []Column{
+				countColumn,
+				{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "amount"}},
+			}},
+			wantErr: ErrDuplicateColumn,
+		},
+		{
+			name:    "unknown column kind",
+			spec:    ReportSpec{Columns: []Column{{Name: "Odd", Kind: ColumnKind(9)}}},
+			wantErr: ErrUnknownColumnKind,
+		},
+
+		// groupBy
+		{
+			name:    "groupBy an unknown field",
+			spec:    ReportSpec{GroupBy: []FieldKey{"nope"}, Columns: []Column{countColumn}},
+			wantErr: ErrUnknownField,
+		},
+		{
+			// You cut by a tag; you sum a dollar amount.
+			name:    "groupBy a measure",
+			spec:    ReportSpec{GroupBy: []FieldKey{"amount"}, Columns: []Column{countColumn}},
+			wantErr: ErrGroupByNotDimension,
+		},
+		{
+			name:    "duplicate groupBy level",
+			spec:    ReportSpec{GroupBy: []FieldKey{"tag", "tag"}, Columns: []Column{countColumn}},
+			wantErr: ErrDuplicateGroupBy,
+		},
+
+		// detail
+		{
+			name:    "aggregate detail without a dimension",
+			spec:    ReportSpec{Detail: DetailSpec{Mode: DetailAggregate}, Columns: []Column{countColumn}},
+			wantErr: ErrDetailByRequired,
+		},
+		{
+			name:    "records detail with a dimension",
+			spec:    ReportSpec{Detail: DetailSpec{Mode: DetailRecords, By: "category"}, Columns: []Column{countColumn}},
+			wantErr: ErrDetailByOnRecords,
+		},
+		{
+			name:    "aggregate detail on an unknown field",
+			spec:    ReportSpec{Detail: DetailSpec{Mode: DetailAggregate, By: "nope"}, Columns: []Column{countColumn}},
+			wantErr: ErrUnknownField,
+		},
+		{
+			name:    "aggregate detail on a measure",
+			spec:    ReportSpec{Detail: DetailSpec{Mode: DetailAggregate, By: "amount"}, Columns: []Column{countColumn}},
+			wantErr: ErrDetailByNotDimension,
+		},
+
+		// label columns
+		{
+			name:    "label column without a field",
+			spec:    ReportSpec{Columns: []Column{{Name: "Blank", Kind: ColumnLabel}}},
+			wantErr: ErrLabelFieldRequired,
+		},
+		{
+			name:    "label column on an unknown field",
+			spec:    ReportSpec{Columns: []Column{{Name: "Ghost", Kind: ColumnLabel, Field: "nope"}}},
+			wantErr: ErrUnknownField,
+		},
+		{
+			// An aggregated detail row sums many records, so there is no single
+			// record whose date it could show.
+			name: "label column unresolvable on an aggregated detail row",
+			spec: ReportSpec{
+				GroupBy: []FieldKey{"paid_by"},
+				Detail:  DetailSpec{Mode: DetailAggregate, By: "category"},
+				Columns: []Column{
+					{Name: "When", Kind: ColumnLabel, Field: "date"},
+					countColumn,
+				},
+			},
+			wantErr: ErrLabelColumnUnresolvable,
+		},
+
+		// aggregate columns
+		{
+			name:    "aggregate without a field",
+			spec:    ReportSpec{Columns: []Column{{Name: "Subtotal", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum}}}},
+			wantErr: ErrAggregateFieldRequired,
+		},
+		{
+			name:    "aggregate over an unknown field",
+			spec:    ReportSpec{Columns: []Column{{Name: "Subtotal", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "nope"}}}},
+			wantErr: ErrUnknownField,
+		},
+		{
+			name:    "sum a dimension",
+			spec:    ReportSpec{Columns: []Column{{Name: "Nonsense", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "tag"}}}},
+			wantErr: ErrAggregateNotMeasure,
+		},
+		{
+			name:    "average a date",
+			spec:    ReportSpec{Columns: []Column{{Name: "Nonsense", Kind: ColumnAggregate, Agg: Aggregate{Func: AggAvg, Field: "date"}}}},
+			wantErr: ErrAggregateNotMeasure,
+		},
+		{
+			name:    "count a field",
+			spec:    ReportSpec{Columns: []Column{{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount, Field: "amount"}}}},
+			wantErr: ErrCountTakesNoField,
+		},
+		{
+			name:    "aggregate source is not a call",
+			spec:    ReportSpec{Columns: []Column{{Name: "Subtotal", Kind: ColumnAggregate, AggSrc: "amount"}}},
+			wantErr: ErrFormulaUnsupported,
+		},
+		{
+			name:    "aggregate source does not parse",
+			spec:    ReportSpec{Columns: []Column{{Name: "Subtotal", Kind: ColumnAggregate, AggSrc: "SUM("}}},
+			wantErr: ErrFormulaSyntax,
+		},
+		{
+			name:    "aggregate source names an unknown function",
+			spec:    ReportSpec{Columns: []Column{{Name: "Subtotal", Kind: ColumnAggregate, AggSrc: "TOTAL(amount)"}}},
+			wantErr: ErrUnknownFunction,
+		},
+
+		// arithmetic columns
+		{
+			name:    "arithmetic does not parse",
+			spec:    ReportSpec{Columns: []Column{countColumn, {Name: "Bad", Kind: ColumnArithmetic, Expr: "Count +"}}},
+			wantErr: ErrFormulaSyntax,
+		},
+		{
+			name:    "arithmetic uses an unsupported operator",
+			spec:    ReportSpec{Columns: []Column{countColumn, {Name: "Bad", Kind: ColumnArithmetic, Expr: "Count % 2"}}},
+			wantErr: ErrFormulaUnsupported,
+		},
+		{
+			name:    "arithmetic calls a reducer",
+			spec:    ReportSpec{Columns: []Column{{Name: "Bad", Kind: ColumnArithmetic, Expr: "SUM(amount)"}}},
+			wantErr: ErrUnknownFunction,
+		},
+		{
+			name:    "arithmetic rounds to too many places",
+			spec:    ReportSpec{Columns: []Column{countColumn, {Name: "Bad", Kind: ColumnArithmetic, Expr: "ROUND(Count, 99)"}}},
+			wantErr: ErrBadRoundPlaces,
+		},
+		{
+			name:    "arithmetic reads an undeclared column",
+			spec:    ReportSpec{Columns: []Column{countColumn, {Name: "Bad", Kind: ColumnArithmetic, Expr: "Count + Missing"}}},
+			wantErr: ErrUnknownColumnRef,
+		},
+		{
+			// A formula cannot add a category name to a number.
+			name: "arithmetic reads a non-numeric label column",
+			spec: ReportSpec{
+				Columns: []Column{
+					{Name: "Cat", Kind: ColumnLabel, Field: "category"},
+					countColumn,
+					{Name: "Bad", Kind: ColumnArithmetic, Expr: "Count + Cat"},
+				},
+			},
+			wantErr: ErrArithmeticNonNumericRef,
+		},
+		{
+			name: "arithmetic reads a date label column",
+			spec: ReportSpec{
+				Columns: []Column{
+					{Name: "When", Kind: ColumnLabel, Field: "date"},
+					{Name: "Bad", Kind: ColumnArithmetic, Expr: "When * 2"},
+				},
+			},
+			wantErr: ErrArithmeticNonNumericRef,
+		},
+		{
+			name:    "arithmetic references itself",
+			spec:    ReportSpec{Columns: []Column{{Name: "Loop", Kind: ColumnArithmetic, Expr: "Loop + 1"}}},
+			wantErr: ErrFormulaCycle,
+		},
+		{
+			name: "two arithmetic columns reference each other",
+			spec: ReportSpec{Columns: []Column{
+				{Name: "A", Kind: ColumnArithmetic, Expr: "B + 1"},
+				{Name: "B", Kind: ColumnArithmetic, Expr: "A + 1"},
+			}},
+			wantErr: ErrFormulaCycle,
+		},
+		{
+			name: "a longer cycle",
+			spec: ReportSpec{Columns: []Column{
+				{Name: "A", Kind: ColumnArithmetic, Expr: "B"},
+				{Name: "B", Kind: ColumnArithmetic, Expr: "C"},
+				{Name: "C", Kind: ColumnArithmetic, Expr: "A"},
+			}},
+			wantErr: ErrFormulaCycle,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := Validate(test.spec, testCatalog(t))
+			if !errors.Is(err, test.wantErr) {
+				t.Errorf("Validate() error = %v, want %v", err, test.wantErr)
+			}
+		})
+	}
+}
+
+// A diamond is not a cycle: two columns may read the same dependency.
+func TestValidate_DiamondDependencyIsNotACycle(t *testing.T) {
+	spec := ReportSpec{
+		Columns: []Column{
+			{Name: "Base", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "amount"}},
+			{Name: "Left", Kind: ColumnArithmetic, Expr: "Base * 2"},
+			{Name: "Right", Kind: ColumnArithmetic, Expr: "Base * 3"},
+			{Name: "Joined", Kind: ColumnArithmetic, Expr: "Left + Right"},
+		},
+	}
+
+	if err := Validate(spec, testCatalog(t)); err != nil {
+		t.Errorf("Validate() error = %v, want nil", err)
+	}
+}
+
+// The engine evaluates arithmetic in this order, so a column must never appear
+// before something it reads.
+func TestCompileSpec_ArithmeticOrderIsTopological(t *testing.T) {
+	spec := ReportSpec{
+		Columns: []Column{
+			{Name: "AvgPerReceipt", Kind: ColumnArithmetic, Expr: "Total / Count"},
+			{Name: "Total", Kind: ColumnArithmetic, Expr: "Subtotal + Hst"},
+			{Name: "Subtotal", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "amount"}},
+			{Name: "Hst", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "custom_1"}},
+			{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}},
+		},
+	}
+
+	compiled, err := compileSpec(spec, testCatalog(t))
+	if err != nil {
+		t.Fatalf("compileSpec() error = %v", err)
+	}
+
+	position := make(map[string]int, len(compiled.arithmeticOrder))
+	for slot, index := range compiled.arithmeticOrder {
+		position[compiled.columns[index].name] = slot
+	}
+
+	if len(compiled.arithmeticOrder) != 2 {
+		t.Fatalf("arithmeticOrder has %d entries, want 2", len(compiled.arithmeticOrder))
+	}
+	if position["Total"] > position["AvgPerReceipt"] {
+		t.Errorf("Total is evaluated after AvgPerReceipt, which reads it")
+	}
+
+	for _, index := range compiled.arithmeticOrder {
+		column := compiled.columns[index]
+		for _, ref := range column.refs {
+			refIndex := -1
+			for candidate, other := range compiled.columns {
+				if other.name == ref {
+					refIndex = candidate
+				}
+			}
+			if compiled.columns[refIndex].kind != ColumnArithmetic {
+				continue
+			}
+			if position[ref] >= position[column.name] {
+				t.Errorf("%s reads %s but is evaluated first", column.name, ref)
+			}
+		}
+	}
+}
+
+// Money combined with a count is still money, so the renderer knows to format
+// the average as currency.
+func TestCompileSpec_DataTypes(t *testing.T) {
+	compiled, err := compileSpec(workedExampleSpec(), testCatalog(t))
+	if err != nil {
+		t.Fatalf("compileSpec() error = %v", err)
+	}
+
+	want := map[string]DataType{
+		"Category":      TypeString,
+		"Count":         TypeNumber,
+		"Subtotal":      TypeCurrency,
+		"Hst":           TypeCurrency,
+		"Total":         TypeCurrency,
+		"AvgPerReceipt": TypeCurrency,
+	}
+
+	for _, column := range compiled.columns {
+		if got := column.dataType; got != want[column.name] {
+			t.Errorf("column %s dataType = %v, want %v", column.name, got, want[column.name])
+		}
+	}
+}
+
+func TestCompileSpec_ArithmeticOverPlainNumbersIsNotCurrency(t *testing.T) {
+	spec := ReportSpec{
+		Columns: []Column{
+			{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}},
+			{Name: "Doubled", Kind: ColumnArithmetic, Expr: "Count * 2"},
+		},
+	}
+
+	compiled, err := compileSpec(spec, testCatalog(t))
+	if err != nil {
+		t.Fatalf("compileSpec() error = %v", err)
+	}
+
+	for _, column := range compiled.columns {
+		if column.dataType != TypeNumber {
+			t.Errorf("column %s dataType = %v, want %v", column.name, column.dataType, TypeNumber)
+		}
+	}
+}
+
+// A label column on an aggregated detail row must know where to read from.
+func TestCompileSpec_LabelLevel(t *testing.T) {
+	spec := ReportSpec{
+		GroupBy: []FieldKey{"paid_by", "tag"},
+		Detail:  DetailSpec{Mode: DetailAggregate, By: "category"},
+		Columns: []Column{
+			{Name: "PaidBy", Kind: ColumnLabel, Field: "paid_by"},
+			{Name: "Child", Kind: ColumnLabel, Field: "tag"},
+			{Name: "Category", Kind: ColumnLabel, Field: "category"},
+		},
+	}
+
+	compiled, err := compileSpec(spec, testCatalog(t))
+	if err != nil {
+		t.Fatalf("compileSpec() error = %v", err)
+	}
+
+	want := map[string]int{
+		"PaidBy":   0,
+		"Child":    1,
+		"Category": labelFromDetailBucket,
+	}
+	for _, column := range compiled.columns {
+		if got := column.labelLevel; got != want[column.name] {
+			t.Errorf("column %s labelLevel = %d, want %d", column.name, got, want[column.name])
+		}
+	}
+}
+
+func TestCompileSpec_AppliesDefaults(t *testing.T) {
+	compiled, err := compileSpec(ReportSpec{
+		Columns: []Column{{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}}},
+	}, testCatalog(t))
+	if err != nil {
+		t.Fatalf("compileSpec() error = %v", err)
+	}
+
+	if compiled.spec.NoneLabel != defaultNoneLabel {
+		t.Errorf("NoneLabel = %q, want %q", compiled.spec.NoneLabel, defaultNoneLabel)
+	}
+	if compiled.spec.Config.DivisionScale != defaultDivisionScale {
+		t.Errorf("DivisionScale = %d, want %d", compiled.spec.Config.DivisionScale, defaultDivisionScale)
+	}
+}
+
+func TestCompileSpec_AggregateSourceOverridesStructuralForm(t *testing.T) {
+	spec := ReportSpec{
+		Columns: []Column{{
+			Name:   "Subtotal",
+			Kind:   ColumnAggregate,
+			Agg:    Aggregate{Func: AggCount},
+			AggSrc: "SUM(amount)",
+		}},
+	}
+
+	compiled, err := compileSpec(spec, testCatalog(t))
+	if err != nil {
+		t.Fatalf("compileSpec() error = %v", err)
+	}
+
+	got := compiled.columns[0].agg
+	if got.Func != AggSum || got.Field != "amount" {
+		t.Errorf("agg = %+v, want SUM(amount)", got)
+	}
+}
+
+func TestIsIdentifier(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"Subtotal", true},
+		{"_private", true},
+		{"a1", true},
+		{"A_B_1", true},
+		{"", false},
+		{"1a", false},
+		{"a b", false},
+		{"a-b", false},
+		{"a.b", false},
+		{"Avg/Receipt", false},
+		{"café", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := isIdentifier(test.name); got != test.want {
+				t.Errorf("isIdentifier(%q) = %v, want %v", test.name, got, test.want)
+			}
+		})
+	}
+}

--- a/api/internal/reporting/validate_test.go
+++ b/api/internal/reporting/validate_test.go
@@ -20,6 +20,11 @@ func testCatalog(t *testing.T) FieldCatalog {
 		FieldRef{Key: "paid_by", Label: "Paid By", DataType: TypeString},
 		FieldRef{Key: "date", Label: "Date", DataType: TypeDate},
 		FieldRef{Key: "resolved", Label: "Resolved", DataType: TypeBool},
+		// No receipt field is a multi-valued number, but nothing in the engine
+		// stops a producer from declaring one, so the rules that reject
+		// measuring it need something to reject.
+		FieldRef{Key: "item_amounts", Label: "Item Amounts", DataType: TypeCurrency, Multi: true},
+		FieldRef{Key: "item_counts", Label: "Item Counts", DataType: TypeNumber, Multi: true},
 	)
 	if err != nil {
 		t.Fatalf("NewFieldCatalog() error = %v", err)
@@ -122,6 +127,26 @@ func TestValidate_AcceptsVariations(t *testing.T) {
 			name: "constant arithmetic reads nothing",
 			spec: ReportSpec{
 				Columns: []Column{{Name: "Fixed", Kind: ColumnArithmetic, Expr: "1 + 1"}},
+			},
+		},
+		{
+			// Measuring a multi-valued field is refused; cutting by one, or
+			// showing every value it holds, is not.
+			name: "a multi-valued field may be grouped on and displayed",
+			spec: ReportSpec{
+				GroupBy: []FieldKey{"tag"},
+				Columns: []Column{
+					{Name: "Cats", Kind: ColumnLabel, Field: "category"},
+					{Name: "Amounts", Kind: ColumnLabel, Field: "item_amounts"},
+					{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}},
+				},
+			},
+		},
+		{
+			name: "COUNT is unaffected by multi-valued fields",
+			spec: ReportSpec{
+				GroupBy: []FieldKey{"category"},
+				Columns: []Column{{Name: "Count", Kind: ColumnAggregate, AggSrc: "COUNT()"}},
 			},
 		},
 		{
@@ -312,6 +337,34 @@ func TestValidate_Rejects(t *testing.T) {
 			name:    "count a field",
 			spec:    ReportSpec{Columns: []Column{{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount, Field: "amount"}}}},
 			wantErr: ErrCountTakesNoField,
+		},
+		{
+			// Reading only the first of several amounts would silently lose money.
+			name:    "sum a multi-valued measure",
+			spec:    ReportSpec{Columns: []Column{{Name: "Total", Kind: ColumnAggregate, Agg: Aggregate{Func: AggSum, Field: "item_amounts"}}}},
+			wantErr: ErrMeasureIsMultiValued,
+		},
+		{
+			name:    "average a multi-valued measure",
+			spec:    ReportSpec{Columns: []Column{{Name: "Mean", Kind: ColumnAggregate, Agg: Aggregate{Func: AggAvg, Field: "item_counts"}}}},
+			wantErr: ErrMeasureIsMultiValued,
+		},
+		{
+			name:    "take the maximum of a multi-valued measure",
+			spec:    ReportSpec{Columns: []Column{{Name: "Most", Kind: ColumnAggregate, AggSrc: "MAX(item_amounts)"}}},
+			wantErr: ErrMeasureIsMultiValued,
+		},
+		{
+			// A label over a multi-valued field shows every value, so a formula
+			// cannot silently pick one.
+			name: "arithmetic reads a multi-valued numeric label column",
+			spec: ReportSpec{
+				Columns: []Column{
+					{Name: "Amounts", Kind: ColumnLabel, Field: "item_amounts"},
+					{Name: "Bad", Kind: ColumnArithmetic, Expr: "Amounts * 2"},
+				},
+			},
+			wantErr: ErrMeasureIsMultiValued,
 		},
 		{
 			name:    "aggregate source is not a call",

--- a/api/internal/reporting/validate_test.go
+++ b/api/internal/reporting/validate_test.go
@@ -354,6 +354,42 @@ func TestValidate_Rejects(t *testing.T) {
 			spec:    ReportSpec{Columns: []Column{{Name: "Most", Kind: ColumnAggregate, AggSrc: "MAX(item_amounts)"}}},
 			wantErr: ErrMeasureIsMultiValued,
 		},
+		// ParseAggregate cannot produce a reduction the accumulator does not
+		// know, but Column.Agg is the canonical form and a persisted template
+		// deserializes straight into it. An unknown reduction used to validate
+		// cleanly and then render every cell of the column empty, at every
+		// level, because finalize's switch fell through to null.
+		{
+			name:    "aggregate with a reduction the accumulator does not know",
+			spec:    ReportSpec{Columns: []Column{{Name: "Total", Kind: ColumnAggregate, Agg: Aggregate{Func: AggFunc(200), Field: "amount"}}}},
+			wantErr: ErrUnknownAggFunc,
+		},
+		{
+			name:    "aggregate one past the last known reduction",
+			spec:    ReportSpec{Columns: []Column{{Name: "Total", Kind: ColumnAggregate, Agg: Aggregate{Func: AggMax + 1, Field: "amount"}}}},
+			wantErr: ErrUnknownAggFunc,
+		},
+		// compileDetail read anything that was not DetailRecords as aggregate,
+		// while compileLabelColumn tested for DetailAggregate exactly. An
+		// unknown mode therefore took the aggregate path everywhere but the
+		// label check, which it skipped — so a label column over any field at
+		// all silently rendered the detail bucket's value instead of its own.
+		{
+			name: "detail mode the engine does not know",
+			spec: ReportSpec{
+				Detail:  DetailSpec{Mode: DetailMode(200), By: "category"},
+				Columns: []Column{countColumn},
+			},
+			wantErr: ErrUnknownDetailMode,
+		},
+		{
+			name: "detail mode one past the last known mode",
+			spec: ReportSpec{
+				Detail:  DetailSpec{Mode: DetailAggregate + 1, By: "category"},
+				Columns: []Column{countColumn},
+			},
+			wantErr: ErrUnknownDetailMode,
+		},
 		{
 			// A label over a multi-valued field shows every value, so a formula
 			// cannot silently pick one.

--- a/api/internal/reporting/value.go
+++ b/api/internal/reporting/value.go
@@ -1,0 +1,201 @@
+package reporting
+
+import (
+	"cmp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// bucketNumberScale is the number of decimal places a numeric value is
+// normalized to when it is used as a grouping key, so that 200 and 200.00 land
+// in the same bucket.
+const bucketNumberScale = 12
+
+// ValueType discriminates the Value union.
+type ValueType uint8
+
+const (
+	// ValueNull is the zero ValueType: an absent or undefined value. It is what
+	// a missing field resolves to, what an aggregate over nothing can produce,
+	// and what an arithmetic expression yields when an operand is null or a
+	// divisor is zero.
+	ValueNull ValueType = iota
+	ValueString
+	ValueNumber
+	ValueDate
+	ValueBool
+)
+
+func (t ValueType) String() string {
+	switch t {
+	case ValueNull:
+		return "null"
+	case ValueString:
+		return "string"
+	case ValueNumber:
+		return "number"
+	case ValueDate:
+		return "date"
+	case ValueBool:
+		return "bool"
+	}
+	return "unknown"
+}
+
+// Value is an immutable typed scalar. The zero Value is null.
+//
+// The payload is unexported so a Value can never hold a type tag that disagrees
+// with its contents; build one with Null, Str, Num, DateVal, or Bool.
+type Value struct {
+	valueType ValueType
+	str       string
+	num       decimal.Decimal
+	date      time.Time
+	b         bool
+}
+
+// Null returns the null Value, equivalent to the zero Value.
+func Null() Value { return Value{} }
+
+// Str returns a string Value.
+func Str(s string) Value { return Value{valueType: ValueString, str: s} }
+
+// Num returns a numeric Value. All money flows through this constructor.
+func Num(d decimal.Decimal) Value { return Value{valueType: ValueNumber, num: d} }
+
+// DateVal returns a date Value.
+func DateVal(t time.Time) Value { return Value{valueType: ValueDate, date: t} }
+
+// Bool returns a boolean Value.
+func Bool(b bool) Value { return Value{valueType: ValueBool, b: b} }
+
+// Type reports the Value's type tag.
+func (v Value) Type() ValueType { return v.valueType }
+
+// IsNull reports whether the Value is null.
+func (v Value) IsNull() bool { return v.valueType == ValueNull }
+
+// Decimal returns the numeric payload. The second result is false when the
+// Value is not a number, in which case the first result is the zero decimal.
+func (v Value) Decimal() (decimal.Decimal, bool) {
+	if v.valueType != ValueNumber {
+		return decimal.Decimal{}, false
+	}
+	return v.num, true
+}
+
+// Text returns the string payload. The second result is false when the Value is
+// not a string.
+func (v Value) Text() (string, bool) {
+	if v.valueType != ValueString {
+		return "", false
+	}
+	return v.str, true
+}
+
+// Time returns the date payload. The second result is false when the Value is
+// not a date.
+func (v Value) Time() (time.Time, bool) {
+	if v.valueType != ValueDate {
+		return time.Time{}, false
+	}
+	return v.date, true
+}
+
+// Boolean returns the boolean payload. The second result is false when the
+// Value is not a boolean.
+func (v Value) Boolean() (bool, bool) {
+	if v.valueType != ValueBool {
+		return false, false
+	}
+	return v.b, true
+}
+
+// String renders the Value for debugging and error messages. Renderers must
+// format from the typed payload instead, since presentation depends on the
+// viewer's currency and locale settings.
+func (v Value) String() string {
+	switch v.valueType {
+	case ValueString:
+		return v.str
+	case ValueNumber:
+		return v.num.String()
+	case ValueDate:
+		return v.date.UTC().Format(time.RFC3339Nano)
+	case ValueBool:
+		return strconv.FormatBool(v.b)
+	}
+	return "<null>"
+}
+
+// Equal reports whether two Values are the same type and payload. Two nulls are
+// equal, and numbers compare by value, so 200 equals 200.00.
+func (v Value) Equal(other Value) bool { return compareValues(v, other) == 0 }
+
+// compareValues gives a total order over Values, returning a negative number,
+// zero, or a positive number as a sorts before, with, or after b.
+//
+// Null sorts after every non-null value, which is what puts the (None) bucket
+// last. Values within one dimension always share a type; the cross-type
+// ordering exists only so the comparison stays total, and therefore the sort
+// stays deterministic, if that ever fails to hold.
+func compareValues(a, b Value) int {
+	if a.IsNull() || b.IsNull() {
+		switch {
+		case a.IsNull() && b.IsNull():
+			return 0
+		case a.IsNull():
+			return 1
+		default:
+			return -1
+		}
+	}
+
+	if a.valueType != b.valueType {
+		return cmp.Compare(a.valueType, b.valueType)
+	}
+
+	switch a.valueType {
+	case ValueString:
+		return strings.Compare(a.str, b.str)
+	case ValueNumber:
+		return a.num.Cmp(b.num)
+	case ValueDate:
+		return a.date.Compare(b.date)
+	case ValueBool:
+		return cmp.Compare(boolOrder(a.b), boolOrder(b.b))
+	}
+	return 0
+}
+
+func boolOrder(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// bucketKey returns a canonical map key identifying the bucket a Value groups
+// into. Keys are prefixed by type so values of different types can never
+// collide, numbers are normalized so 200 and 200.00 share a bucket, and dates
+// key off the absolute instant so the same moment expressed in two time zones
+// does not split into two buckets.
+func bucketKey(v Value) string {
+	switch v.valueType {
+	case ValueString:
+		return "s:" + v.str
+	case ValueNumber:
+		return "n:" + v.num.StringFixed(bucketNumberScale)
+	case ValueDate:
+		return "d:" + strconv.FormatInt(v.date.UnixNano(), 10)
+	case ValueBool:
+		if v.b {
+			return "b:1"
+		}
+		return "b:0"
+	}
+	return "z"
+}

--- a/api/internal/reporting/value.go
+++ b/api/internal/reporting/value.go
@@ -209,3 +209,29 @@ func bucketKey(v Value) string {
 	}
 	return "z"
 }
+
+// canonical returns the representative of the value's equivalence class under
+// compareValues, and is what a bucket stores.
+//
+// Agreeing with compareValues is only half of what a bucket key owes. A bucket
+// keeps whichever value created it and drops every later one sharing its key, so
+// the value it reports must be a function of the class rather than of which
+// member happened to arrive first.
+//
+// Only dates make the two differ. compareValues orders dates by instant, so a
+// Value naming 2026-05-01T00:00:00Z and one naming 2026-04-30T19:00:00-05:00 are
+// equal and merge — yet Time returns the location each carries, and a renderer
+// formatting a calendar day would print a different day for each. Normalizing to
+// UTC, which is what String and bucketKey already do, settles it. It also drops
+// any monotonic clock reading, which no two Values should be distinguished by.
+//
+// Strings and bools compare by identity, so their classes are singletons. Two
+// equal numbers can still differ in exponent (200 and 200.00), but a number is
+// always a measure and never a dimension, so no number reaches a bucket. Were
+// that ever to change, the exponent would need canonicalizing here too.
+func (v Value) canonical() Value {
+	if v.valueType == ValueDate {
+		return DateVal(v.date.UTC())
+	}
+	return v
+}

--- a/api/internal/reporting/value.go
+++ b/api/internal/reporting/value.go
@@ -9,11 +9,6 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-// bucketNumberScale is the number of decimal places a numeric value is
-// normalized to when it is used as a grouping key, so that 200 and 200.00 land
-// in the same bucket.
-const bucketNumberScale = 12
-
 // ValueType discriminates the Value union.
 type ValueType uint8
 
@@ -179,18 +174,33 @@ func boolOrder(b bool) int {
 }
 
 // bucketKey returns a canonical map key identifying the bucket a Value groups
-// into. Keys are prefixed by type so values of different types can never
-// collide, numbers are normalized so 200 and 200.00 share a bucket, and dates
-// key off the absolute instant so the same moment expressed in two time zones
-// does not split into two buckets.
+// into.
+//
+// The one law it must obey is that two values share a key exactly when
+// compareValues finds them equal. A key coarser than that merges distinct
+// values into one bucket — and since a bucket keeps whichever value created it
+// first, the merged bucket's reported value would then depend on the order the
+// rows arrived in, breaking determinism. A key finer than that splits one value
+// across two buckets.
+//
+// Keys are prefixed by type, so values of different types never collide.
+//
+// Numbers key off decimal's canonical rendering, which is both lossless and
+// scale-independent: 200 and 200.00 render alike, while 0 and 0.0000000000001
+// do not.
+//
+// Dates key off the absolute instant, so the same moment expressed in two time
+// zones shares a bucket. That instant is the Unix second plus the nanosecond
+// within it, and deliberately not UnixNano, which is undefined before 1678 and
+// after 2262 — a zero time.Time and a date in 585 share a UnixNano.
 func bucketKey(v Value) string {
 	switch v.valueType {
 	case ValueString:
 		return "s:" + v.str
 	case ValueNumber:
-		return "n:" + v.num.StringFixed(bucketNumberScale)
+		return "n:" + v.num.String()
 	case ValueDate:
-		return "d:" + strconv.FormatInt(v.date.UnixNano(), 10)
+		return "d:" + strconv.FormatInt(v.date.Unix(), 10) + ":" + strconv.Itoa(v.date.Nanosecond())
 	case ValueBool:
 		if v.b {
 			return "b:1"

--- a/api/internal/reporting/value_test.go
+++ b/api/internal/reporting/value_test.go
@@ -1,0 +1,351 @@
+package reporting
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+func dec(s string) decimal.Decimal {
+	return decimal.RequireFromString(s)
+}
+
+func TestValue_ZeroValueIsNull(t *testing.T) {
+	var zero Value
+
+	if !zero.IsNull() {
+		t.Errorf("zero Value.IsNull() = false, want true")
+	}
+	if zero.Type() != ValueNull {
+		t.Errorf("zero Value.Type() = %v, want %v", zero.Type(), ValueNull)
+	}
+	if !zero.Equal(Null()) {
+		t.Errorf("zero Value != Null()")
+	}
+}
+
+func TestValue_ConstructorsAndAccessors(t *testing.T) {
+	instant := time.Date(2026, 5, 1, 12, 30, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		value    Value
+		wantType ValueType
+	}{
+		{"null", Null(), ValueNull},
+		{"string", Str("Clothing"), ValueString},
+		{"empty string", Str(""), ValueString},
+		{"number", Num(dec("120.00")), ValueNumber},
+		{"date", DateVal(instant), ValueDate},
+		{"bool", Bool(true), ValueBool},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.value.Type(); got != test.wantType {
+				t.Errorf("Type() = %v, want %v", got, test.wantType)
+			}
+			if got := test.value.IsNull(); got != (test.wantType == ValueNull) {
+				t.Errorf("IsNull() = %v, want %v", got, test.wantType == ValueNull)
+			}
+		})
+	}
+
+	t.Run("string payload round trips", func(t *testing.T) {
+		got, ok := Str("Clothing").Text()
+		if !ok || got != "Clothing" {
+			t.Errorf("Text() = %q, %v; want %q, true", got, ok, "Clothing")
+		}
+	})
+
+	t.Run("number payload round trips", func(t *testing.T) {
+		got, ok := Num(dec("120.00")).Decimal()
+		if !ok || !got.Equal(dec("120.00")) {
+			t.Errorf("Decimal() = %v, %v; want 120.00, true", got, ok)
+		}
+	})
+
+	t.Run("date payload round trips", func(t *testing.T) {
+		got, ok := DateVal(instant).Time()
+		if !ok || !got.Equal(instant) {
+			t.Errorf("Time() = %v, %v; want %v, true", got, ok, instant)
+		}
+	})
+
+	t.Run("bool payload round trips", func(t *testing.T) {
+		got, ok := Bool(true).Boolean()
+		if !ok || !got {
+			t.Errorf("Boolean() = %v, %v; want true, true", got, ok)
+		}
+	})
+}
+
+// Accessors must refuse to reinterpret a payload of the wrong type, otherwise a
+// null currency field would silently read as a zero amount.
+func TestValue_AccessorsRejectWrongType(t *testing.T) {
+	tests := []struct {
+		name  string
+		value Value
+	}{
+		{"null", Null()},
+		{"string", Str("x")},
+		{"date", DateVal(time.Now())},
+		{"bool", Bool(true)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name+" is not a number", func(t *testing.T) {
+			got, ok := test.value.Decimal()
+			if ok {
+				t.Errorf("Decimal() ok = true, want false")
+			}
+			if !got.IsZero() {
+				t.Errorf("Decimal() = %v, want zero decimal", got)
+			}
+		})
+	}
+
+	t.Run("number is not a string", func(t *testing.T) {
+		if _, ok := Num(dec("1")).Text(); ok {
+			t.Errorf("Text() ok = true, want false")
+		}
+	})
+	t.Run("number is not a date", func(t *testing.T) {
+		if _, ok := Num(dec("1")).Time(); ok {
+			t.Errorf("Time() ok = true, want false")
+		}
+	})
+	t.Run("number is not a bool", func(t *testing.T) {
+		if _, ok := Num(dec("1")).Boolean(); ok {
+			t.Errorf("Boolean() ok = true, want false")
+		}
+	})
+}
+
+func TestValue_String(t *testing.T) {
+	instant := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name  string
+		value Value
+		want  string
+	}{
+		{"null", Null(), "<null>"},
+		{"string", Str("Clothing"), "Clothing"},
+		{"number", Num(dec("120.50")), "120.5"},
+		{"date", DateVal(instant), "2026-05-01T12:00:00Z"},
+		{"bool", Bool(false), "false"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.value.String(); got != test.want {
+				t.Errorf("String() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestValue_Equal(t *testing.T) {
+	utc := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	elsewhere := utc.In(time.FixedZone("plus-one", 3600))
+
+	tests := []struct {
+		name string
+		a, b Value
+		want bool
+	}{
+		{"null equals null", Null(), Null(), true},
+		{"null does not equal empty string", Null(), Str(""), false},
+		{"same string", Str("a"), Str("a"), true},
+		{"different string", Str("a"), Str("b"), false},
+		{"numbers compare by value not scale", Num(dec("200")), Num(dec("200.00")), true},
+		{"different numbers", Num(dec("200")), Num(dec("200.01")), false},
+		{"same instant across zones", DateVal(utc), DateVal(elsewhere), true},
+		{"different instants", DateVal(utc), DateVal(utc.Add(time.Second)), false},
+		{"same bool", Bool(true), Bool(true), true},
+		{"different bool", Bool(true), Bool(false), false},
+		{"different types", Str("1"), Num(dec("1")), false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.a.Equal(test.b); got != test.want {
+				t.Errorf("%v.Equal(%v) = %v, want %v", test.a, test.b, got, test.want)
+			}
+			if got := test.b.Equal(test.a); got != test.want {
+				t.Errorf("Equal is not symmetric for %v / %v", test.a, test.b)
+			}
+		})
+	}
+}
+
+func TestCompareValues_WithinType(t *testing.T) {
+	earlier := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	later := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		a, b Value
+		want int
+	}{
+		{"strings order by bytes", Str("Clothing"), Str("Medical"), -1},
+		{"strings equal", Str("Clothing"), Str("Clothing"), 0},
+		{"uppercase sorts before lowercase", Str("Z"), Str("a"), -1},
+		{"numbers order numerically", Num(dec("9")), Num(dec("10")), -1},
+		{"numbers ignore scale", Num(dec("10.0")), Num(dec("10")), 0},
+		{"negative numbers", Num(dec("-1")), Num(dec("0")), -1},
+		{"dates order chronologically", DateVal(earlier), DateVal(later), -1},
+		{"false before true", Bool(false), Bool(true), -1},
+		{"bools equal", Bool(true), Bool(true), 0},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := sign(compareValues(test.a, test.b)); got != test.want {
+				t.Errorf("compareValues(%v, %v) = %d, want %d", test.a, test.b, got, test.want)
+			}
+			if got := sign(compareValues(test.b, test.a)); got != -test.want {
+				t.Errorf("compareValues is not antisymmetric for %v / %v", test.a, test.b)
+			}
+		})
+	}
+}
+
+// Null is the (None) bucket, and it always sorts last regardless of what it is
+// compared against.
+func TestCompareValues_NullSortsLast(t *testing.T) {
+	others := []Value{
+		Str(""),
+		Str("zzz"),
+		Num(dec("-99999")),
+		DateVal(time.Time{}),
+		Bool(false),
+	}
+
+	for _, other := range others {
+		t.Run(other.Type().String(), func(t *testing.T) {
+			if got := sign(compareValues(Null(), other)); got != 1 {
+				t.Errorf("compareValues(Null, %v) = %d, want 1", other, got)
+			}
+			if got := sign(compareValues(other, Null())); got != -1 {
+				t.Errorf("compareValues(%v, Null) = %d, want -1", other, got)
+			}
+		})
+	}
+
+	if compareValues(Null(), Null()) != 0 {
+		t.Errorf("compareValues(Null, Null) != 0")
+	}
+}
+
+// Mixed types never occur within one dimension, but the comparison must stay
+// total so that a sort remains deterministic if they ever do.
+func TestCompareValues_MixedTypesAreTotallyOrdered(t *testing.T) {
+	values := []Value{
+		Bool(true),
+		DateVal(time.Unix(0, 0)),
+		Num(dec("5")),
+		Str("s"),
+		Null(),
+	}
+
+	sorted := make([]Value, len(values))
+	copy(sorted, values)
+	sort.SliceStable(sorted, func(i, j int) bool { return compareValues(sorted[i], sorted[j]) < 0 })
+
+	// Sorting a reversed copy must land on the same order.
+	reversed := make([]Value, len(values))
+	for i, value := range values {
+		reversed[len(values)-1-i] = value
+	}
+	sort.SliceStable(reversed, func(i, j int) bool { return compareValues(reversed[i], reversed[j]) < 0 })
+
+	for i := range sorted {
+		if !sorted[i].Equal(reversed[i]) {
+			t.Fatalf("sort is not order-independent: %v vs %v at index %d", sorted[i], reversed[i], i)
+		}
+	}
+
+	if !sorted[len(sorted)-1].IsNull() {
+		t.Errorf("null did not sort last, got %v", sorted[len(sorted)-1])
+	}
+}
+
+func TestBucketKey_SameValueSameBucket(t *testing.T) {
+	utc := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	elsewhere := utc.In(time.FixedZone("plus-one", 3600))
+
+	tests := []struct {
+		name string
+		a, b Value
+	}{
+		{"identical strings", Str("Clothing"), Str("Clothing")},
+		{"numbers differing only in scale", Num(dec("200")), Num(dec("200.00"))},
+		{"number with trailing zeros", Num(dec("0.10")), Num(dec("0.1"))},
+		{"same instant in different zones", DateVal(utc), DateVal(elsewhere)},
+		{"same bool", Bool(true), Bool(true)},
+		{"two nulls", Null(), Null()},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if bucketKey(test.a) != bucketKey(test.b) {
+				t.Errorf("bucketKey(%v) = %q, bucketKey(%v) = %q; want equal",
+					test.a, bucketKey(test.a), test.b, bucketKey(test.b))
+			}
+		})
+	}
+}
+
+func TestBucketKey_DistinctValuesDistinctBuckets(t *testing.T) {
+	utc := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	// A wall clock reading of 12:00 in a +1 zone is a different instant to
+	// 12:00 UTC, and must not share its bucket.
+	sameWallClockDifferentInstant := time.Date(2026, 5, 1, 12, 0, 0, 0, time.FixedZone("plus-one", 3600))
+
+	// Every key must be unique: this catches cross-type collisions such as the
+	// string "z" against the null sentinel, or the string "1" against true.
+	values := []Value{
+		Null(),
+		Str("z"),
+		Str(""),
+		Str("1"),
+		Str("0"),
+		Str("Clothing"),
+		Str("Medical"),
+		Num(dec("0")),
+		Num(dec("1")),
+		Num(dec("-1")),
+		Num(dec("0.000000000001")),
+		DateVal(utc),
+		DateVal(sameWallClockDifferentInstant),
+		DateVal(utc.Add(time.Nanosecond)),
+		Bool(false),
+		Bool(true),
+	}
+
+	seen := make(map[string]Value, len(values))
+	for _, value := range values {
+		key := bucketKey(value)
+		if previous, exists := seen[key]; exists {
+			t.Errorf("bucketKey collision on %q: %v (%v) and %v (%v)",
+				key, previous, previous.Type(), value, value.Type())
+			continue
+		}
+		seen[key] = value
+	}
+}
+
+func sign(n int) int {
+	switch {
+	case n < 0:
+		return -1
+	case n > 0:
+		return 1
+	}
+	return 0
+}


### PR DESCRIPTION
Foundation for the report/export system: a pure engine that turns a report definition plus already-fetched data into a format-agnostic model. Renderers, a dashboard widget, template persistence and HTTP delivery will all *call* it; none of them are part of it.

Targets `feature/reporting`, not `main`. Nothing user-facing ships yet.

## What's here

`internal/reporting` — `(ReportSpec + FieldCatalog + []Row + MetaInput) → ReportModel`. It fetches nothing, renders nothing, reads no clock and consults no global, so the same inputs always produce the same output.

`internal/reporting/receiptsource` — the only package that imports `models`. It maps receipts and custom fields into engine rows. Item-grain reporting, or a widget over something else, adds a sibling of it rather than changing the engine.

The purity claim is mechanically checkable, not aspirational:

```
go list -deps receipt-wrangler/api/internal/reporting | grep -E 'gorm|repositories|internal/models'
# prints nothing
```

## The parts worth reviewing closely

**Aggregates roll up by merging accumulators, never by combining finalized values.** For `SUM` the two agree, so the choice looks arbitrary until you reach `AVG`, where averaging the children's averages is simply wrong. Carrying the running sum and count and dividing only at the end makes `AVG` correct at every level with no special case.

**Arithmetic columns are recomputed from the row being rendered**, at detail rows, subtotals and the grand total alike. An additive formula agrees with summing the column; an average per receipt does not — summing gives 73.90 and averaging gives 36.95 where the answer is 35.93.

**A zero divisor yields an empty cell, not a panic.** `shopspring` panics on division by zero, so a report with a zero count would otherwise take down the request that asked for it.

**The multi-value fan-out double-counts on purpose.** A receipt with two tags is attributed to both in full, and that double count reaches the grand total. It matches how the dashboard pie chart attributes, and it is asserted with a comment so a future reader does not "fix" it.

**Formulas use `expr-lang/expr` as a parser front-end only.** Its VM evaluates over `float64`, and money must not touch a float, so the tree is walked by our own decimal evaluator. The whitelist is a closed type switch whose `default` rejects — it holds by construction rather than by remembering to deny. Two shapes are not obvious from expr's docs and both are tested: `??`, `in`, `**` and `%` all parse as binary nodes, so the operator is whitelisted too; and expr ships lower-case builtins named `sum`, `min`, `max`, `count`, `round`, `len`, so `round(a,2)` arrives as a builtin rather than a call.

Arithmetic columns form a DAG, topologically sorted with cycle detection, so a column may be declared before the aggregate it reads. `ColumnDescriptor.Expr` keeps the parsed tree so the spreadsheet renderer can later emit a live `=SUM(...)` formula instead of a computed value.

## Verification

- 530 test cases, 95.2% statement coverage. Full API suite green: 17 packages, 0 failures.
- `engine_test.go` reproduces the design's worked example number for number as a golden test.
- Each invariant above is guarded by a test that **fails when the invariant is broken** — verified by mutating the engine four ways (arithmetic in declaration order; `(None)` buckets dropped; `AVG` dividing by record count; parents combining finalized values) and confirming the right tests go red. That last mutation revealed the `AVG`-at-every-level test was passing by luck on a one-level tree, so it was deepened to two.
- Both packages are pure: no `main_test.go`, no DB, no `app.db` cleanup.

## Deferred

Template persistence, run-time parameters, slot substitution, CSV/XLSX/PDF renderers, `group.reports.*` permissions, handlers, the Asynq job, swagger, desktop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new reporting experience with grouped totals, detailed rows, aggregates, and arithmetic columns.
  * Reporting can now use receipt data, including custom fields and multi-value dimensions.
  * Added support for cleaner table output, including configurable “none” labels and grand totals.

* **Bug Fixes**
  * Improved consistency for date, number, and boolean grouping so results stay stable across runs.
  * Fixed edge cases around empty values, nulls, and division by zero.
  * Reporting output is now more deterministic, with better sorting and rollup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->