### PR TITLE
feat(mobile): QR-scan the server URL on the Connect screen

### DIFF
--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -330,12 +330,21 @@ Native / platform notes:
   (`lib/utils/permissions.dart`) and uses `autoStart: false` before `controller.start()`, so it never
   races the app-init camera request (the `ERROR_ALREADY_REQUESTING_PERMISSIONS` case documented above
   for `cunning_document_scanner`).
-- **Linux / e2e:** mobile_scanner has no Linux desktop implementation, so `qr_scanner_screen.dart`
-  guards on `Platform.isLinux` and renders a message instead of constructing `MobileScanner` —
-  `run-e2e.sh` stays green (no existing spec taps the button; a plain `IconButton` builds fine on
-  Linux). Post-scan logic is covered by `test/widgets/set_homeserver_url_test.dart` via an injectable
-  `scanQrCode` seam (the widget test never builds `MobileScanner`); the validator by
-  `test/utils/url_test.dart`. A real camera scan is exercised only on Android/iOS + manual device runs.
+- **Fallback states + recovery:** besides the live camera, `qr_scanner_screen.dart` renders three
+  non-camera states via a shared `_buildMessage` helper — unsupported (Linux), **permission denied**
+  ("Open Settings"), and **camera error** ("Retry"). `controller.start()` is wrapped in `_safeStart`
+  (catches `MobileScannerException` → camera-error state; skips the start if already running). On
+  `AppLifecycleState.resumed` the screen re-checks permission and clears the denied/error state if
+  access was just granted (so "Open Settings" actually recovers). `_onDetect` is `!mounted`-guarded so
+  a buffered detection can't pop a disposed context.
+- **Linux / e2e + testing:** mobile_scanner has no Linux desktop implementation, so the screen guards
+  on `Platform.isLinux` and renders the unsupported message instead of constructing `MobileScanner` —
+  `run-e2e.sh` stays green. The controller is created **lazily** and the widget exposes small
+  `@visibleForTesting` seams (`debugScannerSupported` / `debugForcePermissionDenied` /
+  `debugForceCameraError`), so `test/widgets/qr_scanner_screen_test.dart` covers the three fallback
+  states + the close button **without a camera or channel mocks**. Post-scan/validation logic is
+  covered by `test/widgets/set_homeserver_url_test.dart` (injectable `scanQrCode` seam) and
+  `test/utils/url_test.dart`. The live-camera path is exercised only on Android/iOS + manual runs.
 
 ### Testing
 

--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -288,6 +288,46 @@ applies `kotlin-android` itself and uses the legacy `kotlinOptions {}` DSL (work
 2.1.0); its `getPictures(noOfPages:)` API — the only call the app uses (`lib/utils/scan.dart`) —
 is identical.
 
