### PR TITLE
fix(roles): reconcile system-role permissions on boot (add-only)

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -266,13 +266,15 @@ will be dropped in a later release.
 - `SeedSystemRoles` creates the roles with `IsDefault = false`; the **default** per scope is set
   separately by `EnsureDefaultRoles` (see "Default roles" below), the one-time data migration assigns
   the roles to existing users/members, and enforcement is wired in `HandleRequest`.
-- Idempotent: keyed on role `Name` (a `uniqueIndex`), safe on every boot; a pre-existing
-  same-named role is left untouched. The five role names are shared constants
-  (`repositories/system_role_names.go`, `Legacy*RoleName`) used by both the seeder and the
-  migration.
-- **Known limitation:** because system roles are immutable and seeding skips existing names, a
-  permission added to the registry later will **not** flow into an already-seeded Legacy Admin /
-  Legacy Owner. Re-syncing system roles would need a dedicated reconciliation step (out of scope).
+- Idempotent and **self-reconciling**: keyed on role `Name` (a `uniqueIndex`), safe on every boot. A
+  missing role is created; an existing one has any permissions it lacks **added — add-only, so a
+  permission already on the role is never removed** (`missingPermissions` computes the add set). The
+  five role names are shared constants (`repositories/system_role_names.go`, `Legacy*RoleName`) used
+  by both the seeder and the migration.
+- Because reconciliation is add-only, a permission **added** to the registry later flows into an
+  already-seeded Legacy Admin / Legacy Owner on the next boot — both sets are dynamic over the
+  registry (`LegacyAppAdminKeys` / `LegacyGroupOwnerKeys`) — while a capability an install already
+  holds is never stripped.
 
 ### Default roles
 

