### PR TITLE
feat(reporting): report data source

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -668,12 +668,25 @@ model, err := reporting.Run(spec, source.Catalog(), source.Rows(receipts), meta)
 **Caller must preload** `PaidByUser`, `Group`, `Categories`, `Tags`, `CustomFields`. An unloaded
 association resolves to no value, which surfaces as a `(None)` bucket — not an error.
 
-**Known gap — no date truncation.** `date`, `resolved_date` and `created_at` are `TypeDate`, hence
-dimensions, hence groupable — but `receiptsource` hands over a raw timestamp, so grouping by `date`
-buckets on the exact instant and yields **one group per receipt**. "Receipts by month" is not
-expressible today. Closing it means either derived fields in `receiptsource` (`date_month`,
-`date_year`) or a `GroupBy` entry carrying a truncation. Decide before `ReportTemplate` persists a
-`GroupBy` shape.
+**Date period grouping — derived string fields.** `date`, `resolved_date` and `created_at` are
+`TypeDate`, so grouping by one buckets on the exact instant (one group per receipt). To group by
+calendar period, `receiptsource` also offers derived **string** fields `<base>_day` / `_month` /
+`_year` (e.g. `date_month`, `created_at_year`, `resolved_date_day`) — zero-padded ISO in **UTC**, so
+they sort chronologically as plain text. A report groups by one of these instead of the raw date field;
+a nil `resolved_date` emits none of its period fields (→ `(None)`).
+
+**`services.ReportDataService`** (`internal/services/report_data.go`) is the first DB-backed caller of
+the engine — it follows the `pie_chart.go` pattern. `Rows(userId, groupId, filter)` fetches the group's
+receipts unpaged and applies the reporting access controls **in order**: narrow the request filter to
+the caller's grants (`IntersectReceiptFilterWithGrants`), hide whole receipts in the query by paid-by
+(`PaidByListResolver`), then substitute the categories/tags the caller can't see. It returns the
+engine's `(FieldCatalog, []Row)` — it does **not** build a `ReportSpec` or call `Run`; a caller does.
+
+**`(Restricted)` vs `(None)`.** Aggregation uses `PermissionService.SubstituteRestrictedCategoriesTags`
+(not the strip variant): a category/tag the caller may not see is replaced with a single `(Restricted)`
+marker, so the receipt still counts toward the totals in its own bucket instead of vanishing. `(None)`
+stays reserved for a receipt that genuinely carries no category/tag. (The pie chart still strips today;
+switching it to `(Restricted)` is a deferred follow-up.)
 
 ### Semantics that are easy to get wrong
 

--- a/api/internal/reporting/README.md
+++ b/api/internal/reporting/README.md
@@ -446,6 +446,12 @@ It offers `receipt_id`, `name`, `amount`, `date`, `resolved_date`, `created_at`,
 `group`, `category`, `tag` (the last two `Multi`), plus one field per custom field, keyed
 `custom_<id>` — **by id, not by name, so renaming a custom field cannot break a saved report**.
 
+Each date field also carries derived `_day` / `_month` / `_year` **string** fields — `date_month`,
+`created_at_year`, `resolved_date_day`, and so on. A report groups by one of these to bucket receipts by
+calendar period; the raw date fields carry the exact instant, so grouping by `date` puts every receipt
+in its own bucket. The strings are zero-padded ISO in UTC (`2026-05`), so they sort chronologically as
+plain text.
+
 The caller must preload `PaidByUser`, `Group`, `Categories`, `Tags`, `CustomFields`. An unloaded
 association resolves to no value, which surfaces as a `(None)` bucket rather than as a crash.
 
@@ -514,12 +520,6 @@ counts as caught; and `-count=1`, or the build cache serves the last verdict.
 ---
 
 ## 13. Known gaps
-
-**No date truncation.** `date`, `resolved_date` and `created_at` are dimensions, but `receiptsource`
-hands the engine a raw timestamp — so grouping by `date` buckets on the exact instant and yields **one
-group per receipt**. "Receipts by month" is not expressible today. Closing it means either derived
-fields in `receiptsource` (`date_month`, `date_year`) or a `GroupBy` entry carrying a truncation.
-Worth deciding before a persisted template fixes a `GroupBy` shape.
 
 **Per-row allocation.** `rowCells` builds a `map[string]Value` for every rendered row. At 50k rows a
 report costs roughly 165 ms and 39 allocations per row, dominated by `decimal`'s `big.Int` arithmetic