+### QR-scan the server URL (login)
+
+The "Connect to Server" screen (`lib/auth/set-homeserver-url/screens/set_homeserver_url.dart`, route
+`/`) has a `qr_code_scanner` suffix-icon button on the URL field. **The server-URL field lives here,
+not on the `/login` username/password screen** — `/login` only *shows* the already-set base path.
+The button opens a full-screen scanner (`qr_scanner_screen.dart`) built on **`mobile_scanner`**
+(`^7.2.0`, QR-only via `formats: [BarcodeFormat.qrCode]`), which pops the raw decoded string back.
+The screen validates it with `normalizeServerUrl` (`lib/utils/url.dart` — trim + require a well-formed
+http/https URL with a non-empty host; **http is allowed** for LAN/self-hosted instances) and, on
+success, `patchValue`s the `url` form field. It **never auto-connects** — the user reviews the
+populated URL and taps Connect (phishing mitigation: a malicious QR can't silently point the app at
+an attacker's server that would then harvest credentials). Invalid content shows an error snackbar and
+leaves the field untouched.
+
+Native / platform notes:
+- **iOS: no deployment-target change.** mobile_scanner 7.x uses Apple's **Vision framework** on
+  iOS/macOS (not GoogleMLKit — see its issue #1225), and its pod declares
+  `s.ios.deployment_target = '12.0'`, so the repo's existing **13.0** is fine. Verified:
+  `flutter build ios --simulator --no-codesign` builds clean at 13.0 (an earlier plan to bump to 15.5
+  for a supposed GoogleMLKit requirement was wrong and was reverted — no iOS device support dropped).
+  `NSCameraUsageDescription` already existed (shared with `cunning_document_scanner`); only its wording
+  was broadened to mention QR scanning. After pulling this change, iOS needs `cd ios && pod install`.
+- **Android** needs no gradle/manifest change: `CAMERA` is already declared and the inherited
+  `flutter.minSdkVersion` (24) / `compileSdkVersion` (36) exceed mobile_scanner's floor (21 / 35). ML
+  Kit is **bundled** by default; to shrink the APK set
+  `dev.steenbakker.mobile_scanner.useUnbundled=true` in `android/gradle.properties` (needs Play
+  Services).
+- **`pubspec.yaml`** Dart SDK floor was raised `>=3.2.5` → `>=3.7.0` (mobile_scanner 7.2.0 requires it;
+  the resolved toolchain is already 3.10+).
+- **Permission double-request race:** the scanner `await`s the shared-in-flight `requestPermissions()`
+  (`lib/utils/permissions.dart`) and uses `autoStart: false` before `controller.start()`, so it never
+  races the app-init camera request (the `ERROR_ALREADY_REQUESTING_PERMISSIONS` case documented above
+  for `cunning_document_scanner`).
+- **Linux / e2e:** mobile_scanner has no Linux desktop implementation, so `qr_scanner_screen.dart`
+  guards on `Platform.isLinux` and renders a message instead of constructing `MobileScanner` —
+  `run-e2e.sh` stays green (no existing spec taps the button; a plain `IconButton` builds fine on
+  Linux). Post-scan logic is covered by `test/widgets/set_homeserver_url_test.dart` via an injectable
+  `scanQrCode` seam (the widget test never builds `MobileScanner`); the validator by
+  `test/utils/url_test.dart`. A real camera scan is exercised only on Android/iOS + manual device runs.
+
 ### Testing
 
 Run tests with `flutter test`. Run a single file with `flutter test test/path/to/file_test.dart`.

--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -295,7 +295,12 @@ The "Connect to Server" screen (`lib/auth/set-homeserver-url/screens/set_homeser
 not on the `/login` username/password screen** — `/login` only *shows* the already-set base path.
 The button opens a full-screen scanner (`qr_scanner_screen.dart`) built on **`mobile_scanner`**
 (`^7.2.0`, QR-only via `formats: [BarcodeFormat.qrCode]`), which pops the raw decoded string back.
-The screen validates it with `normalizeServerUrl` (`lib/utils/url.dart` — trim + require a well-formed
+The scanner draws a centered **targeting box** (dimmed scrim + four L-shaped corner brackets + a hint
+line, via a small private `_CornerBracketPainter`) and **gates detection to it** through
+`MobileScanner.scanWindow`. The box Rect is computed once from a `LayoutBuilder` and passed to both
+`scanWindow` and the `overlayBuilder`, so the drawn box and the detection area stay aligned (the
+scanner sits below an AppBar, so `MediaQuery.sizeOf` would misalign — use the layout constraints).
+The screen validates the decoded string with `normalizeServerUrl` (`lib/utils/url.dart` — trim + require a well-formed
 http/https URL with a non-empty host; **http is allowed** for LAN/self-hosted instances) and, on
 success, `patchValue`s the `url` form field. It **never auto-connects** — the user reviews the
 populated URL and taps Connect (phishing mitigation: a malicious QR can't silently point the app at

--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -296,10 +296,14 @@ not on the `/login` username/password screen** — `/login` only *shows* the alr
 The button opens a full-screen scanner (`qr_scanner_screen.dart`) built on **`mobile_scanner`**
 (`^7.2.0`, QR-only via `formats: [BarcodeFormat.qrCode]`), which pops the raw decoded string back.
 The scanner draws a centered **targeting box** (dimmed scrim + four L-shaped corner brackets + a hint
-line, via a small private `_CornerBracketPainter`) and **gates detection to it** through
-`MobileScanner.scanWindow`. The box Rect is computed once from a `LayoutBuilder` and passed to both
-`scanWindow` and the `overlayBuilder`, so the drawn box and the detection area stay aligned (the
-scanner sits below an AppBar, so `MediaQuery.sizeOf` would misalign — use the layout constraints).
+line, via a small private `_CornerBracketPainter`) as a **visual aim guide only** — detection runs on
+the **whole camera frame**. We deliberately do **not** use `MobileScanner.scanWindow` to gate
+detection: it made scanning intermittent (a QR visibly inside the box would scan only sometimes).
+Per mobile_scanner's own changelog the scan-window intersection test is unreliable — Android accuracy
+was only just improved in 7.2.0 ("migrated boundingBox to cornerPoints") and 7.x lists "[Apple] scan
+window does not work correctly" as a known issue — so whole-frame detection is the reliable choice.
+The box Rect is computed inside the `overlayBuilder` from its `constraints` (the scanner sits below an
+AppBar, where `MediaQuery.sizeOf` would misalign the box).
 The screen validates the decoded string with `normalizeServerUrl` (`lib/utils/url.dart` — trim + require a well-formed
 http/https URL with a non-empty host; **http is allowed** for LAN/self-hosted instances) and, on
 success, `patchValue`s the `url` form field. It **never auto-connects** — the user reviews the

--- a/mobile/ios/Podfile.lock
+++ b/mobile/ios/Podfile.lock
@@ -14,6 +14,9 @@ PODS:
     - FlutterMacOS
   - integration_test (0.0.1):
     - Flutter
+  - mobile_scanner (7.0.0):
+    - Flutter
+    - FlutterMacOS
   - permission_handler_apple (9.4.8):
     - Flutter
   - shared_preferences_foundation (0.0.1):
@@ -28,6 +31,7 @@ DEPENDENCIES:
   - flutter_secure_storage_darwin (from `.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
   - gal (from `.symlinks/plugins/gal/darwin`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
+  - mobile_scanner (from `.symlinks/plugins/mobile_scanner/darwin`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
 
@@ -46,6 +50,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/gal/darwin"
   integration_test:
     :path: ".symlinks/plugins/integration_test/ios"
+  mobile_scanner:
+    :path: ".symlinks/plugins/mobile_scanner/darwin"
   permission_handler_apple:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
   shared_preferences_foundation:
@@ -59,6 +65,7 @@ SPEC CHECKSUMS:
   flutter_secure_storage_darwin: 557817588b80e60213cbecb573c45c76b788018d
   gal: 6a522c75909f1244732d4596d11d6a2f86ff37a5
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
+  mobile_scanner: 77265f3dc8d580810e91849d4a0811a90467ed5e
   permission_handler_apple: ee2fe0fd04551b304eb002714ff067c371c822ed
   shared_preferences_foundation: 5086985c1d43c5ba4d5e69a4e8083a389e2909e6
 

--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -48,7 +48,7 @@
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
-	<string>Receipt Wrangler uses your camera to scan and photograph receipts. For example, you can take a photo of a paper receipt so the app can extract its details for tracking and splitting expenses.</string>
+	<string>Receipt Wrangler uses your camera to scan and photograph receipts, and to scan a QR code to connect to your server. For example, you can take a photo of a paper receipt so the app can extract its details for tracking and splitting expenses.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Receipt Wrangler accesses your photo library so you can select existing photos of receipts to upload. For example, you can choose a receipt image you previously photographed to add it to a group for expense tracking.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>

--- a/mobile/lib/auth/set-homeserver-url/screens/qr_scanner_screen.dart
+++ b/mobile/lib/auth/set-homeserver-url/screens/qr_scanner_screen.dart
@@ -1,0 +1,151 @@
+import 'dart:async';
+import 'dart:io' show Platform;
+
+import 'package:flutter/material.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'package:receipt_wrangler_mobile/utils/permissions.dart';
+
+/// Full-screen QR scanner used to fill the server URL on the "Connect to Server"
+/// screen. Pops the raw scanned string back to the caller (validation happens
+/// there); pops null when the user cancels or camera access is unavailable.
+class QrScannerScreen extends StatefulWidget {
+  const QrScannerScreen({super.key});
+
+  @override
+  State<QrScannerScreen> createState() => _QrScannerScreenState();
+}
+
+class _QrScannerScreenState extends State<QrScannerScreen>
+    with WidgetsBindingObserver {
+  final MobileScannerController _controller = MobileScannerController(
+    formats: const [BarcodeFormat.qrCode],
+    detectionSpeed: DetectionSpeed.noDuplicates,
+    autoStart: false, // start manually once camera permission is resolved
+  );
+
+  StreamSubscription<BarcodeCapture>? _subscription;
+  bool _handled = false; // hard single-fire guard: exactly one pop
+  bool _permissionDenied = false;
+
+  // mobile_scanner has no Linux desktop implementation; constructing/starting it
+  // on the run-e2e.sh (Linux) target throws. Degrade to a message rather than
+  // crash the process.
+  bool get _scannerSupported => !Platform.isLinux;
+
+  @override
+  void initState() {
+    super.initState();
+    if (!_scannerSupported) {
+      return;
+    }
+    WidgetsBinding.instance.addObserver(this);
+    _subscription = _controller.barcodes.listen(_onDetect);
+    _ensurePermissionThenStart();
+  }
+
+  Future<void> _ensurePermissionThenStart() async {
+    // Reuse the app-startup camera request (a shared in-flight future) so we
+    // never fire a second *concurrent* request, which would throw
+    // ERROR_ALREADY_REQUESTING_PERMISSIONS on Android.
+    await requestPermissions();
+    final status = await Permission.camera.status;
+    if (!mounted) {
+      return;
+    }
+    if (!status.isGranted) {
+      setState(() => _permissionDenied = true);
+      return;
+    }
+    await _controller.start();
+  }
+
+  void _onDetect(BarcodeCapture capture) {
+    if (_handled) {
+      return;
+    }
+    final raw =
+        capture.barcodes.isNotEmpty ? capture.barcodes.first.rawValue : null;
+    if (raw == null || raw.isEmpty) {
+      return;
+    }
+    _handled = true;
+    Navigator.of(context).pop(raw);
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (!_scannerSupported || _permissionDenied) {
+      return;
+    }
+    switch (state) {
+      case AppLifecycleState.resumed:
+        _subscription = _controller.barcodes.listen(_onDetect);
+        unawaited(_controller.start());
+        break;
+      case AppLifecycleState.inactive:
+        unawaited(_subscription?.cancel());
+        _subscription = null;
+        unawaited(_controller.stop());
+        break;
+      default:
+        break;
+    }
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (_scannerSupported) {
+      WidgetsBinding.instance.removeObserver(this);
+    }
+    unawaited(_subscription?.cancel());
+    _subscription = null;
+    super.dispose();
+    await _controller.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("Scan server QR code"),
+        leading: IconButton(
+          key: const ValueKey("qr-scanner-close"),
+          icon: const Icon(Icons.close),
+          onPressed: () => Navigator.of(context).pop(), // null => cancel
+        ),
+      ),
+      body: _buildBody(),
+    );
+  }
+
+  Widget _buildBody() {
+    if (!_scannerSupported) {
+      return const Center(
+        child: Text("QR scanning isn't supported on this device."),
+      );
+    }
+    if (_permissionDenied) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Padding(
+              padding: EdgeInsets.all(24),
+              child: Text(
+                "Camera access is required to scan a QR code. Enable it in "
+                "Settings, or type the URL manually.",
+                textAlign: TextAlign.center,
+              ),
+            ),
+            ElevatedButton(
+              onPressed: openAppSettings,
+              child: const Text("Open Settings"),
+            ),
+          ],
+        ),
+      );
+    }
+    return MobileScanner(controller: _controller);
+  }
+}

