### PR TITLE
feat(pie-chart): show hidden categories/tags as a (Restricted) slice

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -393,8 +393,11 @@ will be dropped in a later release.
   whole pool), keeping their view consistent with the global lists.
 - **Receipt enforcement wiring:** every receipt surface that returns or accepts categories/tags is
   gated. **Reads** strip via `FilterReceiptCategoriesTags` (receipt-, item-, and linked-item-level):
-  `GetReceipt`, `GetPagedReceiptsForGroup`, `GetReceiptsForGroupIds`, the pie-chart service, and both
-  CSV export handlers; `DuplicateReceipt` strips the source before copying. **Writes**
+  `GetReceipt`, `GetPagedReceiptsForGroup`, `GetReceiptsForGroupIds`, and both CSV export handlers;
+  `DuplicateReceipt` strips the source before copying. **Aggregation** reads substitute instead of
+  stripping via `SubstituteRestrictedCategoriesTags` (receipt-level; a hidden category/tag becomes a
+  `(Restricted)` bucket rather than collapsing into `(None)`): the pie-chart service and the reporting
+  data source. **Writes**
   (`CreateReceipt` / `UpdateReceipt`) call `enforceReceiptGrantSelection` — existing ids must be in
   the caller's grants (else 403) and a new-by-name category/tag requires `app.categories.create` /
   `app.tags.create`. **List/pie/export filters** are narrowed by `IntersectReceiptFilterWithGrants`
@@ -685,8 +688,10 @@ engine's `(FieldCatalog, []Row)` — it does **not** build a `ReportSpec` or cal
 **`(Restricted)` vs `(None)`.** Aggregation uses `PermissionService.SubstituteRestrictedCategoriesTags`
 (not the strip variant): a category/tag the caller may not see is replaced with a single `(Restricted)`
 marker, so the receipt still counts toward the totals in its own bucket instead of vanishing. `(None)`
-stays reserved for a receipt that genuinely carries no category/tag. (The pie chart still strips today;
-switching it to `(Restricted)` is a deferred follow-up.)
+stays reserved for a receipt that genuinely carries no category/tag. The **pie chart** (`pie_chart.go`)
+substitutes the same way, so a restricted viewer sees a `(Restricted)` slice rather than hidden spend
+folding into `Uncategorized`/`Untagged`. (The CSV export handlers still strip — export is a per-receipt
+listing, not an aggregation.)
 
 ### Semantics that are easy to get wrong
 

--- a/api/internal/services/pie_chart.go
+++ b/api/internal/services/pie_chart.go
@@ -63,9 +63,11 @@ func (service PieChartService) GetPieChartData(
 		return structs.PieChartData{}, err
 	}
 
-	// Strip categories/tags the caller cannot see so they are not aggregated into
-	// the chart (a disallowed category collapses to Uncategorized/Untagged).
-	err = permissionService.FilterReceiptCategoriesTags(userId, receipts)
+	// Replace categories/tags the caller cannot see with a (Restricted) marker so
+	// their spend aggregates into its own slice rather than collapsing into
+	// Uncategorized/Untagged (which would hide it among genuinely uncategorized
+	// receipts). This matches the reporting engine's treatment of hidden values.
+	err = permissionService.SubstituteRestrictedCategoriesTags(userId, receipts)
 	if err != nil {
 		return structs.PieChartData{}, err
 	}

--- a/api/internal/services/pie_chart_test.go
+++ b/api/internal/services/pie_chart_test.go
@@ -832,6 +832,12 @@ func TestPieChartService_GetPieChartData_GroupByCategories_RestrictedCategory(t 
 		return
 	}
 
+	// Exactly two slices: one visible category and one shared (Restricted). Asserted
+	// on the raw data because pieDataByLabel would fold a duplicate (Restricted) point.
+	if len(result.Data) != 2 {
+		utils.PrintTestError(t, len(result.Data), 2)
+	}
+
 	byLabel := pieDataByLabel(result.Data)
 	if byLabel["Groceries"] != 100.0 {
 		utils.PrintTestError(t, byLabel["Groceries"], 100.0)
@@ -874,6 +880,11 @@ func TestPieChartService_GetPieChartData_GroupByCategories_RestrictedDistinctFro
 		return
 	}
 