--- a/api/internal/reporting/receiptsource/receiptsource.go
+++ b/api/internal/reporting/receiptsource/receiptsource.go
@@ -14,6 +14,7 @@ package receiptsource
 import (
 	"sort"
 	"strconv"
+	"time"
 
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/reporting"
@@ -35,6 +36,21 @@ const (
 	KeyGroup        reporting.FieldKey = "group"
 	KeyCategory     reporting.FieldKey = "category"
 	KeyTag          reporting.FieldKey = "tag"
+
+	// Derived date-period fields. A report groups by one of these to bucket
+	// receipts by calendar day, month, or year; the raw date fields above carry
+	// the exact instant, which would put every receipt in its own group.
+	KeyDateDay   reporting.FieldKey = "date_day"
+	KeyDateMonth reporting.FieldKey = "date_month"
+	KeyDateYear  reporting.FieldKey = "date_year"
+
+	KeyResolvedDateDay   reporting.FieldKey = "resolved_date_day"
+	KeyResolvedDateMonth reporting.FieldKey = "resolved_date_month"
+	KeyResolvedDateYear  reporting.FieldKey = "resolved_date_year"
+
+	KeyCreatedAtDay   reporting.FieldKey = "created_at_day"
+	KeyCreatedAtMonth reporting.FieldKey = "created_at_month"
+	KeyCreatedAtYear  reporting.FieldKey = "created_at_year"
 )
 
 // customFieldKeyPrefix builds a custom field's key from its id rather than its
@@ -52,7 +68,7 @@ func CustomFieldKey(customFieldID uint) reporting.FieldKey {
 // every bucket it belongs to, attributing the whole amount to each, exactly as
 // the dashboard pie chart does.
 func builtinFields() []reporting.FieldRef {
-	return []reporting.FieldRef{
+	fields := []reporting.FieldRef{
 		{Key: KeyReceiptID, Label: "Receipt Id", DataType: reporting.TypeNumber},
 		{Key: KeyName, Label: "Name", DataType: reporting.TypeString},
 		{Key: KeyAmount, Label: "Amount", DataType: reporting.TypeCurrency},
@@ -64,6 +80,21 @@ func builtinFields() []reporting.FieldRef {
 		{Key: KeyGroup, Label: "Group", DataType: reporting.TypeString},
 		{Key: KeyCategory, Label: "Category", DataType: reporting.TypeString, Multi: true},
 		{Key: KeyTag, Label: "Tag", DataType: reporting.TypeString, Multi: true},
+	}
+	fields = append(fields, dateFieldRefs(KeyDateDay, KeyDateMonth, KeyDateYear, "Date")...)
+	fields = append(fields, dateFieldRefs(KeyResolvedDateDay, KeyResolvedDateMonth, KeyResolvedDateYear, "Resolved Date")...)
+	fields = append(fields, dateFieldRefs(KeyCreatedAtDay, KeyCreatedAtMonth, KeyCreatedAtYear, "Added At")...)
+	return fields
+}
+
+// dateFieldRefs builds the day/month/year string fields derived from one date
+// column, labelled off a shared prefix (e.g. "Date (Month)"). They are strings,
+// not dates, so the engine buckets them by their exact ISO text.
+func dateFieldRefs(dayKey, monthKey, yearKey reporting.FieldKey, labelPrefix string) []reporting.FieldRef {
+	return []reporting.FieldRef{
+		{Key: dayKey, Label: labelPrefix + " (Day)", DataType: reporting.TypeString},
+		{Key: monthKey, Label: labelPrefix + " (Month)", DataType: reporting.TypeString},
+		{Key: yearKey, Label: labelPrefix + " (Year)", DataType: reporting.TypeString},
 	}
 }
 
@@ -179,8 +210,12 @@ func (s Source) row(receipt *models.Receipt) reporting.Row {
 		KeyTag:       tagValues(receipt.Tags),
 	}
 
+	setDateParts(row, KeyDateDay, KeyDateMonth, KeyDateYear, receipt.Date)
+	setDateParts(row, KeyCreatedAtDay, KeyCreatedAtMonth, KeyCreatedAtYear, receipt.CreatedAt)
+
 	if receipt.ResolvedDate != nil {
 		row[KeyResolvedDate] = []reporting.Value{reporting.DateVal(*receipt.ResolvedDate)}
+		setDateParts(row, KeyResolvedDateDay, KeyResolvedDateMonth, KeyResolvedDateYear, *receipt.ResolvedDate)
 	}
 	if displayName := userDisplayName(receipt.PaidByUser); len(displayName) > 0 {
 		row[KeyPaidBy] = []reporting.Value{reporting.Str(displayName)}
@@ -192,6 +227,18 @@ func (s Source) row(receipt *models.Receipt) reporting.Row {
 	s.addCustomFields(row, receipt)
 
 	return row
+}
+
+// setDateParts writes the day/month/year strings derived from one date onto the
+// row. Each is zero-padded ISO in UTC ("2006-01-02" / "2006-01" / "2006"), so
+// the values sort chronologically as plain strings and group into calendar
+// buckets. The zone is fixed to UTC so a bucket does not depend on where the
+// instant is read.
+func setDateParts(row reporting.Row, dayKey, monthKey, yearKey reporting.FieldKey, moment time.Time) {
+	utc := moment.UTC()
+	row[dayKey] = []reporting.Value{reporting.Str(utc.Format("2006-01-02"))}
+	row[monthKey] = []reporting.Value{reporting.Str(utc.Format("2006-01"))}
+	row[yearKey] = []reporting.Value{reporting.Str(utc.Format("2006"))}
 }
 
 // addCustomFields resolves each of a receipt's custom field values against its

--- a/api/internal/reporting/receiptsource/receiptsource_test.go
+++ b/api/internal/reporting/receiptsource/receiptsource_test.go
@@ -146,6 +146,138 @@ func TestSource_CatalogBuiltins(t *testing.T) {
 	}
 }
 
+func TestSource_CatalogHasDatePeriodFields(t *testing.T) {
+	catalog := mustNew(t).Catalog()
+
+	keys := []reporting.FieldKey{
+		KeyDateDay, KeyDateMonth, KeyDateYear,
+		KeyResolvedDateDay, KeyResolvedDateMonth, KeyResolvedDateYear,
+		KeyCreatedAtDay, KeyCreatedAtMonth, KeyCreatedAtYear,
+	}
+	for _, key := range keys {
+		t.Run(string(key), func(t *testing.T) {
+			field, exists := catalog.Get(key)
+			if !exists {
+				t.Fatalf("catalog is missing %s", key)
+			}
+			// String so the engine buckets on the exact label, and a dimension so a
+			// report may group by it.
+			if field.DataType != reporting.TypeString {
+				t.Errorf("dataType = %v, want %v", field.DataType, reporting.TypeString)
+			}
+			if field.Multi {
+				t.Errorf("%s is single-valued", key)
+			}
+			if field.Role() != reporting.RoleDimension {
+				t.Errorf("role = %v, want dimension", field.Role())
+			}
+		})
+	}
+}
+
+func TestSource_DerivesDatePeriodFields(t *testing.T) {
+	row := mustNew(t).Rows([]models.Receipt{fullReceipt()})[0]
+
+	tests := []struct {
+		key  reporting.FieldKey
+		want string
+	}{
+		// date = 2026-05-15
+		{KeyDateDay, "2026-05-15"},
+		{KeyDateMonth, "2026-05"},
+		{KeyDateYear, "2026"},
+		// resolved_date = 2026-05-20
+		{KeyResolvedDateDay, "2026-05-20"},
+		{KeyResolvedDateMonth, "2026-05"},
+		{KeyResolvedDateYear, "2026"},
+		// created_at = 2026-05-01T08:00Z
+		{KeyCreatedAtDay, "2026-05-01"},
+		{KeyCreatedAtMonth, "2026-05"},
+		{KeyCreatedAtYear, "2026"},
+	}
+	for _, test := range tests {
+		t.Run(string(test.key), func(t *testing.T) {
+			text, isText := row.Measure(test.key).Text()
+			if !isText || text != test.want {
+				t.Errorf("%s = %v, want %q", test.key, row.Measure(test.key), test.want)
+			}
+		})
+	}
+}
+
+// A nil resolved date emits none of the resolved_date period fields, so it lands
+// in the (None) bucket just like the raw resolved_date field.
+func TestSource_NilResolvedDateOmitsResolvedPeriodFields(t *testing.T) {
+	receipt := fullReceipt()
+	receipt.ResolvedDate = nil
+
+	row := mustNew(t).Rows([]models.Receipt{receipt})[0]
+
+	for _, key := range []reporting.FieldKey{KeyResolvedDate, KeyResolvedDateDay, KeyResolvedDateMonth, KeyResolvedDateYear} {
+		if values := row.Get(key); len(values) != 0 {
+			t.Errorf("%s = %v, want no value", key, values)
+		}
+	}
+}
+
+// Grouping by date_month buckets receipts into calendar months: same-month
+// receipts merge into one bucket, and the buckets sort chronologically because
+// zero-padded ISO strings compare that way.
+func TestSource_GroupByMonthBucketsByCalendarMonth(t *testing.T) {
+	source := mustNew(t)
+
+	receipt := func(year int, month time.Month, day int, amount string) models.Receipt {
+		return models.Receipt{
+			Date:   time.Date(year, month, day, 0, 0, 0, 0, time.UTC),
+			Amount: dec(amount),
+		}
+	}
+
+	receipts := []models.Receipt{
+		receipt(2026, time.May, 15, "100.00"),
+		receipt(2026, time.May, 20, "50.00"), // same month as the first -> one bucket
+		receipt(2026, time.March, 1, "30.00"),
+		receipt(2026, time.December, 31, "20.00"),
+		receipt(2027, time.January, 1, "10.00"),
+	}
+
+	spec := reporting.ReportSpec{
+		GroupBy:     []reporting.FieldKey{KeyDateMonth},
+		Columns:     []reporting.Column{{Name: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"}},
+		Subtotals:   true,
+		GrandTotals: true,
+	}
+
+	model, err := reporting.Run(spec, source.Catalog(), source.Rows(receipts), reporting.MetaInput{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	wantBuckets := []string{"2026-03", "2026-05", "2026-12", "2027-01"}
+	if len(model.Root.Children) != len(wantBuckets) {
+		t.Fatalf("got %d month buckets, want %d", len(model.Root.Children), len(wantBuckets))
+	}
+	for index, want := range wantBuckets {
+		if got := model.Root.Children[index].Value.String(); got != want {
+			t.Errorf("bucket %d = %s, want %s", index, got, want)
+		}
+	}
+
+	find := func(cells []reporting.Cell, column string) string {
+		for _, candidate := range cells {
+			if candidate.Column == column {
+				return candidate.Value().String()
+			}
+		}
+		t.Fatalf("no cell for %s", column)
+		return ""
+	}
+	// The two May receipts merged into one bucket that sums both.
+	if got := find(model.Root.Children[1].Subtotals, "Total"); got != "150" {
+		t.Errorf("May total = %s, want 150", got)
+	}
+}
+
 func TestNew_RejectsDuplicateCustomFieldIds(t *testing.T) {
 	_, err := New([]models.CustomField{
 		{BaseModel: models.BaseModel{ID: 1}, Name: "HST", Type: models.CURRENCY},

--- a/api/internal/reporting/receiptsource/receiptsource_test.go
+++ b/api/internal/reporting/receiptsource/receiptsource_test.go
@@ -220,6 +220,42 @@ func TestSource_NilResolvedDateOmitsResolvedPeriodFields(t *testing.T) {
 	}
 }
 
+// The period fields are derived in UTC by design (matching the engine's date
+// buckets), so a non-UTC instant near midnight is bucketed by its UTC calendar
+// day, not its local one. This pins that choice: a later switch to a local zone
+// would have to break this test deliberately.
+func TestSource_DatePeriodFieldsTruncateInUTC(t *testing.T) {
+	minus5 := time.FixedZone("minus5", -5*60*60)
+	receipt := fullReceipt()
+	// 2026-05-31 23:30 -05:00 is 2026-06-01 04:30 UTC -> crosses into June.
+	receipt.Date = time.Date(2026, 5, 31, 23, 30, 0, 0, minus5)
+	// 2026-12-31 20:00 -05:00 is 2027-01-01 01:00 UTC -> crosses into 2027.
+	resolved := time.Date(2026, 12, 31, 20, 0, 0, 0, minus5)
+	receipt.ResolvedDate = &resolved
+
+	row := mustNew(t).Rows([]models.Receipt{receipt})[0]
+
+	tests := []struct {
+		key  reporting.FieldKey
+		want string
+	}{
+		{KeyDateDay, "2026-06-01"},
+		{KeyDateMonth, "2026-06"},
+		{KeyDateYear, "2026"},
+		{KeyResolvedDateDay, "2027-01-01"},
+		{KeyResolvedDateMonth, "2027-01"},
+		{KeyResolvedDateYear, "2027"},
+	}
+	for _, test := range tests {
+		t.Run(string(test.key), func(t *testing.T) {
+			text, isText := row.Measure(test.key).Text()
+			if !isText || text != test.want {
+				t.Errorf("%s = %v, want %q (UTC)", test.key, row.Measure(test.key), test.want)
+			}
+		})
+	}
+}
+
 // Grouping by date_month buckets receipts into calendar months: same-month
 // receipts merge into one bucket, and the buckets sort chronologically because
 // zero-padded ISO strings compare that way.

--- a/api/internal/services/grant_filter.go
+++ b/api/internal/services/grant_filter.go
@@ -42,6 +42,35 @@ func (service PermissionService) FilterReceiptCategoriesTags(userId uint, receip
 	return nil
 }
 
+// SubstituteRestrictedCategoriesTags rewrites every receipt's Categories/Tags in
+// place, replacing the entries the user may not see with a single (Restricted)
+// marker rather than dropping them (as FilterReceiptCategoriesTags does).
+// Aggregation surfaces — reports, charts — use this so a hidden category is
+// attributed to its own (Restricted) bucket instead of vanishing from the totals
+// or collapsing into (None). Like the strip variant, the allowed sets resolve
+// once per group, and a receipt whose group is unrestricted (or whose viewer
+// bypasses grants) is left untouched.
+//
+// It operates on receipt-level Categories/Tags only, which is all an aggregation
+// reads; it does not recurse into receipt items.
+func (service PermissionService) SubstituteRestrictedCategoriesTags(userId uint, receipts []models.Receipt) error {
+	if len(receipts) == 0 {
+		return nil
+	}
+
+	filter, err := service.newReceiptGrantFilter(userId)
+	if err != nil {
+		return err
+	}
+
+	for i := range receipts {
+		if err := filter.substitute(&receipts[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // FilterReceiptCategoriesTagsForReceipt is the single-receipt variant of
 // FilterReceiptCategoriesTags (single GetReceipt, duplicate source, etc.).
 func (service PermissionService) FilterReceiptCategoriesTagsForReceipt(userId uint, receipt *models.Receipt) error {
@@ -380,4 +409,68 @@ func filterTagsBySet(tags []models.Tag, allowed map[uint]struct{}) []models.Tag 
 		}
 	}
 	return filtered
+}
+
+// restrictedCategoryTagName is the marker a hidden category or tag is replaced
+// with on an aggregation surface. It forms its own bucket, kept distinct from
+// (None) — a receipt that genuinely carries no category or tag.
+const restrictedCategoryTagName = "(Restricted)"
+
+// substitute is the substitution counterpart of apply: it keeps every receipt
+// but replaces the categories/tags the user may not see with a (Restricted)
+// marker. It stays at receipt level because that is all an aggregation reads.
+func (filter *receiptGrantFilter) substitute(receipt *models.Receipt) error {
+	if filter.bypassCategories && filter.bypassTags {
+		return nil
+	}
+
+	grants, err := filter.grantsForGroup(receipt.GroupId)
+	if err != nil {
+		return err
+	}
+
+	if !filter.bypassCategories && !grants.categoryUnrestricted {
+		receipt.Categories = substituteCategoriesBySet(receipt.Categories, grants.categoryAllowed)
+	}
+	if !filter.bypassTags && !grants.tagUnrestricted {
+		receipt.Tags = substituteTagsBySet(receipt.Tags, grants.tagAllowed)
+	}
+	return nil
+}
+
+// substituteCategoriesBySet keeps the allowed categories and, if any category was
+// disallowed, appends exactly one (Restricted) marker. Several hidden categories
+// collapse to that one marker, which is enough: the engine attributes a receipt
+// to a multi-valued bucket once no matter how many times it carries the value. A
+// receipt with no disallowed category gets no marker.
+func substituteCategoriesBySet(categories []models.Category, allowed map[uint]struct{}) []models.Category {
+	result := make([]models.Category, 0, len(categories))
+	hidden := false
+	for _, category := range categories {
+		if _, ok := allowed[category.ID]; ok {
+			result = append(result, category)
+			continue
+		}
+		hidden = true
+	}
+	if hidden {
+		result = append(result, models.Category{Name: restrictedCategoryTagName})
+	}
+	return result
+}
+
+func substituteTagsBySet(tags []models.Tag, allowed map[uint]struct{}) []models.Tag {
+	result := make([]models.Tag, 0, len(tags))
+	hidden := false
+	for _, tag := range tags {
+		if _, ok := allowed[tag.ID]; ok {
+			result = append(result, tag)
+			continue
+		}
+		hidden = true
+	}
+	if hidden {
+		result = append(result, models.Tag{Name: restrictedCategoryTagName})
+	}
+	return result
 }

--- a/api/internal/services/grant_filter_test.go
+++ b/api/internal/services/grant_filter_test.go
@@ -378,3 +378,185 @@ func TestValidateCategoryTagSelectionUnrestricted(t *testing.T) {
 		t.Error("expected unrestricted role to allow any category selection")
 	}
 }
+
+func TestSubstituteReplacesDisallowedCategoriesWithMarker(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	cat2 := makeCategory(t, "Utilities")
+	tag1 := makeTag(t, "Reimbursable")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-sub", []uint{cat1}, nil)
+
+	receipts := []models.Receipt{{
+		GroupId:    groupId,
+		Categories: []models.Category{categoryWithId(cat1), categoryWithId(cat2)},
+		Tags:       []models.Tag{tagWithId(tag1)},
+	}}
+
+	service := NewPermissionService(nil)
+	if err := service.SubstituteRestrictedCategoriesTags(userId, receipts); err != nil {
+		t.Fatalf("SubstituteRestrictedCategoriesTags: %v", err)
+	}
+
+	// cat1 survives; the hidden cat2 becomes one (Restricted) marker.
+	got := receipts[0].Categories
+	if len(got) != 2 || got[0].ID != cat1 || got[1].Name != restrictedCategoryTagName {
+		t.Errorf("expected [cat1, (Restricted)], got %v", got)
+	}
+	// The role grants no tags, so tags are unrestricted and left untouched.
+	if len(receipts[0].Tags) != 1 || receipts[0].Tags[0].ID != tag1 {
+		t.Errorf("expected tags untouched (unrestricted), got %v", receipts[0].Tags)
+	}
+}
+
+func TestSubstituteOnlyHiddenCategoriesBecomeSingleMarker(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	cat2 := makeCategory(t, "Utilities")
+	cat3 := makeCategory(t, "Travel")
+	// The role grants only cat1; the receipt carries two hidden categories.
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-sub-hidden", []uint{cat1}, nil)
+
+	receipts := []models.Receipt{{
+		GroupId:    groupId,
+		Categories: []models.Category{categoryWithId(cat2), categoryWithId(cat3)},
+	}}
+
+	service := NewPermissionService(nil)
+	if err := service.SubstituteRestrictedCategoriesTags(userId, receipts); err != nil {
+		t.Fatalf("SubstituteRestrictedCategoriesTags: %v", err)
+	}
+
+	// Two hidden categories collapse to one marker, not two.
+	got := receipts[0].Categories
+	if len(got) != 1 || got[0].Name != restrictedCategoryTagName {
+		t.Errorf("expected a single (Restricted) marker, got %v", got)
+	}
+}
+
+func TestSubstituteNoHiddenLeavesNoMarker(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-sub-visible", []uint{cat1}, nil)
+
+	receipts := []models.Receipt{{
+		GroupId:    groupId,
+		Categories: []models.Category{categoryWithId(cat1)},
+	}}
+
+	service := NewPermissionService(nil)
+	if err := service.SubstituteRestrictedCategoriesTags(userId, receipts); err != nil {
+		t.Fatalf("SubstituteRestrictedCategoriesTags: %v", err)
+	}
+
+	got := receipts[0].Categories
+	if len(got) != 1 || got[0].ID != cat1 {
+		t.Errorf("expected only the visible category and no marker, got %v", got)
+	}
+}
+
+// A receipt with no categories stays empty, so it lands in (None) rather than
+// (Restricted) — the two buckets mean different things.
+func TestSubstituteEmptyCategoriesStayEmpty(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-sub-empty", []uint{cat1}, nil)
+
+	receipts := []models.Receipt{{GroupId: groupId}}
+
+	service := NewPermissionService(nil)
+	if err := service.SubstituteRestrictedCategoriesTags(userId, receipts); err != nil {
+		t.Fatalf("SubstituteRestrictedCategoriesTags: %v", err)
+	}
+
+	if len(receipts[0].Categories) != 0 {
+		t.Errorf("expected no categories (None), got %v", receipts[0].Categories)
+	}
+}
+
+func TestSubstituteReplacesDisallowedTagsWithMarker(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	tag1 := makeTag(t, "Reimbursable")
+	tag2 := makeTag(t, "Personal")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-sub-tag", nil, []uint{tag1})
+
+	receipts := []models.Receipt{{
+		GroupId: groupId,
+		Tags:    []models.Tag{tagWithId(tag1), tagWithId(tag2)},
+	}}
+
+	service := NewPermissionService(nil)
+	if err := service.SubstituteRestrictedCategoriesTags(userId, receipts); err != nil {
+		t.Fatalf("SubstituteRestrictedCategoriesTags: %v", err)
+	}
+
+	got := receipts[0].Tags
+	if len(got) != 2 || got[0].ID != tag1 || got[1].Name != restrictedCategoryTagName {
+		t.Errorf("expected [tag1, (Restricted)], got %v", got)
+	}
+}
+
+func TestSubstituteUnrestrictedNoOp(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	cat2 := makeCategory(t, "Utilities")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-sub-open", nil, nil)
+
+	receipts := []models.Receipt{{
+		GroupId:    groupId,
+		Categories: []models.Category{categoryWithId(cat1), categoryWithId(cat2)},
+	}}
+
+	service := NewPermissionService(nil)
+	if err := service.SubstituteRestrictedCategoriesTags(userId, receipts); err != nil {
+		t.Fatalf("SubstituteRestrictedCategoriesTags: %v", err)
+	}
+
+	if len(receipts[0].Categories) != 2 {
+		t.Errorf("expected unrestricted receipt untouched, got %v", receipts[0].Categories)
+	}
+}
+
+func TestSubstituteAdminBypassNoOp(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	cat1 := makeCategory(t, "Groceries")
+	cat2 := makeCategory(t, "Utilities")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "u-sub-admin", []uint{cat1}, nil)
+	// The user holds app.categories.read, so grants do not apply and nothing is
+	// marked restricted.
+	grantUserAppPermissions(t, userId, []string{permissions.AppCategoriesRead})
+
+	receipts := []models.Receipt{{
+		GroupId:    groupId,
+		Categories: []models.Category{categoryWithId(cat1), categoryWithId(cat2)},
+	}}
+
+	service := NewPermissionService(nil)
+	if err := service.SubstituteRestrictedCategoriesTags(userId, receipts); err != nil {
+		t.Fatalf("SubstituteRestrictedCategoriesTags: %v", err)
+	}
+
+	if len(receipts[0].Categories) != 2 {
+		t.Errorf("expected bypass user untouched, got %v", receipts[0].Categories)
+	}
+}

--- a/api/internal/services/report_data.go
+++ b/api/internal/services/report_data.go
@@ -1,0 +1,105 @@
+package services
+
+import (
+	"gorm.io/gorm"
+	"receipt-wrangler/api/internal/commands"
+	"receipt-wrangler/api/internal/reporting"
+	"receipt-wrangler/api/internal/reporting/receiptsource"
+	"receipt-wrangler/api/internal/repositories"
+	"receipt-wrangler/api/internal/utils"
+)
+
+// ReportDataService resolves a group's receipts into the reporting engine's two
+// inputs — a field catalog and the rows — with the reporting access controls
+// applied. It is the only place that reads the database for a report; the engine
+// itself fetches nothing and enforces nothing.
+//
+// It stops at the engine's inputs: it does not build a ReportSpec or call
+// reporting.Run. A caller assembles the spec and runs the report.
+type ReportDataService struct {
+	BaseService
+}
+
+func NewReportDataService(tx *gorm.DB) ReportDataService {
+	service := ReportDataService{BaseService: BaseService{
+		DB: repositories.GetDB(),
+		TX: tx,
+	}}
+	return service
+}
+
+// Rows fetches a group's receipts, applies the three reporting access controls,
+// and maps the survivors to engine rows. The controls run in the order they must:
+//
+//   - the request filter is narrowed to what the caller may see, so a restricted
+//     caller cannot probe for hidden categories/tags through the filter;
+//   - paid-by visibility is enforced in the query, so a receipt the caller may
+//     not see is never fetched (whole-receipt hiding);
+//   - categories/tags the caller may not see are replaced with a (Restricted)
+//     marker, so a hidden category still counts toward the totals in its own
+//     bucket rather than vanishing.
+//
+// The returned catalog carries every built-in field plus one per custom field.
+func (service ReportDataService) Rows(userId uint, groupId string, filter commands.ReceiptPagedRequestFilter) (reporting.FieldCatalog, []reporting.Row, error) {
+	receiptRepository := repositories.NewReceiptRepository(service.TX)
+	customFieldRepository := repositories.NewCustomFieldRepository(service.TX)
+	permissionService := NewPermissionService(service.TX)
+
+	uintGroupId, err := utils.StringToUint(groupId)
+	if err != nil {
+		return reporting.FieldCatalog{}, nil, err
+	}
+
+	// The catalog spans every custom field (a global pool), with their options
+	// loaded so a select value resolves to its text rather than a bare option id.
+	customFields, _, err := customFieldRepository.GetPagedCustomFields(commands.PagedRequestCommand{
+		Page:          -1,
+		PageSize:      -1,
+		OrderBy:       "name",
+		SortDirection: commands.ASCENDING,
+	})
+	if err != nil {
+		return reporting.FieldCatalog{}, nil, err
+	}
+
+	source, err := receiptsource.New(customFields)
+	if err != nil {
+		return reporting.FieldCatalog{}, nil, err
+	}
+
+	pagedRequest := commands.ReceiptPagedRequestCommand{
+		PagedRequestCommand: commands.PagedRequestCommand{
+			Page:          -1,
+			PageSize:      -1,
+			OrderBy:       "date",
+			SortDirection: commands.DESCENDING,
+		},
+		Filter: filter,
+	}
+
+	// Narrow any category/tag filter to what the caller may see (anti-probing).
+	if err := permissionService.IntersectReceiptFilterWithGrants(userId, uintGroupId, &pagedRequest.Filter); err != nil {
+		return reporting.FieldCatalog{}, nil, err
+	}
+
+	// The paid-by resolver hides whole receipts in the query; the extra preloads
+	// are what receiptsource reads beyond the always-loaded Categories/Tags.
+	receipts, _, err := receiptRepository.GetPagedReceiptsByGroupId(
+		userId,
+		groupId,
+		pagedRequest,
+		[]string{"PaidByUser", "Group", "CustomFields"},
+		permissionService.PaidByListResolver(userId),
+	)
+	if err != nil {
+		return reporting.FieldCatalog{}, nil, err
+	}
+
+	// Replace categories/tags the caller cannot see with a (Restricted) marker so
+	// they aggregate into their own bucket rather than disappearing.
+	if err := permissionService.SubstituteRestrictedCategoriesTags(userId, receipts); err != nil {
+		return reporting.FieldCatalog{}, nil, err
+	}
+
+	return source.Catalog(), source.Rows(receipts), nil
+}

--- a/api/internal/services/report_data_test.go
+++ b/api/internal/services/report_data_test.go
@@ -1,0 +1,158 @@
+package services
+
+import (
+	"receipt-wrangler/api/internal/commands"
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/reporting"
+	"receipt-wrangler/api/internal/reporting/receiptsource"
+	"receipt-wrangler/api/internal/repositories"
+	"slices"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+func loadCategory(t *testing.T, id uint) models.Category {
+	t.Helper()
+	var category models.Category
+	if err := repositories.GetDB().First(&category, id).Error; err != nil {
+		t.Fatalf("load category %d: %v", id, err)
+	}
+	return category
+}
+
+// createReportReceipt inserts a receipt in a group. Categories must be loaded
+// rows (not bare ids), so the association write does not blank their names.
+func createReportReceipt(t *testing.T, name string, paidByUserId uint, groupId uint, categories []models.Category) models.Receipt {
+	t.Helper()
+	receipt := models.Receipt{
+		Name:         name,
+		Amount:       decimal.NewFromInt(100),
+		Date:         time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC),
+		PaidByUserID: paidByUserId,
+		GroupId:      groupId,
+		Status:       models.OPEN,
+		Categories:   categories,
+	}
+	if err := repositories.GetDB().Create(&receipt).Error; err != nil {
+		t.Fatalf("create receipt %q: %v", name, err)
+	}
+	return receipt
+}
+
+func groupIdString(groupId uint) string {
+	return strconv.FormatUint(uint64(groupId), 10)
+}
+
+// Paid-by visibility hides a whole receipt: one paid by an allowed payer is
+// returned, one paid by a disallowed payer never reaches the engine.
+func TestReportDataService_HidesReceiptsByPaidBy(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	allowedPayer := makeUser(t, "rpt-allowed-payer")
+	hiddenPayer := makeUser(t, "rpt-hidden-payer")
+	userId, groupId, _ := seedMemberWithPaidByRole(t, "rpt-reviewer", []uint{allowedPayer}, false)
+
+	visible := createReportReceipt(t, "visible", allowedPayer, groupId, nil)
+	createReportReceipt(t, "hidden", hiddenPayer, groupId, nil)
+
+	_, rows, err := NewReportDataService(nil).Rows(userId, groupIdString(groupId), commands.ReceiptPagedRequestFilter{})
+	if err != nil {
+		t.Fatalf("Rows: %v", err)
+	}
+
+	if len(rows) != 1 {
+		t.Fatalf("expected only the allowed-payer receipt, got %d rows", len(rows))
+	}
+	id, _ := rows[0].Measure(receiptsource.KeyReceiptID).Decimal()
+	if id.IntPart() != int64(visible.ID) {
+		t.Errorf("row is receipt %s, want %d", id, visible.ID)
+	}
+}
+
+// A category the caller may not see becomes (Restricted) in the row rather than
+// being stripped (which would silently drop it from the totals).
+func TestReportDataService_SubstitutesRestrictedCategory(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	allowedCatId := makeCategory(t, "Groceries")
+	hiddenCatId := makeCategory(t, "Salary")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "rpt-cat", []uint{allowedCatId}, nil)
+
+	createReportReceipt(t, "mixed", userId, groupId, []models.Category{loadCategory(t, allowedCatId), loadCategory(t, hiddenCatId)})
+
+	_, rows, err := NewReportDataService(nil).Rows(userId, groupIdString(groupId), commands.ReceiptPagedRequestFilter{})
+	if err != nil {
+		t.Fatalf("Rows: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+
+	got := make([]string, 0)
+	for _, value := range rows[0].Get(receiptsource.KeyCategory) {
+		text, _ := value.Text()
+		got = append(got, text)
+	}
+	if !slices.Contains(got, "Groceries") || !slices.Contains(got, "(Restricted)") {
+		t.Errorf("category values = %v, want Groceries and (Restricted)", got)
+	}
+	if slices.Contains(got, "Salary") {
+		t.Errorf("hidden category leaked into the row: %v", got)
+	}
+}
+
+// The catalog carries the built-ins, the derived date fields, and one field per
+// custom field; and the rows resolve a receipt's custom field value.
+func TestReportDataService_ResolvesCustomFieldsInCatalogAndRows(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "rpt-custom", nil, nil)
+
+	customField := models.CustomField{Name: "HST", Type: models.CURRENCY}
+	if err := repositories.GetDB().Create(&customField).Error; err != nil {
+		t.Fatalf("seed custom field: %v", err)
+	}
+
+	hst := decimal.RequireFromString("15.60")
+	receipt := models.Receipt{
+		Name:         "with-hst",
+		Amount:       decimal.NewFromInt(100),
+		Date:         time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC),
+		PaidByUserID: userId,
+		GroupId:      groupId,
+		Status:       models.OPEN,
+		CustomFields: []models.CustomFieldValue{{CustomFieldId: customField.ID, CurrencyValue: &hst}},
+	}
+	if err := repositories.GetDB().Create(&receipt).Error; err != nil {
+		t.Fatalf("create receipt: %v", err)
+	}
+
+	customKey := receiptsource.CustomFieldKey(customField.ID)
+	catalog, rows, err := NewReportDataService(nil).Rows(userId, groupIdString(groupId), commands.ReceiptPagedRequestFilter{})
+	if err != nil {
+		t.Fatalf("Rows: %v", err)
+	}
+
+	for _, key := range []reporting.FieldKey{receiptsource.KeyAmount, receiptsource.KeyDateMonth, customKey} {
+		if _, ok := catalog.Get(key); !ok {
+			t.Errorf("catalog missing %s", key)
+		}
+	}
+
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	value, isNumber := rows[0].Measure(customKey).Decimal()
+	if !isNumber || !value.Equal(hst) {
+		t.Errorf("custom field value = %v, want %v", rows[0].Measure(customKey), hst)
+	}
+}

--- a/api/internal/services/report_data_test.go
+++ b/api/internal/services/report_data_test.go
@@ -156,3 +156,49 @@ func TestReportDataService_ResolvesCustomFieldsInCatalogAndRows(t *testing.T) {
 		t.Errorf("custom field value = %v, want %v", rows[0].Measure(customKey), hst)
 	}
 }
+
+// A non-numeric group id cannot be resolved, so Rows fails fast rather than
+// fetching against a bad scope.
+func TestReportDataService_Rows_InvalidGroupIdReturnsError(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	userId, _, _ := seedMemberWithGroupRoleGrants(t, "rpt-badid", nil, nil)
+
+	catalog, rows, err := NewReportDataService(nil).Rows(userId, "not-a-number", commands.ReceiptPagedRequestFilter{})
+	if err == nil {
+		t.Fatalf("expected an error for a non-numeric group id, got none")
+	}
+	if rows != nil {
+		t.Errorf("expected nil rows on error, got %d", len(rows))
+	}
+	if _, ok := catalog.Get(receiptsource.KeyAmount); ok {
+		t.Errorf("expected an empty catalog on error")
+	}
+}
+
+// Rows is NOT the group-membership boundary: it trusts that a caller was already
+// authorized (the handler enforces group.reports.read before calling it, exactly
+// as pie_chart.go does). A non-member therefore receives the group's rows, and a
+// non-member's grants resolve as unrestricted. This test pins that boundary so
+// the service is not mistaken for the gate, nor the gate accidentally moved here.
+func TestReportDataService_Rows_DoesNotGateGroupMembership(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	memberId, groupId, _ := seedMemberWithGroupRoleGrants(t, "rpt-member", nil, nil)
+	createReportReceipt(t, "r1", memberId, groupId, nil)
+	createReportReceipt(t, "r2", memberId, groupId, nil)
+
+	nonMemberId := makeUser(t, "rpt-outsider")
+
+	_, rows, err := NewReportDataService(nil).Rows(nonMemberId, groupIdString(groupId), commands.ReceiptPagedRequestFilter{})
+	if err != nil {
+		t.Fatalf("Rows: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Errorf("expected the service to return the group's 2 rows to a non-member (membership is the handler's gate), got %d", len(rows))
+	}
+}


### PR DESCRIPTION
## What

Wires the pure reporting engine to the database for the first time. Adds `ReportDataService.Rows(userId, groupId, filter)` — the one place that fetches a group's receipts, applies the reporting access controls, and returns the engine's two inputs (field catalog + rows). It stops there: it does **not** build a `ReportSpec`, call `reporting.Run`, or expose an endpoint (later slices).

It mirrors the existing `services/pie_chart.go` fetch-and-enforce sequence, so the enforcement wiring is a known, tested pattern — not new security code.

Three access controls, three distinct mechanisms, all applied **before** the engine (which enforces nothing):

- **Paid-by** removes *whole receipts* the caller can't see — a SQL `WHERE` via `PaidByListResolver`.
- **Category/tag** keeps the receipt but replaces values the caller can't see with a single **`(Restricted)`** marker — a new substitution, distinct from the existing *strip*.
- **Filter narrowing** stops a restricted caller probing for hidden data through the request filter — `IntersectReceiptFilterWithGrants`.

## Commits (one per phase)

1. **Derived date-period fields** (`receiptsource`). Grouping by a raw date bucketed on the exact instant → one group per receipt. Added `date_day`/`_month`/`_year` (and the same for `resolved_date` and `created_at`) as `TypeString` fields emitting zero-padded ISO in UTC, so a report can group "by month" and the buckets sort chronologically. Pure package change, no engine change.
2. **`(Restricted)` substitution** (`grant_filter.go`). `PermissionService.SubstituteRestrictedCategoriesTags` reuses the same per-group grant resolution as the strip variant, but replaces a hidden category/tag with one `(Restricted)` marker instead of dropping it — kept distinct from the `(None)` bucket a receipt with no category earns. Receipt-level only (all an aggregation reads).
3. **`ReportDataService`** (`report_data.go`) + docs.

## Scope / deferred

- The **reports permission** is not added here (it does not exist yet; its gate belongs at the future handler layer). Slice 1 (system-role reconciliation, #622) ensures it reaches upgraded installs when added.
- The **pie chart** still strips today; switching it to `(Restricted)` is a deliberate follow-up (changes existing behavior + a desktop label).
- No `ReportSpec` persistence, params, `Run` wiring, renderer, handler, Asynq job, swagger, or desktop.

## `(Restricted)` vs `(None)`

`(None)` = the receipt genuinely has no category/tag. `(Restricted)` = the caller isn't allowed to see it. Paid-by *subtracts rows*; category/tag *relabels fields* — so a paid-by-hidden receipt vanishes from totals, while a category-hidden one still counts, in its own `(Restricted)` bucket.

## Tests

- `receiptsource_test.go`: the nine derived fields resolve to the exact ISO strings; catalog carries them as `TypeString` dimensions; nil `resolved_date` emits none; end-to-end `Run` grouping by `date_month` merges same-month receipts into one bucket, chronologically ordered.
- `grant_filter_test.go`: visible+hidden → `[visible, (Restricted)]`; only-hidden → one marker; no-hidden → no marker; empty stays empty; tags symmetric; unrestricted role and app-`categories.read` bypass untouched.
- `report_data_test.go`: a disallowed-paid-by receipt is absent from the rows; a hidden category surfaces as `(Restricted)` (not stripped, not `(None)`); the catalog + rows resolve custom fields.

`go test ./internal/reporting/... ./internal/services/...` passes; gofmt + vet clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reports can now group receipts by day, month, or year using UTC calendar periods.
  * Restricted categories and tags remain represented in report totals as “(Restricted)” instead of being omitted.
  * Report data now supports custom fields and applies visibility controls consistently.

* **Bug Fixes**
  * Improved protection against exposing hidden receipts, categories, tags, and payer information.
  * Corrected calendar-period ordering and grouping across time zones.

* **Documentation**
  * Updated reporting guidance for date-period grouping and access-control behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->