--- a/mobile/lib/auth/set-homeserver-url/screens/qr_scanner_screen.dart
+++ b/mobile/lib/auth/set-homeserver-url/screens/qr_scanner_screen.dart
@@ -146,6 +146,119 @@ class _QrScannerScreenState extends State<QrScannerScreen>
         ),
       );
     }
-    return MobileScanner(controller: _controller);
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final scanWindow = _scanWindowFor(constraints.biggest);
+        return MobileScanner(
+          controller: _controller,
+          scanWindow: scanWindow, // gate detection to the box
+          overlayBuilder: (context, _) => _QrTargetOverlay(
+            scanWindow: scanWindow,
+            color: Theme.of(context).colorScheme.primary,
+          ),
+        );
+      },
+    );
   }
+
+  // Centered square, 70% of the shorter side. The same Rect drives both the
+  // detection window and the drawn box, so they stay aligned.
+  Rect _scanWindowFor(Size size) {
+    final side = size.shortestSide * 0.7;
+    return Rect.fromCenter(
+      center: Offset(size.width / 2, size.height / 2),
+      width: side,
+      height: side,
+    );
+  }
+}
+
+/// Dimmed scrim outside a centered square, four L-shaped corner brackets, and a
+/// hint line below the box. Drawn from the same [scanWindow] Rect passed to
+/// [MobileScanner.scanWindow] so the box matches the detection area.
+class _QrTargetOverlay extends StatelessWidget {
+  const _QrTargetOverlay({required this.scanWindow, required this.color});
+
+  final Rect scanWindow;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: CustomPaint(
+            painter: _CornerBracketPainter(scanWindow: scanWindow, color: color),
+          ),
+        ),
+        Positioned(
+          top: scanWindow.bottom + 24,
+          left: 24,
+          right: 24,
+          child: const Text(
+            "Point your camera at the server's QR code",
+            textAlign: TextAlign.center,
+            style: TextStyle(color: Colors.white, fontSize: 16),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _CornerBracketPainter extends CustomPainter {
+  const _CornerBracketPainter({required this.scanWindow, required this.color});
+
+  final Rect scanWindow;
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    // Dim everything outside the cutout (same technique as ScanWindowPainter).
+    final cutout = RRect.fromRectAndRadius(scanWindow, const Radius.circular(12));
+    final scrim = Path.combine(
+      PathOperation.difference,
+      Path()..addRect(Offset.zero & size),
+      Path()..addRRect(cutout),
+    );
+    canvas.drawPath(scrim, Paint()..color = const Color(0x99000000));
+
+    // Four L-shaped corner brackets.
+    final arm = scanWindow.shortestSide * 0.12;
+    final paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 4
+      ..strokeCap = StrokeCap.round;
+    final r = scanWindow;
+    canvas
+      ..drawPath(
+          Path()
+            ..moveTo(r.left, r.top + arm)
+            ..lineTo(r.left, r.top)
+            ..lineTo(r.left + arm, r.top),
+          paint)
+      ..drawPath(
+          Path()
+            ..moveTo(r.right - arm, r.top)
+            ..lineTo(r.right, r.top)
+            ..lineTo(r.right, r.top + arm),
+          paint)
+      ..drawPath(
+          Path()
+            ..moveTo(r.left, r.bottom - arm)
+            ..lineTo(r.left, r.bottom)
+            ..lineTo(r.left + arm, r.bottom),
+          paint)
+      ..drawPath(
+          Path()
+            ..moveTo(r.right - arm, r.bottom)
+            ..lineTo(r.right, r.bottom)
+            ..lineTo(r.right, r.bottom - arm),
+          paint);
+  }
+
+  @override
+  bool shouldRepaint(_CornerBracketPainter oldDelegate) =>
+      oldDelegate.scanWindow != scanWindow || oldDelegate.color != color;
 }

--- a/mobile/lib/auth/set-homeserver-url/screens/qr_scanner_screen.dart
+++ b/mobile/lib/auth/set-homeserver-url/screens/qr_scanner_screen.dart
@@ -146,25 +146,20 @@ class _QrScannerScreenState extends State<QrScannerScreen>
         ),
       );
     }
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final scanWindow = _scanWindowFor(constraints.biggest);
-        return MobileScanner(
-          controller: _controller,
-          scanWindow: scanWindow, // gate detection to the box
-          overlayBuilder: (context, _) => _QrTargetOverlay(
-            scanWindow: scanWindow,
-            color: Theme.of(context).colorScheme.primary,
-          ),
-        );
-      },
+    return MobileScanner(
+      controller: _controller,
+      overlayBuilder: (context, constraints) => _QrTargetOverlay(
+        box: _targetBoxFor(constraints.biggest),
+        color: Theme.of(context).colorScheme.primary,
+      ),
     );
   }
 
