### PR TITLE
feat(reporting): add flat CSV renderer for the ReportModel

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -685,6 +685,19 @@ the caller's grants (`IntersectReceiptFilterWithGrants`), hide whole receipts in
 (`PaidByListResolver`), then substitute the categories/tags the caller can't see. It returns the
 engine's `(FieldCatalog, []Row)` — it does **not** build a `ReportSpec` or call `Run`; a caller does.
 
+**Renderers** (`internal/reporting/render`) are pure downstream consumers of a `ReportModel` — they
+fetch and compute nothing, and never reach back into the engine, so a new format (or a future layout)
+touches no upstream code. `render.CSV(model, groupBy)` is the first: a flat, **data-only** CSV — the
+group-by dimensions become leading columns (`groupBy []render.Dimension` supplies their order and header
+labels, since the model carries dimension keys but not labels), each detail leaf is one row, and a
+leading `Row Type` column marks each row `Detail` / `Subtotal` / `Grand Total`. It renders only what the
+model carries (subtotal/grand-total rows appear only when the spec toggled them on), draws no document
+chrome, and is unit-tested in isolation against models built via `reporting.Run` (there is no orchestrator
+or handler yet). Per `docs/engine-design.md` §5, CSV is deliberately the minimal renderer; the
+grouped/visual "looks like the on-screen report" layout belongs to the XLSX/PDF renderers, each a separate
+consumer of the same tree. Currency renders at 2dp, other numbers at full precision, `(None)` buckets use
+`Meta.NoneLabel`.
+
 **`(Restricted)` vs `(None)`.** Aggregation uses `PermissionService.SubstituteRestrictedCategoriesTags`
 (not the strip variant): a category/tag the caller may not see is replaced with a single `(Restricted)`
 marker, so the receipt still counts toward the totals in its own bucket instead of vanishing. `(None)`

--- a/api/internal/reporting/README.md
+++ b/api/internal/reporting/README.md
@@ -111,6 +111,14 @@ ReportModel
 A `Cell` holds `[]Value`. Aggregate and arithmetic cells always hold exactly one value, possibly null.
 A label cell in records mode may hold several, because a record can carry several categories or tags.
 
+**Renderers consume this tree.** `internal/reporting/render` is the first: `render.CSV(model, groupBy)`
+emits a flat, data-only CSV — the group-by dimensions become leading columns, each detail leaf is one
+row, and a leading `Row Type` column marks each row `Detail` / `Subtotal` / `Grand Total`. It renders
+only what the model carries: subtotal and grand-total rows appear when the spec asked for them, and never
+otherwise. The `Row Type` column is what keeps the file safe to aggregate — filter `Row Type=Detail`
+before summing an additive column, or the roll-up rows double-count it. It draws no document chrome;
+grouped/visual layouts are the XLSX/PDF renderers' job, each a separate consumer of the same tree.
+
 ---
 
 ## 4. A worked example, end to end

