### PR TITLE
feat(reporting): HTML renderer + shared faithful walk

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -705,9 +705,20 @@ and a subtotal/grand-total row carries a `Total`/`Grand Total` marker in the col
 to `#,##0.00` (or `ColumnDescriptor.Format`/`Meta.CurrencyFormat` if set), so the workbook is analyzable —
 and header/subtotal/grand-total rows are bold; sheet name `Report`. It writes the engine-computed values
 **statically** — live `=SUM`/expression formulas (the reason `ColumnDescriptor.Expr` is an exported AST)
-are a later slice, and document chrome/slots (title, logo) await the template work. It shares the
-`Dimension` type and the `groupBy`-depth guard (`validateGroupByDepth`) with the CSV renderer but not the
-walk (flat vs faithful). Tested by round-tripping the bytes back through `excelize.OpenReader`.
+are a later slice, and document chrome/slots (logo) await the template work. It shares the `Dimension`
+type and the `groupBy`-depth guard (`validateGroupByDepth`) with the CSV renderer, and the faithful
+**walk** with the HTML renderer (`faithfulWalk` in `render/walk.go`, driving a per-format `faithfulSink`);
+CSV keeps its own flat walk. Tested by round-tripping the bytes back through `excelize.OpenReader`.
+
+`render.HTML(model, groupBy)` is the **PDF format's HTML stage** (via `html/template`): a self-contained
+document — a `Meta.Title` heading, a preamble of the resolved `Meta.Params`, the same faithful table as
+XLSX (through the shared `faithfulWalk`), and a `Meta.GeneratedAt` footer, each omitted when the model
+carries nothing for it. All CSS is inline and it references no external resources or scripts, so it renders
+through the headless-Chromium HTML-to-PDF pipeline (`services/html_to_pdf.go`, which blocks network loads
+and disables JS by default). It returns **HTML bytes** — the reporting package is pure, so the chromedp
+conversion to PDF stays in the services layer and is wired up by the future handler (deferred until the
+UI). Unit-tested against the same faithful golden grids as XLSX (parsed with `golang.org/x/net/html`) plus
+document-chrome and HTML-escaping cases.
 
 **`(Restricted)` vs `(None)`.** Aggregation uses `PermissionService.SubstituteRestrictedCategoriesTags`
 (not the strip variant): a category/tag the caller may not see is replaced with a single `(Restricted)`

--- a/api/internal/reporting/README.md
+++ b/api/internal/reporting/README.md
@@ -125,6 +125,15 @@ at the group's depth, and numbers are written as **native cells** with a number 
 header and total rows bold. It writes the engine-computed values **statically** — translating arithmetic
 columns into live cell formulas (the reason `ColumnDescriptor.Expr` is exported) is a later slice.
 
+`render.HTML(model, groupBy)` is the PDF format's HTML stage: a self-contained document — a `Meta.Title`
+heading, a preamble of the report's resolved `Meta.Params`, the same faithful table as XLSX, and a
+`Meta.GeneratedAt` footer (each omitted when the model carries nothing for it). All CSS is inline and it
+references no external resources or scripts, so it converts to PDF through the headless-Chromium pipeline
+in `services/html_to_pdf.go` (which blocks network loads and disables JavaScript). It returns HTML bytes;
+the chromedp conversion to PDF is the caller's job. The two faithful renderers (XLSX and HTML) share one
+traversal — `faithfulWalk` in `render/walk.go`, which drives a format-specific `faithfulSink` — while CSV
+keeps its own flat walk.
+
 ---
 
 ## 4. A worked example, end to end