+	// Exactly two slices: (Restricted) and Uncategorized, kept separate.
+	if len(result.Data) != 2 {
+		utils.PrintTestError(t, len(result.Data), 2)
+	}
+
 	byLabel := pieDataByLabel(result.Data)
 	if byLabel["(Restricted)"] != 100.0 {
 		utils.PrintTestError(t, byLabel["(Restricted)"], 100.0)
@@ -907,6 +918,11 @@ func TestPieChartService_GetPieChartData_GroupByTags_RestrictedTag(t *testing.T)
 	if err != nil {
 		utils.PrintTestError(t, err, "no error")
 		return
+	}
+
+	// Exactly two slices: one visible tag and one shared (Restricted).
+	if len(result.Data) != 2 {
+		utils.PrintTestError(t, len(result.Data), 2)
 	}
 
 	byLabel := pieDataByLabel(result.Data)

--- a/api/internal/services/pie_chart_test.go
+++ b/api/internal/services/pie_chart_test.go
@@ -807,6 +807,10 @@ func pieDataByLabel(data []structs.PieChartDataPoint) map[string]float64 {
 // being stripped — stripping would fold its spend into Uncategorized and hide it
 // among genuinely uncategorized receipts. The allowed and the restricted slice
 // each carry the receipt amount (the chart's existing multi-value fan-out).
+//
+// The receipt carries TWO hidden categories to pin that they collapse to a
+// SINGLE (Restricted) slice: (Restricted) is counted once per receipt, so its
+// value is the receipt amount, not a multiple of the hidden-category count.
 func TestPieChartService_GetPieChartData_GroupByCategories_RestrictedCategory(t *testing.T) {
 	defer repositories.TruncateTestDb()
 	clearGroupRoleGrantCacheAll()
@@ -814,10 +818,11 @@ func TestPieChartService_GetPieChartData_GroupByCategories_RestrictedCategory(t 
 
 	allowedCatId := makeCategory(t, "Groceries")
 	hiddenCatId := makeCategory(t, "Salary")
+	otherHiddenCatId := makeCategory(t, "Bonus")
 	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "pie-cat", []uint{allowedCatId}, nil)
 
 	createTestReceipt("mixed", 100.00, userId, groupId,
-		[]models.Category{loadCategory(t, allowedCatId), loadCategory(t, hiddenCatId)}, nil)
+		[]models.Category{loadCategory(t, allowedCatId), loadCategory(t, hiddenCatId), loadCategory(t, otherHiddenCatId)}, nil)
 
 	result, err := NewPieChartService(nil).GetPieChartData(userId, groupIdString(groupId), commands.PieChartDataCommand{
 		ChartGrouping: models.CHART_GROUPING_CATEGORIES,
@@ -831,11 +836,15 @@ func TestPieChartService_GetPieChartData_GroupByCategories_RestrictedCategory(t 
 	if byLabel["Groceries"] != 100.0 {
 		utils.PrintTestError(t, byLabel["Groceries"], 100.0)
 	}
+	// 100.0, not 200.0 — the two hidden categories share one (Restricted) slice.
 	if byLabel["(Restricted)"] != 100.0 {
 		utils.PrintTestError(t, byLabel["(Restricted)"], 100.0)
 	}
 	if _, ok := byLabel["Salary"]; ok {
 		utils.PrintTestError(t, "hidden category leaked into the chart", "no Salary slice")
+	}
+	if _, ok := byLabel["Bonus"]; ok {
+		utils.PrintTestError(t, "second hidden category leaked into the chart", "no Bonus slice")
 	}
 	if _, ok := byLabel["Uncategorized"]; ok {
 		utils.PrintTestError(t, "hidden spend collapsed into Uncategorized", "no Uncategorized slice")
@@ -878,7 +887,8 @@ func TestPieChartService_GetPieChartData_GroupByCategories_RestrictedDistinctFro
 }
 
 // The tag side mirrors categories: a tag the caller may not see becomes a
-// (Restricted) slice rather than folding into Untagged.
+// (Restricted) slice rather than folding into Untagged. Two hidden tags on the
+// one receipt collapse to a single (Restricted) slice counted once per receipt.
 func TestPieChartService_GetPieChartData_GroupByTags_RestrictedTag(t *testing.T) {
 	defer repositories.TruncateTestDb()
 	clearGroupRoleGrantCacheAll()
@@ -886,9 +896,10 @@ func TestPieChartService_GetPieChartData_GroupByTags_RestrictedTag(t *testing.T)
 
 	allowedTag := createTestTag("Reimbursable")
 	hiddenTag := createTestTag("Personal")
+	otherHiddenTag := createTestTag("Confidential")
 	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "pie-tag", nil, []uint{allowedTag.ID})
 
-	createTestReceipt("mixed", 100.00, userId, groupId, nil, []models.Tag{allowedTag, hiddenTag})
+	createTestReceipt("mixed", 100.00, userId, groupId, nil, []models.Tag{allowedTag, hiddenTag, otherHiddenTag})
 
 	result, err := NewPieChartService(nil).GetPieChartData(userId, groupIdString(groupId), commands.PieChartDataCommand{
 		ChartGrouping: models.CHART_GROUPING_TAGS,
@@ -902,11 +913,15 @@ func TestPieChartService_GetPieChartData_GroupByTags_RestrictedTag(t *testing.T)
 	if byLabel["Reimbursable"] != 100.0 {
 		utils.PrintTestError(t, byLabel["Reimbursable"], 100.0)
 	}
+	// 100.0, not 200.0 — the two hidden tags share one (Restricted) slice.
 	if byLabel["(Restricted)"] != 100.0 {
 		utils.PrintTestError(t, byLabel["(Restricted)"], 100.0)
 	}
 	if _, ok := byLabel["Personal"]; ok {
 		utils.PrintTestError(t, "hidden tag leaked into the chart", "no Personal slice")
+	}
+	if _, ok := byLabel["Confidential"]; ok {
+		utils.PrintTestError(t, "second hidden tag leaked into the chart", "no Confidential slice")
 	}
 	if _, ok := byLabel["Untagged"]; ok {
 		utils.PrintTestError(t, "hidden spend collapsed into Untagged", "no Untagged slice")

--- a/api/internal/services/pie_chart_test.go
+++ b/api/internal/services/pie_chart_test.go
@@ -4,6 +4,7 @@ import (
 	"receipt-wrangler/api/internal/commands"
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/repositories"
+	"receipt-wrangler/api/internal/structs"
 	"receipt-wrangler/api/internal/utils"
 	"testing"
 	"time"
@@ -789,5 +790,125 @@ func TestPieChartService_GetPieChartData_SingleReceiptAllGroupings(t *testing.T)
 
 	if len(paidByResult.Data) != 1 || paidByResult.Data[0].Value != 150.0 {
 		utils.PrintTestError(t, paidByResult.Data, "expected single entry with value 150.0")
+	}
+}
+
+// pieDataByLabel indexes pie chart data points by their label. Buckets are keyed
+// by name in the chart output, so labels are unique and this is lossless.
+func pieDataByLabel(data []structs.PieChartDataPoint) map[string]float64 {
+	byLabel := make(map[string]float64, len(data))
+	for _, point := range data {
+		byLabel[point.Label] = point.Value
+	}
+	return byLabel
+}
+
+// A category the caller may not see becomes a (Restricted) slice rather than
+// being stripped — stripping would fold its spend into Uncategorized and hide it
+// among genuinely uncategorized receipts. The allowed and the restricted slice
+// each carry the receipt amount (the chart's existing multi-value fan-out).
+func TestPieChartService_GetPieChartData_GroupByCategories_RestrictedCategory(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	allowedCatId := makeCategory(t, "Groceries")
+	hiddenCatId := makeCategory(t, "Salary")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "pie-cat", []uint{allowedCatId}, nil)
+
+	createTestReceipt("mixed", 100.00, userId, groupId,
+		[]models.Category{loadCategory(t, allowedCatId), loadCategory(t, hiddenCatId)}, nil)
+
+	result, err := NewPieChartService(nil).GetPieChartData(userId, groupIdString(groupId), commands.PieChartDataCommand{
+		ChartGrouping: models.CHART_GROUPING_CATEGORIES,
+	})
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+
+	byLabel := pieDataByLabel(result.Data)
+	if byLabel["Groceries"] != 100.0 {
+		utils.PrintTestError(t, byLabel["Groceries"], 100.0)
+	}
+	if byLabel["(Restricted)"] != 100.0 {
+		utils.PrintTestError(t, byLabel["(Restricted)"], 100.0)
+	}
+	if _, ok := byLabel["Salary"]; ok {
+		utils.PrintTestError(t, "hidden category leaked into the chart", "no Salary slice")
+	}
+	if _, ok := byLabel["Uncategorized"]; ok {
+		utils.PrintTestError(t, "hidden spend collapsed into Uncategorized", "no Uncategorized slice")
+	}
+}
+
+// (Restricted) and Uncategorized are distinct buckets: a receipt whose only
+// category is hidden lands in (Restricted); a receipt with no category at all
+// lands in Uncategorized. They must not merge.
+func TestPieChartService_GetPieChartData_GroupByCategories_RestrictedDistinctFromUncategorized(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	allowedCatId := makeCategory(t, "Groceries")
+	hiddenCatId := makeCategory(t, "Salary")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "pie-distinct", []uint{allowedCatId}, nil)
+
+	createTestReceipt("hidden-only", 100.00, userId, groupId, []models.Category{loadCategory(t, hiddenCatId)}, nil)
+	createTestReceipt("no-category", 40.00, userId, groupId, nil, nil)
+
+	result, err := NewPieChartService(nil).GetPieChartData(userId, groupIdString(groupId), commands.PieChartDataCommand{
+		ChartGrouping: models.CHART_GROUPING_CATEGORIES,
+	})
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+
+	byLabel := pieDataByLabel(result.Data)
+	if byLabel["(Restricted)"] != 100.0 {
+		utils.PrintTestError(t, byLabel["(Restricted)"], 100.0)
+	}
+	if byLabel["Uncategorized"] != 40.0 {
+		utils.PrintTestError(t, byLabel["Uncategorized"], 40.0)
+	}
+	if _, ok := byLabel["Salary"]; ok {
+		utils.PrintTestError(t, "hidden category leaked into the chart", "no Salary slice")
+	}
+}
+
+// The tag side mirrors categories: a tag the caller may not see becomes a
+// (Restricted) slice rather than folding into Untagged.
+func TestPieChartService_GetPieChartData_GroupByTags_RestrictedTag(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	allowedTag := createTestTag("Reimbursable")
+	hiddenTag := createTestTag("Personal")
+	userId, groupId, _ := seedMemberWithGroupRoleGrants(t, "pie-tag", nil, []uint{allowedTag.ID})
+
+	createTestReceipt("mixed", 100.00, userId, groupId, nil, []models.Tag{allowedTag, hiddenTag})
+
+	result, err := NewPieChartService(nil).GetPieChartData(userId, groupIdString(groupId), commands.PieChartDataCommand{
+		ChartGrouping: models.CHART_GROUPING_TAGS,
+	})
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+
+	byLabel := pieDataByLabel(result.Data)
+	if byLabel["Reimbursable"] != 100.0 {
+		utils.PrintTestError(t, byLabel["Reimbursable"], 100.0)
+	}
+	if byLabel["(Restricted)"] != 100.0 {
+		utils.PrintTestError(t, byLabel["(Restricted)"], 100.0)
+	}
+	if _, ok := byLabel["Personal"]; ok {
+		utils.PrintTestError(t, "hidden tag leaked into the chart", "no Personal slice")
+	}
+	if _, ok := byLabel["Untagged"]; ok {
+		utils.PrintTestError(t, "hidden spend collapsed into Untagged", "no Untagged slice")
 	}
 }


### PR DESCRIPTION
## What

Brings the dashboard pie chart to parity with the reporting data source in how it treats a category/tag the current viewer is **not** permitted to see.

- **Before:** the pie chart *stripped* hidden categories/tags (`FilterReceiptCategoriesTags`). A receipt whose only category was hidden then had zero categories, so it collapsed into the `Uncategorized`/`Untagged` bucket — its spend vanished among genuinely uncategorized receipts, indistinguishable from them.
- **After:** it *substitutes* a single `(Restricted)` marker (`SubstituteRestrictedCategoriesTags`, already used by the reporting engine). Hidden spend now aggregates into its own `(Restricted)` slice, kept distinct from `Uncategorized`/`Untagged`.

## Behavior notes

- A receipt carrying both a visible and a hidden value fans out into **both** slices (each gets the full amount) — the same multi-value fan-out the chart already applies to multi-category/multi-tag receipts.
- A receipt with **only** hidden values → `(Restricted)`. A receipt with **no** category/tag at all → `Uncategorized`/`Untagged`. The two buckets stay separate.
- Paid-by grouping is unaffected (it never read categories/tags).

## Scope

- One-line production change plus its comment in `services/pie_chart.go`; both helpers already exist on `PermissionService`. No new production code, no client regeneration.
- **Desktop:** no change required — the widget renders the backend `label` string verbatim (no category-name lookup, no id-keyed coloring, no `Uncategorized` special-case), so `(Restricted)` flows straight to the slice, legend, and tooltip.
- **Out of scope:** the CSV export handlers still strip — export is a per-receipt listing, not an aggregation, so that is a separate decision.

## Tests

Adds three `pie_chart_test.go` cases (grant-restricted category/tag scenarios): a hidden category surfaces as `(Restricted)` and does not collapse into `Uncategorized`; `(Restricted)` and `Uncategorized` remain distinct buckets; and the tag-side mirror. Existing pie chart tests seed no grants, so they are unaffected and stay green. Full `internal/services/...` suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pie charts now group caller-inaccessible categories and tags into a dedicated **“(Restricted)”** segment, preventing restricted spend from merging into **Uncategorized**/**Untagged**.
  * Restricted labels are no longer shown individually; multiple hidden items collapse into the single **“(Restricted)”** slice.
* **Documentation**
  * Updated guidance to reflect the revised restricted-visibility semantics across charts, reporting data, CSV exports, and receipt duplication.
* **Tests**
  * Added coverage to confirm correct bucket separation and non-disclosure for restricted categories/tags in pie charts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->