### PR TITLE
fix(reports): CSV formula-injection guard + honor -All perms in the builder

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -861,6 +861,12 @@ not generate" is only a real boundary via this path); **`GET /report/template/op
 `app.roles.read`, the role editor's own gate) feeds the role-form access matrix. Create/update additionally
 require `CanReportOverGroups` on the attached groups (createAll/updateAll bypass).
 
+The per-template matrix is **UX scoping** (which saved templates a member sees/acts on) layered on the hard
+data-access controls — the group-access ceiling plus the category/tag/paid-by grants — which alone bound the
+receipt data any report can reach; so the ad-hoc `POST /report/generate` (no template id, so the matrix never
+applies) and a `duplicate`'s resulting copy (which starts matrix-unrestricted) are intentionally not bound by
+the per-template matrix and never widen data access beyond those hard controls, which every generation re-resolves.
+
 **`(Restricted)` vs `(None)`.** Aggregation uses `PermissionService.SubstituteRestrictedCategoriesTags`
 (not the strip variant): a category/tag the caller may not see is replaced with a single `(Restricted)`
 marker, so the receipt still counts toward the totals in its own bucket instead of vanishing. `(None)`

--- a/api/internal/handlers/generic_handler.go
+++ b/api/internal/handlers/generic_handler.go
@@ -73,7 +73,7 @@ func HandleRequest(handler structs.Handler) {
 // the caller is not authorized. Handlers that declare no permissions are allowed
 // through (authentication is already enforced by the router middleware).
 func enforcePermissions(handler structs.Handler) bool {
-	if len(handler.AppPermissions) == 0 && len(handler.GroupPermissions) == 0 {
+	if len(handler.AppPermissions) == 0 && len(handler.AnyAppPermissions) == 0 && len(handler.GroupPermissions) == 0 {
 		return true
 	}
 
@@ -83,6 +83,13 @@ func enforcePermissions(handler structs.Handler) bool {
 	if len(handler.AppPermissions) > 0 {
 		hasPermissions, err := permissionService.HasAppPermissions(token.UserId, handler.AppPermissions...)
 		if err != nil || !hasPermissions {
+			return denyUnauthorized(handler, err)
+		}
+	}
+
+	if len(handler.AnyAppPermissions) > 0 {
+		hasAny, err := permissionService.HasAnyAppPermission(token.UserId, handler.AnyAppPermissions...)
+		if err != nil || !hasAny {
 			return denyUnauthorized(handler, err)
 		}
 	}

--- a/api/internal/handlers/generic_handler_test.go
+++ b/api/internal/handlers/generic_handler_test.go
@@ -115,6 +115,47 @@ func TestShouldAcceptWhenUserHasAppPermission(t *testing.T) {
 	assertStatus(t, w, http.StatusOK)
 }
 
+func TestShouldAcceptWhenUserHasAnyAppPermission(t *testing.T) {
+	defer tearDownGenericHandlerTest()
+	repositories.CreateTestGroupWithUsers()
+	// The caller holds one of the two any-of permissions, which satisfies the gate.
+	grantAppPerms(t, 1, permissions.AppUsersRead)
+	w, r := requestForUser(1)
+
+	handler := structs.Handler{
+		Writer:            w,
+		Request:           r,
+		ResponseType:      constants.ApplicationJson,
+		AnyAppPermissions: []string{permissions.AppUsersRead, permissions.AppUsersDelete},
+		HandlerFunction:   okHandlerFunc,
+	}
+
+	HandleRequest(handler)
+
+	assertStatus(t, w, http.StatusOK)
+}
+
+func TestShouldRejectWhenUserHasNoneOfAnyAppPermission(t *testing.T) {
+	defer tearDownGenericHandlerTest()
+	repositories.CreateTestGroupWithUsers()
+	// The caller holds an unrelated permission but neither of the any-of set, so the
+	// gate denies.
+	grantAppPerms(t, 1, permissions.AppUsersCreate)
+	w, r := requestForUser(1)
+
+	handler := structs.Handler{
+		Writer:            w,
+		Request:           r,
+		ResponseType:      constants.ApplicationJson,
+		AnyAppPermissions: []string{permissions.AppUsersRead, permissions.AppUsersDelete},
+		HandlerFunction:   okHandlerFunc,
+	}
+
+	HandleRequest(handler)
+
+	assertStatus(t, w, http.StatusForbidden)
+}
+
 func TestShouldRejectGroupPermissionWhenNotAssignedRole(t *testing.T) {
 	defer tearDownGenericHandlerTest()
 	repositories.CreateTestGroupWithUsers()

--- a/api/internal/handlers/report.go
+++ b/api/internal/handlers/report.go
@@ -136,6 +136,12 @@ func GenerateReport(w http.ResponseWriter, r *http.Request) {
 // JSON { html, receiptCount } body instead of a downloadable file — the preview is
 // the engine's own rendered HTML (row-capped), so the builder never re-implements
 // the engine.
+//
+// Preview additionally requires the app-level app.reports.read OR app.reports.readAll
+// (matching the desktop ReportsModule route guard: if you can open the builder, you can
+// preview). That OR can't be expressed by the declarative AppPermissions gate (which is
+// AND-only), so it is enforced in-body — like GetPagedReportTemplates — alongside the
+// per-group group.reports.read gate above.
 func PreviewReport(w http.ResponseWriter, r *http.Request) {
 	command, ok := loadReportCommand(w, r)
 	if !ok {
@@ -151,6 +157,18 @@ func PreviewReport(w http.ResponseWriter, r *http.Request) {
 		GroupPermissions: []string{permissions.GroupReportsRead},
 		HandlerFunction: func(w http.ResponseWriter, r *http.Request) (int, error) {
 			token := structs.GetClaims(r)
+
+			// Report access at all is app.reports.read OR readAll (an OR the declarative
+			// AppPermissions gate can't express); deny outright without either.
+			canPreview, err := services.NewPermissionService(nil).HasAnyAppPermission(token.UserId, permissions.AppReportsRead, permissions.AppReportsReadAll)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+			if !canPreview {
+				utils.WriteCustomErrorResponse(w, "User is unauthorized to preview reports", http.StatusForbidden)
+				return 0, nil
+			}
+
 			reportService := services.NewReportService(nil)
 
 			preview, err := reportService.Preview(token.UserId, command)

--- a/api/internal/handlers/report.go
+++ b/api/internal/handlers/report.go
@@ -139,9 +139,9 @@ func GenerateReport(w http.ResponseWriter, r *http.Request) {
 //
 // Preview additionally requires the app-level app.reports.read OR app.reports.readAll
 // (matching the desktop ReportsModule route guard: if you can open the builder, you can
-// preview). That OR can't be expressed by the declarative AppPermissions gate (which is
-// AND-only), so it is enforced in-body — like GetPagedReportTemplates — alongside the
-// per-group group.reports.read gate above.
+// preview). That any-of requirement is declared via the AnyAppPermissions gate (resolved
+// by HandleRequest), no longer enforced in-body, alongside the per-group group.reports.read
+// gate above.
 func PreviewReport(w http.ResponseWriter, r *http.Request) {
 	command, ok := loadReportCommand(w, r)
 	if !ok {
@@ -149,25 +149,15 @@ func PreviewReport(w http.ResponseWriter, r *http.Request) {
 	}
 
 	handler := structs.Handler{
-		ErrorMessage:     "Error generating report preview",
-		Writer:           w,
-		Request:          r,
-		ResponseType:     constants.ApplicationJson,
-		GroupIds:         command.GroupIds,
-		GroupPermissions: []string{permissions.GroupReportsRead},
+		ErrorMessage:      "Error generating report preview",
+		Writer:            w,
+		Request:           r,
+		ResponseType:      constants.ApplicationJson,
+		AnyAppPermissions: []string{permissions.AppReportsRead, permissions.AppReportsReadAll},
+		GroupIds:          command.GroupIds,
+		GroupPermissions:  []string{permissions.GroupReportsRead},
 		HandlerFunction: func(w http.ResponseWriter, r *http.Request) (int, error) {
 			token := structs.GetClaims(r)
-
-			// Report access at all is app.reports.read OR readAll (an OR the declarative
-			// AppPermissions gate can't express); deny outright without either.
-			canPreview, err := services.NewPermissionService(nil).HasAnyAppPermission(token.UserId, permissions.AppReportsRead, permissions.AppReportsReadAll)
-			if err != nil {
-				return http.StatusInternalServerError, err
-			}
-			if !canPreview {
-				utils.WriteCustomErrorResponse(w, "User is unauthorized to preview reports", http.StatusForbidden)
-				return 0, nil
-			}
 
 			reportService := services.NewReportService(nil)
 

--- a/api/internal/handlers/report_test.go
+++ b/api/internal/handlers/report_test.go
@@ -195,6 +195,7 @@ func TestGenerateReport_BodyReadErrorIsServerError(t *testing.T) {
 func TestPreviewReport_ReturnsHtmlWhenAuthorized(t *testing.T) {
 	defer tearDownReportTest()
 	repositories.CreateTestGroupWithUsers()
+	grantAppPerms(t, 1, permissions.AppReportsRead)
 	grantGroupPerms(t, 1, 1, permissions.GroupReportsRead)
 	seedReportReceipt(1, 1)
 
@@ -231,6 +232,7 @@ func TestPreviewReport_ForbidsWhenMemberLacksPermission(t *testing.T) {
 func TestPreviewReport_MapsInvalidSpecToBadRequest(t *testing.T) {
 	defer tearDownReportTest()
 	repositories.CreateTestGroupWithUsers()
+	grantAppPerms(t, 1, permissions.AppReportsRead)
 	grantGroupPerms(t, 1, 1, permissions.GroupReportsRead)
 	seedReportReceipt(1, 1)
 
@@ -240,6 +242,36 @@ func TestPreviewReport_MapsInvalidSpecToBadRequest(t *testing.T) {
 	PreviewReport(w, r)
 
 	assertStatus(t, w, http.StatusBadRequest)
+}
+
+// A caller who passes the per-group gate (group.reports.read) but holds no app-level
+// report permission is denied preview — the builder's live feedback loop mirrors the
+// desktop route guard "if you can open the builder, you can preview".
+func TestPreviewReport_ForbidsWithoutAppReportsPermission(t *testing.T) {
+	defer tearDownReportTest()
+	repositories.CreateTestGroupWithUsers()
+	grantGroupPerms(t, 1, 1, permissions.GroupReportsRead)
+	seedReportReceipt(1, 1)
+
+	w, r := generateReportRequest(1, recordsReportBody)
+	PreviewReport(w, r)
+
+	assertStatus(t, w, http.StatusForbidden)
+}
+
+// The app-level readAll bypass satisfies the preview app-permission gate just like
+// app.reports.read does.
+func TestPreviewReport_AllowedByReadAll(t *testing.T) {
+	defer tearDownReportTest()
+	repositories.CreateTestGroupWithUsers()
+	grantAppPerms(t, 1, permissions.AppReportsReadAll)
+	grantGroupPerms(t, 1, 1, permissions.GroupReportsRead)
+	seedReportReceipt(1, 1)
+
+	w, r := generateReportRequest(1, recordsReportBody)
+	PreviewReport(w, r)
+
+	assertStatus(t, w, http.StatusOK)
 }
 
 func TestPreviewReport_MalformedBodyIsBadRequest(t *testing.T) {

--- a/api/internal/handlers/report_test.go
+++ b/api/internal/handlers/report_test.go
@@ -259,6 +259,20 @@ func TestPreviewReport_ForbidsWithoutAppReportsPermission(t *testing.T) {
 	assertStatus(t, w, http.StatusForbidden)
 }
 
+// A caller who passes the app-level gate (app.reports.read) but holds no per-group
+// group.reports.read is denied preview — the group layer still applies even when the
+// app layer passes.
+func TestPreviewReport_ForbidsWithoutGroupReportsPermission(t *testing.T) {
+	defer tearDownReportTest()
+	repositories.CreateTestGroupWithUsers()
+	grantAppPerms(t, 1, permissions.AppReportsRead)
+
+	w, r := generateReportRequest(1, recordsReportBody)
+	PreviewReport(w, r)
+
+	assertStatus(t, w, http.StatusForbidden)
+}
+
 // The app-level readAll bypass satisfies the preview app-permission gate just like
 // app.reports.read does.
 func TestPreviewReport_AllowedByReadAll(t *testing.T) {

--- a/api/internal/reporting/render/csv.go
+++ b/api/internal/reporting/render/csv.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/csv"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"receipt-wrangler/api/internal/reporting"
@@ -86,9 +87,9 @@ func header(model reporting.ReportModel, groupBy []Dimension) []string {
 // label, so a column is never blank-headed.
 func dimensionHeading(dimension Dimension) string {
 	if len(dimension.Label) > 0 {
-		return dimension.Label
+		return SanitizeCSVField(dimension.Label)
 	}
-	return string(dimension.Key)
+	return SanitizeCSVField(string(dimension.Key))
 }
 
 // validateGroupByDepth rejects a groupBy that does not match how deep the report
@@ -169,9 +170,9 @@ func buildRecord(model reporting.ReportModel, groupBy []Dimension, rowType strin
 
 func columnHeading(column reporting.ColumnDescriptor) string {
 	if len(column.Label) > 0 {
-		return column.Label
+		return SanitizeCSVField(column.Label)
 	}
-	return column.Name
+	return SanitizeCSVField(column.Name)
 }
 
 // formatDimension renders a group bucket's value for a leading column. The
@@ -180,7 +181,7 @@ func formatDimension(value reporting.Value, noneLabel string) string {
 	if value.IsNull() {
 		return noneLabel
 	}
-	return value.String()
+	return SanitizeCSVField(value.String())
 }
 
 // formatCell renders one report cell the way this format presents it: money per
@@ -204,7 +205,7 @@ func formatCell(column reporting.ColumnDescriptor, cell reporting.Cell, noneLabe
 				parts = append(parts, noneLabel)
 				continue
 			}
-			parts = append(parts, value.String())
+			parts = append(parts, SanitizeCSVField(value.String()))
 		}
 		return strings.Join(parts, ", ")
 	}
@@ -216,7 +217,7 @@ func formatCell(column reporting.ColumnDescriptor, cell reporting.Cell, noneLabe
 
 	number, isNumber := value.Decimal()
 	if !isNumber {
-		return value.String()
+		return SanitizeCSVField(value.String())
 	}
 	if column.DataType == reporting.TypeCurrency {
 		if currency != nil {
@@ -225,4 +226,26 @@ func formatCell(column reporting.ColumnDescriptor, cell reporting.Cell, noneLabe
 		return number.StringFixed(2)
 	}
 	return number.String()
+}
+
+// SanitizeCSVField neutralizes spreadsheet formula/DDE injection: a text cell whose
+// first byte is a character Excel/Sheets may treat as a formula lead (= + - @) or a
+// control character (tab, CR) is prefixed with a single quote so the app renders it as
+// literal text. A value that parses as a number (e.g. a negative amount) is left intact
+// so the CSV stays machine-readable.
+//
+// It is exported so the receipt CSV export (services.ReceiptCsvService) can apply the
+// same guard to its user-controlled text columns without duplicating the logic.
+func SanitizeCSVField(s string) string {
+	if s == "" {
+		return s
+	}
+	switch s[0] {
+	case '=', '+', '-', '@', '\t', '\r':
+		if _, err := strconv.ParseFloat(strings.TrimSpace(s), 64); err == nil {
+			return s
+		}
+		return "'" + s
+	}
+	return s
 }

--- a/api/internal/reporting/render/csv.go
+++ b/api/internal/reporting/render/csv.go
@@ -179,7 +179,7 @@ func columnHeading(column reporting.ColumnDescriptor) string {
 // (None) bucket — a null value — gets the report's name for it.
 func formatDimension(value reporting.Value, noneLabel string) string {
 	if value.IsNull() {
-		return noneLabel
+		return SanitizeCSVField(noneLabel)
 	}
 	return SanitizeCSVField(value.String())
 }
@@ -202,7 +202,7 @@ func formatCell(column reporting.ColumnDescriptor, cell reporting.Cell, noneLabe
 		parts := make([]string, 0, len(cell.Values))
 		for _, value := range cell.Values {
 			if value.IsNull() {
-				parts = append(parts, noneLabel)
+				parts = append(parts, SanitizeCSVField(noneLabel))
 				continue
 			}
 			parts = append(parts, SanitizeCSVField(value.String()))

--- a/api/internal/reporting/render/csv_test.go
+++ b/api/internal/reporting/render/csv_test.go
@@ -555,6 +555,49 @@ func TestFormatDimension_NullIsNoneLabel(t *testing.T) {
 	}
 }
 
+// A NoneLabel configured to a formula-like value is neutralized with a leading
+// apostrophe wherever the renderer draws it — both the leading dimension column (a
+// (None) group bucket) and a label cell (a (None) label bucket) — so the (None) name
+// can't smuggle a formula into the export.
+func TestCSV_SanitizesNoneLabel(t *testing.T) {
+	catalog := paidByCatalog(t)
+	spec := reporting.ReportSpec{
+		GroupBy:   []reporting.FieldKey{"paid_by"},
+		Detail:    reporting.DetailSpec{Mode: reporting.DetailAggregate, By: "category"},
+		NoneLabel: "=cmd",
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+		},
+	}
+	// A row with no paid_by (→ (None) dimension bucket) and no category (→ (None)
+	// label cell) exercises both null paths in one render.
+	rows := []reporting.Row{
+		{"amount": {money("100")}},
+	}
+
+	out, err := CSV(mustRun(t, spec, catalog, rows), []Dimension{{Key: "paid_by", Label: "Paid By"}})
+	if err != nil {
+		t.Fatalf("CSV: %v", err)
+	}
+
+	records, err := csv.NewReader(strings.NewReader(string(out))).ReadAll()
+	if err != nil {
+		t.Fatalf("re-parse CSV: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("record count = %d, want 2 (header + one detail row)", len(records))
+	}
+	// Detail row columns: Row Type, Paid By, Category, Total.
+	detail := records[1]
+	if detail[1] != "'=cmd" {
+		t.Errorf("paid-by (None) dimension = %q, want it neutralized to %q", detail[1], "'=cmd")
+	}
+	if detail[2] != "'=cmd" {
+		t.Errorf("category (None) label = %q, want it neutralized to %q", detail[2], "'=cmd")
+	}
+}
+
 // Subtotals without grand totals: the per-group subtotal rows appear, and no
 // Grand Total row follows.
 func TestCSV_SubtotalsWithoutGrandTotal(t *testing.T) {

--- a/api/internal/reporting/render/csv_test.go
+++ b/api/internal/reporting/render/csv_test.go
@@ -436,6 +436,79 @@ func TestCSV_EscapingAndUnicodeRoundTrip(t *testing.T) {
 	}
 }
 
+// --- formula/DDE injection ------------------------------------------------
+
+// A user-controlled label cell (a category name) or a group dimension value whose
+// first character is a spreadsheet formula lead is neutralized with a leading
+// apostrophe, so opening the CSV in Excel/Sheets renders it as literal text rather
+// than executing it. The value still round-trips through a CSV reader unchanged.
+func TestCSV_SanitizesFormulaInjection(t *testing.T) {
+	catalog := paidByCatalog(t)
+	spec := reporting.ReportSpec{
+		GroupBy: []reporting.FieldKey{"paid_by"},
+		Detail:  reporting.DetailSpec{Mode: reporting.DetailRecords},
+		Columns: []reporting.Column{
+			{Name: "Category", Label: "Category", Kind: reporting.ColumnLabel, Field: "category"},
+			{Name: "Total", Label: "Total", Kind: reporting.ColumnAggregate, AggSrc: "SUM(amount)"},
+		},
+	}
+	rows := []reporting.Row{
+		{"paid_by": {reporting.Str("+cmd")}, "category": {reporting.Str(`=HYPERLINK("http://x")`)}, "amount": {money("10")}},
+	}
+
+	out, err := CSV(mustRun(t, spec, catalog, rows), []Dimension{{Key: "paid_by", Label: "Paid By"}})
+	if err != nil {
+		t.Fatalf("CSV: %v", err)
+	}
+
+	records, err := csv.NewReader(strings.NewReader(string(out))).ReadAll()
+	if err != nil {
+		t.Fatalf("re-parse CSV: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("record count = %d, want 2 (header + one detail row)", len(records))
+	}
+	// Detail row columns: Row Type, Paid By, Category, Total.
+	detail := records[1]
+	if detail[1] != "'+cmd" {
+		t.Errorf("paid-by dimension = %q, want it neutralized to %q", detail[1], "'+cmd")
+	}
+	if detail[2] != `'=HYPERLINK("http://x")` {
+		t.Errorf("category label = %q, want it neutralized with a leading apostrophe", detail[2])
+	}
+}
+
+// SanitizeCSVField prefixes a formula/DDE/control lead with an apostrophe but leaves
+// plain text and anything that parses as a number untouched, so a negative amount
+// stays machine-readable.
+func TestSanitizeCSVField(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"hyperlink formula", `=HYPERLINK("http://x")`, `'=HYPERLINK("http://x")`},
+		{"at-sign formula", "@SUM(A1)", "'@SUM(A1)"},
+		{"plus command", "+cmd", "'+cmd"},
+		{"dde payload", "=cmd|'/c calc'!A0", "'=cmd|'/c calc'!A0"},
+		{"leading tab", "\tfoo", "'\tfoo"},
+		{"leading carriage return", "\rfoo", "'\rfoo"},
+		{"plain name", "Groceries", "Groceries"},
+		{"negative integer", "-5", "-5"},
+		{"negative amount", "-5.20", "-5.20"},
+		{"signed positive number", "+3", "+3"},
+		{"zero", "0", "0"},
+		{"empty", "", ""},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := SanitizeCSVField(testCase.in); got != testCase.want {
+				t.Errorf("SanitizeCSVField(%q) = %q, want %q", testCase.in, got, testCase.want)
+			}
+		})
+	}
+}
+
 // --- cell formatting ------------------------------------------------------
 
 func TestFormatCell_ByTypeAndKind(t *testing.T) {

--- a/api/internal/services/receipt_csv.go
+++ b/api/internal/services/receipt_csv.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/reporting/render"
 	"receipt-wrangler/api/internal/repositories"
 	"receipt-wrangler/api/internal/structs"
 	"receipt-wrangler/api/internal/utils"
@@ -52,12 +53,12 @@ func (service *ReceiptCsvService) BuildReceiptCsv(receipts []models.Receipt) (st
 			utils.UintToString(receipt.ID),
 			receipt.CreatedAt.Format(dateFormat),
 			receipt.Date.Format(dateFormat),
-			receipt.Name,
-			receipt.PaidByUser.DisplayName,
+			render.SanitizeCSVField(receipt.Name),
+			render.SanitizeCSVField(receipt.PaidByUser.DisplayName),
 			receipt.Amount.String(),
 			string(receipt.Status),
-			service.BuildCategoryString(receipt.Categories),
-			service.BuildTagString(receipt.Tags),
+			render.SanitizeCSVField(service.BuildCategoryString(receipt.Categories)),
+			render.SanitizeCSVField(service.BuildTagString(receipt.Tags)),
 			resolvedDateString,
 		}
 		rowData = append(rowData, newRow)
@@ -97,14 +98,14 @@ func (service *ReceiptCsvService) BuildItemCsv(items []models.Item) ([]byte, err
 		newRow := []string{
 			utils.UintToString(item.ID),
 			utils.UintToString(item.ReceiptId),
-			item.Receipt.Name,
+			render.SanitizeCSVField(item.Receipt.Name),
 			item.Receipt.Date.Format(dateFormat),
-			item.Name,
-			item.ChargedToUser.DisplayName,
+			render.SanitizeCSVField(item.Name),
+			render.SanitizeCSVField(item.ChargedToUser.DisplayName),
 			item.Amount.String(),
 			string(item.Status),
-			service.BuildCategoryString(item.Categories),
-			service.BuildTagString(item.Tags),
+			render.SanitizeCSVField(service.BuildCategoryString(item.Categories)),
+			render.SanitizeCSVField(service.BuildTagString(item.Tags)),
 		}
 		rowData = append(rowData, newRow)
 	}

--- a/api/internal/services/receipt_csv_service_test.go
+++ b/api/internal/services/receipt_csv_service_test.go
@@ -107,6 +107,66 @@ func TestBuildReceiptCsvNeutralizesFormulaInjection(t *testing.T) {
 	}
 }
 
+// A malicious item whose user-controlled text columns (receipt name, item name,
+// charged-to display name, category/tag names) begin with a spreadsheet formula lead
+// are neutralized with a leading apostrophe in the item export, so opening it in
+// Excel/Sheets renders them as literal text rather than executing them.
+func TestBuildItemCsvNeutralizesFormulaInjection(t *testing.T) {
+	date := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	service := NewReceiptCsvService()
+	items := []models.Item{
+		{
+			BaseModel: models.BaseModel{ID: 1},
+			ReceiptId: 2,
+			Receipt: models.Receipt{
+				Name: `=HYPERLINK("http://evil")`,
+				Date: date,
+			},
+			Name:          "+cmd",
+			ChargedToUser: models.User{DisplayName: "@who"},
+			Amount:        decimal.NewFromFloat(1),
+			Status:        models.ITEM_OPEN,
+			Categories:    []models.Category{{Name: "=SUM(A1)"}},
+			Tags:          []models.Tag{{Name: "@danger"}},
+		},
+	}
+
+	result, err := service.BuildItemCsv(items)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	records, err := csv.NewReader(bytes.NewReader(result)).ReadAll()
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if len(records) != 2 {
+		utils.PrintTestError(t, len(records), 2)
+		return
+	}
+
+	// Data row columns: Id, Receipt Id, Receipt Name, Receipt Date, Name,
+	// Charged to User, Amount, Status, Categories, Tags.
+	row := records[1]
+	assertions := []struct {
+		column int
+		want   string
+	}{
+		{2, `'=HYPERLINK("http://evil")`}, // Receipt Name
+		{4, "'+cmd"},                      // Name
+		{5, "'@who"},                      // Charged to User
+		{8, "'=SUM(A1)"},                  // Categories
+		{9, "'@danger"},                   // Tags
+	}
+	for _, assertion := range assertions {
+		if row[assertion.column] != assertion.want {
+			utils.PrintTestError(t, row[assertion.column], assertion.want)
+		}
+	}
+}
+
 func TestShouldBuildItemCsv(t *testing.T) {
 	expected :=
 		"Id,Receipt Id,Receipt Name,Receipt Date,Name,Charged to User,Amount,Status,Categories,Tags\n" +

--- a/api/internal/services/receipt_csv_service_test.go
+++ b/api/internal/services/receipt_csv_service_test.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"bytes"
+	"encoding/csv"
 	"github.com/shopspring/decimal"
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/utils"
@@ -47,6 +49,61 @@ func TestShouldBuildReceiptCsv(t *testing.T) {
 	bytes := result.ReceiptCsvBytes
 	if string(bytes) != expected {
 		utils.PrintTestError(t, string(bytes), expected)
+	}
+}
+
+// A receipt whose user-controlled text columns (name, paid-by display name,
+// category/tag names) begin with a spreadsheet formula lead are neutralized with a
+// leading apostrophe in the export, so opening it in Excel/Sheets renders them as
+// literal text rather than executing them.
+func TestBuildReceiptCsvNeutralizesFormulaInjection(t *testing.T) {
+	date := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	service := NewReceiptCsvService()
+	receipts := []models.Receipt{
+		{
+			BaseModel:  models.BaseModel{ID: 1, CreatedAt: date},
+			Date:       date,
+			Name:       `=HYPERLINK("http://evil")`,
+			PaidByUser: models.User{DisplayName: "+cmd"},
+			Amount:     decimal.NewFromFloat(1),
+			Status:     models.OPEN,
+			Categories: []models.Category{{Name: "=SUM(A1)"}},
+			Tags:       []models.Tag{{Name: "@danger"}},
+		},
+	}
+
+	result, err := service.BuildReceiptCsv(receipts)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	records, err := csv.NewReader(bytes.NewReader(result.ReceiptCsvBytes)).ReadAll()
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if len(records) != 2 {
+		utils.PrintTestError(t, len(records), 2)
+		return
+	}
+
+	// Data row columns: Id, Added At, Receipt Date, Name, Paid By, Amount, Status,
+	// Categories, Tags, Resolved Date.
+	row := records[1]
+	assertions := []struct {
+		column int
+		want   string
+	}{
+		{3, `'=HYPERLINK("http://evil")`}, // Name
+		{4, "'+cmd"},                      // Paid By
+		{7, "'=SUM(A1)"},                  // Categories
+		{8, "'@danger"},                   // Tags
+	}
+	for _, assertion := range assertions {
+		if row[assertion.column] != assertion.want {
+			utils.PrintTestError(t, row[assertion.column], assertion.want)
+		}
 	}
 }
 

--- a/api/internal/structs/handler.go
+++ b/api/internal/structs/handler.go
@@ -16,15 +16,20 @@ type Handler struct {
 	ResponseType    string
 
 	// AppPermissions are the app-scoped permissions a caller must hold (logical
-	// AND) to run the handler. GroupPermissions are the group-scoped permissions
-	// the caller must hold (logical AND) in each resolved group (resolved from
-	// GroupId / GroupIds, or from ReceiptId / ReceiptIds). OrAppPermissions is an
-	// app-scoped fallback: holding any of them bypasses the group-permission check
-	// (the modern replacement for an admin override). All are resolved from the
-	// database at request time by HandleRequest via the PermissionService.
-	AppPermissions   []string
-	GroupPermissions []string
-	OrAppPermissions []string
+	// AND) to run the handler. AnyAppPermissions are app-scoped permissions of
+	// which the caller must hold at least one (logical OR) — a *required* any-of
+	// gate, distinct from AppPermissions (all-of / AND) and from OrAppPermissions
+	// (a group-check bypass, below). GroupPermissions are the group-scoped
+	// permissions the caller must hold (logical AND) in each resolved group
+	// (resolved from GroupId / GroupIds, or from ReceiptId / ReceiptIds).
+	// OrAppPermissions is an app-scoped fallback: holding any of them bypasses the
+	// group-permission check (the modern replacement for an admin override). All
+	// are resolved from the database at request time by HandleRequest via the
+	// PermissionService.
+	AppPermissions    []string
+	AnyAppPermissions []string
+	GroupPermissions  []string
+	OrAppPermissions  []string
 
 	// SkipPaidByVisibilityCheck, when true, tells HandleRequest to skip the
 	// row-level "paid by" visibility check for receipts resolved from

--- a/desktop/src/reports/report-builder/report-builder.component.html
+++ b/desktop/src/reports/report-builder/report-builder.component.html
@@ -49,7 +49,8 @@
     [canSaveTemplate]="canSaveTemplate()"
     [saving]="saving()"
     [isEditMode]="isEditMode"
-    [saveTemplatePermission]="saveButtonPermission"
+    [saveTemplateAllowed]="saveTemplateAllowed()"
+    [generateAllowed]="generateAllowed()"
     (generate)="generate()"
     (saveTemplate)="saveTemplate()"
   ></app-report-generate-bar>

--- a/desktop/src/reports/report-builder/report-builder.component.spec.ts
+++ b/desktop/src/reports/report-builder/report-builder.component.spec.ts
@@ -247,6 +247,58 @@ describe("ReportBuilderComponent", () => {
       expect(local.isEditMode).toBe(true);
       expect(local.saveTemplateAllowed()).toBe(true);
     });
+
+    it("gates Save on the base update permission in edit mode", async () => {
+      const configuration: ReportRequestCommand = {
+        name: "Saved Report",
+        groupIds: ["1"],
+        period: { preset: ReportPeriod.PresetEnum.ThisMonth },
+        filter: {},
+        groupBy: [],
+        detail: { mode: ReportDetail.ModeEnum.Records },
+        columns: [{ kind: ReportColumn.KindEnum.Dimension, name: "Name", label: "Name", field: "name" }],
+        subtotals: false,
+        grandTotals: false,
+        formats: [ReportRequestCommand.FormatsEnum.Csv],
+      };
+      activatedRoute.snapshot.data = {
+        template: { id: 7, name: "Saved Report", createdAt: "2026-01-01T00:00:00Z", configuration, configurationVersion: 1 },
+      };
+      // Only the base update key — not create, not the "*All" variant.
+      store.dispatch(new SetPermissions([Permission.AppReportsUpdate], {}));
+
+      const local = TestBed.createComponent(ReportBuilderComponent).componentInstance;
+      await fixture.whenStable();
+
+      expect(local.isEditMode).toBe(true);
+      expect(local.saveTemplateAllowed()).toBe(true);
+    });
+
+    it("does not let create authorize Save in edit mode", async () => {
+      const configuration: ReportRequestCommand = {
+        name: "Saved Report",
+        groupIds: ["1"],
+        period: { preset: ReportPeriod.PresetEnum.ThisMonth },
+        filter: {},
+        groupBy: [],
+        detail: { mode: ReportDetail.ModeEnum.Records },
+        columns: [{ kind: ReportColumn.KindEnum.Dimension, name: "Name", label: "Name", field: "name" }],
+        subtotals: false,
+        grandTotals: false,
+        formats: [ReportRequestCommand.FormatsEnum.Csv],
+      };
+      activatedRoute.snapshot.data = {
+        template: { id: 7, name: "Saved Report", createdAt: "2026-01-01T00:00:00Z", configuration, configurationVersion: 1 },
+      };
+      // Create only — editing an existing template needs update, so Save stays hidden.
+      store.dispatch(new SetPermissions([Permission.AppReportsCreate], {}));
+
+      const local = TestBed.createComponent(ReportBuilderComponent).componentInstance;
+      await fixture.whenStable();
+
+      expect(local.isEditMode).toBe(true);
+      expect(local.saveTemplateAllowed()).toBe(false);
+    });
   });
 
   it("cannot save a template without a name", async () => {

--- a/desktop/src/reports/report-builder/report-builder.component.spec.ts
+++ b/desktop/src/reports/report-builder/report-builder.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { FormArray, FormBuilder, FormControl } from "@angular/forms";
 import { ActivatedRoute } from "@angular/router";
 import { UntilDestroy } from "@ngneat/until-destroy";
+import { NgxsModule, Store } from "@ngxs/store";
 import { of, Subject, throwError } from "rxjs";
 import { SnackbarService } from "../../services";
 import {
@@ -15,6 +16,8 @@ import {
   ReportRequestCommand,
   ReportTemplate,
 } from "../../open-api";
+import { AuthState } from "../../store";
+import { SetPermissions } from "../../store/auth.state.actions";
 import { buildReceiptFilterForm } from "../../utils/receipt-filter";
 import { ReportBuilderValue, toReportRequestCommand } from "../models/report-command.mapper";
 import { buildColumnGroup, readStringArray } from "../models/report-form.factory";
@@ -38,6 +41,7 @@ describe("ReportBuilderComponent", () => {
     updateTemplate: jest.Mock;
   };
   let snackbar: { success: jest.Mock };
+  let store: Store;
   // Mutable route stub: the builder reads snapshot.data.template in its field
   // initializer, so a test sets this before creating its own component instance.
   const activatedRoute = { snapshot: { data: {} as Record<string, unknown> } };
@@ -54,6 +58,9 @@ describe("ReportBuilderComponent", () => {
 
     await TestBed.configureTestingModule({
       declarations: [ReportBuilderComponent, NoopComponent],
+      // AuthState feeds the Save/Generate permission gates (saveTemplateAllowed /
+      // generateAllowed), which resolve through the hasAnyAppPermission selector.
+      imports: [NgxsModule.forRoot([AuthState])],
       providers: [
         provideZonelessChangeDetection(),
         FormBuilder,
@@ -64,6 +71,8 @@ describe("ReportBuilderComponent", () => {
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
+
+    store = TestBed.inject(Store);
 
     fixture = TestBed.createComponent(ReportBuilderComponent);
     component = fixture.componentInstance;
@@ -138,10 +147,9 @@ describe("ReportBuilderComponent", () => {
   });
 
   it("saves a new template and shows a success snackbar on the new route", async () => {
-    // The blank builder creates (save-as-new is retired): the Save action gates on
-    // create, calls saveTemplate (not updateTemplate), and toasts "Template saved".
+    // The blank builder creates (save-as-new is retired): the Save action calls
+    // saveTemplate (not updateTemplate), and toasts "Template saved".
     expect(component.isEditMode).toBe(false);
-    expect(component.saveButtonPermission).toBe(Permission.AppReportsCreate);
 
     (component.form.get("scope") as FormArray).push(new FormControl("1"));
     await fixture.whenStable();
@@ -177,9 +185,8 @@ describe("ReportBuilderComponent", () => {
     activatedRoute.snapshot.data = { template };
 
     const local = TestBed.createComponent(ReportBuilderComponent).componentInstance;
-    // Edit mode gates Save on update, not create.
+    // Edit mode saves the opened template in place, not create.
     expect(local.isEditMode).toBe(true);
-    expect(local.saveButtonPermission).toBe(Permission.AppReportsUpdate);
     expect(local.canSaveTemplate()).toBe(true);
 
     local.saveTemplate();
@@ -188,6 +195,58 @@ describe("ReportBuilderComponent", () => {
     expect(runner.updateTemplate).toHaveBeenCalledWith(7, expect.objectContaining({ name: "Saved Report" }));
     expect(runner.saveTemplate).not.toHaveBeenCalled();
     expect(snackbar.success).toHaveBeenCalledWith("Template updated");
+  });
+
+  describe("Save/Generate permission gates honor the -All variants", () => {
+    // The matcher treats "…create" and "…createAll" as unrelated keys, so gating on the
+    // base key alone would hide the control from a role holding only the "*All" variant.
+    it("shows Save (create) and Generate with only the base permissions", async () => {
+      store.dispatch(new SetPermissions([Permission.AppReportsCreate, Permission.AppReportsGenerate], {}));
+      await fixture.whenStable();
+      expect(component.isEditMode).toBe(false);
+      expect(component.saveTemplateAllowed()).toBe(true);
+      expect(component.generateAllowed()).toBe(true);
+    });
+
+    it("shows Save (create) and Generate with only the -All permissions", async () => {
+      store.dispatch(new SetPermissions([Permission.AppReportsCreateAll, Permission.AppReportsGenerateAll], {}));
+      await fixture.whenStable();
+      expect(component.saveTemplateAllowed()).toBe(true);
+      expect(component.generateAllowed()).toBe(true);
+    });
+
+    it("hides Save and Generate for a read-only holder (neither variant)", async () => {
+      store.dispatch(new SetPermissions([Permission.AppReportsRead], {}));
+      await fixture.whenStable();
+      expect(component.saveTemplateAllowed()).toBe(false);
+      expect(component.generateAllowed()).toBe(false);
+    });
+
+    it("gates Save on update (base or -All) in edit mode", async () => {
+      const configuration: ReportRequestCommand = {
+        name: "Saved Report",
+        groupIds: ["1"],
+        period: { preset: ReportPeriod.PresetEnum.ThisMonth },
+        filter: {},
+        groupBy: [],
+        detail: { mode: ReportDetail.ModeEnum.Records },
+        columns: [{ kind: ReportColumn.KindEnum.Dimension, name: "Name", label: "Name", field: "name" }],
+        subtotals: false,
+        grandTotals: false,
+        formats: [ReportRequestCommand.FormatsEnum.Csv],
+      };
+      activatedRoute.snapshot.data = {
+        template: { id: 7, name: "Saved Report", createdAt: "2026-01-01T00:00:00Z", configuration, configurationVersion: 1 },
+      };
+      // Only the "*All" update variant — not create, not the base update key.
+      store.dispatch(new SetPermissions([Permission.AppReportsUpdateAll], {}));
+
+      const local = TestBed.createComponent(ReportBuilderComponent).componentInstance;
+      await fixture.whenStable();
+
+      expect(local.isEditMode).toBe(true);
+      expect(local.saveTemplateAllowed()).toBe(true);
+    });
   });
 
   it("cannot save a template without a name", async () => {

--- a/desktop/src/reports/report-builder/report-builder.component.ts
+++ b/desktop/src/reports/report-builder/report-builder.component.ts
@@ -10,10 +10,12 @@ import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import { FormArray, FormBuilder, FormGroup } from "@angular/forms";
 import { ActivatedRoute } from "@angular/router";
 import { UntilDestroy } from "@ngneat/until-destroy";
+import { Store } from "@ngxs/store";
 import { EMPTY, catchError, debounceTime, finalize, startWith, switchMap, take, tap } from "rxjs";
 import { Permission, ReportPeriod, ReportRequestCommand, ReportTemplate } from "../../open-api";
 import { enabledReportColumns, ReportBuilderValue, toReportRequestCommand } from "../models/report-command.mapper";
 import { SnackbarService } from "../../services";
+import { AuthState } from "../../store";
 import { buildReportForm, buildReportFormFromCommand } from "../models/report-form.factory";
 import { ReportCatalogService } from "../services/report-catalog.service";
 import { ReportRunnerService } from "../services/report-runner.service";
@@ -40,6 +42,7 @@ export class ReportBuilderComponent {
   private readonly snackbar = inject(SnackbarService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly route = inject(ActivatedRoute);
+  private readonly store = inject(Store);
 
   // On the edit route a resolver supplies the saved template; on "new" it is absent.
   // Read it before the form initializer so the form can be built from its stored
@@ -54,11 +57,25 @@ export class ReportBuilderComponent {
   public readonly isEditMode: boolean = this.loadedTemplate != null;
 
   // Save creates a new template on the "new" route and updates in place on the edit
-  // route, so its permission gate follows the mode: create vs update. A user who can
-  // open a template (read) but not update it therefore sees no Save action.
-  public readonly saveButtonPermission: Permission = this.isEditMode
-    ? Permission.AppReportsUpdate
-    : Permission.AppReportsCreate;
+  // route, so its permission gate follows the mode: create vs update. Each mode honors
+  // both the base and the "*All" variant — the permission matcher treats "…create" and
+  // "…createAll" as unrelated keys, so gating on the base alone would hide Save from an
+  // "*All"-only holder. Resolved through the AuthState selector, exactly like the sidebar.
+  public readonly saveTemplateAllowed = this.store.selectSignal(
+    AuthState.hasAnyAppPermission(
+      this.isEditMode
+        ? [Permission.AppReportsUpdate, Permission.AppReportsUpdateAll]
+        : [Permission.AppReportsCreate, Permission.AppReportsCreateAll]
+    )
+  );
+
+  // Generate honors app.reports.generate and its "*All" variant for the same reason.
+  public readonly generateAllowed = this.store.selectSignal(
+    AuthState.hasAnyAppPermission([
+      Permission.AppReportsGenerate,
+      Permission.AppReportsGenerateAll,
+    ])
+  );
 
   public readonly form: FormGroup = this.loadedTemplate
     ? buildReportFormFromCommand(this.formBuilder, this, this.loadedTemplate.configuration)

--- a/desktop/src/reports/report-generate-bar/report-generate-bar.component.html
+++ b/desktop/src/reports/report-generate-bar/report-generate-bar.component.html
@@ -17,21 +17,23 @@
   @if (generating()) {
     <mat-icon class="gen-bar__spinner">autorenew</mat-icon>
   }
-  <app-button
-    *hasAppPermission="saveTemplatePermission()"
-    matButtonType="basic"
-    [buttonText]="saveTemplateText()"
-    icon="bookmark_add"
-    [disabled]="!canSaveTemplate() || saving()"
-    (clicked)="onSaveTemplate()"
-    data-testid="report-save-template"
-  ></app-button>
-  <app-button
-    *hasAppPermission="Permission.AppReportsGenerate"
-    [buttonText]="generating() ? 'Generating…' : 'Generate Report'"
-    [icon]="generating() ? '' : 'play_arrow'"
-    [disabled]="!canGenerate() || generating()"
-    (clicked)="onGenerate()"
-    data-testid="report-generate"
-  ></app-button>
+  @if (saveTemplateAllowed()) {
+    <app-button
+      matButtonType="basic"
+      [buttonText]="saveTemplateText()"
+      icon="bookmark_add"
+      [disabled]="!canSaveTemplate() || saving()"
+      (clicked)="onSaveTemplate()"
+      data-testid="report-save-template"
+    ></app-button>
+  }
+  @if (generateAllowed()) {
+    <app-button
+      [buttonText]="generating() ? 'Generating…' : 'Generate Report'"
+      [icon]="generating() ? '' : 'play_arrow'"
+      [disabled]="!canGenerate() || generating()"
+      (clicked)="onGenerate()"
+      data-testid="report-generate"
+    ></app-button>
+  }
 </div>

--- a/desktop/src/reports/report-generate-bar/report-generate-bar.component.spec.ts
+++ b/desktop/src/reports/report-generate-bar/report-generate-bar.component.spec.ts
@@ -5,27 +5,21 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { FormBuilder, FormGroup } from "@angular/forms";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { provideRouter } from "@angular/router";
-import { NgxsModule, Store } from "@ngxs/store";
 import { ButtonModule } from "../../button/button.module";
-import { DirectivesModule } from "../../directives/directives.module";
-import { Permission } from "../../open-api";
-import { AuthState } from "../../store";
-import { SetPermissions } from "../../store/auth.state.actions";
 import { ReportGenerateBarComponent } from "./report-generate-bar.component";
 
 describe("ReportGenerateBarComponent", () => {
   let fixture: ComponentFixture<ReportGenerateBarComponent>;
   let component: ReportGenerateBarComponent;
   let form: FormGroup;
-  let store: Store;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [ReportGenerateBarComponent],
-      // The real ButtonModule renders the Generate app-button as a real <button>
-      // whose disabled state can be asserted; DirectivesModule + AuthState make the
-      // permission-gated Save/Generate buttons resolve for a permitted caller.
-      imports: [ButtonModule, DirectivesModule, NgxsModule.forRoot([AuthState]), NoopAnimationsModule],
+      // The real ButtonModule renders the Save/Generate app-buttons as real <button>s
+      // whose rendered/disabled state the DOM assertions below can inspect. The bar no
+      // longer gates on permissions itself — the parent passes resolved booleans.
+      imports: [ButtonModule, NoopAnimationsModule],
       providers: [
         provideZonelessChangeDetection(),
         provideRouter([]),
@@ -34,11 +28,6 @@ describe("ReportGenerateBarComponent", () => {
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
-
-    store = TestBed.inject(Store);
-    // Grant the report permissions so the *hasAppPermission-gated Save/Generate
-    // buttons render (the DOM assertions below target the Generate button).
-    store.dispatch(new SetPermissions([Permission.AppReportsCreate, Permission.AppReportsGenerate], {}));
 
     const formBuilder = new FormBuilder();
     form = formBuilder.group({
@@ -50,6 +39,10 @@ describe("ReportGenerateBarComponent", () => {
     fixture.componentRef.setInput("form", form);
     fixture.componentRef.setInput("generating", false);
     fixture.componentRef.setInput("canGenerate", true);
+    // The parent resolves the permission gates into these booleans (honoring the base +
+    // "*All" variants); grant both so the Save/Generate buttons render for the DOM tests.
+    fixture.componentRef.setInput("saveTemplateAllowed", true);
+    fixture.componentRef.setInput("generateAllowed", true);
     await fixture.whenStable();
   });
 
@@ -100,19 +93,28 @@ describe("ReportGenerateBarComponent", () => {
     expect(component.saveTemplateText()).toBe("Updating…");
   });
 
-  it("gates the Save action on the mode's permission", async () => {
+  it("gates the Save and Generate actions on the resolved permission booleans", async () => {
     const el = fixture.nativeElement as HTMLElement;
     const saveButton = () => el.querySelector('[data-testid="report-save-template"]');
+    const generateButton = () => el.querySelector('[data-testid="report-generate"]');
 
-    // New mode gates on create (granted in beforeEach) → the Save action renders.
-    fixture.componentRef.setInput("saveTemplatePermission", Permission.AppReportsCreate);
-    await fixture.whenStable();
+    // Both allowed (granted in beforeEach) → both actions render. The parent resolves
+    // these booleans honoring the base + "*All" permission variants.
     expect(saveButton()).not.toBeNull();
+    expect(generateButton()).not.toBeNull();
 
-    // Edit mode gates on update, which this caller lacks → the Save action is hidden.
-    fixture.componentRef.setInput("saveTemplatePermission", Permission.AppReportsUpdate);
+    // A read-only holder gets neither boolean → both actions are hidden.
+    fixture.componentRef.setInput("saveTemplateAllowed", false);
+    fixture.componentRef.setInput("generateAllowed", false);
     await fixture.whenStable();
     expect(saveButton()).toBeNull();
+    expect(generateButton()).toBeNull();
+
+    // Each gate is independent: Generate can be allowed while Save is not.
+    fixture.componentRef.setInput("generateAllowed", true);
+    await fixture.whenStable();
+    expect(saveButton()).toBeNull();
+    expect(generateButton()).not.toBeNull();
   });
 
   it("renders the format chips and the Generate button's disabled state", async () => {

--- a/desktop/src/reports/report-generate-bar/report-generate-bar.component.ts
+++ b/desktop/src/reports/report-generate-bar/report-generate-bar.component.ts
@@ -1,6 +1,5 @@
 import { ChangeDetectionStrategy, Component, computed, input, output } from "@angular/core";
 import { FormGroup } from "@angular/forms";
-import { Permission } from "../../open-api";
 
 interface FormatChip {
   key: string;
@@ -26,15 +25,15 @@ export class ReportGenerateBarComponent {
   public readonly canGenerate = input<boolean>(false);
   public readonly canSaveTemplate = input<boolean>(false);
   public readonly saving = input<boolean>(false);
-  // Editing an opened template updates it in place (permission app.reports.update);
-  // the blank builder creates a new one (app.reports.create). The parent supplies
-  // both so the Save action's gate and label follow the mode.
+  // Editing an opened template updates it in place; the blank builder creates a new
+  // one — isEditMode drives the Save action's label. The parent resolves the Save and
+  // Generate permission gates (each honoring the base + "*All" variant) into these
+  // booleans, so this bar just renders the actions it is told the user may perform.
   public readonly isEditMode = input<boolean>(false);
-  public readonly saveTemplatePermission = input<Permission>(Permission.AppReportsCreate);
+  public readonly saveTemplateAllowed = input<boolean>(false);
+  public readonly generateAllowed = input<boolean>(false);
   public readonly generate = output<void>();
   public readonly saveTemplate = output<void>();
-
-  protected readonly Permission = Permission;
 
   /** The Save button's label, reflecting create-vs-update and the in-flight state. */
   public readonly saveTemplateText = computed<string>(() => {

--- a/desktop/src/reports/report-template-list/report-template-list.component.html
+++ b/desktop/src/reports/report-template-list/report-template-list.component.html
@@ -7,7 +7,7 @@
       </p>
     </div>
     <div class="tools">
-      @if (canCreate()) {
+      @if (canEnterBuilder()) {
         <app-button
           icon="add"
           buttonText="New Report"
@@ -35,7 +35,7 @@
       <span class="empty-icon"><mat-icon>summarize</mat-icon></span>
       <h2>No report templates yet</h2>
       <p>Build a report and save it as a template to reuse it later.</p>
-      @if (canCreate()) {
+      @if (canEnterBuilder()) {
         <app-button
           icon="add"
           buttonText="New Report"

--- a/desktop/src/reports/report-template-list/report-template-list.component.html
+++ b/desktop/src/reports/report-template-list/report-template-list.component.html
@@ -7,12 +7,14 @@
       </p>
     </div>
     <div class="tools">
-      <app-button
-        icon="add"
-        buttonText="New Report"
-        data-testid="report-template-new"
-        (clicked)="newReport()"
-      ></app-button>
+      @if (canCreate()) {
+        <app-button
+          icon="add"
+          buttonText="New Report"
+          data-testid="report-template-new"
+          (clicked)="newReport()"
+        ></app-button>
+      }
     </div>
   </div>
 
@@ -33,12 +35,14 @@
       <span class="empty-icon"><mat-icon>summarize</mat-icon></span>
       <h2>No report templates yet</h2>
       <p>Build a report and save it as a template to reuse it later.</p>
-      <app-button
-        icon="add"
-        buttonText="New Report"
-        data-testid="report-template-new-empty"
-        (clicked)="newReport()"
-      ></app-button>
+      @if (canCreate()) {
+        <app-button
+          icon="add"
+          buttonText="New Report"
+          data-testid="report-template-new-empty"
+          (clicked)="newReport()"
+        ></app-button>
+      }
     </div>
   }
 </div>

--- a/desktop/src/reports/report-template-list/report-template-list.component.spec.ts
+++ b/desktop/src/reports/report-template-list/report-template-list.component.spec.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from "@angular/common";
-import { NO_ERRORS_SCHEMA, provideZonelessChangeDetection, signal } from "@angular/core";
+import { NO_ERRORS_SCHEMA, provideZonelessChangeDetection, signal, WritableSignal } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { MatDialog } from "@angular/material/dialog";
 import { Router } from "@angular/router";
@@ -13,6 +13,7 @@ import {
   ReportTemplate,
 } from "../../open-api";
 import { SnackbarService } from "../../services";
+import { GroupState } from "../../store";
 import { ReportRunnerService } from "../services/report-runner.service";
 import { ReportTemplateListComponent } from "./report-template-list.component";
 
@@ -52,12 +53,16 @@ describe("ReportTemplateListComponent", () => {
   let snackbar: { success: jest.Mock; error: jest.Mock };
   let dialogResult: boolean;
   let dialogInstance: { headerText: string; dialogContent: string };
+  // Drives the component's canCreate gate (the "New Report" button). The store mock
+  // routes the AuthState.hasAnyAppPermission selectSignal to this controllable signal.
+  let canCreate: WritableSignal<boolean>;
 
   const templates = [makeTemplate(1, "Alpha"), makeTemplate(2, "Beta")];
 
   beforeEach(async () => {
     dialogResult = true;
     dialogInstance = { headerText: "", dialogContent: "" };
+    canCreate = signal(true);
     runner = {
       listTemplates: jest.fn(() => of({ data: templates, totalCount: templates.length })),
       duplicateTemplate: jest.fn(() => of(makeTemplate(3, "Alpha duplicate"))),
@@ -69,7 +74,12 @@ describe("ReportTemplateListComponent", () => {
     snackbar = { success: jest.fn(), error: jest.fn() };
 
     const store = {
-      selectSignal: jest.fn(() => signal([])), // GroupState.groupsWithoutAll
+      // The component makes two selectSignal calls: GroupState.groupsWithoutAll (the
+      // group list) and AuthState.hasAnyAppPermission([...]) (the create gate). Route
+      // the group one to an empty list and everything else to the canCreate signal.
+      selectSignal: jest.fn((selector: unknown) =>
+        selector === GroupState.groupsWithoutAll ? signal([]) : canCreate,
+      ),
       selectSnapshot: jest.fn(() => ({ page: 1, pageSize: 50, orderBy: "updated_at", sortDirection: "desc" })),
       select: jest.fn(() => of(1)),
       dispatch: jest.fn(),
@@ -111,6 +121,22 @@ describe("ReportTemplateListComponent", () => {
   it("New Report navigates to the builder", () => {
     component.newReport();
     expect(router.navigate).toHaveBeenCalledWith(["/reports/new"]);
+  });
+
+  it("shows the New Report button for a create (or createAll) holder", async () => {
+    canCreate.set(true);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('[data-testid="report-template-new"]')).not.toBeNull();
+  });
+
+  it("hides the New Report button for a read-only user (no create)", async () => {
+    canCreate.set(false);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('[data-testid="report-template-new"]')).toBeNull();
   });
 
   it("generate runs the template by id and clears the in-flight id", () => {

--- a/desktop/src/reports/report-template-list/report-template-list.component.spec.ts
+++ b/desktop/src/reports/report-template-list/report-template-list.component.spec.ts
@@ -6,6 +6,7 @@ import { Router } from "@angular/router";
 import { Store } from "@ngxs/store";
 import { of, Subject, throwError } from "rxjs";
 import {
+  Permission,
   ReportColumn,
   ReportDetail,
   ReportPeriod,
@@ -13,7 +14,7 @@ import {
   ReportTemplate,
 } from "../../open-api";
 import { SnackbarService } from "../../services";
-import { GroupState } from "../../store";
+import { AuthState, GroupState } from "../../store";
 import { ReportRunnerService } from "../services/report-runner.service";
 import { ReportTemplateListComponent } from "./report-template-list.component";
 
@@ -53,16 +54,16 @@ describe("ReportTemplateListComponent", () => {
   let snackbar: { success: jest.Mock; error: jest.Mock };
   let dialogResult: boolean;
   let dialogInstance: { headerText: string; dialogContent: string };
-  // Drives the component's canCreate gate (the "New Report" button). The store mock
+  // Drives the component's canEnterBuilder gate (the "New Report" button). The store mock
   // routes the AuthState.hasAnyAppPermission selectSignal to this controllable signal.
-  let canCreate: WritableSignal<boolean>;
+  let canEnterBuilder: WritableSignal<boolean>;
 
   const templates = [makeTemplate(1, "Alpha"), makeTemplate(2, "Beta")];
 
   beforeEach(async () => {
     dialogResult = true;
     dialogInstance = { headerText: "", dialogContent: "" };
-    canCreate = signal(true);
+    canEnterBuilder = signal(true);
     runner = {
       listTemplates: jest.fn(() => of({ data: templates, totalCount: templates.length })),
       duplicateTemplate: jest.fn(() => of(makeTemplate(3, "Alpha duplicate"))),
@@ -75,10 +76,11 @@ describe("ReportTemplateListComponent", () => {
 
     const store = {
       // The component makes two selectSignal calls: GroupState.groupsWithoutAll (the
-      // group list) and AuthState.hasAnyAppPermission([...]) (the create gate). Route
-      // the group one to an empty list and everything else to the canCreate signal.
+      // group list) and AuthState.hasAnyAppPermission([...]) (the builder-entry gate).
+      // Route the group one to an empty list and everything else to the canEnterBuilder
+      // signal.
       selectSignal: jest.fn((selector: unknown) =>
-        selector === GroupState.groupsWithoutAll ? signal([]) : canCreate,
+        selector === GroupState.groupsWithoutAll ? signal([]) : canEnterBuilder,
       ),
       selectSnapshot: jest.fn(() => ({ page: 1, pageSize: 50, orderBy: "updated_at", sortDirection: "desc" })),
       select: jest.fn(() => of(1)),
@@ -105,10 +107,19 @@ describe("ReportTemplateListComponent", () => {
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
 
+    // Installed before createComponent because the builder-entry gate reads the selector
+    // at field init. Call through (default) so selectSignal still receives a real selector
+    // object, which the store mock maps to the controllable canEnterBuilder signal.
+    jest.spyOn(AuthState, "hasAnyAppPermission");
+
     fixture = TestBed.createComponent(ReportTemplateListComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
     await fixture.whenStable();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it("loads templates into the table on init", () => {
@@ -123,20 +134,50 @@ describe("ReportTemplateListComponent", () => {
     expect(router.navigate).toHaveBeenCalledWith(["/reports/new"]);
   });
 
-  it("shows the New Report button for a create (or createAll) holder", async () => {
-    canCreate.set(true);
-    fixture.detectChanges();
+  it("gates the builder entry on report access (read/readAll)", () => {
+    expect(AuthState.hasAnyAppPermission).toHaveBeenCalledWith([
+      Permission.AppReportsRead,
+      Permission.AppReportsReadAll,
+    ]);
+  });
+
+  it("shows the New Report button for a holder with report access (read/readAll)", async () => {
+    canEnterBuilder.set(true);
     await fixture.whenStable();
     const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector('[data-testid="report-template-new"]')).not.toBeNull();
   });
 
-  it("hides the New Report button for a read-only user (no create)", async () => {
-    canCreate.set(false);
-    fixture.detectChanges();
+  it("hides the New Report button without report access (read/readAll)", async () => {
+    canEnterBuilder.set(false);
     await fixture.whenStable();
     const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector('[data-testid="report-template-new"]')).toBeNull();
+  });
+
+  it("shows the empty-state New Report button with report access (read/readAll)", async () => {
+    // No templates → the empty state renders; a fresh component picks up the empty list.
+    runner.listTemplates.mockReturnValue(of({ data: [], totalCount: 0 }));
+    canEnterBuilder.set(true);
+
+    const emptyFixture = TestBed.createComponent(ReportTemplateListComponent);
+    emptyFixture.detectChanges();
+    await emptyFixture.whenStable();
+
+    const el = emptyFixture.nativeElement as HTMLElement;
+    expect(el.querySelector('[data-testid="report-template-new-empty"]')).not.toBeNull();
+  });
+
+  it("hides the empty-state New Report button without report access (read/readAll)", async () => {
+    runner.listTemplates.mockReturnValue(of({ data: [], totalCount: 0 }));
+    canEnterBuilder.set(false);
+
+    const emptyFixture = TestBed.createComponent(ReportTemplateListComponent);
+    emptyFixture.detectChanges();
+    await emptyFixture.whenStable();
+
+    const el = emptyFixture.nativeElement as HTMLElement;
+    expect(el.querySelector('[data-testid="report-template-new-empty"]')).toBeNull();
   });
 
   it("generate runs the template by id and clears the in-flight id", () => {

--- a/desktop/src/reports/report-template-list/report-template-list.component.ts
+++ b/desktop/src/reports/report-template-list/report-template-list.component.ts
@@ -64,14 +64,16 @@ export class ReportTemplateListComponent extends BaseTableComponent<ReportTempla
 
   protected readonly Permission = Permission;
 
-  // "New Report" creates a template, so it gates on create — honoring both the base and
-  // the "*All" variant (the permission matcher treats "…create"/"…createAll" as unrelated
-  // keys, so the base alone would hide it from an "*All"-only holder). Resolved through the
-  // AuthState selector, exactly like the sidebar's report gate.
-  protected readonly canCreate = this.store.selectSignal(
+  // "New Report" opens the builder entry (/reports/new) — a preview/generate/ad-hoc-download
+  // tool, not the Save operation — so it gates on report **read** access, honoring both the
+  // base and the "*All" variant (the permission matcher treats "…read"/"…readAll" as unrelated
+  // keys, so the base alone would hide it from an "*All"-only holder). The Save control stays
+  // create-gated in the builder. Resolved through the AuthState selector, exactly like the
+  // sidebar's report gate.
+  protected readonly canEnterBuilder = this.store.selectSignal(
     AuthState.hasAnyAppPermission([
-      Permission.AppReportsCreate,
-      Permission.AppReportsCreateAll,
+      Permission.AppReportsRead,
+      Permission.AppReportsReadAll,
     ])
   );
 

--- a/desktop/src/reports/report-template-list/report-template-list.component.ts
+++ b/desktop/src/reports/report-template-list/report-template-list.component.ts
@@ -20,7 +20,7 @@ import { SnackbarService } from "../../services";
 import { BaseTableService } from "../../services/base-table.service";
 import { BaseTableComponent } from "../../shared-ui/base-table/base-table.component";
 import { ConfirmationDialogComponent } from "../../shared-ui/confirmation-dialog/confirmation-dialog.component";
-import { GroupState } from "../../store";
+import { AuthState, GroupState } from "../../store";
 import {
   columnCount,
   detailSummary,
@@ -63,6 +63,17 @@ export class ReportTemplateListComponent extends BaseTableComponent<ReportTempla
   private readonly actionsCell = viewChild.required<TemplateRef<any>>("actionsCell");
 
   protected readonly Permission = Permission;
+
+  // "New Report" creates a template, so it gates on create — honoring both the base and
+  // the "*All" variant (the permission matcher treats "…create"/"…createAll" as unrelated
+  // keys, so the base alone would hide it from an "*All"-only holder). Resolved through the
+  // AuthState selector, exactly like the sidebar's report gate.
+  protected readonly canCreate = this.store.selectSignal(
+    AuthState.hasAnyAppPermission([
+      Permission.AppReportsCreate,
+      Permission.AppReportsCreateAll,
+    ])
+  );
 
   // Guards the empty-state against a first-paint flash: it renders only once a load
   // has completed and returned nothing.


### PR DESCRIPTION
Follow-ups from a security review of the reporting feature (post #634). The authorization model itself came out clean — all report routes gate, the 3-layer model (app-perm/`-All` → group ceiling → per-template matrix) is fully enforced, no SQLi/IDOR/XSS/path-traversal/formula-eval escape. Four items were worth acting on.

## Changes

**CSV formula/DDE injection (MEDIUM).** The report CSV renderer wrote user-controlled text cells (receipt/category/tag/status/group/paid-by names, custom text, column labels) verbatim, and Go's `encoding/csv` doesn't neutralize a leading `=`/`+`/`-`/`@`. A low-privilege member could name a receipt `=HYPERLINK(...)` or a DDE payload; a higher-privilege user generating a CSV and opening it in Excel/Sheets would execute it. Now a text cell starting with a formula/control lead is single-quote prefixed — unless it parses as a number, so negative amounts stay machine-readable. The same guard is shared with the receipt CSV export, which had the identical gap. XLSX was never affected (typed string cells).

**`/report/preview` app-permission gate (defense-in-depth).** Preview gated only on the per-group `group.reports.read`. It now also requires app `reports.read` OR `reports.readAll`, matching the Report Builder's route guard (enforced in-body, since the declarative app-permission gate is AND-only and this is an OR).

**Builder Save/Generate + "New Report" honor the `-All` variants (UX).** These gated on the base `create`/`update`/`generate` keys only; the matcher treats `…create` and `…createAll` as unrelated, so a role holding only an `-All` permission saw no Save/Generate/New-Report control even though the templates list rows and the nav already honored `-All`. All three now gate on `hasAnyAppPermission([base, allVariant])`, mirroring the sidebar.

**Docs.** Clarified in `api/CLAUDE.md` that the per-template access matrix is UX scoping layered on the hard group-access + category/tag/paid-by controls (ad-hoc `/report/generate` and `duplicate` are intentionally not bound by it and never widen data access).

## Tests
- Backend: full `go test ./...` green; new cases cover CSV neutralization (formula/DDE/tab/CR prefixed; `-5`/`+3`/`0` untouched) and the preview gate (403 without an app-reports perm, 200 with read/readAll).
- Desktop: changed-area jest suites (42 tests) green; `ng build` strict template typecheck clean. New cases prove an `-All`-only role still sees Save/Generate/New-Report and a read-only user does not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Report builder, template saving, and report generation UI now gate actions using resolved permission booleans.
  * “New Report” is shown only when you have report read access (read or readAll).
* **Bug Fixes**
  * Report preview authorization now requires app-level read (read or readAll) plus group-level read.
  * CSV exports neutralize spreadsheet formula/control-character values to prevent spreadsheet injection; receipts and items are covered too.
* **Documentation**
  * Clarified report-template access scoping boundaries for ad-hoc generation and duplicated templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->