--- a/api/internal/reporting/render/html.go
+++ b/api/internal/reporting/render/html.go
@@ -1,0 +1,183 @@
+package render
+
+import (
+	"bytes"
+	"html/template"
+	"sort"
+
+	"receipt-wrangler/api/internal/reporting"
+)
+
+// HTML renders a ReportModel as a self-contained HTML document: a title, a
+// key/value preamble drawn from the report's resolved parameters, the faithful
+// grouped table (the same layout the XLSX renderer produces, via the shared
+// faithfulWalk), and a generated-at footer. Anything the model does not carry —
+// an empty title, no parameters, a zero timestamp — is simply omitted.
+//
+// The document is deliberately self-contained: all styling is inline and it
+// references no external resources or scripts, so it renders faithfully through
+// the headless-Chromium HTML-to-PDF pipeline (services/html_to_pdf.go), which
+// blocks network loads and disables JavaScript by default. This renderer is the
+// PDF format's HTML stage; turning that HTML into PDF bytes is the caller's job.
+//
+// Like every renderer it is a pure consumer of the model. groupBy supplies the
+// dimension order and header labels and must match the report's grouping depth —
+// see validateGroupByDepth.
+func HTML(model reporting.ReportModel, groupBy []Dimension) ([]byte, error) {
+	sink := &htmlSink{model: model}
+	if err := faithfulWalk(model, groupBy, sink); err != nil {
+		return nil, err
+	}
+
+	document := htmlDocument{
+		Title:    model.Meta.Title,
+		Params:   sortedParams(model.Meta.Params),
+		Headings: sink.headings,
+		Rows:     sink.rows,
+	}
+	if !model.Meta.GeneratedAt.IsZero() {
+		document.GeneratedAt = model.Meta.GeneratedAt.UTC().Format("2006-01-02 15:04:05 UTC")
+	}
+
+	var buffer bytes.Buffer
+	if err := htmlTemplate.Execute(&buffer, document); err != nil {
+		return nil, err
+	}
+	return buffer.Bytes(), nil
+}
+
+// htmlDocument is the view model the report template renders. Its strings are
+// interpolated through html/template, which escapes them.
+type htmlDocument struct {
+	Title       string
+	Params      []htmlParam
+	Headings    []string
+	Rows        []htmlRow
+	GeneratedAt string
+}
+
+type htmlParam struct {
+	Key   string
+	Value string
+}
+
+type htmlRow struct {
+	Class string
+	Cells []htmlCell
+}
+
+type htmlCell struct {
+	Text    string
+	Numeric bool
+}
+
+// htmlSink is the faithfulSink that collects the walk into the view model the
+// report template renders.
+type htmlSink struct {
+	model    reporting.ReportModel
+	headings []string
+	rows     []htmlRow
+}
+
+func (s *htmlSink) writeHeader(headings []string) error {
+	s.headings = headings
+	return nil
+}
+
+func (s *htmlSink) writeRow(kind rowKind, cells []faithfulCell) error {
+	row := htmlRow{Class: rowClass(kind), Cells: make([]htmlCell, len(cells))}
+	for index, cell := range cells {
+		row.Cells[index] = s.cellView(cell)
+	}
+	s.rows = append(s.rows, row)
+	return nil
+}
+
+// cellView maps a positioned walk cell to its view model: a marker/dimension is
+// plain text, a report column is formatted the same way the CSV renderer formats
+// it and is right-aligned unless it is a label.
+func (s *htmlSink) cellView(cell faithfulCell) htmlCell {
+	switch cell.kind {
+	case textCell:
+		return htmlCell{Text: cell.text}
+	case reportCell:
+		return htmlCell{
+			Text:    formatCell(cell.descriptor, cell.cell, s.model.Meta.NoneLabel),
+			Numeric: cell.descriptor.Kind != reporting.ColumnLabel,
+		}
+	default: // blankCell
+		return htmlCell{}
+	}
+}
+
+// rowClass names a data row's CSS class; detail rows are unclassed.
+func rowClass(kind rowKind) string {
+	switch kind {
+	case subtotalKind:
+		return "subtotal"
+	case grandTotalKind:
+		return "grand-total"
+	default:
+		return ""
+	}
+}
+
+// sortedParams flattens the report's resolved parameters into a stable,
+// alphabetically ordered slice, so the preamble renders deterministically.
+func sortedParams(params map[string]string) []htmlParam {
+	if len(params) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(params))
+	for key := range params {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	ordered := make([]htmlParam, 0, len(keys))
+	for _, key := range keys {
+		ordered = append(ordered, htmlParam{Key: key, Value: params[key]})
+	}
+	return ordered
+}
+
+var htmlTemplate = template.Must(template.New("report").Parse(reportHTML))
+
+// reportHTML is the document skeleton: a styled title, a parameter preamble, the
+// data table, and a generated-at footer. All CSS is inline so the document needs
+// no external resources when it is converted to PDF.
+const reportHTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{{if .Title}}{{.Title}}{{else}}Report{{end}}</title>
+<style>
+  body { font-family: Arial, Helvetica, sans-serif; color: #222; margin: 24px; }
+  h1 { font-size: 20px; margin: 0 0 12px; }
+  .preamble { margin: 0 0 16px; color: #555; font-size: 12px; }
+  .preamble div { margin: 2px 0; }
+  .preamble .key { font-weight: 600; }
+  table { border-collapse: collapse; width: 100%; font-size: 12px; }
+  th, td { border: 1px solid #ccc; padding: 4px 8px; text-align: left; }
+  thead th { background: #f2f2f2; font-weight: 700; }
+  td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  tr.subtotal td { font-weight: 700; background: #fafafa; }
+  tr.grand-total td { font-weight: 700; background: #f2f2f2; border-top: 2px solid #888; }
+  footer { margin-top: 16px; color: #777; font-size: 11px; }
+</style>
+</head>
+<body>
+{{if .Title}}<h1>{{.Title}}</h1>
+{{end}}{{if .Params}}<div class="preamble">
+{{range .Params}}<div><span class="key">{{.Key}}</span>: {{.Value}}</div>
+{{end}}</div>
+{{end}}<table>
+<thead><tr>{{range .Headings}}<th>{{.}}</th>{{end}}</tr></thead>
+<tbody>
+{{range .Rows}}<tr{{if .Class}} class="{{.Class}}"{{end}}>{{range .Cells}}<td{{if .Numeric}} class="num"{{end}}>{{.Text}}</td>{{end}}</tr>
+{{end}}</tbody>
+</table>
+{{if .GeneratedAt}}<footer>Generated {{.GeneratedAt}}</footer>
+{{end}}</body>
+</html>
+`

--- a/api/internal/reporting/render/html_test.go
+++ b/api/internal/reporting/render/html_test.go
@@ -1,0 +1,516 @@
+package render
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"receipt-wrangler/api/internal/reporting"
+
+	"golang.org/x/net/html"
+)
+
+// --- helpers --------------------------------------------------------------
+
+func parseHTML(t *testing.T, out []byte) *html.Node {
+	t.Helper()
+	doc, err := html.Parse(bytes.NewReader(out))
+	if err != nil {
+		t.Fatalf("parse html: %v", err)
+	}
+	return doc
+}
+
+// findFirst returns the first element of the given tag in document order.
+func findFirst(node *html.Node, tag string) *html.Node {
+	if node.Type == html.ElementNode && node.Data == tag {
+		return node
+	}
+	for child := node.FirstChild; child != nil; child = child.NextSibling {
+		if found := findFirst(child, tag); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// elementChildren returns the direct child elements of the given tag.
+func elementChildren(node *html.Node, tag string) []*html.Node {
+	var out []*html.Node
+	for child := node.FirstChild; child != nil; child = child.NextSibling {
+		if child.Type == html.ElementNode && child.Data == tag {
+			out = append(out, child)
+		}
+	}
+	return out
+}
+
+func textOf(node *html.Node) string {
+	var builder strings.Builder
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.TextNode {
+			builder.WriteString(n.Data)
+		}
+		for child := n.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(node)
+	return builder.String()
+}
+
+func attrOf(node *html.Node, key string) string {
+	for _, attr := range node.Attr {
+		if attr.Key == key {
+			return attr.Val
+		}
+	}
+	return ""
+}
+
+func cellTexts(row *html.Node, cellTag string) []string {
+	cells := elementChildren(row, cellTag)
+	texts := make([]string, len(cells))
+	for index, cell := range cells {
+		texts[index] = textOf(cell)
+	}
+	return texts
+}
+
+// htmlGrid renders the model and returns the table as a grid whose first row is
+// the header, so it can be asserted against the same golden grids as the XLSX
+// renderer (via assertGrid, which trims trailing blanks).
+func htmlGrid(t *testing.T, model reporting.ReportModel, groupBy []Dimension) [][]string {
+	t.Helper()
+	out, err := HTML(model, groupBy)
+	if err != nil {
+		t.Fatalf("HTML: %v", err)
+	}
+	table := findFirst(parseHTML(t, out), "table")
+	if table == nil {
+		t.Fatal("no <table> in rendered document")
+	}
+
+	grid := [][]string{cellTexts(findFirst(findFirst(table, "thead"), "tr"), "th")}
+	for _, row := range elementChildren(findFirst(table, "tbody"), "tr") {
+		grid = append(grid, cellTexts(row, "td"))
+	}
+	return grid
+}
+
+// bodyRows renders the model and returns the <tbody> <tr> nodes, for asserting
+// per-row classes and per-cell attributes the grid text drops.
+func bodyRows(t *testing.T, model reporting.ReportModel, groupBy []Dimension) []*html.Node {
+	t.Helper()
+	out, err := HTML(model, groupBy)
+	if err != nil {
+		t.Fatalf("HTML: %v", err)
+	}
+	return elementChildren(findFirst(findFirst(parseHTML(t, out), "table"), "tbody"), "tr")
+}
+
+// --- faithful parity: the same grids the XLSX renderer produces -----------
+
+// The dimension shows once per group, subtotal/grand-total rows carry a Total
+// marker, additive columns roll up, and the non-linear Avg is recomputed per
+// level — the same faithful grid the XLSX renderer emits.
+func TestHTML_SumsAggregatesAndNonLinearRollUp(t *testing.T) {
+	model := mustRun(t, oneLevelSpec(), paidByCatalog(t), oneLevelRows())
+
+	assertGrid(t, htmlGrid(t, model, paidByDimension()), [][]string{
+		{"Paid By", "Category", "Count", "Total", "Avg"},
+		{"Dana", "Food", "2", "300.00", "150.00"},
+		{"", "Gas", "1", "60.00", "60.00"},
+		{"", "Total", "3", "360.00", "120.00"},
+		{"Sam", "Food", "1", "40.00", "40.00"},
+		{"", "Total", "1", "40.00", "40.00"},
+		{"Grand Total", "", "4", "400.00", "100.00"},
+	})
+}
+
+// Two grouping levels prove the staircase (a group's Total marker sits in the
+// column at its depth) and dimension blanking (a value shows once per group).
+func TestHTML_NestedGroupsStaircaseAndBlanking(t *testing.T) {
+	spec := reporting.ReportSpec{
+		GroupBy: []reporting.FieldKey{"paid_by", "tag"},
+		Detail:  reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "category"},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+		},
+		Subtotals:   true,
+		GrandTotals: true,
+	}
+	rows := []reporting.Row{
+		{"paid_by": {reporting.Str("Dana")}, "tag": {reporting.Str("Alex")}, "category": {reporting.Str("Food")}, "amount": {money("100")}},
+		{"paid_by": {reporting.Str("Dana")}, "tag": {reporting.Str("Alex")}, "category": {reporting.Str("Gas")}, "amount": {money("50")}},
+		{"paid_by": {reporting.Str("Dana")}, "tag": {reporting.Str("Bob")}, "category": {reporting.Str("Food")}, "amount": {money("30")}},
+		{"paid_by": {reporting.Str("Sam")}, "tag": {reporting.Str("Alex")}, "category": {reporting.Str("Food")}, "amount": {money("20")}},
+	}
+
+	grid := htmlGrid(t, mustRun(t, spec, paidByCatalog(t), rows),
+		[]Dimension{{Key: "paid_by", Label: "Paid By"}, {Key: "tag", Label: "Tag"}})
+	assertGrid(t, grid, [][]string{
+		{"Paid By", "Tag", "Category", "Total"},
+		{"Dana", "Alex", "Food", "100.00"},
+		{"", "", "Gas", "50.00"},
+		{"", "", "Total", "150.00"},
+		{"", "Bob", "Food", "30.00"},
+		{"", "", "Total", "30.00"},
+		{"", "Total", "", "180.00"},
+		{"Sam", "Alex", "Food", "20.00"},
+		{"", "", "Total", "20.00"},
+		{"", "Total", "", "20.00"},
+		{"Grand Total", "", "", "200.00"},
+	})
+}
+
+// Each aggregate function renders at detail and roll-up level.
+func TestHTML_AllAggregateFunctions(t *testing.T) {
+	spec := reporting.ReportSpec{
+		GroupBy: []reporting.FieldKey{"paid_by"},
+		Detail:  reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "category"},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Sum", Label: "Sum", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+			{Name: "Count", Label: "Count", Kind: reporting.ColumnAggregate, AggSrc: "COUNT()"},
+			{Name: "Avg", Label: "Avg", Kind: reporting.ColumnAggregate, AggSrc: "AVG(amount)"},
+			{Name: "Min", Label: "Min", Kind: reporting.ColumnAggregate, AggSrc: "MIN(amount)"},
+			{Name: "Max", Label: "Max", Kind: reporting.ColumnAggregate, AggSrc: "MAX(amount)"},
+		},
+		Subtotals:   true,
+		GrandTotals: true,
+	}
+	rows := []reporting.Row{
+		{"paid_by": {reporting.Str("Dana")}, "category": {reporting.Str("Food")}, "amount": {money("10")}},
+		{"paid_by": {reporting.Str("Dana")}, "category": {reporting.Str("Food")}, "amount": {money("30")}},
+		{"paid_by": {reporting.Str("Dana")}, "category": {reporting.Str("Gas")}, "amount": {money("110")}},
+	}
+
+	grid := htmlGrid(t, mustRun(t, spec, paidByCatalog(t), rows), paidByDimension())
+	assertGrid(t, grid, [][]string{
+		{"Paid By", "Category", "Sum", "Count", "Avg", "Min", "Max"},
+		{"Dana", "Food", "40.00", "2", "20.00", "10.00", "30.00"},
+		{"", "Gas", "110.00", "1", "110.00", "110.00", "110.00"},
+		{"", "Total", "150.00", "3", "50.00", "10.00", "110.00"},
+		{"Grand Total", "", "150.00", "3", "50.00", "10.00", "110.00"},
+	})
+}
+
+// Records mode emits one row per record; a multi-value label is joined with
+// commas into a single cell.
+func TestHTML_RecordsModeMultiValueLabel(t *testing.T) {
+	spec := reporting.ReportSpec{
+		GroupBy: []reporting.FieldKey{"paid_by"},
+		Detail:  reporting.DetailSpec{Mode: reporting.DetailRecords},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+		},
+		Subtotals:   true,
+		GrandTotals: true,
+	}
+	rows := []reporting.Row{
+		{"paid_by": {reporting.Str("Dana")}, "category": {reporting.Str("Food"), reporting.Str("Gas")}, "amount": {money("100")}},
+		{"paid_by": {reporting.Str("Dana")}, "category": {reporting.Str("Food")}, "amount": {money("50")}},
+	}
+
+	grid := htmlGrid(t, mustRun(t, spec, paidByCatalog(t), rows), paidByDimension())
+	assertGrid(t, grid, [][]string{
+		{"Paid By", "Category", "Total"},
+		{"Dana", "Food, Gas", "100.00"},
+		{"", "Food", "50.00"},
+		{"", "Total", "150.00"},
+		{"Grand Total", "", "150.00"},
+	})
+}
+
+// With no grouping there are no dimension columns and the grand-total marker
+// lands in the first report column.
+func TestHTML_NoGrouping(t *testing.T) {
+	spec := reporting.ReportSpec{
+		Detail: reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "category"},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+		},
+		GrandTotals: true,
+	}
+	rows := []reporting.Row{
+		{"category": {reporting.Str("Food")}, "amount": {money("100")}},
+		{"category": {reporting.Str("Gas")}, "amount": {money("50")}},
+		{"category": {reporting.Str("Food")}, "amount": {money("25")}},
+	}
+
+	assertGrid(t, htmlGrid(t, mustRun(t, spec, paidByCatalog(t), rows), nil), [][]string{
+		{"Category", "Total"},
+		{"Food", "125.00"},
+		{"Gas", "50.00"},
+		{"Grand Total", "175.00"},
+	})
+}
+
+// Subtotals on, grand totals off: subtotal rows appear, no grand-total row.
+func TestHTML_SubtotalsWithoutGrandTotal(t *testing.T) {
+	spec := reporting.ReportSpec{
+		GroupBy: []reporting.FieldKey{"paid_by"},
+		Detail:  reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "category"},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+		},
+		Subtotals: true,
+	}
+	rows := []reporting.Row{
+		{"paid_by": {reporting.Str("Dana")}, "category": {reporting.Str("Food")}, "amount": {money("100")}},
+		{"paid_by": {reporting.Str("Dana")}, "category": {reporting.Str("Gas")}, "amount": {money("50")}},
+		{"paid_by": {reporting.Str("Sam")}, "category": {reporting.Str("Food")}, "amount": {money("40")}},
+	}
+
+	assertGrid(t, htmlGrid(t, mustRun(t, spec, paidByCatalog(t), rows), paidByDimension()), [][]string{
+		{"Paid By", "Category", "Total"},
+		{"Dana", "Food", "100.00"},
+		{"", "Gas", "50.00"},
+		{"", "Total", "150.00"},
+		{"Sam", "Food", "40.00"},
+		{"", "Total", "40.00"},
+	})
+}
+
+// A row with no value for the grouping dimension is the (None) bucket; it prints
+// the report's name for it.
+func TestHTML_NoneBucket(t *testing.T) {
+	spec := reporting.ReportSpec{
+		GroupBy: []reporting.FieldKey{"paid_by"},
+		Detail:  reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "category"},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+		},
+		Subtotals:   true,
+		GrandTotals: true,
+	}
+	rows := []reporting.Row{
+		{"category": {reporting.Str("Food")}, "amount": {money("100")}},
+		{"paid_by": {reporting.Str("Dana")}, "category": {reporting.Str("Food")}, "amount": {money("50")}},
+	}
+
+	assertGrid(t, htmlGrid(t, mustRun(t, spec, paidByCatalog(t), rows), paidByDimension()), [][]string{
+		{"Paid By", "Category", "Total"},
+		{"Dana", "Food", "50.00"},
+		{"", "Total", "50.00"},
+		{"(None)", "Food", "100.00"},
+		{"", "Total", "100.00"},
+		{"Grand Total", "", "150.00"},
+	})
+}
+
+// A multi-value grouping dimension fans a row into every bucket in full.
+func TestHTML_MultiValueGroupFanOut(t *testing.T) {
+	spec := reporting.ReportSpec{
+		GroupBy: []reporting.FieldKey{"tag"},
+		Detail:  reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "category"},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+		},
+		GrandTotals: true,
+	}
+	rows := []reporting.Row{
+		{"tag": {reporting.Str("Alex"), reporting.Str("Bob")}, "category": {reporting.Str("Food")}, "amount": {money("100")}},
+	}
+
+	assertGrid(t, htmlGrid(t, mustRun(t, spec, paidByCatalog(t), rows), []Dimension{{Key: "tag", Label: "Tag"}}), [][]string{
+		{"Tag", "Category", "Total"},
+		{"Alex", "Food", "100.00"},
+		{"Bob", "Food", "100.00"},
+		{"Grand Total", "", "200.00"},
+	})
+}
+
+// An empty report is the header plus a grand-total row (zero count, zero sum).
+func TestHTML_EmptyReport(t *testing.T) {
+	spec := reporting.ReportSpec{
+		GroupBy: []reporting.FieldKey{"paid_by"},
+		Detail:  reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "category"},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Count", Label: "Count", Kind: reporting.ColumnAggregate, AggSrc: "COUNT()"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+		},
+		GrandTotals: true,
+	}
+
+	assertGrid(t, htmlGrid(t, mustRun(t, spec, paidByCatalog(t), nil), paidByDimension()), [][]string{
+		{"Paid By", "Category", "Count", "Total"},
+		{"Grand Total", "", "0", "0.00"},
+	})
+}
+
+// Unicode passes through into a cell unchanged.
+func TestHTML_Unicode(t *testing.T) {
+	spec := reporting.ReportSpec{
+		Detail: reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "category"},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+		},
+	}
+	rows := []reporting.Row{
+		{"category": {reporting.Str("日本語 🎉")}, "amount": {money("10")}},
+	}
+
+	assertGrid(t, htmlGrid(t, mustRun(t, spec, paidByCatalog(t), rows), nil), [][]string{
+		{"Category", "Total"},
+		{"日本語 🎉", "10.00"},
+	})
+}
+
+// Supplying fewer dimensions than the report groups by is rejected, reusing the
+// shared depth guard, and yields no bytes.
+func TestHTML_GroupByDepthMismatchErrors(t *testing.T) {
+	spec := reporting.ReportSpec{
+		GroupBy: []reporting.FieldKey{"paid_by", "tag"},
+		Detail:  reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "category"},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+		},
+	}
+	rows := []reporting.Row{
+		{"paid_by": {reporting.Str("Dana")}, "tag": {reporting.Str("Alex")}, "category": {reporting.Str("Food")}, "amount": {money("100")}},
+	}
+
+	out, err := HTML(mustRun(t, spec, paidByCatalog(t), rows), paidByDimension())
+	if err == nil {
+		t.Fatalf("expected an error for a group-depth mismatch, got none")
+	}
+	if out != nil {
+		t.Errorf("expected nil bytes on error, got %d", len(out))
+	}
+}
+
+// --- HTML-specific structure: row classes and numeric alignment -----------
+
+// Detail rows are unclassed; subtotal and grand-total rows carry their CSS class
+// so the stylesheet can emphasize them.
+func TestHTML_RowClassesMarkRollUps(t *testing.T) {
+	rows := bodyRows(t, mustRun(t, oneLevelSpec(), paidByCatalog(t), oneLevelRows()), paidByDimension())
+
+	want := []string{"", "", "subtotal", "", "subtotal", "grand-total"}
+	if len(rows) != len(want) {
+		t.Fatalf("row count = %d, want %d", len(rows), len(want))
+	}
+	for index, class := range want {
+		if got := attrOf(rows[index], "class"); got != class {
+			t.Errorf("row %d class = %q, want %q", index, got, class)
+		}
+	}
+}
+
+// Report columns are right-aligned via the "num" class, except label columns;
+// dimension columns are never numeric.
+func TestHTML_NumericCellsAreRightAligned(t *testing.T) {
+	rows := bodyRows(t, mustRun(t, oneLevelSpec(), paidByCatalog(t), oneLevelRows()), paidByDimension())
+
+	// First detail row: Paid By, Category (both label), then Count, Total, Avg.
+	cells := elementChildren(rows[0], "td")
+	wantNum := []bool{false, false, true, true, true}
+	if len(cells) != len(wantNum) {
+		t.Fatalf("cell count = %d, want %d", len(cells), len(wantNum))
+	}
+	for index, num := range wantNum {
+		isNum := attrOf(cells[index], "class") == "num"
+		if isNum != num {
+			t.Errorf("cell %d numeric = %v, want %v", index, isNum, num)
+		}
+	}
+}
+
+// --- document chrome ------------------------------------------------------
+
+// A title, resolved parameters, and a generated-at timestamp render as the
+// document's heading, a sorted preamble, and a footer.
+func TestHTML_DocumentChromeRendersFromMeta(t *testing.T) {
+	spec := oneLevelSpec()
+	spec.Title = "Quarterly Expenses"
+	meta := reporting.MetaInput{
+		GeneratedAt: time.Date(2026, 7, 13, 9, 30, 0, 0, time.UTC),
+		Params:      map[string]string{"Period": "2026-Q2", "Group": "Household"},
+	}
+	model, err := reporting.Run(spec, paidByCatalog(t), oneLevelRows(), meta)
+	if err != nil {
+		t.Fatalf("run report: %v", err)
+	}
+
+	out, err := HTML(model, paidByDimension())
+	if err != nil {
+		t.Fatalf("HTML: %v", err)
+	}
+	rendered := string(out)
+
+	if !strings.Contains(rendered, "<h1>Quarterly Expenses</h1>") {
+		t.Errorf("title heading missing:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "Generated 2026-07-13 09:30:00 UTC") {
+		t.Errorf("generated-at footer missing:\n%s", rendered)
+	}
+	for _, want := range []string{
+		`<span class="key">Group</span>: Household`,
+		`<span class="key">Period</span>: 2026-Q2`,
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("preamble missing %q", want)
+		}
+	}
+	// Params render alphabetically: Group before Period.
+	if strings.Index(rendered, ">Group<") > strings.Index(rendered, ">Period<") {
+		t.Error("params not sorted: Group should precede Period")
+	}
+}
+
+// With no title, no params, and a zero timestamp the document omits its chrome
+// entirely rather than rendering empty elements.
+func TestHTML_DocumentChromeOmittedWhenEmpty(t *testing.T) {
+	out, err := HTML(mustRun(t, oneLevelSpec(), paidByCatalog(t), oneLevelRows()), paidByDimension())
+	if err != nil {
+		t.Fatalf("HTML: %v", err)
+	}
+	rendered := string(out)
+
+	for _, absent := range []string{"<h1>", `class="preamble"`, "<footer>"} {
+		if strings.Contains(rendered, absent) {
+			t.Errorf("expected %q to be omitted:\n%s", absent, rendered)
+		}
+	}
+}
+
+// Cell text is HTML-escaped, so a value containing markup cannot break out of
+// its cell.
+func TestHTML_EscapesCellText(t *testing.T) {
+	spec := reporting.ReportSpec{
+		Detail: reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "category"},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+		},
+	}
+	rows := []reporting.Row{
+		{"category": {reporting.Str("A & <b>")}, "amount": {money("10")}},
+	}
+
+	out, err := HTML(mustRun(t, spec, paidByCatalog(t), rows), nil)
+	if err != nil {
+		t.Fatalf("HTML: %v", err)
+	}
+	rendered := string(out)
+
+	if !strings.Contains(rendered, "A &amp; &lt;b&gt;") {
+		t.Errorf("cell text not escaped:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "<b>") {
+		t.Errorf("unescaped markup leaked into output:\n%s", rendered)
+	}
+}

--- a/api/internal/reporting/render/walk.go
+++ b/api/internal/reporting/render/walk.go
@@ -1,0 +1,189 @@
+package render
+
+import "receipt-wrangler/api/internal/reporting"
+
+// The faithful renderers — XLSX and the HTML/PDF document — lay a report out the
+// way it looks on screen: the group-by dimensions are leading columns with each
+// value shown once per group, and a subtotal/grand-total row carries its marker
+// in the column at the group's depth (the "staircase"). This file holds that
+// shared traversal. A format supplies a faithfulSink that decides how a cell
+// looks; the walk decides where every cell goes. The CSV renderer is
+// deliberately not built on this — it is flat, not faithful, and keeps its own
+// walk.
+
+// totalMarker and grandTotalMarker are the labels a roll-up row shows in its
+// staircase column.
+const (
+	totalMarker      = "Total"
+	grandTotalMarker = "Grand Total"
+)
+
+// rowKind is the kind of data row the walk emits. Emphasis (bold, shading) is
+// uniform per kind — detail rows are plain, subtotal and grand-total rows are
+// emphasized — so a sink derives it from the kind rather than from each cell.
+type rowKind int
+
+const (
+	detailKind rowKind = iota
+	subtotalKind
+	grandTotalKind
+)
+
+// cellKind tags one positioned cell of a faithful row.
+type cellKind int
+
+const (
+	// blankCell is an empty grid position: a blanked repeated dimension, or a
+	// dimension column on a roll-up row that names no bucket.
+	blankCell cellKind = iota
+	// textCell is a dimension value or a Total/Grand Total marker.
+	textCell
+	// reportCell is a report column's cell; it carries its descriptor and value
+	// so each sink formats it its own way — a native number in XLSX, a formatted
+	// string in HTML.
+	reportCell
+)
+
+// faithfulCell is one cell of a faithful row, already placed at its grid column.
+type faithfulCell struct {
+	kind       cellKind
+	text       string
+	descriptor reporting.ColumnDescriptor
+	cell       reporting.Cell
+}
+
+// faithfulSink consumes the shared walk. The walk hands it fully positioned rows
+// (blanks included), so a sink only decides how a cell looks, never where it
+// goes.
+type faithfulSink interface {
+	writeHeader(headings []string) error
+	writeRow(kind rowKind, cells []faithfulCell) error
+}
+
+// faithfulWalk drives sink over the report the way a reader expects it: a header
+// row, then each group's detail rows with its subtotal beneath the rows it sums,
+// then the grand total last. It runs the group-by depth guard first, so a sink
+// never has to.
+func faithfulWalk(model reporting.ReportModel, groupBy []Dimension, sink faithfulSink) error {
+	if err := validateGroupByDepth(model, groupBy); err != nil {
+		return err
+	}
+
+	headings := make([]string, 0, len(groupBy)+len(model.Columns))
+	for _, dimension := range groupBy {
+		headings = append(headings, dimensionHeading(dimension))
+	}
+	for _, descriptor := range model.Columns {
+		headings = append(headings, columnHeading(descriptor))
+	}
+	if err := sink.writeHeader(headings); err != nil {
+		return err
+	}
+
+	walker := &faithfulWalker{
+		model:     model,
+		numDims:   len(groupBy),
+		totalCols: len(groupBy) + len(model.Columns),
+		sink:      sink,
+	}
+	if err := walker.walk(model.Root, 0, nil); err != nil {
+		return err
+	}
+	if model.GrandTotals != nil {
+		return walker.emitTotal(0, grandTotalKind, model.GrandTotals)
+	}
+	return nil
+}
+
+// faithfulWalker carries the walk's running state: the sink, the grid width, and
+// the previous detail row's group path for dimension blanking.
+type faithfulWalker struct {
+	model     reporting.ReportModel
+	numDims   int
+	totalCols int
+	sink      faithfulSink
+
+	prevPath []reporting.Value
+}
+
+// walk emits a node's descendants then its own subtotal, so a subtotal always
+// follows the rows it sums. level is the node's depth (root is 0), which places
+// its subtotal marker's column.
+func (w *faithfulWalker) walk(node reporting.GroupNode, level int, path []reporting.Value) error {
+	if len(node.Children) > 0 {
+		for _, child := range node.Children {
+			childPath := make([]reporting.Value, len(path), len(path)+1)
+			copy(childPath, path)
+			childPath = append(childPath, child.Value)
+			if err := w.walk(child, level+1, childPath); err != nil {
+				return err
+			}
+		}
+	} else {
+		for _, detail := range node.DetailRows {
+			if err := w.emitDetail(path, detail.Cells); err != nil {
+				return err
+			}
+		}
+	}
+
+	if node.Subtotals != nil {
+		if err := w.emitTotal(level, subtotalKind, node.Subtotals); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// emitDetail lays out one detail row. A dimension value is placed only from the
+// first level that differs from the previous detail row's path; the unchanged
+// leading levels stay blank, so a value shows once per group.
+func (w *faithfulWalker) emitDetail(path []reporting.Value, cells []reporting.Cell) error {
+	row := make([]faithfulCell, w.totalCols)
+	for index := w.firstDiff(path); index < len(path); index++ {
+		row[index] = faithfulCell{kind: textCell, text: formatDimension(path[index], w.model.Meta.NoneLabel)}
+	}
+	for offset, descriptor := range w.model.Columns {
+		row[w.numDims+offset] = faithfulCell{kind: reportCell, descriptor: descriptor, cell: cells[offset]}
+	}
+
+	w.prevPath = append(w.prevPath[:0], path...)
+	return w.sink.writeRow(detailKind, row)
+}
+
+// emitTotal lays out a subtotal or grand-total row: the marker lands in the
+// column at the group's depth (the staircase) and the report columns carry the
+// roll-up values. kind picks the marker text and tells the sink how to
+// emphasize the row.
+func (w *faithfulWalker) emitTotal(level int, kind rowKind, cells []reporting.Cell) error {
+	label := totalMarker
+	if kind == grandTotalKind {
+		label = grandTotalMarker
+	}
+
+	row := make([]faithfulCell, w.totalCols)
+	if level < w.numDims {
+		row[level] = faithfulCell{kind: textCell, text: label}
+	}
+	for offset, descriptor := range w.model.Columns {
+		column := w.numDims + offset
+		if column == level {
+			row[column] = faithfulCell{kind: textCell, text: label}
+			continue
+		}
+		row[column] = faithfulCell{kind: reportCell, descriptor: descriptor, cell: cells[offset]}
+	}
+	return w.sink.writeRow(kind, row)
+}
+
+// firstDiff is the first group level whose value differs from the previous
+// detail row's, or the path length when the row repeats the previous group
+// entirely.
+func (w *faithfulWalker) firstDiff(path []reporting.Value) int {
+	for index := range path {
+		if index >= len(w.prevPath) || !path[index].Equal(w.prevPath[index]) {
+			return index
+		}
+	}
+	return len(path)
+}

--- a/api/internal/reporting/render/xlsx.go
+++ b/api/internal/reporting/render/xlsx.go
@@ -11,190 +11,96 @@ import (
 
 const (
 	xlsxSheet          = "Report"
-	xlsxTotalLabel     = "Total"
-	xlsxGrandLabel     = "Grand Total"
 	defaultCurrencyFmt = "#,##0.00"
 )
 
 // XLSX renders a ReportModel as a faithful, grouped spreadsheet: the group-by
 // dimensions are leading columns (each value shown once per group), the report
-// columns follow, and subtotal/grand-total rows carry a Total marker in the
-// column at the group's depth. Numbers are written as native, typed cells with a
-// number format — not strings — so the workbook is analyzable, and the header,
+// columns follow, and subtotal/grand-total rows carry a marker in the column at
+// the group's depth. Numbers are written as native, typed cells with a number
+// format — not strings — so the workbook is analyzable, and the header,
 // subtotal, and grand-total rows are bold.
 //
 // It writes the engine-computed values statically; it does not (yet) translate
 // arithmetic columns into live cell formulas. Like every renderer it is a pure
-// consumer of the model — it fetches and computes nothing, and reaches back into
-// no upstream code.
+// consumer of the model. It shares the faithful walk (faithfulWalk) with the
+// HTML/PDF renderer; only the per-cell writing below is spreadsheet-specific.
 //
 // groupBy supplies the dimension order and header labels (the model carries
 // dimension keys but not labels), and must match the report's grouping depth —
 // see validateGroupByDepth.
 func XLSX(model reporting.ReportModel, groupBy []Dimension) ([]byte, error) {
-	if err := validateGroupByDepth(model, groupBy); err != nil {
+	file := excelize.NewFile()
+	defer file.Close()
+	if err := file.SetSheetName(file.GetSheetName(0), xlsxSheet); err != nil {
 		return nil, err
 	}
 
-	writer := &xlsxWriter{
-		file:    excelize.NewFile(),
-		model:   model,
-		groupBy: groupBy,
-		numDims: len(groupBy),
-		styles:  map[string]int{},
-		row:     1,
+	sink := &xlsxSink{
+		file:   file,
+		model:  model,
+		styles: map[string]int{},
+		row:    1,
 	}
-	defer writer.file.Close()
-	if err := writer.file.SetSheetName(writer.file.GetSheetName(0), xlsxSheet); err != nil {
+	if err := faithfulWalk(model, groupBy, sink); err != nil {
 		return nil, err
 	}
 
-	if err := writer.writeHeader(); err != nil {
-		return nil, err
-	}
-	if err := writer.walk(model.Root, 0, nil); err != nil {
-		return nil, err
-	}
-	if model.GrandTotals != nil {
-		if err := writer.emitTotal(0, xlsxGrandLabel, model.GrandTotals); err != nil {
-			return nil, err
-		}
-	}
-
-	buffer, err := writer.file.WriteToBuffer()
+	buffer, err := file.WriteToBuffer()
 	if err != nil {
 		return nil, err
 	}
 	return buffer.Bytes(), nil
 }
 
-// xlsxWriter carries the workbook and the walk's running state: the next row to
-// write, the previous detail row's group path (for dimension blanking), and a
-// cache of registered styles keyed by (number format, bold).
-type xlsxWriter struct {
-	file    *excelize.File
-	model   reporting.ReportModel
-	groupBy []Dimension
-	numDims int
+// xlsxSink is the faithfulSink that writes the walk into an excelize worksheet.
+// It tracks the next row to write and caches registered styles keyed by (number
+// format, bold).
+type xlsxSink struct {
+	file  *excelize.File
+	model reporting.ReportModel
 
-	styles   map[string]int
-	row      int
-	prevPath []reporting.Value
+	styles map[string]int
+	row    int
 }
 
-func (w *xlsxWriter) writeHeader() error {
-	column := 1
-	for _, dimension := range w.groupBy {
-		if err := w.setString(column, w.row, dimensionHeading(dimension), true); err != nil {
+func (s *xlsxSink) writeHeader(headings []string) error {
+	for index, heading := range headings {
+		if err := s.setString(index+1, s.row, heading, true); err != nil {
 			return err
 		}
-		column++
 	}
-	for _, descriptor := range w.model.Columns {
-		if err := w.setString(column, w.row, columnHeading(descriptor), true); err != nil {
-			return err
-		}
-		column++
-	}
-	w.row++
+	s.row++
 	return nil
 }
 
-// walk emits a node's descendants then its own subtotal, so a subtotal always
-// follows the rows it sums. level is the node's depth (root is 0), which places
-// the subtotal marker's column.
-func (w *xlsxWriter) walk(node reporting.GroupNode, level int, path []reporting.Value) error {
-	if len(node.Children) > 0 {
-		for _, child := range node.Children {
-			childPath := make([]reporting.Value, len(path), len(path)+1)
-			copy(childPath, path)
-			childPath = append(childPath, child.Value)
-			if err := w.walk(child, level+1, childPath); err != nil {
+func (s *xlsxSink) writeRow(kind rowKind, cells []faithfulCell) error {
+	bold := kind != detailKind
+	for index, cell := range cells {
+		column := index + 1
+		switch cell.kind {
+		case blankCell:
+			// An empty grid position writes nothing.
+		case textCell:
+			if err := s.setString(column, s.row, cell.text, bold); err != nil {
 				return err
 			}
-		}
-	} else {
-		for _, detail := range node.DetailRows {
-			if err := w.emitDetail(path, detail.Cells); err != nil {
+		case reportCell:
+			if err := s.writeReportCell(column, s.row, cell.descriptor, cell.cell, bold); err != nil {
 				return err
 			}
 		}
 	}
-
-	if node.Subtotals != nil {
-		if err := w.emitTotal(level, xlsxTotalLabel, node.Subtotals); err != nil {
-			return err
-		}
-	}
+	s.row++
 	return nil
 }
 
-// emitDetail writes one detail row. A dimension value is printed only from the
-// first level that differs from the previous detail row's path; the unchanged
-// leading levels stay blank, so a value shows once per group.
-func (w *xlsxWriter) emitDetail(path []reporting.Value, cells []reporting.Cell) error {
-	firstDiff := w.firstDiff(path)
-	for index := firstDiff; index < len(path); index++ {
-		if err := w.setString(index+1, w.row, formatDimension(path[index], w.model.Meta.NoneLabel), false); err != nil {
-			return err
-		}
-	}
-
-	for offset, descriptor := range w.model.Columns {
-		if err := w.writeReportCell(w.numDims+offset+1, w.row, descriptor, cells[offset], false); err != nil {
-			return err
-		}
-	}
-
-	w.prevPath = append(w.prevPath[:0], path...)
-	w.row++
-	return nil
-}
-
-// emitTotal writes a subtotal or grand-total row. The label lands in the column
-// at the group's depth (the staircase); every other dimension cell is blank, and
-// the measure columns carry the roll-up numbers. The whole row is bold.
-func (w *xlsxWriter) emitTotal(level int, label string, cells []reporting.Cell) error {
-	if level < w.numDims {
-		if err := w.setString(level+1, w.row, label, true); err != nil {
-			return err
-		}
-	}
-
-	for offset, descriptor := range w.model.Columns {
-		column := w.numDims + offset
-		if column == level {
-			if err := w.setString(column+1, w.row, label, true); err != nil {
-				return err
-			}
-			continue
-		}
-		if err := w.writeReportCell(column+1, w.row, descriptor, cells[offset], true); err != nil {
-			return err
-		}
-	}
-
-	w.row++
-	return nil
-}
-
-// firstDiff is the first group level whose value differs from the previous detail
-// row's, or the path length when the row repeats the previous group entirely.
-func (w *xlsxWriter) firstDiff(path []reporting.Value) int {
-	for index := range path {
-		if index >= len(w.prevPath) || !path[index].Equal(w.prevPath[index]) {
-			return index
-		}
-	}
-	return len(path)
-}
-
-// writeReportCell writes one report column's cell. A label column is joined text;
-// a numeric column is a native number with the column's format; a null is left
-// blank. bold styles the whole cell (subtotal/grand-total rows).
-func (w *xlsxWriter) writeReportCell(column, row int, descriptor reporting.ColumnDescriptor, cell reporting.Cell, bold bool) error {
+// writeReportCell writes one report column's cell. A label column is joined
+// text; a numeric column is a native number with the column's format; a null is
+// left blank. bold styles the whole cell (subtotal/grand-total rows).
+func (s *xlsxSink) writeReportCell(column, row int, descriptor reporting.ColumnDescriptor, cell reporting.Cell, bold bool) error {
 	if descriptor.Kind == reporting.ColumnLabel {
-		return w.setString(column, row, joinLabel(cell, w.model.Meta.NoneLabel), bold)
+		return s.setString(column, row, joinLabel(cell, s.model.Meta.NoneLabel), bold)
 	}
 
 	value := cell.Value()
@@ -202,30 +108,30 @@ func (w *xlsxWriter) writeReportCell(column, row int, descriptor reporting.Colum
 		return nil
 	}
 	if number, ok := value.Decimal(); ok {
-		return w.setNumber(column, row, number.InexactFloat64(), w.numberFormat(descriptor), bold)
+		return s.setNumber(column, row, number.InexactFloat64(), s.numberFormat(descriptor), bold)
 	}
 	// A non-number, non-null measure cell cannot arise through Run; render its
 	// text defensively, matching the CSV renderer.
-	return w.setString(column, row, value.String(), bold)
+	return s.setString(column, row, value.String(), bold)
 }
 
 // numberFormat resolves a numeric column's Excel format: the column's own format
 // override, else a currency default (the report's currency format, or a plain
 // two-place format), else General for other numbers.
-func (w *xlsxWriter) numberFormat(descriptor reporting.ColumnDescriptor) string {
+func (s *xlsxSink) numberFormat(descriptor reporting.ColumnDescriptor) string {
 	if descriptor.Format != "" {
 		return descriptor.Format
 	}
 	if descriptor.DataType == reporting.TypeCurrency {
-		if w.model.Meta.CurrencyFormat != "" {
-			return w.model.Meta.CurrencyFormat
+		if s.model.Meta.CurrencyFormat != "" {
+			return s.model.Meta.CurrencyFormat
 		}
 		return defaultCurrencyFmt
 	}
 	return ""
 }
 
-func (w *xlsxWriter) setString(column, row int, text string, bold bool) error {
+func (s *xlsxSink) setString(column, row int, text string, bold bool) error {
 	if text == "" {
 		return nil
 	}
@@ -233,39 +139,39 @@ func (w *xlsxWriter) setString(column, row int, text string, bold bool) error {
 	if err != nil {
 		return err
 	}
-	if err := w.file.SetCellValue(xlsxSheet, cell, text); err != nil {
+	if err := s.file.SetCellValue(xlsxSheet, cell, text); err != nil {
 		return err
 	}
-	return w.applyStyle(cell, "", bold)
+	return s.applyStyle(cell, "", bold)
 }
 
-func (w *xlsxWriter) setNumber(column, row int, value float64, numberFormat string, bold bool) error {
+func (s *xlsxSink) setNumber(column, row int, value float64, numberFormat string, bold bool) error {
 	cell, err := excelize.CoordinatesToCellName(column, row)
 	if err != nil {
 		return err
 	}
-	if err := w.file.SetCellValue(xlsxSheet, cell, value); err != nil {
+	if err := s.file.SetCellValue(xlsxSheet, cell, value); err != nil {
 		return err
 	}
-	return w.applyStyle(cell, numberFormat, bold)
+	return s.applyStyle(cell, numberFormat, bold)
 }
 
-func (w *xlsxWriter) applyStyle(cell, numberFormat string, bold bool) error {
-	id, err := w.styleID(numberFormat, bold)
+func (s *xlsxSink) applyStyle(cell, numberFormat string, bold bool) error {
+	id, err := s.styleID(numberFormat, bold)
 	if err != nil || id == 0 {
 		return err
 	}
-	return w.file.SetCellStyle(xlsxSheet, cell, cell, id)
+	return s.file.SetCellStyle(xlsxSheet, cell, cell, id)
 }
 
 // styleID registers (and caches) a style for a number-format/bold combination.
 // The default cell — no format, not bold — needs no style, so it returns 0.
-func (w *xlsxWriter) styleID(numberFormat string, bold bool) (int, error) {
+func (s *xlsxSink) styleID(numberFormat string, bold bool) (int, error) {
 	if numberFormat == "" && !bold {
 		return 0, nil
 	}
 	key := numberFormat + "|" + strconv.FormatBool(bold)
-	if id, ok := w.styles[key]; ok {
+	if id, ok := s.styles[key]; ok {
 		return id, nil
 	}
 
@@ -278,11 +184,11 @@ func (w *xlsxWriter) styleID(numberFormat string, bold bool) (int, error) {
 		style.CustomNumFmt = &format
 	}
 
-	id, err := w.file.NewStyle(style)
+	id, err := s.file.NewStyle(style)
 	if err != nil {
 		return 0, err
 	}
-	w.styles[key] = id
+	s.styles[key] = id
 	return id, nil
 }
 


### PR DESCRIPTION
## What

Adds the third reporting renderer — `render.HTML(model, groupBy) ([]byte, error)` — the **PDF format's HTML stage**, and extracts the faithful pivot/staircase layout it shares with the XLSX renderer into a single reusable walk.

### Shared faithful walk (`render/walk.go`)
The faithful layout (group-by dimensions as leading columns with each value shown once per group; subtotal/grand-total markers placed in the column at the group's depth) lived entirely inside the XLSX renderer. It's now `faithfulWalk`, which drives a format-specific `faithfulSink` over the model and hands it fully positioned rows (blanks included) — the walk decides *where* every cell goes, a sink decides only *how* it looks.

- **XLSX is refactored onto it**, with **byte-identical output**. The traversal, dimension blanking, staircase placement, and depth guard now live in the walk; `xlsxSink` keeps only the excelize-specific cell writing (native typed numbers, number formats, bold styles). The untouched `xlsx_test.go` round-trip suite is the guard.
- **CSV keeps its own flat walk** — it is data-only, not faithful.

### HTML renderer (`render/html.go`)
A self-contained document: a `Meta.Title` heading, a preamble of the report's resolved `Meta.Params`, the same faithful table as XLSX, and a `Meta.GeneratedAt` footer — each omitted when the model carries nothing for it. Built with `html/template`, so every value is auto-escaped.

All CSS is inline and it references no external resources or scripts, so it converts to PDF through the existing headless-Chromium pipeline (`services/html_to_pdf.go`), which blocks network loads and disables JavaScript by default. It returns **HTML bytes**; the reporting package is pure, so the chromedp conversion stays in the services layer and is wired up by the future handler (deferred until the UI).

## Scope

- No orchestrator/handler and no chromedp wiring in this slice — matching how CSV/XLSX shipped. Live `=SUM`/expression formulas and document slots (logo/branding) remain later work.

## Tests

- HTML is tested against the **same faithful golden grids** as the XLSX renderer (parsed with `golang.org/x/net/html`), proving layout parity.
- Plus row-class, numeric-alignment, document-chrome (present + omitted), and HTML-escaping cases.
- `go test ./internal/reporting/...` green; `gofmt`/`go vet` clean; full `go build ./...` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTML report rendering for self-contained, PDF-ready documents.
  * HTML reports include titles, parameters, optional generation timestamps, grouped data, subtotals, grand totals, and formatted values.
  * Added HTML escaping and layout improvements for numeric and summary rows.
  * XLSX and HTML reports now share consistent grouping and subtotal behavior.

* **Documentation**
  * Documented HTML report output, PDF conversion behavior, and renderer traversal details.

* **Tests**
  * Added comprehensive coverage for aggregation, grouping, formatting, escaping, metadata, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->