--- a/api/internal/repositories/seed_roles.go
+++ b/api/internal/repositories/seed_roles.go
@@ -1,6 +1,7 @@
 package repositories
 
 import (
+	"errors"
 	"fmt"
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/permissions"
@@ -8,14 +9,19 @@ import (
 	"gorm.io/gorm"
 )
 
-// SeedSystemRoles creates the five immutable, legacy-equivalent system roles if
-// they do not already exist. The roles reproduce the legacy UserRole/GroupRole
-// capabilities exactly so that upgrading installs see no behavior change.
+// SeedSystemRoles ensures the five immutable, legacy-equivalent system roles
+// exist and carry their full permission sets. The roles reproduce the legacy
+// UserRole/GroupRole capabilities exactly so that upgrading installs see no
+// behavior change.
 //
-// It is idempotent: keyed on the role Name (a uniqueIndex on both AppRole and
-// GroupRoleDefinition), it is safe to run on every startup and on upgrades, and
-// a partially-seeded database self-heals on the next boot. The roles are seeded
-// only — they are not assigned to any user or group member here.
+// It is idempotent and self-reconciling: keyed on the role Name (a uniqueIndex
+// on both AppRole and GroupRoleDefinition), a missing role is created and an
+// existing one has any permissions it lacks added — add-only, so a permission
+// already on the role is never removed. This is what lets a permission added to
+// the registry later flow into an already-seeded Legacy Admin / Legacy Owner on
+// the next boot. It is safe to run on every startup, and a partially-seeded or
+// partially-reconciled database self-heals on the next boot. The roles are
+// seeded only — they are not assigned to any user or group member here.
 func SeedSystemRoles() error {
 	db := GetDB()
 
@@ -51,17 +57,39 @@ func SeedSystemRoles() error {
 	return nil
 }
 
-// seedAppRole creates a system app role with the given permissions if no app
-// role with that name already exists.
+// seedAppRole creates a system app role with the given permissions when no app
+// role with that name exists, or reconciles an existing one by adding any
+// permissions it is missing (add-only).
 func seedAppRole(db *gorm.DB, name string, description string, perms []string) error {
-	var count int64
-	if err := db.Model(&models.AppRole{}).Where("name = ?", name).Count(&count).Error; err != nil {
+	var existing models.AppRole
+	err := db.Preload("Permissions").Where("name = ?", name).First(&existing).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return createAppRole(db, name, description, perms)
+	}
+	if err != nil {
 		return err
 	}
-	if count > 0 {
+
+	have := make([]string, 0, len(existing.Permissions))
+	for _, permission := range existing.Permissions {
+		have = append(have, permission.Permission)
+	}
+
+	missing := missingPermissions(have, perms)
+	if len(missing) == 0 {
 		return nil
 	}
 
+	rows := make([]models.AppRolePermission, 0, len(missing))
+	for _, permission := range missing {
+		rows = append(rows, models.AppRolePermission{AppRoleID: existing.ID, Permission: permission})
+	}
+
+	return db.Create(&rows).Error
+}
+
+// createAppRole inserts a new system app role with its permission rows.
+func createAppRole(db *gorm.DB, name string, description string, perms []string) error {
 	rolePermissions := make([]models.AppRolePermission, 0, len(perms))
 	for _, permission := range perms {
 		rolePermissions = append(rolePermissions, models.AppRolePermission{Permission: permission})
@@ -77,17 +105,39 @@ func seedAppRole(db *gorm.DB, name string, description string, perms []string) e
 	return db.Create(&role).Error
 }
 
-// seedGroupRole creates a system group role with the given permissions if no
-// group role with that name already exists.
+// seedGroupRole creates a system group role with the given permissions when no
+// group role with that name exists, or reconciles an existing one by adding any
+// permissions it is missing (add-only).
 func seedGroupRole(db *gorm.DB, name string, description string, perms []string) error {
-	var count int64
-	if err := db.Model(&models.GroupRoleDefinition{}).Where("name = ?", name).Count(&count).Error; err != nil {
+	var existing models.GroupRoleDefinition
+	err := db.Preload("Permissions").Where("name = ?", name).First(&existing).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return createGroupRole(db, name, description, perms)
+	}
+	if err != nil {
 		return err
 	}
-	if count > 0 {
+
+	have := make([]string, 0, len(existing.Permissions))
+	for _, permission := range existing.Permissions {
+		have = append(have, permission.Permission)
+	}
+
+	missing := missingPermissions(have, perms)
+	if len(missing) == 0 {
 		return nil
 	}
 
+	rows := make([]models.GroupRolePermission, 0, len(missing))
+	for _, permission := range missing {
+		rows = append(rows, models.GroupRolePermission{GroupRoleID: existing.ID, Permission: permission})
+	}
+
+	return db.Create(&rows).Error
+}
+
+// createGroupRole inserts a new system group role with its permission rows.
+func createGroupRole(db *gorm.DB, name string, description string, perms []string) error {
 	rolePermissions := make([]models.GroupRolePermission, 0, len(perms))
 	for _, permission := range perms {
 		rolePermissions = append(rolePermissions, models.GroupRolePermission{Permission: permission})
@@ -102,6 +152,27 @@ func seedGroupRole(db *gorm.DB, name string, description string, perms []string)
 	}
 
 	return db.Create(&role).Error
+}
+
+// missingPermissions returns the desired permissions not already present in
+// have, de-duplicated and in desired's order. Reconciliation is add-only: a
+// permission in have but absent from desired is left untouched, never removed.
+func missingPermissions(have []string, desired []string) []string {
+	present := make(map[string]struct{}, len(have))
+	for _, permission := range have {
+		present[permission] = struct{}{}
+	}
+
+	missing := make([]string, 0)
+	for _, permission := range desired {
+		if _, ok := present[permission]; ok {
+			continue
+		}
+		present[permission] = struct{}{} // also de-dupes desired against itself
+		missing = append(missing, permission)
+	}
+
+	return missing
 }
 
 // EnsureDefaultRoles guarantees that exactly one app role and one group role are

--- a/api/internal/repositories/seed_roles_test.go
+++ b/api/internal/repositories/seed_roles_test.go
@@ -167,10 +167,11 @@ func TestSeedSystemRolesScopeAndFlags(t *testing.T) {
 	}
 }
 
-func TestSeedSystemRolesPreservesExisting(t *testing.T) {
+func TestSeedSystemRolesReconcilesExistingRolePermissions(t *testing.T) {
 	defer TruncateTestDb()
 
-	// Pre-create a role with the same name but a different permission set.
+	// Pre-create the Legacy Admin system role holding a single permission, as an
+	// install seeded before the admin permission set grew would have.
 	existing := models.AppRole{
 		Name:        "Legacy Admin",
 		Description: "pre-existing",
@@ -198,14 +199,167 @@ func TestSeedSystemRolesPreservesExisting(t *testing.T) {
 		utils.PrintTestError(t, len(roles), 5)
 	}
 
-	// The pre-existing role must not have been overwritten with the full admin set.
 	role, ok := findRole(roles, "Legacy Admin")
 	if !ok {
 		utils.PrintTestError(t, "missing role Legacy Admin", "present")
 		return
 	}
-	if !equalKeySet(role.Permissions, []string{permissions.AppUsersRead}) {
-		utils.PrintTestError(t, role.Permissions, []string{permissions.AppUsersRead})
+
+	// The missing permissions were added: the role now holds the full admin set,
+	// and the permission it already had was neither dropped nor duplicated.
+	if !equalKeySet(role.Permissions, permissions.LegacyAppAdminKeys()) {
+		utils.PrintTestError(t, role.Permissions, permissions.LegacyAppAdminKeys())
+	}
+	// Reconciled in place — the same row, not dropped and recreated.
+	if role.Id != existing.ID {
+		utils.PrintTestError(t, role.Id, existing.ID)
+	}
+	// Still a protected system role.
+	if !role.IsSystem {
+		utils.PrintTestError(t, role.IsSystem, true)
+	}
+}
+
+func TestSeedSystemRolesReconcileIsAddOnly(t *testing.T) {
+	defer TruncateTestDb()
+
+	// Pre-create the Legacy Owner system role with the full owner set plus an
+	// extra permission that is not part of it.
+	const extra = "group.bogus.extra"
+	ownerKeys := permissions.LegacyGroupOwnerKeys()
+	seededPerms := make([]models.GroupRolePermission, 0, len(ownerKeys)+1)
+	for _, permission := range ownerKeys {
+		seededPerms = append(seededPerms, models.GroupRolePermission{Permission: permission})
+	}
+	seededPerms = append(seededPerms, models.GroupRolePermission{Permission: extra})
+
+	existing := models.GroupRoleDefinition{
+		Name:        "Legacy Owner",
+		Description: "pre-existing",
+		IsSystem:    true,
+		Permissions: seededPerms,
+	}
+	if err := GetDB().Create(&existing).Error; err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	if err := SeedSystemRoles(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	repository := NewRoleRepository(nil)
+	roles, err := repository.GetAllRoles()
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	role, ok := findRole(roles, "Legacy Owner")
+	if !ok {
+		utils.PrintTestError(t, "missing role Legacy Owner", "present")
+		return
+	}
+
+	// Add-only: the extra permission survives and every owner permission is present.
+	want := append(append([]string(nil), ownerKeys...), extra)
+	if !equalKeySet(role.Permissions, want) {
+		utils.PrintTestError(t, role.Permissions, want)
+	}
+}
+
+func TestSeedSystemRolesReSeedAddsNoDuplicatePermissions(t *testing.T) {
+	defer TruncateTestDb()
+
+	if err := SeedSystemRoles(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	// The second boot runs every role through the reconcile branch. It must add
+	// nothing and must not trip the (roleId, permission) unique index.
+	if err := SeedSystemRoles(); err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	repository := NewRoleRepository(nil)
+	roles, err := repository.GetAllRoles()
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	expected := map[string][]string{
+		"Legacy Admin":  permissions.LegacyAppAdminKeys(),
+		"Legacy User":   permissions.LegacyAppUserKeys(),
+		"Legacy Viewer": permissions.LegacyGroupViewerKeys(),
+		"Legacy Editor": permissions.LegacyGroupEditorKeys(),
+		"Legacy Owner":  permissions.LegacyGroupOwnerKeys(),
+	}
+	for name, wantPerms := range expected {
+		role, ok := findRole(roles, name)
+		if !ok {
+			utils.PrintTestError(t, "missing role "+name, "present")
+			continue
+		}
+		// equalKeySet fails if a duplicate row lengthened the set; the explicit
+		// length check states the same intent directly.
+		if !equalKeySet(role.Permissions, wantPerms) {
+			utils.PrintTestError(t, role.Permissions, wantPerms)
+		}
+		if len(role.Permissions) != len(wantPerms) {
+			utils.PrintTestError(t, len(role.Permissions), len(wantPerms))
+		}
+	}
+}
+
+func TestMissingPermissions(t *testing.T) {
+	tests := []struct {
+		name    string
+		have    []string
+		desired []string
+		want    []string
+	}{
+		{
+			name:    "returns the missing permissions in desired order",
+			have:    []string{"a", "b"},
+			desired: []string{"a", "b", "c", "d"},
+			want:    []string{"c", "d"},
+		},
+		{
+			name:    "returns nothing when have already covers desired",
+			have:    []string{"a", "b", "c"},
+			desired: []string{"a", "b"},
+			want:    []string{},
+		},
+		{
+			name:    "de-duplicates repeats within desired",
+			have:    []string{},
+			desired: []string{"a", "a", "b", "b"},
+			want:    []string{"a", "b"},
+		},
+		{
+			name:    "add-only: a permission only in have is never returned",
+			have:    []string{"x", "y"},
+			desired: []string{"a"},
+			want:    []string{"a"},
+		},
+		{
+			name:    "empty desired yields nothing",
+			have:    []string{"a"},
+			desired: []string{},
+			want:    []string{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := missingPermissions(test.have, test.desired)
+			if !slices.Equal(got, test.want) {
+				utils.PrintTestError(t, got, test.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What

`SeedSystemRoles` was **create-if-absent** only — `seedAppRole`/`seedGroupRole` counted rows by name and returned early when the role already existed. So once a **Legacy Admin** / **Legacy Owner** row existed, any permission added to the registry later never flowed into it, and upgraded installs quietly missed capabilities their system roles were supposed to carry. This was previously documented as a known limitation.

This PR makes seeding **create-or-reconcile**:

- A **missing** role is still created with its full permission set (unchanged).
- An **existing** role now has any permissions it lacks **inserted** — **add-only**: a permission already on the role is never removed.

A shared `missingPermissions(have, desired)` helper computes the add set and de-duplicates. Reconciliation runs on every boot and is idempotent; the `(roleId, permission)` unique index plus the missing-only filter mean re-seeding inserts nothing and never trips the constraint.

Because both dynamic legacy sets (`LegacyAppAdminKeys` = every app permission, `LegacyGroupOwnerKeys` = every group permission) grow with the registry, this is what will let a future permission (e.g. reporting) reach every already-seeded Admin/Owner role on the next boot.

**Fresh-database behavior is unchanged.**

## Why add-only

Reconciliation never strips a capability an install already holds; the realistic and needed case is *adding* new registry permissions to the dynamic Admin/Owner sets, which add-only handles exactly.

## Scope

Permissions only — role description, flags, and group grants are untouched. No new permission is added to the registry here (that lands in a later slice). This is the prerequisite for the reporting permissions and the report data source.

## Tests

`internal/repositories/seed_roles_test.go`:

- **Rewrote** `PreservesExisting` → `ReconcilesExistingRolePermissions`: a partial Legacy Admin (one permission) is reconciled to the full admin set, **in place** (same row id), still `IsSystem`.
- **Added** `ReconcileIsAddOnly`: an extra permission not in the owner set survives reconciliation.
- **Added** `ReSeedAddsNoDuplicatePermissions`: seeding twice leaves each role's set equal to its `Legacy*Keys()` with no duplicate rows.
- **Added** `TestMissingPermissions`: unit-tests the helper (missing subset in order, dedupe, add-only, empty cases).
- Fresh-DB tests unchanged and green.

`go test ./internal/repositories/...` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Existing system roles now automatically receive any missing permissions when role seeding runs.
  - Existing permissions are preserved, including custom additions.
  - Re-running role setup is safe and does not create duplicate permissions.
  - Existing roles retain their identity and system-role status.

- **Documentation**
  - Updated role-seeding guidance to explain its idempotent, self-reconciling, add-only behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->