--- a/api/internal/reporting/render/csv.go
+++ b/api/internal/reporting/render/csv.go
@@ -6,6 +6,7 @@ package render
 import (
 	"bytes"
 	"encoding/csv"
+	"fmt"
 	"strings"
 
 	"receipt-wrangler/api/internal/reporting"
@@ -47,6 +48,16 @@ const (
 // It renders no document chrome (title, intro, branding); that is the richer
 // formats' job. This is the minimal, machine-friendly export.
 func CSV(model reporting.ReportModel, groupBy []Dimension) ([]byte, error) {
+	// groupBy is a contract between the caller and the model's shape. If the
+	// report actually groups, the supplied dimensions must match its depth — too
+	// few would drop deeper ancestor values, so distinct buckets would print
+	// identical leading columns; too many would pad every row with blanks. An
+	// empty grouped report has a childless root and no discoverable depth, so it
+	// is left to render: its dimension columns come from groupBy.
+	if depth := groupDepth(model.Root); depth > 0 && depth != len(groupBy) {
+		return nil, fmt.Errorf("render: report groups %d level(s) deep, but %d dimension(s) were supplied", depth, len(groupBy))
+	}
+
 	records := [][]string{header(model, groupBy)}
 	records = appendGroup(records, model, groupBy, model.Root, nil)
 
@@ -84,6 +95,19 @@ func dimensionHeading(dimension Dimension) string {
 		return dimension.Label
 	}
 	return string(dimension.Key)
+}
+
+// groupDepth is how many grouping levels the tree nests. Every branch of a tree
+// for a fixed spec has the same depth, so walking the first child suffices. It is
+// 0 for an ungrouped report and for an empty one (a childless root), which is why
+// the caller's depth check only fires when the tree actually groups.
+func groupDepth(node reporting.GroupNode) int {
+	depth := 0
+	for len(node.Children) > 0 {
+		depth++
+		node = node.Children[0]
+	}
+	return depth
 }
 
 // appendGroup walks the tree in the order a reader expects: a node's children

--- a/api/internal/reporting/render/csv.go
+++ b/api/internal/reporting/render/csv.go
@@ -1,0 +1,192 @@
+// Package render turns the reporting engine's format-agnostic ReportModel into a
+// concrete output format. It is a pure downstream consumer: it reads a
+// ReportModel and never fetches, computes, or reaches back into the engine.
+package render
+
+import (
+	"bytes"
+	"encoding/csv"
+	"strings"
+
+	"receipt-wrangler/api/internal/reporting"
+)
+
+// Dimension is one group-by level: the field it cuts on and the header a
+// renderer prints for it.
+//
+// The ReportModel carries a dimension key on each group node but not its label,
+// and a flat table needs the levels up front and in order — an empty report
+// still needs its dimension columns. So a caller supplies them, in the same
+// order as the spec's GroupBy. A future orchestrator builds this from the spec
+// and the field catalog.
+type Dimension struct {
+	Key   reporting.FieldKey
+	Label string
+}
+
+const (
+	rowTypeHeader = "Row Type"
+	detailRow     = "Detail"
+	subtotalRow   = "Subtotal"
+	grandTotalRow = "Grand Total"
+)
+
+// CSV renders a ReportModel as a flat, data-only CSV table: the group-by
+// dimensions become leading columns, each detail leaf is one row, and a leading
+// "Row Type" column marks whether a row is a Detail, a Subtotal, or the Grand
+// Total. Subtotal and grand-total rows are emitted only when the model carries
+// them (the spec's Subtotals/GrandTotals toggles decide that upstream); the
+// renderer never drops what it is given.
+//
+// The "Row Type" column is what keeps the file safe to aggregate: a consumer
+// filters Row Type=Detail before summing an additive column — otherwise the
+// subtotal and grand-total rows double-count it — and reads the roll-up rows
+// for a non-additive column such as an average, which the engine recomputed at
+// each level rather than summing.
+//
+// It renders no document chrome (title, intro, branding); that is the richer
+// formats' job. This is the minimal, machine-friendly export.
+func CSV(model reporting.ReportModel, groupBy []Dimension) ([]byte, error) {
+	records := [][]string{header(model, groupBy)}
+	records = appendGroup(records, model, groupBy, model.Root, nil)
+
+	if model.GrandTotals != nil {
+		records = append(records, buildRecord(model, groupBy, grandTotalRow, nil, model.GrandTotals))
+	}
+
+	buffer := new(bytes.Buffer)
+	writer := csv.NewWriter(buffer)
+	writer.UseCRLF = true // RFC 4180 line endings, which Excel prefers.
+	if err := writer.WriteAll(records); err != nil {
+		return nil, err
+	}
+	return buffer.Bytes(), nil
+}
+
+// header is: Row Type, then one column per group-by dimension, then one per
+// report column.
+func header(model reporting.ReportModel, groupBy []Dimension) []string {
+	head := make([]string, 0, 1+len(groupBy)+len(model.Columns))
+	head = append(head, rowTypeHeader)
+	for _, dimension := range groupBy {
+		head = append(head, dimensionHeading(dimension))
+	}
+	for _, column := range model.Columns {
+		head = append(head, columnHeading(column))
+	}
+	return head
+}
+
+// dimensionHeading falls back to the raw field key when a caller supplies no
+// label, so a column is never blank-headed.
+func dimensionHeading(dimension Dimension) string {
+	if len(dimension.Label) > 0 {
+		return dimension.Label
+	}
+	return string(dimension.Key)
+}
+
+// appendGroup walks the tree in the order a reader expects: a node's children
+// (each of which emits its own detail and subtotal rows) come before the node's
+// own subtotal, so a subtotal always follows the rows it sums.
+//
+// path carries the bucket value of each ancestor level, which fills the leading
+// dimension columns.
+func appendGroup(records [][]string, model reporting.ReportModel, groupBy []Dimension, node reporting.GroupNode, path []reporting.Value) [][]string {
+	// A node holds either Children or DetailRows, never both; an empty root has
+	// neither, and falls through the detail loop harmlessly.
+	if len(node.Children) > 0 {
+		for _, child := range node.Children {
+			childPath := make([]reporting.Value, len(path), len(path)+1)
+			copy(childPath, path)
+			childPath = append(childPath, child.Value)
+			records = appendGroup(records, model, groupBy, child, childPath)
+		}
+	} else {
+		for _, detail := range node.DetailRows {
+			records = append(records, buildRecord(model, groupBy, detailRow, path, detail.Cells))
+		}
+	}
+
+	if node.Subtotals != nil {
+		records = append(records, buildRecord(model, groupBy, subtotalRow, path, node.Subtotals))
+	}
+	return records
+}
+
+// buildRecord assembles one CSV record: the row-type marker, the leading
+// dimension columns (the ancestor path, padded with blanks for the levels below
+// this row), then one formatted cell per report column.
+func buildRecord(model reporting.ReportModel, groupBy []Dimension, rowType string, path []reporting.Value, cells []reporting.Cell) []string {
+	record := make([]string, 0, 1+len(groupBy)+len(model.Columns))
+	record = append(record, rowType)
+
+	for index := range groupBy {
+		if index < len(path) {
+			record = append(record, formatDimension(path[index], model.Meta.NoneLabel))
+		} else {
+			record = append(record, "")
+		}
+	}
+
+	for index, column := range model.Columns {
+		record = append(record, formatCell(column, cells[index], model.Meta.NoneLabel))
+	}
+	return record
+}
+
+func columnHeading(column reporting.ColumnDescriptor) string {
+	if len(column.Label) > 0 {
+		return column.Label
+	}
+	return column.Name
+}
+
+// formatDimension renders a group bucket's value for a leading column. The
+// (None) bucket — a null value — gets the report's name for it.
+func formatDimension(value reporting.Value, noneLabel string) string {
+	if value.IsNull() {
+		return noneLabel
+	}
+	return value.String()
+}
+
+// formatCell renders one report cell the way this format presents it: money to
+// two places, other numbers at full precision, an undefined value as an empty
+// cell, and a multi-value label (a record carrying several categories/tags)
+// joined with commas.
+//
+// A cell with no values is a label column on a subtotal row — no single bucket
+// named it — and stays blank. A label cell holding one null value is the (None)
+// bucket, a bucket like any other, and gets the report's name for it.
+func formatCell(column reporting.ColumnDescriptor, cell reporting.Cell, noneLabel string) string {
+	if len(cell.Values) == 0 {
+		return ""
+	}
+
+	if column.Kind == reporting.ColumnLabel {
+		parts := make([]string, 0, len(cell.Values))
+		for _, value := range cell.Values {
+			if value.IsNull() {
+				parts = append(parts, noneLabel)
+				continue
+			}
+			parts = append(parts, value.String())
+		}
+		return strings.Join(parts, ", ")
+	}
+
+	value := cell.Value()
+	if value.IsNull() {
+		return ""
+	}
+
+	number, isNumber := value.Decimal()
+	if !isNumber {
+		return value.String()
+	}
+	if column.DataType == reporting.TypeCurrency {
+		return number.StringFixed(2)
+	}
+	return number.String()
+}

--- a/api/internal/reporting/render/csv_test.go
+++ b/api/internal/reporting/render/csv_test.go
@@ -607,6 +607,33 @@ func TestCSV_ArithmeticNullRendersBlank(t *testing.T) {
 	}
 }
 
+// Supplying fewer dimensions than the report groups by is a caller contract
+// violation the renderer rejects, rather than silently dropping the deeper
+// ancestor values and letting distinct buckets print identical leading columns.
+func TestCSV_GroupByDepthMismatchErrors(t *testing.T) {
+	catalog := paidByCatalog(t)
+	spec := reporting.ReportSpec{
+		GroupBy: []reporting.FieldKey{"paid_by", "tag"},
+		Detail:  reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "category"},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+		},
+	}
+	rows := []reporting.Row{
+		{"paid_by": {reporting.Str("Dana")}, "tag": {reporting.Str("Alex")}, "category": {reporting.Str("Food")}, "amount": {money("100")}},
+	}
+
+	// The report groups two levels deep; supply only one dimension.
+	out, err := CSV(mustRun(t, spec, catalog, rows), []Dimension{{Key: "paid_by", Label: "Paid By"}})
+	if err == nil {
+		t.Fatalf("expected an error for a group-depth mismatch, got none")
+	}
+	if out != nil {
+		t.Errorf("expected nil bytes on error, got %d", len(out))
+	}
+}
+
 // columnHeading falls back to the column name when no label is set. Run always
 // defaults a label to its name, so this defensive path is pinned directly.
 func TestColumnHeading_FallsBackToName(t *testing.T) {

--- a/api/internal/reporting/render/csv_test.go
+++ b/api/internal/reporting/render/csv_test.go
@@ -455,6 +455,7 @@ func TestFormatCell_ByTypeAndKind(t *testing.T) {
 		{"currency rounds", currency, reporting.Cell{Values: []reporting.Value{money("1234.5")}}, "1234.50"},
 		{"plain number full precision", number, reporting.Cell{Values: []reporting.Value{money("1.5")}}, "1.5"},
 		{"plain integer", number, reporting.Cell{Values: []reporting.Value{num(2)}}, "2"},
+		{"non-number in a measure column", number, reporting.Cell{Values: []reporting.Value{reporting.Str("n/a")}}, "n/a"},
 		{"string label", label, reporting.Cell{Values: []reporting.Value{reporting.Str("Food")}}, "Food"},
 		{"date label utc", label, reporting.Cell{Values: []reporting.Value{reporting.DateVal(date)}}, "2026-05-15T00:00:00Z"},
 		{"bool label", label, reporting.Cell{Values: []reporting.Value{reporting.Bool(true)}}, "true"},
@@ -478,5 +479,141 @@ func TestFormatDimension_NullIsNoneLabel(t *testing.T) {
 	}
 	if got := formatDimension(reporting.Str("Dana"), "(None)"); got != "Dana" {
 		t.Errorf("string dimension = %q, want Dana", got)
+	}
+}
+
+// Subtotals without grand totals: the per-group subtotal rows appear, and no
+// Grand Total row follows.
+func TestCSV_SubtotalsWithoutGrandTotal(t *testing.T) {
+	catalog := paidByCatalog(t)
+	spec := reporting.ReportSpec{
+		GroupBy: []reporting.FieldKey{"paid_by"},
+		Detail:  reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "category"},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+		},
+		Subtotals:   true,
+		GrandTotals: false,
+	}
+	rows := []reporting.Row{
+		{"paid_by": {reporting.Str("Dana")}, "category": {reporting.Str("Food")}, "amount": {money("100")}},
+		{"paid_by": {reporting.Str("Dana")}, "category": {reporting.Str("Gas")}, "amount": {money("50")}},
+		{"paid_by": {reporting.Str("Sam")}, "category": {reporting.Str("Food")}, "amount": {money("40")}},
+	}
+
+	got := mustCSV(t, mustRun(t, spec, catalog, rows), []Dimension{{Key: "paid_by", Label: "Paid By"}})
+	want := crlf(
+		"Row Type,Paid By,Category,Total",
+		"Detail,Dana,Food,100.00",
+		"Detail,Dana,Gas,50.00",
+		"Subtotal,Dana,,150.00",
+		"Detail,Sam,Food,40.00",
+		"Subtotal,Sam,,40.00",
+	)
+	if got != want {
+		t.Errorf("csv mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+// A boolean grouping dimension renders its bucket value as true/false, with
+// false sorting before true.
+func TestCSV_BoolGroupDimension(t *testing.T) {
+	catalog := mustCatalog(t,
+		reporting.FieldRef{Key: "reimbursable", Label: "Reimbursable", DataType: reporting.TypeBool},
+		reporting.FieldRef{Key: "category", Label: "Category", DataType: reporting.TypeString, Multi: true},
+		reporting.FieldRef{Key: "amount", Label: "Amount", DataType: reporting.TypeCurrency},
+	)
+	spec := reporting.ReportSpec{
+		GroupBy: []reporting.FieldKey{"reimbursable"},
+		Detail:  reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "category"},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+		},
+	}
+	rows := []reporting.Row{
+		{"reimbursable": {reporting.Bool(false)}, "category": {reporting.Str("Food")}, "amount": {money("100")}},
+		{"reimbursable": {reporting.Bool(true)}, "category": {reporting.Str("Food")}, "amount": {money("50")}},
+	}
+
+	got := mustCSV(t, mustRun(t, spec, catalog, rows), []Dimension{{Key: "reimbursable", Label: "Reimbursable"}})
+	want := crlf(
+		"Row Type,Reimbursable,Category,Total",
+		"Detail,false,Food,100.00",
+		"Detail,true,Food,50.00",
+	)
+	if got != want {
+		t.Errorf("csv mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+// A date grouping dimension renders its bucket as the instant in UTC (RFC 3339),
+// which sorts chronologically.
+func TestCSV_DateGroupDimension(t *testing.T) {
+	catalog := mustCatalog(t,
+		reporting.FieldRef{Key: "date", Label: "Date", DataType: reporting.TypeDate},
+		reporting.FieldRef{Key: "category", Label: "Category", DataType: reporting.TypeString, Multi: true},
+		reporting.FieldRef{Key: "amount", Label: "Amount", DataType: reporting.TypeCurrency},
+	)
+	spec := reporting.ReportSpec{
+		GroupBy: []reporting.FieldKey{"date"},
+		Detail:  reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "category"},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+		},
+	}
+	rows := []reporting.Row{
+		{"date": {reporting.DateVal(time.Date(2026, 2, 20, 0, 0, 0, 0, time.UTC))}, "category": {reporting.Str("Food")}, "amount": {money("50")}},
+		{"date": {reporting.DateVal(time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC))}, "category": {reporting.Str("Food")}, "amount": {money("100")}},
+	}
+
+	got := mustCSV(t, mustRun(t, spec, catalog, rows), []Dimension{{Key: "date", Label: "Date"}})
+	want := crlf(
+		"Row Type,Date,Category,Total",
+		"Detail,2026-01-15T00:00:00Z,Food,100.00",
+		"Detail,2026-02-20T00:00:00Z,Food,50.00",
+	)
+	if got != want {
+		t.Errorf("csv mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+// An arithmetic column whose divisor is zero (Avg over an empty report, 0/0)
+// yields a null the renderer prints as a blank cell — distinct from the SUM
+// column, whose empty total is a real 0.00.
+func TestCSV_ArithmeticNullRendersBlank(t *testing.T) {
+	catalog := paidByCatalog(t)
+	spec := reporting.ReportSpec{
+		GroupBy: []reporting.FieldKey{"paid_by"},
+		Detail:  reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "category"},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Count", Label: "Count", Kind: reporting.ColumnAggregate, AggSrc: "COUNT()"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+			{Name: "Avg", Label: "Avg", Kind: reporting.ColumnArithmetic, Expr: "Total / Count"},
+		},
+		GrandTotals: true,
+	}
+
+	got := mustCSV(t, mustRun(t, spec, catalog, nil), []Dimension{{Key: "paid_by", Label: "Paid By"}})
+	want := crlf(
+		"Row Type,Paid By,Category,Count,Total,Avg",
+		"Grand Total,,,0,0.00,",
+	)
+	if got != want {
+		t.Errorf("csv mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+// columnHeading falls back to the column name when no label is set. Run always
+// defaults a label to its name, so this defensive path is pinned directly.
+func TestColumnHeading_FallsBackToName(t *testing.T) {
+	if got := columnHeading(reporting.ColumnDescriptor{Name: "amount"}); got != "amount" {
+		t.Errorf("empty label = %q, want the name", got)
+	}
+	if got := columnHeading(reporting.ColumnDescriptor{Name: "amount", Label: "Total"}); got != "Total" {
+		t.Errorf("with label = %q, want the label", got)
 	}
 }

--- a/api/internal/reporting/render/csv_test.go
+++ b/api/internal/reporting/render/csv_test.go
@@ -1,0 +1,482 @@
+package render
+
+import (
+	"encoding/csv"
+	"strings"
+	"testing"
+	"time"
+
+	"receipt-wrangler/api/internal/reporting"
+
+	"github.com/shopspring/decimal"
+)
+
+// --- fixtures -------------------------------------------------------------
+
+func num(v int64) reporting.Value { return reporting.Num(decimal.NewFromInt(v)) }
+
+func money(s string) reporting.Value { return reporting.Num(decimal.RequireFromString(s)) }
+
+func mustCatalog(t *testing.T, fields ...reporting.FieldRef) reporting.FieldCatalog {
+	t.Helper()
+	catalog, err := reporting.NewFieldCatalog(fields...)
+	if err != nil {
+		t.Fatalf("build catalog: %v", err)
+	}
+	return catalog
+}
+
+func mustRun(t *testing.T, spec reporting.ReportSpec, catalog reporting.FieldCatalog, rows []reporting.Row) reporting.ReportModel {
+	t.Helper()
+	model, err := reporting.Run(spec, catalog, rows, reporting.MetaInput{})
+	if err != nil {
+		t.Fatalf("run report: %v", err)
+	}
+	return model
+}
+
+// crlf joins the given lines with the writer's RFC 4180 line ending and a
+// trailing terminator, which is what encoding/csv emits with UseCRLF set.
+func crlf(lines ...string) string {
+	return strings.Join(lines, "\r\n") + "\r\n"
+}
+
+func mustCSV(t *testing.T, model reporting.ReportModel, groupBy []Dimension) string {
+	t.Helper()
+	out, err := CSV(model, groupBy)
+	if err != nil {
+		t.Fatalf("CSV: %v", err)
+	}
+	return string(out)
+}
+
+// paidByCatalog is the common set of fields the grouped tests reference.
+func paidByCatalog(t *testing.T) reporting.FieldCatalog {
+	t.Helper()
+	return mustCatalog(t,
+		reporting.FieldRef{Key: "paid_by", Label: "Paid By", DataType: reporting.TypeString},
+		reporting.FieldRef{Key: "tag", Label: "Tag", DataType: reporting.TypeString, Multi: true},
+		reporting.FieldRef{Key: "category", Label: "Category", DataType: reporting.TypeString, Multi: true},
+		reporting.FieldRef{Key: "amount", Label: "Amount", DataType: reporting.TypeCurrency},
+	)
+}
+
+// --- headline: sums, aggregates, and non-linear roll-up -------------------
+
+// A one-level grouped report with a COUNT, a SUM, and an arithmetic average
+// proves the whole roll-up: additive columns (Count, Total) sum up — a subtotal
+// is the sum of its detail rows and the grand total the sum of them all — while
+// the non-linear Avg is recomputed at every level (120.00 = 360/3 and 100.00 =
+// 400/4), which is neither the sum nor the average of the rows above it.
+func TestCSV_SumsAggregatesAndNonLinearRollUp(t *testing.T) {
+	catalog := paidByCatalog(t)
+	spec := reporting.ReportSpec{
+		GroupBy: []reporting.FieldKey{"paid_by"},
+		Detail:  reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "category"},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Count", Label: "Count", Kind: reporting.ColumnAggregate, AggSrc: "COUNT()"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+			{Name: "Avg", Label: "Avg", Kind: reporting.ColumnArithmetic, Expr: "Total / Count"},
+		},
+		Subtotals:   true,
+		GrandTotals: true,
+	}
+	rows := []reporting.Row{
+		{"paid_by": {reporting.Str("Dana")}, "category": {reporting.Str("Food")}, "amount": {money("100")}},
+		{"paid_by": {reporting.Str("Dana")}, "category": {reporting.Str("Food")}, "amount": {money("200")}},
+		{"paid_by": {reporting.Str("Dana")}, "category": {reporting.Str("Gas")}, "amount": {money("60")}},
+		{"paid_by": {reporting.Str("Sam")}, "category": {reporting.Str("Food")}, "amount": {money("40")}},
+	}
+
+	got := mustCSV(t, mustRun(t, spec, catalog, rows), []Dimension{{Key: "paid_by", Label: "Paid By"}})
+	want := crlf(
+		"Row Type,Paid By,Category,Count,Total,Avg",
+		"Detail,Dana,Food,2,300.00,150.00",
+		"Detail,Dana,Gas,1,60.00,60.00",
+		"Subtotal,Dana,,3,360.00,120.00",
+		"Detail,Sam,Food,1,40.00,40.00",
+		"Subtotal,Sam,,1,40.00,40.00",
+		"Grand Total,,,4,400.00,100.00",
+	)
+	if got != want {
+		t.Errorf("csv mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+// Two grouping levels prove nested subtotals: each level emits its own subtotal
+// row after the rows it sums, the leading dimension columns fill to that level
+// and blank below it, and the ordering is deterministic (values ascending).
+func TestCSV_NestedGroupsSubtotalsAndPadding(t *testing.T) {
+	catalog := paidByCatalog(t)
+	spec := reporting.ReportSpec{
+		GroupBy: []reporting.FieldKey{"paid_by", "tag"},
+		Detail:  reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "category"},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+		},
+		Subtotals:   true,
+		GrandTotals: true,
+	}
+	rows := []reporting.Row{
+		{"paid_by": {reporting.Str("Dana")}, "tag": {reporting.Str("Alex")}, "category": {reporting.Str("Food")}, "amount": {money("100")}},
+		{"paid_by": {reporting.Str("Dana")}, "tag": {reporting.Str("Alex")}, "category": {reporting.Str("Gas")}, "amount": {money("50")}},
+		{"paid_by": {reporting.Str("Dana")}, "tag": {reporting.Str("Bob")}, "category": {reporting.Str("Food")}, "amount": {money("30")}},
+		{"paid_by": {reporting.Str("Sam")}, "tag": {reporting.Str("Alex")}, "category": {reporting.Str("Food")}, "amount": {money("20")}},
+	}
+
+	got := mustCSV(t, mustRun(t, spec, catalog, rows),
+		[]Dimension{{Key: "paid_by", Label: "Paid By"}, {Key: "tag", Label: "Tag"}})
+	want := crlf(
+		"Row Type,Paid By,Tag,Category,Total",
+		"Detail,Dana,Alex,Food,100.00",
+		"Detail,Dana,Alex,Gas,50.00",
+		"Subtotal,Dana,Alex,,150.00",
+		"Detail,Dana,Bob,Food,30.00",
+		"Subtotal,Dana,Bob,,30.00",
+		"Subtotal,Dana,,,180.00",
+		"Detail,Sam,Alex,Food,20.00",
+		"Subtotal,Sam,Alex,,20.00",
+		"Subtotal,Sam,,,20.00",
+		"Grand Total,,,,200.00",
+	)
+	if got != want {
+		t.Errorf("csv mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+// Every aggregate function renders at detail, subtotal, and grand-total level.
+// The single group keeps its subtotal equal to the grand total, so one set of
+// expected values covers both roll-up levels.
+func TestCSV_AllAggregateFunctions(t *testing.T) {
+	catalog := paidByCatalog(t)
+	spec := reporting.ReportSpec{
+		GroupBy: []reporting.FieldKey{"paid_by"},
+		Detail:  reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "category"},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Sum", Label: "Sum", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+			{Name: "Count", Label: "Count", Kind: reporting.ColumnAggregate, AggSrc: "COUNT()"},
+			{Name: "Avg", Label: "Avg", Kind: reporting.ColumnAggregate, AggSrc: "AVG(amount)"},
+			{Name: "Min", Label: "Min", Kind: reporting.ColumnAggregate, AggSrc: "MIN(amount)"},
+			{Name: "Max", Label: "Max", Kind: reporting.ColumnAggregate, AggSrc: "MAX(amount)"},
+		},
+		Subtotals:   true,
+		GrandTotals: true,
+	}
+	rows := []reporting.Row{
+		{"paid_by": {reporting.Str("Dana")}, "category": {reporting.Str("Food")}, "amount": {money("10")}},
+		{"paid_by": {reporting.Str("Dana")}, "category": {reporting.Str("Food")}, "amount": {money("30")}},
+		{"paid_by": {reporting.Str("Dana")}, "category": {reporting.Str("Gas")}, "amount": {money("110")}},
+	}
+
+	got := mustCSV(t, mustRun(t, spec, catalog, rows), []Dimension{{Key: "paid_by", Label: "Paid By"}})
+	// SUM/MIN/MAX/AVG follow their measure (currency, 2dp); COUNT is a plain number.
+	want := crlf(
+		"Row Type,Paid By,Category,Sum,Count,Avg,Min,Max",
+		"Detail,Dana,Food,40.00,2,20.00,10.00,30.00",
+		"Detail,Dana,Gas,110.00,1,110.00,110.00,110.00",
+		"Subtotal,Dana,,150.00,3,50.00,10.00,110.00",
+		"Grand Total,,,150.00,3,50.00,10.00,110.00",
+	)
+	if got != want {
+		t.Errorf("csv mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+// --- modes and shapes -----------------------------------------------------
+
+// Records mode emits one row per source record in input order, and a label cell
+// carrying several values (a receipt with two categories) is joined with commas
+// — which forces the field to be quoted.
+func TestCSV_RecordsModeMultiValueLabel(t *testing.T) {
+	catalog := paidByCatalog(t)
+	spec := reporting.ReportSpec{
+		GroupBy: []reporting.FieldKey{"paid_by"},
+		Detail:  reporting.DetailSpec{Mode: reporting.DetailRecords},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+		},
+		Subtotals:   true,
+		GrandTotals: true,
+	}
+	rows := []reporting.Row{
+		{"paid_by": {reporting.Str("Dana")}, "category": {reporting.Str("Food"), reporting.Str("Gas")}, "amount": {money("100")}},
+		{"paid_by": {reporting.Str("Dana")}, "category": {reporting.Str("Food")}, "amount": {money("50")}},
+	}
+
+	got := mustCSV(t, mustRun(t, spec, catalog, rows), []Dimension{{Key: "paid_by", Label: "Paid By"}})
+	want := crlf(
+		"Row Type,Paid By,Category,Total",
+		`Detail,Dana,"Food, Gas",100.00`,
+		"Detail,Dana,Food,50.00",
+		"Subtotal,Dana,,150.00",
+		"Grand Total,,,150.00",
+	)
+	if got != want {
+		t.Errorf("csv mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+// With no grouping the detail rows hang off the root and there are no leading
+// dimension columns.
+func TestCSV_NoGrouping(t *testing.T) {
+	catalog := paidByCatalog(t)
+	spec := reporting.ReportSpec{
+		Detail: reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "category"},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+		},
+		GrandTotals: true,
+	}
+	rows := []reporting.Row{
+		{"category": {reporting.Str("Food")}, "amount": {money("100")}},
+		{"category": {reporting.Str("Gas")}, "amount": {money("50")}},
+		{"category": {reporting.Str("Food")}, "amount": {money("25")}},
+	}
+
+	got := mustCSV(t, mustRun(t, spec, catalog, rows), nil)
+	want := crlf(
+		"Row Type,Category,Total",
+		"Detail,Food,125.00",
+		"Detail,Gas,50.00",
+		"Grand Total,,175.00",
+	)
+	if got != want {
+		t.Errorf("csv mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+// With subtotals and grand totals off, every row is a Detail — but the Row Type
+// column is still present, so the schema is stable regardless of the toggles.
+func TestCSV_NoTotalsStillHasRowTypeColumn(t *testing.T) {
+	catalog := paidByCatalog(t)
+	spec := reporting.ReportSpec{
+		Detail: reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "category"},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+		},
+	}
+	rows := []reporting.Row{
+		{"category": {reporting.Str("Food")}, "amount": {money("100")}},
+		{"category": {reporting.Str("Gas")}, "amount": {money("50")}},
+	}
+
+	got := mustCSV(t, mustRun(t, spec, catalog, rows), nil)
+	want := crlf(
+		"Row Type,Category,Total",
+		"Detail,Food,100.00",
+		"Detail,Gas,50.00",
+	)
+	if got != want {
+		t.Errorf("csv mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+// A row with no value for the grouping dimension falls into the (None) bucket,
+// which sorts last and prints the report's name for it in the dimension column.
+func TestCSV_NoneBucket(t *testing.T) {
+	catalog := paidByCatalog(t)
+	spec := reporting.ReportSpec{
+		GroupBy: []reporting.FieldKey{"paid_by"},
+		Detail:  reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "category"},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+		},
+		Subtotals:   true,
+		GrandTotals: true,
+	}
+	rows := []reporting.Row{
+		{"category": {reporting.Str("Food")}, "amount": {money("100")}},
+		{"paid_by": {reporting.Str("Dana")}, "category": {reporting.Str("Food")}, "amount": {money("50")}},
+	}
+
+	got := mustCSV(t, mustRun(t, spec, catalog, rows), []Dimension{{Key: "paid_by", Label: "Paid By"}})
+	want := crlf(
+		"Row Type,Paid By,Category,Total",
+		"Detail,Dana,Food,50.00",
+		"Subtotal,Dana,,50.00",
+		"Detail,(None),Food,100.00",
+		"Subtotal,(None),,100.00",
+		"Grand Total,,,150.00",
+	)
+	if got != want {
+		t.Errorf("csv mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+// A multi-value grouping dimension fans a row out into every bucket, in full, so
+// one $100 receipt tagged twice contributes $100 to each tag and $200 to the
+// grand total — the intended double count, surfaced honestly in the CSV.
+func TestCSV_MultiValueGroupFanOut(t *testing.T) {
+	catalog := paidByCatalog(t)
+	spec := reporting.ReportSpec{
+		GroupBy: []reporting.FieldKey{"tag"},
+		Detail:  reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "category"},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+		},
+		GrandTotals: true,
+	}
+	rows := []reporting.Row{
+		{"tag": {reporting.Str("Alex"), reporting.Str("Bob")}, "category": {reporting.Str("Food")}, "amount": {money("100")}},
+	}
+
+	got := mustCSV(t, mustRun(t, spec, catalog, rows), []Dimension{{Key: "tag", Label: "Tag"}})
+	want := crlf(
+		"Row Type,Tag,Category,Total",
+		"Detail,Alex,Food,100.00",
+		"Detail,Bob,Food,100.00",
+		"Grand Total,,,200.00",
+	)
+	if got != want {
+		t.Errorf("csv mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+// An empty report is just the header, plus a grand-total row of blanks (and a
+// zero count) when grand totals are on.
+func TestCSV_EmptyReportHeaderAndGrandTotalOnly(t *testing.T) {
+	catalog := paidByCatalog(t)
+	spec := reporting.ReportSpec{
+		GroupBy: []reporting.FieldKey{"paid_by"},
+		Detail:  reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "category"},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Count", Label: "Count", Kind: reporting.ColumnAggregate, AggSrc: "COUNT()"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+		},
+		GrandTotals: true,
+	}
+
+	// SUM over no rows is zero (not null), and COUNT is zero, so the grand total
+	// row is fully populated even with an empty report.
+	got := mustCSV(t, mustRun(t, spec, catalog, nil), []Dimension{{Key: "paid_by", Label: "Paid By"}})
+	want := crlf(
+		"Row Type,Paid By,Category,Count,Total",
+		"Grand Total,,,0,0.00",
+	)
+	if got != want {
+		t.Errorf("csv mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+// A dimension supplied without a label falls back to its raw field key, so a
+// column is never blank-headed.
+func TestCSV_MissingDimensionLabelFallsBackToKey(t *testing.T) {
+	catalog := paidByCatalog(t)
+	spec := reporting.ReportSpec{
+		GroupBy: []reporting.FieldKey{"paid_by"},
+		Detail:  reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "category"},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+		},
+	}
+	rows := []reporting.Row{
+		{"paid_by": {reporting.Str("Dana")}, "category": {reporting.Str("Food")}, "amount": {money("100")}},
+	}
+
+	got := mustCSV(t, mustRun(t, spec, catalog, rows), []Dimension{{Key: "paid_by"}})
+	if first, _, _ := strings.Cut(got, "\r\n"); first != "Row Type,paid_by,Category,Total" {
+		t.Errorf("header = %q, want the raw key as the dimension heading", first)
+	}
+}
+
+// --- escaping and unicode -------------------------------------------------
+
+// Values carrying commas, quotes, and newlines survive a round trip through a
+// CSV reader unchanged, and unicode is preserved — the writer quotes and escapes
+// them, so the file is safe to re-parse.
+func TestCSV_EscapingAndUnicodeRoundTrip(t *testing.T) {
+	catalog := paidByCatalog(t)
+	spec := reporting.ReportSpec{
+		Detail: reporting.DetailSpec{Mode: reporting.DetailRecords},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+		},
+	}
+	rows := []reporting.Row{
+		{"category": {reporting.Str("Groceries, Inc")}, "amount": {money("10")}},
+		{"category": {reporting.Str(`Say "hi"`)}, "amount": {money("20")}},
+		{"category": {reporting.Str("line1\nline2")}, "amount": {money("30")}},
+		{"category": {reporting.Str("日本語 🎉")}, "amount": {money("40")}},
+	}
+
+	out, err := CSV(mustRun(t, spec, catalog, rows), nil)
+	if err != nil {
+		t.Fatalf("CSV: %v", err)
+	}
+
+	got, err := csv.NewReader(strings.NewReader(string(out))).ReadAll()
+	if err != nil {
+		t.Fatalf("re-parse CSV: %v", err)
+	}
+	want := [][]string{
+		{"Row Type", "Category", "Total"},
+		{"Detail", "Groceries, Inc", "10.00"},
+		{"Detail", `Say "hi"`, "20.00"},
+		{"Detail", "line1\nline2", "30.00"},
+		{"Detail", "日本語 🎉", "40.00"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("row count = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if strings.Join(got[i], "\x00") != strings.Join(want[i], "\x00") {
+			t.Errorf("row %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// --- cell formatting ------------------------------------------------------
+
+func TestFormatCell_ByTypeAndKind(t *testing.T) {
+	currency := reporting.ColumnDescriptor{Kind: reporting.ColumnAggregate, DataType: reporting.TypeCurrency}
+	number := reporting.ColumnDescriptor{Kind: reporting.ColumnAggregate, DataType: reporting.TypeNumber}
+	label := reporting.ColumnDescriptor{Kind: reporting.ColumnLabel, DataType: reporting.TypeString}
+
+	date := time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name   string
+		column reporting.ColumnDescriptor
+		cell   reporting.Cell
+		want   string
+	}{
+		{"currency two places", currency, reporting.Cell{Values: []reporting.Value{money("1.5")}}, "1.50"},
+		{"currency rounds", currency, reporting.Cell{Values: []reporting.Value{money("1234.5")}}, "1234.50"},
+		{"plain number full precision", number, reporting.Cell{Values: []reporting.Value{money("1.5")}}, "1.5"},
+		{"plain integer", number, reporting.Cell{Values: []reporting.Value{num(2)}}, "2"},
+		{"string label", label, reporting.Cell{Values: []reporting.Value{reporting.Str("Food")}}, "Food"},
+		{"date label utc", label, reporting.Cell{Values: []reporting.Value{reporting.DateVal(date)}}, "2026-05-15T00:00:00Z"},
+		{"bool label", label, reporting.Cell{Values: []reporting.Value{reporting.Bool(true)}}, "true"},
+		{"null measure is blank", currency, reporting.Cell{Values: []reporting.Value{reporting.Null()}}, ""},
+		{"null label is none", label, reporting.Cell{Values: []reporting.Value{reporting.Null()}}, "(None)"},
+		{"no values is blank", label, reporting.Cell{}, ""},
+		{"multi-value label joined", label, reporting.Cell{Values: []reporting.Value{reporting.Str("A"), reporting.Str("B")}}, "A, B"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := formatCell(testCase.column, testCase.cell, "(None)"); got != testCase.want {
+				t.Errorf("formatCell = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestFormatDimension_NullIsNoneLabel(t *testing.T) {
+	if got := formatDimension(reporting.Null(), "(None)"); got != "(None)" {
+		t.Errorf("null dimension = %q, want (None)", got)
+	}
+	if got := formatDimension(reporting.Str("Dana"), "(None)"); got != "Dana" {
+		t.Errorf("string dimension = %q, want Dana", got)
+	}
+}


### PR DESCRIPTION
## What

Adds `internal/reporting/render` — the **first renderer** over the engine's `ReportModel`. `render.CSV(model, groupBy)` produces a flat, **data-only** CSV.

## Layout

Group-by dimensions become leading columns, each detail leaf is one row, and a leading `Row Type` column marks each row `Detail` / `Subtotal` / `Grand Total`:

```csv
Row Type,Paid By,Category,Count,Total,Avg
Detail,Dana,Food,2,300.00,150.00
Detail,Dana,Gas,1,60.00,60.00
Subtotal,Dana,,3,360.00,120.00
Detail,Sam,Food,1,40.00,40.00
Subtotal,Sam,,1,40.00,40.00
Grand Total,,,4,400.00,100.00
```

The `Row Type` column keeps the file safe to aggregate: filter `Row Type=Detail` before summing an additive column (otherwise the subtotal/grand-total rows double-count it), and read the roll-up rows for a non-additive column like `Avg`, which the engine recomputes per level (`120.00 = 360/3`, not a sum or average of the rows above it).

## Design notes

- **Pure downstream consumer.** The renderer fetches and computes nothing and never reaches back into the engine — so a future format or layout touches no upstream code. This is the pluggability the architecture already guarantees via the data-only `ReportModel`, not a new abstraction.
- **`groupBy []render.Dimension`** supplies the dimension order and header labels, because the model carries dimension *keys* but not labels (and an empty report still needs its dimension columns). A future orchestrator builds this from the spec + field catalog.
- **Renders only what the model carries** — subtotal/grand-total rows appear only when the spec toggled them on. It draws no document chrome; per `docs/engine-design.md` §5, CSV is deliberately the minimal renderer. The grouped/visual "looks like the report" layout is the XLSX/PDF renderers' job (separate consumers of the same tree).
- Currency at 2dp, other numbers at full precision, `(None)` buckets use `Meta.NoneLabel`.

## Tests

Models are built via `reporting.Run` and the exact CSV bytes asserted:

- **Sums, aggregates, and non-linear roll-up** — additive columns (Count, Total) roll up (subtotal = sum of its details, grand total = sum of all) while the arithmetic `Avg` is recomputed at each level.
- **Every aggregate function** (SUM / COUNT / AVG / MIN / MAX) at detail, subtotal, and grand-total level.
- **Nested groups** — two levels, subtotal ordering and dimension-column padding.
- **Records mode** with a multi-value label cell (joined, quoted).
- **No grouping**, **totals off** (Row Type column still present), the **`(None)` bucket**, **multi-value fan-out** (the intended double count), an **empty report**, **CSV escaping + unicode** (via a reader round trip), and the per-type/kind **cell formatting** matrix.

No orchestrator or HTTP handler is wired in this slice — the renderer produces bytes and is unit-tested in isolation, consistent with the engine and `ReportDataService` before it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CSV report export that writes grouped dimension columns plus ordered Detail rows, with Subtotal and Grand Total rows when applicable.
  * Included a leading “Row Type” column to clearly label Detail/Subtotal/Grand Total (kept stable even when grand totals are disabled).
  * Improved formatting and output correctness, including currency precision, label joining, RFC 4180 CSV with CRLF, and consistent “(None)” handling.
* **Documentation**
  * Documented CSV output structure and how renderers consume the generated report model.
* **Tests**
  * Added comprehensive CSV renderer tests covering roll-ups, totals, edge cases, and CSV escaping/unicode round-tripping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->