-  // Centered square, 70% of the shorter side. The same Rect drives both the
-  // detection window and the drawn box, so they stay aligned.
-  Rect _scanWindowFor(Size size) {
-    final side = size.shortestSide * 0.7;
+  // Centered square used only as a visual aim guide. Detection runs on the whole
+  // frame -- mobile_scanner's scanWindow gate is unreliable -- so this box does
+  // not restrict what scans.
+  Rect _targetBoxFor(Size size) {
+    final side = size.shortestSide * 0.75;
     return Rect.fromCenter(
       center: Offset(size.width / 2, size.height / 2),
       width: side,
@@ -174,12 +169,12 @@ class _QrScannerScreenState extends State<QrScannerScreen>
 }
 
 /// Dimmed scrim outside a centered square, four L-shaped corner brackets, and a
-/// hint line below the box. Drawn from the same [scanWindow] Rect passed to
-/// [MobileScanner.scanWindow] so the box matches the detection area.
+/// hint line below the box. Purely a visual aim guide -- detection runs on the
+/// whole camera frame (mobile_scanner's scanWindow gate is unreliable).
 class _QrTargetOverlay extends StatelessWidget {
-  const _QrTargetOverlay({required this.scanWindow, required this.color});
+  const _QrTargetOverlay({required this.box, required this.color});
 
-  final Rect scanWindow;
+  final Rect box;
   final Color color;
 
   @override
@@ -188,11 +183,11 @@ class _QrTargetOverlay extends StatelessWidget {
       children: [
         Positioned.fill(
           child: CustomPaint(
-            painter: _CornerBracketPainter(scanWindow: scanWindow, color: color),
+            painter: _CornerBracketPainter(box: box, color: color),
           ),
         ),
         Positioned(
-          top: scanWindow.bottom + 24,
+          top: box.bottom + 24,
           left: 24,
           right: 24,
           child: const Text(
@@ -207,15 +202,15 @@ class _QrTargetOverlay extends StatelessWidget {
 }
 
 class _CornerBracketPainter extends CustomPainter {
-  const _CornerBracketPainter({required this.scanWindow, required this.color});
+  const _CornerBracketPainter({required this.box, required this.color});
 
-  final Rect scanWindow;
+  final Rect box;
   final Color color;
 
   @override
   void paint(Canvas canvas, Size size) {
     // Dim everything outside the cutout (same technique as ScanWindowPainter).
-    final cutout = RRect.fromRectAndRadius(scanWindow, const Radius.circular(12));
+    final cutout = RRect.fromRectAndRadius(box, const Radius.circular(12));
     final scrim = Path.combine(
       PathOperation.difference,
       Path()..addRect(Offset.zero & size),
@@ -224,13 +219,13 @@ class _CornerBracketPainter extends CustomPainter {
     canvas.drawPath(scrim, Paint()..color = const Color(0x99000000));
 
     // Four L-shaped corner brackets.
-    final arm = scanWindow.shortestSide * 0.12;
+    final arm = box.shortestSide * 0.12;
     final paint = Paint()
       ..color = color
       ..style = PaintingStyle.stroke
       ..strokeWidth = 4
       ..strokeCap = StrokeCap.round;
-    final r = scanWindow;
+    final r = box;
     canvas
       ..drawPath(
           Path()
@@ -260,5 +255,5 @@ class _CornerBracketPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(_CornerBracketPainter oldDelegate) =>
-      oldDelegate.scanWindow != scanWindow || oldDelegate.color != color;
+      oldDelegate.box != box || oldDelegate.color != color;
 }

--- a/mobile/lib/auth/set-homeserver-url/screens/qr_scanner_screen.dart
+++ b/mobile/lib/auth/set-homeserver-url/screens/qr_scanner_screen.dart
@@ -10,7 +10,24 @@ import 'package:receipt_wrangler_mobile/utils/permissions.dart';
 /// screen. Pops the raw scanned string back to the caller (validation happens
 /// there); pops null when the user cancels or camera access is unavailable.
 class QrScannerScreen extends StatefulWidget {
-  const QrScannerScreen({super.key});
+  const QrScannerScreen({
+    super.key,
+    this.debugScannerSupported,
+    this.debugForcePermissionDenied = false,
+    this.debugForceCameraError = false,
+  });
+
+  /// Test seam: overrides the `Platform.isLinux` support check. Null in prod.
+  @visibleForTesting
+  final bool? debugScannerSupported;
+
+  /// Test seam: render the permission-denied fallback without the camera flow.
+  @visibleForTesting
+  final bool debugForcePermissionDenied;
+
+  /// Test seam: render the camera-error fallback without the camera flow.
+  @visibleForTesting
+  final bool debugForceCameraError;
 
   @override
   State<QrScannerScreen> createState() => _QrScannerScreenState();
@@ -18,20 +35,30 @@ class QrScannerScreen extends StatefulWidget {
 
 class _QrScannerScreenState extends State<QrScannerScreen>
     with WidgetsBindingObserver {
-  final MobileScannerController _controller = MobileScannerController(
-    formats: const [BarcodeFormat.qrCode],
-    detectionSpeed: DetectionSpeed.noDuplicates,
-    autoStart: false, // start manually once camera permission is resolved
-  );
+  // Created lazily so the fallback states (unsupported / permission denied /
+  // camera error) never construct a controller. That keeps those states
+  // renderable under flutter_test without hitting camera platform channels.
+  MobileScannerController? _controller;
 
   StreamSubscription<BarcodeCapture>? _subscription;
+  bool _observerAdded = false;
   bool _handled = false; // hard single-fire guard: exactly one pop
   bool _permissionDenied = false;
+  bool _cameraError = false;
 
   // mobile_scanner has no Linux desktop implementation; constructing/starting it
   // on the run-e2e.sh (Linux) target throws. Degrade to a message rather than
   // crash the process.
-  bool get _scannerSupported => !Platform.isLinux;
+  bool get _scannerSupported =>
+      widget.debugScannerSupported ?? !Platform.isLinux;
+
+  MobileScannerController _ensureController() {
+    return _controller ??= MobileScannerController(
+      formats: const [BarcodeFormat.qrCode],
+      detectionSpeed: DetectionSpeed.noDuplicates,
+      autoStart: false, // start manually once camera permission is resolved
+    );
+  }
 
   @override
   void initState() {
@@ -39,8 +66,18 @@ class _QrScannerScreenState extends State<QrScannerScreen>
     if (!_scannerSupported) {
       return;
     }
+    // Test seams: render a fallback state without the real camera flow.
+    if (widget.debugForcePermissionDenied) {
+      _permissionDenied = true;
+      return;
+    }
+    if (widget.debugForceCameraError) {
+      _cameraError = true;
+      return;
+    }
     WidgetsBinding.instance.addObserver(this);
-    _subscription = _controller.barcodes.listen(_onDetect);
+    _observerAdded = true;
+    _subscription = _ensureController().barcodes.listen(_onDetect);
     _ensurePermissionThenStart();
   }
 
@@ -54,14 +91,50 @@ class _QrScannerScreenState extends State<QrScannerScreen>
       return;
     }
     if (!status.isGranted) {
-      setState(() => _permissionDenied = true);
+      setState(() {
+        _permissionDenied = true;
+        _cameraError = false;
+      });
       return;
     }
-    await _controller.start();
+    // Permission is granted (possibly just now, via "Open Settings"): clear any
+    // stale fallback state before (re)starting the camera.
+    if (_permissionDenied || _cameraError) {
+      setState(() {
+        _permissionDenied = false;
+        _cameraError = false;
+      });
+    }
+    await _safeStart();
+  }
+
+  // Starts the camera, tolerating an already-running controller and surfacing a
+  // MobileScannerException as the retryable camera-error state instead of an
+  // unhandled async error.
+  Future<void> _safeStart() async {
+    final controller = _ensureController();
+    try {
+      if (!controller.value.isRunning) {
+        await controller.start();
+      }
+    } on MobileScannerException catch (_) {
+      if (!mounted) {
+        return;
+      }
+      setState(() => _cameraError = true);
+    }
+  }
+
+  void _retryStart() {
+    setState(() => _cameraError = false);
+    unawaited(_ensurePermissionThenStart());
   }
 
   void _onDetect(BarcodeCapture capture) {
-    if (_handled) {
+    // `!mounted` guards against a buffered detection firing after dispose (the
+    // subscription is cancelled with `unawaited`), which would pop a defunct
+    // context.
+    if (_handled || !mounted) {
       return;
     }
     final raw =
@@ -75,18 +148,30 @@ class _QrScannerScreenState extends State<QrScannerScreen>
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (!_scannerSupported || _permissionDenied) {
+    if (!_scannerSupported) {
       return;
+    }
+    final controller = _controller;
+    if (controller == null) {
+      return; // not in an active camera session
     }
     switch (state) {
       case AppLifecycleState.resumed:
-        _subscription = _controller.barcodes.listen(_onDetect);
-        unawaited(_controller.start());
+        _subscription ??= controller.barcodes.listen(_onDetect);
+        // Recover if we were showing a permission/camera error (e.g. the user
+        // just granted access via "Open Settings" and returned).
+        if (_permissionDenied || _cameraError) {
+          unawaited(_ensurePermissionThenStart());
+        } else {
+          unawaited(_safeStart());
+        }
         break;
       case AppLifecycleState.inactive:
         unawaited(_subscription?.cancel());
         _subscription = null;
-        unawaited(_controller.stop());
+        if (!_permissionDenied && !_cameraError) {
+          unawaited(controller.stop());
+        }
         break;
       default:
         break;
@@ -95,13 +180,13 @@ class _QrScannerScreenState extends State<QrScannerScreen>
 
   @override
   Future<void> dispose() async {
-    if (_scannerSupported) {
+    if (_observerAdded) {
       WidgetsBinding.instance.removeObserver(this);
     }
     unawaited(_subscription?.cancel());
     _subscription = null;
     super.dispose();
-    await _controller.dispose();
+    await _controller?.dispose();
   }
 
   @override
@@ -121,36 +206,52 @@ class _QrScannerScreenState extends State<QrScannerScreen>
 
   Widget _buildBody() {
     if (!_scannerSupported) {
-      return const Center(
-        child: Text("QR scanning isn't supported on this device."),
+      return _buildMessage(
+        message: "QR scanning isn't supported on this device.",
       );
     }
     if (_permissionDenied) {
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Padding(
-              padding: EdgeInsets.all(24),
-              child: Text(
-                "Camera access is required to scan a QR code. Enable it in "
-                "Settings, or type the URL manually.",
-                textAlign: TextAlign.center,
-              ),
-            ),
-            ElevatedButton(
-              onPressed: openAppSettings,
-              child: const Text("Open Settings"),
-            ),
-          ],
-        ),
+      return _buildMessage(
+        message: "Camera access is required to scan a QR code. Enable it in "
+            "Settings, or type the URL manually.",
+        actionLabel: "Open Settings",
+        onAction: openAppSettings,
+      );
+    }
+    if (_cameraError) {
+      return _buildMessage(
+        message: "Couldn't start the camera. Please try again.",
+        actionLabel: "Retry",
+        onAction: _retryStart,
       );
     }
     return MobileScanner(
-      controller: _controller,
+      controller: _ensureController(),
       overlayBuilder: (context, constraints) => _QrTargetOverlay(
         box: _targetBoxFor(constraints.biggest),
         color: Theme.of(context).colorScheme.primary,
+      ),
+    );
+  }
+
+  // Shared shape for the three non-camera states: a centered message with an
+  // optional action button.
+  Widget _buildMessage({
+    required String message,
+    String? actionLabel,
+    VoidCallback? onAction,
+  }) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(24),
+            child: Text(message, textAlign: TextAlign.center),
+          ),
+          if (actionLabel != null && onAction != null)
+            ElevatedButton(onPressed: onAction, child: Text(actionLabel)),
+        ],
       ),
     );
   }

--- a/mobile/lib/auth/set-homeserver-url/screens/qr_scanner_screen.dart
+++ b/mobile/lib/auth/set-homeserver-url/screens/qr_scanner_screen.dart
@@ -45,6 +45,10 @@ class _QrScannerScreenState extends State<QrScannerScreen>
   bool _handled = false; // hard single-fire guard: exactly one pop
   bool _permissionDenied = false;
   bool _cameraError = false;
+  // Set once the initial permission/start flow has resolved. Until then we
+  // ignore app-lifecycle events, because the permission dialog raises
+  // inactive/resumed while the controller exists but isn't ready yet.
+  bool _startupDone = false;
 
   // mobile_scanner has no Linux desktop implementation; constructing/starting it
   // on the run-e2e.sh (Linux) target throws. Degrade to a message rather than
@@ -95,6 +99,7 @@ class _QrScannerScreenState extends State<QrScannerScreen>
         _permissionDenied = true;
         _cameraError = false;
       });
+      _startupDone = true;
       return;
     }
     // Permission is granted (possibly just now, via "Open Settings"): clear any
@@ -106,6 +111,7 @@ class _QrScannerScreenState extends State<QrScannerScreen>
       });
     }
     await _safeStart();
+    _startupDone = true;
   }
 
   // Starts the camera, tolerating an already-running controller and surfacing a
@@ -152,8 +158,11 @@ class _QrScannerScreenState extends State<QrScannerScreen>
       return;
     }
     final controller = _controller;
-    if (controller == null) {
-      return; // not in an active camera session
+    // Ignore lifecycle churn until the initial permission/start flow has
+    // finished: during the permission dialog the controller exists but isn't
+    // ready, so start()/stop() here would race startup or throw.
+    if (controller == null || !_startupDone) {
+      return;
     }
     switch (state) {
       case AppLifecycleState.resumed:
@@ -169,7 +178,9 @@ class _QrScannerScreenState extends State<QrScannerScreen>
       case AppLifecycleState.inactive:
         unawaited(_subscription?.cancel());
         _subscription = null;
-        if (!_permissionDenied && !_cameraError) {
+        // Only tear down a live camera; stopping a not-running controller can
+        // throw.
+        if (controller.value.isRunning) {
           unawaited(controller.stop());
         }
         break;
@@ -179,14 +190,14 @@ class _QrScannerScreenState extends State<QrScannerScreen>
   }
 
   @override
-  Future<void> dispose() async {
+  void dispose() {
     if (_observerAdded) {
       WidgetsBinding.instance.removeObserver(this);
     }
     unawaited(_subscription?.cancel());
     _subscription = null;
+    unawaited(_controller?.dispose());
     super.dispose();
-    await _controller?.dispose();
   }
 
   @override

--- a/mobile/lib/auth/set-homeserver-url/screens/set_homeserver_url.dart
+++ b/mobile/lib/auth/set-homeserver-url/screens/set_homeserver_url.dart
@@ -4,13 +4,19 @@ import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:form_builder_validators/form_builder_validators.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
+import 'package:receipt_wrangler_mobile/auth/set-homeserver-url/screens/qr_scanner_screen.dart';
 import 'package:receipt_wrangler_mobile/client/client.dart';
 import 'package:receipt_wrangler_mobile/constants/spacing.dart';
 import 'package:receipt_wrangler_mobile/models/auth_model.dart';
 import 'package:receipt_wrangler_mobile/utils/snackbar.dart';
+import 'package:receipt_wrangler_mobile/utils/url.dart';
 
 class SetHomeserverUrl extends StatefulWidget {
-  const SetHomeserverUrl({super.key});
+  const SetHomeserverUrl({super.key, this.scanQrCode});
+
+  /// Injectable for tests: returns the raw scanned string, or null if the user
+  /// cancelled. Defaults to opening [QrScannerScreen].
+  final Future<String?> Function(BuildContext context)? scanQrCode;
 
   @override
   State<SetHomeserverUrl> createState() => _SetHomeserverUrl();
@@ -37,6 +43,29 @@ class _SetHomeserverUrl extends State<SetHomeserverUrl> {
     }
   }
 
+  Future<void> _onScanPressed() async {
+    final scan = widget.scanQrCode ?? _openScanner;
+    final raw = await scan(context);
+    if (!mounted || raw == null) {
+      return; // null => user cancelled
+    }
+
+    final normalized = normalizeServerUrl(raw);
+    if (normalized == null) {
+      showErrorSnackbar(
+          context, "That QR code doesn't contain a valid server URL");
+      return;
+    }
+
+    _formKey.currentState?.patchValue({"url": normalized});
+  }
+
+  Future<String?> _openScanner(BuildContext context) {
+    return Navigator.of(context).push<String>(
+      MaterialPageRoute(builder: (_) => const QrScannerScreen()),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     var serverModel = Provider.of<AuthModel>(context);
@@ -54,10 +83,16 @@ class _SetHomeserverUrl extends State<SetHomeserverUrl> {
           headerSpacing,
           FormBuilderTextField(
               name: "url",
-              decoration: const InputDecoration(
+              decoration: InputDecoration(
                   hintText: "https://demo.receiptwrangler.io/api",
                   labelText: "Server URL",
-                  border: OutlineInputBorder()),
+                  border: const OutlineInputBorder(),
+                  suffixIcon: IconButton(
+                    key: const ValueKey("qr-scan-button"),
+                    icon: const Icon(Icons.qr_code_scanner),
+                    tooltip: "Scan server QR code",
+                    onPressed: _onScanPressed,
+                  )),
               initialValue: serverModel.basePath,
               validator: FormBuilderValidators.compose([
                 FormBuilderValidators.required(),

--- a/mobile/lib/utils/url.dart
+++ b/mobile/lib/utils/url.dart
@@ -1,0 +1,29 @@
+/// Returns the trimmed URL when [raw] is a well-formed absolute http/https URL
+/// with a non-empty host; otherwise null.
+///
+/// Both http and https are accepted on purpose: self-hosted instances are
+/// commonly reached over plain http on a LAN or bare IP. The string is returned
+/// trimmed but otherwise verbatim (no trailing-slash rewriting) so it matches
+/// exactly what hand-typed input produces and what the user reviews in the field
+/// before connecting.
+String? normalizeServerUrl(String raw) {
+  final trimmed = raw.trim();
+  if (trimmed.isEmpty) {
+    return null;
+  }
+
+  final uri = Uri.tryParse(trimmed);
+  if (uri == null || !uri.hasScheme) {
+    return null;
+  }
+
+  final scheme = uri.scheme.toLowerCase();
+  if (scheme != 'http' && scheme != 'https') {
+    return null;
+  }
+  if (uri.host.isEmpty) {
+    return null;
+  }
+
+  return trimmed;
+}

--- a/mobile/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/mobile/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,11 +8,13 @@ import Foundation
 import file_selector_macos
 import flutter_secure_storage_darwin
 import gal
+import mobile_scanner
 import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   GalPlugin.register(with: registry.registrar(forPlugin: "GalPlugin"))
+  MobileScannerPlugin.register(with: registry.registrar(forPlugin: "MobileScannerPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -668,6 +668,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  mobile_scanner:
+    dependency: "direct main"
+    description:
+      name: mobile_scanner
+      sha256: c92c26bf2231695b6d3477c8dcf435f51e28f87b1745966b1fe4c47a286171ce
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.0"
   mocktail:
     dependency: "direct dev"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 2.0.0+20
 
 environment:
-  sdk: ">=3.2.5 <4.0.0"
+  sdk: ">=3.7.0 <4.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -51,6 +51,7 @@ dependencies:
   flutter_native_splash: ^2.3.10
   permission_handler: ^12.0.1
   cunning_document_scanner: ^2.3.0
+  mobile_scanner: ^7.2.0
   file_selector: ^1.0.3
   rxdart: ^0.28.0
   flutter_launcher_icons: ^0.14.1

--- a/mobile/test/utils/url_test.dart
+++ b/mobile/test/utils/url_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:receipt_wrangler_mobile/utils/url.dart';
+
+void main() {
+  group('normalizeServerUrl', () {
+    test('accepts an https URL with a path', () {
+      expect(
+        normalizeServerUrl('https://demo.receiptwrangler.io/api'),
+        'https://demo.receiptwrangler.io/api',
+      );
+    });
+
+    test('accepts a plain-http LAN URL with a port', () {
+      expect(
+        normalizeServerUrl('http://192.168.1.5:8081/api'),
+        'http://192.168.1.5:8081/api',
+      );
+    });
+
+    test('trims surrounding whitespace and newlines', () {
+      expect(
+        normalizeServerUrl('  https://demo.receiptwrangler.io/api\n'),
+        'https://demo.receiptwrangler.io/api',
+      );
+    });
+
+    test('returns null for empty or whitespace-only input', () {
+      expect(normalizeServerUrl(''), isNull);
+      expect(normalizeServerUrl('   '), isNull);
+    });
+
+    test('returns null for a scheme-less host', () {
+      expect(normalizeServerUrl('demo.receiptwrangler.io'), isNull);
+    });
+
+    test('returns null for a non-http(s) scheme', () {
+      expect(normalizeServerUrl('ftp://demo.receiptwrangler.io'), isNull);
+      expect(normalizeServerUrl('javascript:alert(1)'), isNull);
+    });
+
+    test('returns null when the host is empty', () {
+      expect(normalizeServerUrl('http://'), isNull);
+    });
+
+    test('returns null for arbitrary non-URL text', () {
+      expect(normalizeServerUrl('hello world'), isNull);
+    });
+  });
+}

--- a/mobile/test/widgets/qr_scanner_screen_test.dart
+++ b/mobile/test/widgets/qr_scanner_screen_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:receipt_wrangler_mobile/auth/set-homeserver-url/screens/qr_scanner_screen.dart';
+
+void main() {
+  // These cover the non-camera fallback states only. The live-camera path
+  // constructs MobileScanner / starts the controller, which hits platform
+  // channels unavailable under flutter_test — it's exercised on device /
+  // integration tests. The lazy controller + debug seams let the fallback
+  // states render here without any camera or channel mocks.
+
+  Future<void> pumpScreen(WidgetTester tester, Widget screen) async {
+    await tester.pumpWidget(MaterialApp(home: screen));
+    await tester.pump();
+  }
+
+  testWidgets('shows an unsupported message when the scanner is unavailable',
+      (tester) async {
+    await pumpScreen(tester, const QrScannerScreen(debugScannerSupported: false));
+
+    expect(
+      find.text("QR scanning isn't supported on this device."),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('permission-denied state shows the message and Open Settings',
+      (tester) async {
+    await pumpScreen(
+      tester,
+      const QrScannerScreen(debugForcePermissionDenied: true),
+    );
+
+    expect(find.textContaining('Camera access is required'), findsOneWidget);
+    expect(
+      find.widgetWithText(ElevatedButton, 'Open Settings'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('camera-error state shows the message and Retry', (tester) async {
+    await pumpScreen(
+      tester,
+      const QrScannerScreen(debugForceCameraError: true),
+    );
+
+    expect(find.textContaining("Couldn't start the camera"), findsOneWidget);
+    expect(find.widgetWithText(ElevatedButton, 'Retry'), findsOneWidget);
+  });
+
+  testWidgets('close button pops the screen', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                onPressed: () => Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) =>
+                        const QrScannerScreen(debugScannerSupported: false),
+                  ),
+                ),
+                child: const Text('open scanner'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open scanner'));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('qr-scanner-close')), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('qr-scanner-close')));
+    await tester.pumpAndSettle();
+
+    // Back on the launcher screen; the scanner is gone.
+    expect(find.byKey(const ValueKey('qr-scanner-close')), findsNothing);
+    expect(find.text('open scanner'), findsOneWidget);
+  });
+}

--- a/mobile/test/widgets/set_homeserver_url_test.dart
+++ b/mobile/test/widgets/set_homeserver_url_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:receipt_wrangler_mobile/auth/set-homeserver-url/screens/set_homeserver_url.dart';
+import 'package:receipt_wrangler_mobile/models/auth_model.dart';
+import 'package:receipt_wrangler_mobile/persistence/global_shared_preferences.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const qrButtonKey = ValueKey('qr-scan-button');
+  const invalidMessage = "That QR code doesn't contain a valid server URL";
+
+  setUp(() async {
+    // The screen reads AuthModel.basePath -> GlobalSharedPreferences on build.
+    SharedPreferences.setMockInitialValues({});
+    await GlobalSharedPreferences.initialize();
+  });
+
+  // The injected scanQrCode seam lets us drive the post-scan flow without
+  // constructing MobileScanner (which throws under flutter_test).
+  Future<void> pumpScreen(
+    WidgetTester tester,
+    Future<String?> Function(BuildContext context) scanQrCode,
+  ) async {
+    await tester.pumpWidget(
+      ChangeNotifierProvider<AuthModel>(
+        create: (_) => AuthModel(),
+        child: MaterialApp(
+          home: Scaffold(
+            body: SetHomeserverUrl(scanQrCode: scanQrCode),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  Future<void> tapScanAndSettle(WidgetTester tester) async {
+    await tester.tap(find.byKey(qrButtonKey));
+    await tester.pump(); // resume the async scan handler
+    await tester.pump(const Duration(milliseconds: 400)); // render patch/snackbar
+  }
+
+  testWidgets('renders the QR scan button', (tester) async {
+    await pumpScreen(tester, (_) async => null);
+
+    expect(find.byKey(qrButtonKey), findsOneWidget);
+  });
+
+  testWidgets('a valid scan populates the URL field (trimmed)', (tester) async {
+    await pumpScreen(tester, (_) async => '  https://scanned.example.io/api  ');
+
+    await tapScanAndSettle(tester);
+
+    expect(find.text('https://scanned.example.io/api'), findsOneWidget);
+    expect(find.text(invalidMessage), findsNothing);
+  });
+
+  testWidgets('an invalid scan shows an error and leaves the field empty',
+      (tester) async {
+    await pumpScreen(tester, (_) async => 'not a url');
+
+    await tapScanAndSettle(tester);
+
+    expect(find.text(invalidMessage), findsOneWidget);
+    expect(find.text('not a url'), findsNothing);
+  });
+
+  testWidgets('a cancelled scan (null) is a no-op', (tester) async {
+    await pumpScreen(tester, (_) async => null);
+
+    await tapScanAndSettle(tester);
+
+    expect(find.text(invalidMessage), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary

Adds a **QR-scan button** to the mobile app's "Connect to Server" screen so users can scan a QR code containing their server URL instead of typing it — error-prone for non-technical users (`https://`, ports, `/api` suffix, typos). The scanned text is validated as a URL and populated into the field; the user still reviews it and taps **Connect** — it **never auto-connects** (a malicious QR can't silently point the app at an attacker's server that would then harvest credentials).

> Note: the server-URL field lives on the **Connect to Server** screen (`set_homeserver_url.dart`, route `/`), not the `/login` username/password screen.

## What's included

- **Full-screen QR scanner** (`qr_scanner_screen.dart`) on `mobile_scanner` 7.2.0 (QR-only): a corner-bracket targeting box + hint, camera-permission-denied fallback ("Open Settings"), proper controller lifecycle/disposal, single-fire detection, and a `Platform.isLinux` guard so the Linux e2e runner degrades gracefully (mobile_scanner has no Linux desktop impl).
- **URL validation** — `normalizeServerUrl` (`utils/url.dart`): trims + requires a well-formed `http`/`https` URL with a host (`http` allowed for LAN/self-hosted); rejects garbage with an error snackbar, field untouched.
- **Button wiring** — a `qr_code_scanner` suffix-icon button on the URL field, plus an injectable `scanQrCode` seam so the flow is widget-testable without building `MobileScanner`.
- **Whole-frame detection** — the box is a **visual aim guide only**; we deliberately don't use `MobileScanner.scanWindow` (its intersection gate is unreliable in 7.x and made scanning intermittent). Confirmed fast/reliable on a real Android device.

## Platform / dependency notes

- **iOS: no deployment-target change.** mobile_scanner 7.x uses Apple's **Vision** framework (not GoogleMLKit; pod min iOS 12.0), so the repo stays at **13.0** — verified with `flutter build ios --simulator`. Only the `NSCameraUsageDescription` wording was broadened to mention QR scanning. Needs `cd ios && pod install` after pulling.
- **Android: no gradle/manifest change.** `CAMERA` already declared; inherited `flutter.minSdkVersion` (24) / `compileSdkVersion` (36) exceed mobile_scanner's floor. ML Kit is bundled (default).
- **pubspec:** adds `mobile_scanner: ^7.2.0`; raises the Dart SDK floor `>=3.2.5` → `>=3.7.0` (required by the package; resolved toolchain is 3.10+).

## Testing

- `flutter analyze` clean on touched files.
- New tests: `test/utils/url_test.dart` (validator) + `test/widgets/set_homeserver_url_test.dart` (button renders / valid scan patches field / invalid snackbars / cancel no-op) — **12 pass**.
- Full `flutter test` green **except one pre-existing, unrelated failure** in `test/interceptors/auth_interceptor_test.dart` (dio 5.10 `reject()` signature drift — confirmed present on `main` before this branch).
- iOS simulator build ✓; real-device Android scan confirmed working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added QR code scanning on the server connection screen to prefill (and validate) the server URL for review.
  * Added a full-screen, QR-only scanner experience with permission-aware behavior and safe close/cancel handling.
  * Added support for injecting a custom QR scan callback for the server URL flow.
* **Bug Fixes**
  * Improved scanner start/stop reliability across app lifecycle and error states, including unsupported-device fallback.
  * Registered the missing scanner plugin on macOS.
* **Documentation**
  * Updated “Connect to Server” QR flow docs with platform notes, validation rules, and fallback behavior.
* **Tests**
  * Added unit/widget tests for URL normalization and scanner fallback UI states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->