### PR TITLE
Reporting pre-merge hardening: arithmetic OOM guard + disabled-column persistence

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -771,8 +771,11 @@ engine's own output rather than a client-side re-implementation. A separate **ap
 permission gates the desktop report-builder route/nav and the saved-template read endpoints (Legacy Admin
 picks it up via add-only role reconciliation; reporting is admin-by-default). Generate additionally
 requires the app-level **`app.reports.generate`** (ANDed with the per-group `group.reports.read`), so a
-non-admin needs both a custom role granting `app.reports.generate` and per-group generation access;
-**preview stays group-scoped only** (no app gate), since it is the builder's live feedback loop.
+non-admin needs both a custom role granting `app.reports.generate` and per-group generation access.
+**Preview enforces that same app-level read gate** — `app.reports.read` **or** `app.reports.readAll`,
+declared on the handler as an `AnyAppPermissions` any-of and ANDed with the per-group
+`group.reports.read` — so the builder's live feedback loop is reachable by exactly the users who can
+open the builder, and preview is never merely group-scoped.
 
 **Custom currency formatting.** `buildModel` loads System Settings (`SystemSettingsRepository.GetSystemSettings`,
 a get-or-create singleton) and passes the app's currency configuration — symbol, symbol position (START/END),

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -801,7 +801,14 @@ filter already flows through.
 **Report templates.** `POST /api/report/template` saves a report configuration for reuse. It reuses the
 shared `loadReportCommand` parse+validate and stores the whole `ReportRequestCommand` verbatim as a
 `json.RawMessage` blob on `models.ReportTemplate` (name + owner taken from the request / JWT), so a
-template round-trips back into the builder unchanged. Because this is the first feature to **re-serialize
+template round-trips back into the builder unchanged. A stored config may include a dimension column
+that is currently **disabled** in the builder (aggregate mode, a label whose field is neither the
+aggregate dimension nor a grouping level) — persisted deliberately so it round-trips and self-heals
+rather than being silently dropped on save. `buildReportSpec` (`services/report_service.go`,
+`isDisabledDimensionColumn`) **projects such a column out** before running the engine, mirroring the
+desktop `isDimensionColumnDisabled` and the engine's own `ErrLabelColumnUnresolvable` rejection — so
+verbatim generation of a stored template (including `POST /report/template/{id}/generate`) succeeds
+with the column omitted instead of returning a 400. Because this is the first feature to **re-serialize
 a `ReceiptPagedRequestFilter` back to a client**, the filter's json tags must be correct:
 `PagedRequestField.Value` carries `json:"value"` and the filter's `Tags` field `json:"tags"` (both
 lowercase, matching swagger) — a capitalized key would deserialize fine (Go is case-insensitive) but

--- a/api/internal/commands/report_request_command.go
+++ b/api/internal/commands/report_request_command.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"time"
 
 	"receipt-wrangler/api/internal/structs"
@@ -36,6 +37,14 @@ const (
 // report template's stored configuration. Bump it and write an upcaster when a
 // breaking change to the ReportRequestCommand shape lands.
 const CurrentReportConfigurationVersion = 1
+
+// maxReportColumns caps how many columns one report may declare. Arithmetic
+// columns may reference one another, so an unbounded column list is a way to
+// chain expensive per-cell work; the engine also bounds the magnitude of any
+// single computed value, but rejecting an absurd column count here turns that
+// into a clean 400 instead of a silently-nulled cell. Real reports use a
+// handful of columns — this is a generous ceiling, not a design target.
+const maxReportColumns = 100
 
 // Period presets. Everything but "custom" resolves to a date window from the
 // server clock at generation time; "custom" uses the supplied start/end.
@@ -201,6 +210,11 @@ func (command *ReportRequestCommand) validateDetail(errorMap map[string]string) 
 func (command *ReportRequestCommand) validateColumns(errorMap map[string]string) {
 	if len(command.Columns) == 0 {
 		errorMap["columns"] = "At least one column is required"
+		return
+	}
+
+	if len(command.Columns) > maxReportColumns {
+		errorMap["columns"] = "A report may have at most " + strconv.Itoa(maxReportColumns) + " columns"
 		return
 	}
 

--- a/api/internal/commands/report_request_command_test.go
+++ b/api/internal/commands/report_request_command_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -154,4 +155,34 @@ func TestReportRequestCommand_Validate_CountNeedsNoMeasure(t *testing.T) {
 	if _, ok := command.Validate().Errors["columns"]; ok {
 		t.Error("COUNT should not require a measure")
 	}
+}
+
+// An unbounded column list is a way to chain expensive per-cell work (arithmetic
+// columns reference one another), so the count is capped at the boundary.
+func TestReportRequestCommand_Validate_BoundsColumnCount(t *testing.T) {
+	dimensionColumns := func(n int) []ReportColumn {
+		columns := make([]ReportColumn, n)
+		for i := range columns {
+			columns[i] = ReportColumn{Kind: ReportColumnDimension, Name: "c" + strconv.Itoa(i), Field: "category"}
+		}
+		return columns
+	}
+
+	t.Run("a report at the column ceiling is accepted", func(t *testing.T) {
+		command := validReportCommand()
+		command.Detail = ReportDetail{Mode: ReportDetailRecords}
+		command.Columns = dimensionColumns(maxReportColumns)
+		if _, ok := command.Validate().Errors["columns"]; ok {
+			t.Errorf("exactly %d columns should be accepted", maxReportColumns)
+		}
+	})
+
+	t.Run("one column past the ceiling is rejected", func(t *testing.T) {
+		command := validReportCommand()
+		command.Detail = ReportDetail{Mode: ReportDetailRecords}
+		command.Columns = dimensionColumns(maxReportColumns + 1)
+		if _, ok := command.Validate().Errors["columns"]; !ok {
+			t.Errorf("more than %d columns should be rejected", maxReportColumns)
+		}
+	})
 }

--- a/api/internal/reporting/adversarial_test.go
+++ b/api/internal/reporting/adversarial_test.go
@@ -2,6 +2,7 @@ package reporting
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -292,6 +293,56 @@ func TestParseArithmetic_SizeLimits(t *testing.T) {
 			t.Errorf("error = %v, want ErrFormulaTooLong", err)
 		}
 	})
+}
+
+// Bounding a formula's source (above) bounds what one expression costs to parse;
+// it does nothing about what an expression costs to evaluate. Arithmetic columns
+// may reference one another, so a chain that each squares the previous — c1 =
+// c0 * c0, c2 = c1 * c1, … — makes cN equal 99^(2^N): one decimal whose big.Int
+// coefficient doubles in length every column, reaching hundreds of megabytes
+// within ~30 columns and exhausting memory, all from a spec a few hundred bytes
+// long. evalBinary caps a computed value's magnitude, so an over-large
+// intermediate collapses to a null cell (the engine's "correct or null, never
+// wrong" contract) and the report stays cheap. That it returns promptly at all
+// is as much the assertion as anything checked about the result.
+func TestRun_BoundsRunawayArithmeticGrowth(t *testing.T) {
+	const depth = 40
+
+	columns := []Column{
+		{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}},
+		{Name: "c0", Kind: ColumnArithmetic, Expr: "99 * 99"},
+	}
+	for i := 1; i < depth; i++ {
+		prev := fmt.Sprintf("c%d", i-1)
+		columns = append(columns, Column{
+			Name: fmt.Sprintf("c%d", i),
+			Kind: ColumnArithmetic,
+			Expr: prev + " * " + prev,
+		})
+	}
+
+	spec := ReportSpec{
+		GroupBy:     []FieldKey{"tag"},
+		Columns:     columns,
+		GrandTotals: true,
+	}
+
+	model := mustRun(t, spec, []Row{{"tag": {Str("Alex")}}})
+
+	// The deepest column has to have collapsed to a null cell rather than
+	// materialized an astronomically large number.
+	deepest := fmt.Sprintf("c%d", depth-1)
+	if got := cell(t, model.GrandTotals, deepest); !got.IsNull() {
+		t.Errorf("deep arithmetic column %s = %v, want a null (bounded) cell", deepest, got)
+	}
+
+	// And nothing that did survive exceeds the digit ceiling.
+	for _, c := range model.GrandTotals {
+		if number, ok := c.Value().Decimal(); ok && number.NumDigits() > maxDecimalDigits {
+			t.Errorf("column %s survived with %d digits, over the %d ceiling",
+				c.Column, number.NumDigits(), maxDecimalDigits)
+		}
+	}
 }
 
 // Validate is total: whatever it is handed, it answers, and it never panics.

--- a/api/internal/reporting/adversarial_test.go
+++ b/api/internal/reporting/adversarial_test.go
@@ -336,11 +336,12 @@ func TestRun_BoundsRunawayArithmeticGrowth(t *testing.T) {
 		t.Errorf("deep arithmetic column %s = %v, want a null (bounded) cell", deepest, got)
 	}
 
-	// And nothing that did survive exceeds the digit ceiling.
+	// And nothing that did survive exceeds an independent sanity ceiling (not the
+	// production bound, so a weakened bound is caught rather than tracked).
 	for _, c := range model.GrandTotals {
-		if number, ok := c.Value().Decimal(); ok && number.NumDigits() > maxDecimalDigits {
-			t.Errorf("column %s survived with %d digits, over the %d ceiling",
-				c.Column, number.NumDigits(), maxDecimalDigits)
+		if number, ok := c.Value().Decimal(); ok && number.NumDigits() > runawayDigitCeiling {
+			t.Errorf("column %s survived with %d digits, past the independent %d ceiling",
+				c.Column, number.NumDigits(), runawayDigitCeiling)
 		}
 	}
 }

--- a/api/internal/reporting/adversarial_test.go
+++ b/api/internal/reporting/adversarial_test.go
@@ -303,10 +303,14 @@ func TestParseArithmetic_SizeLimits(t *testing.T) {
 // within ~30 columns and exhausting memory, all from a spec a few hundred bytes
 // long. evalBinary caps a computed value's magnitude, so an over-large
 // intermediate collapses to a null cell (the engine's "correct or null, never
-// wrong" contract) and the report stays cheap. That it returns promptly at all
-// is as much the assertion as anything checked about the result.
+// wrong" contract).
+//
+// The chain here is kept deliberately short: even with the guard removed the
+// deepest column stays a few kilobytes, so a regression fails the assertions
+// below rather than OOMing the test process — while still being long enough that
+// the guard must null the deep columns for the test to pass.
 func TestRun_BoundsRunawayArithmeticGrowth(t *testing.T) {
-	const depth = 40
+	const depth = 14
 
 	columns := []Column{
 		{Name: "Count", Kind: ColumnAggregate, Agg: Aggregate{Func: AggCount}},

--- a/api/internal/reporting/eval.go
+++ b/api/internal/reporting/eval.go
@@ -138,5 +138,5 @@ func evalRound(call *ast.CallNode, columns map[string]Value, divisionScale int32
 		return Null()
 	}
 
-	return Num(operand.Round(places))
+	return boundedNum(operand.Round(places))
 }

--- a/api/internal/reporting/eval.go
+++ b/api/internal/reporting/eval.go
@@ -64,6 +64,38 @@ func evalUnary(node *ast.UnaryNode, columns map[string]Value, divisionScale int3
 	return Num(operand)
 }
 
+// maxDecimalDigits bounds the coefficient of a computed arithmetic value. A
+// result whose coefficient carries more digits than this is treated as
+// undefined (null) rather than materialized. Money never needs anywhere near
+// this many significant digits; the bound exists so a chain of arithmetic
+// columns that fold into one another — c1 = c0 * c0, c2 = c1 * c1, … — cannot
+// grow a single decimal's big.Int coefficient without limit and exhaust memory.
+// Because each column reads the previous column's already-bounded value, capping
+// each result transitively bounds every later operand too.
+const maxDecimalDigits = 1000
+
+// maxDecimalExponent bounds a computed value's scale. shopspring stores the
+// exponent as an int32, so a chain that keeps multiplying a large-exponent
+// literal (1e308 * 1e308 * …) would eventually overflow it and wrap to a
+// silently wrong number. Real money exponents sit within a few dozen places, so
+// this leaves vast headroom while keeping the exponent far from the int32 edge.
+const maxDecimalExponent = 10_000
+
+// boundedNum wraps an arithmetic result, collapsing it to null when it has grown
+// too large to be meaningful money — too many coefficient digits (a
+// memory-exhaustion guard) or an out-of-range exponent (an int32-overflow
+// guard). It keeps the engine's contract that an undefined result is a blank
+// cell, never a wrong one.
+func boundedNum(d decimal.Decimal) Value {
+	if d.NumDigits() > maxDecimalDigits {
+		return Null()
+	}
+	if exponent := d.Exponent(); exponent > maxDecimalExponent || exponent < -maxDecimalExponent {
+		return Null()
+	}
+	return Num(d)
+}
+
 func evalBinary(operator string, left, right Value, divisionScale int32) Value {
 	leftNumber, leftIsNumber := left.Decimal()
 	rightNumber, rightIsNumber := right.Decimal()
@@ -73,16 +105,16 @@ func evalBinary(operator string, left, right Value, divisionScale int32) Value {
 
 	switch operator {
 	case "+":
-		return Num(leftNumber.Add(rightNumber))
+		return boundedNum(leftNumber.Add(rightNumber))
 	case "-":
-		return Num(leftNumber.Sub(rightNumber))
+		return boundedNum(leftNumber.Sub(rightNumber))
 	case "*":
-		return Num(leftNumber.Mul(rightNumber))
+		return boundedNum(leftNumber.Mul(rightNumber))
 	case "/":
 		if rightNumber.IsZero() {
 			return Null()
 		}
-		return Num(leftNumber.DivRound(rightNumber, divisionScale))
+		return boundedNum(leftNumber.DivRound(rightNumber, divisionScale))
 	}
 
 	return Null()

--- a/api/internal/reporting/eval_test.go
+++ b/api/internal/reporting/eval_test.go
@@ -117,18 +117,20 @@ func TestEvalArithmetic_DivisionScale(t *testing.T) {
 func TestEvalArithmetic_BoundsMagnitude(t *testing.T) {
 	t.Run("a squaring chain collapses to null rather than growing without bound", func(t *testing.T) {
 		columns := map[string]Value{"c": Num(dec("99"))}
-		maxDigits := 0
 		for i := 0; i < 40; i++ {
 			columns["c"] = evalSrc(t, "c * c", columns)
-			if number, ok := columns["c"].Decimal(); ok && number.NumDigits() > maxDigits {
-				maxDigits = number.NumDigits()
+			// Check inside the loop and bail immediately: if the bound were removed
+			// the value would keep doubling until it exhausted memory, so failing
+			// here — at a small intermediate — beats OOMing the test process. A
+			// guarded chain nulls the value (Decimal returns false) well before it
+			// reaches the independent ceiling, so this never trips in practice.
+			if number, ok := columns["c"].Decimal(); ok && number.NumDigits() > runawayDigitCeiling {
+				t.Fatalf("a value grew to %d digits, past the independent %d ceiling — growth is not bounded",
+					number.NumDigits(), runawayDigitCeiling)
 			}
 		}
 		if !columns["c"].IsNull() {
 			t.Errorf("deep squaring chain = %v, want a null cell", columns["c"])
-		}
-		if maxDigits > runawayDigitCeiling {
-			t.Errorf("a value survived with %d digits, past the independent %d ceiling", maxDigits, runawayDigitCeiling)
 		}
 	})
 

--- a/api/internal/reporting/eval_test.go
+++ b/api/internal/reporting/eval_test.go
@@ -1,6 +1,7 @@
 package reporting
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -8,6 +9,13 @@ import (
 )
 
 const testDivisionScale = 6
+
+// runawayDigitCeiling is an independent sanity bound for the arithmetic-growth
+// tests, deliberately NOT the production maxDecimalDigits: if the real bound were
+// weakened or removed, a surviving value would blow past this and the test would
+// fail — a test law must not be derived from the code it judges. Money never needs
+// anywhere near this many significant digits, and the real bound is well below it.
+const runawayDigitCeiling = 2000
 
 func mustParseArithmetic(t *testing.T, src string) ast.Node {
 	t.Helper()
@@ -119,8 +127,8 @@ func TestEvalArithmetic_BoundsMagnitude(t *testing.T) {
 		if !columns["c"].IsNull() {
 			t.Errorf("deep squaring chain = %v, want a null cell", columns["c"])
 		}
-		if maxDigits > maxDecimalDigits {
-			t.Errorf("a value survived with %d digits, over the %d ceiling", maxDigits, maxDecimalDigits)
+		if maxDigits > runawayDigitCeiling {
+			t.Errorf("a value survived with %d digits, past the independent %d ceiling", maxDigits, runawayDigitCeiling)
 		}
 	})
 
@@ -134,6 +142,18 @@ func TestEvalArithmetic_BoundsMagnitude(t *testing.T) {
 		}
 		t.Fatalf("a 1e308 squaring chain never collapsed: %v", columns["c"])
 	})
+}
+
+// ROUND funnels through the same magnitude guard as every other arithmetic op, so
+// an operand past the coefficient ceiling rounds to a null cell rather than a
+// materialized giant. 1100 significant digits is comfortably past the bound; the
+// null result — not the digit count — is the law being asserted.
+func TestEvalArithmetic_RoundIsBounded(t *testing.T) {
+	columns := map[string]Value{"big": Num(dec(strings.Repeat("9", 1100)))}
+	got := evalArithmetic(mustParseArithmetic(t, "ROUND(big, 2)"), columns, testDivisionScale)
+	if !got.IsNull() {
+		t.Errorf("ROUND of an over-ceiling operand = %v, want a null cell", got)
+	}
 }
 
 // A zero divisor must yield an empty cell. shopspring panics on this, so the

--- a/api/internal/reporting/eval_test.go
+++ b/api/internal/reporting/eval_test.go
@@ -101,6 +101,41 @@ func TestEvalArithmetic_DivisionScale(t *testing.T) {
 	}
 }
 
+// A computed value that grows past what money can mean collapses to null instead
+// of being materialized. Both growth modes are covered: a coefficient that keeps
+// doubling (a memory-exhaustion vector) and an exponent that keeps climbing
+// toward the int32 boundary (a silent-overflow vector). Feeding each column's
+// result back into the next is exactly what the engine's arithmetic columns do.
+func TestEvalArithmetic_BoundsMagnitude(t *testing.T) {
+	t.Run("a squaring chain collapses to null rather than growing without bound", func(t *testing.T) {
+		columns := map[string]Value{"c": Num(dec("99"))}
+		maxDigits := 0
+		for i := 0; i < 40; i++ {
+			columns["c"] = evalSrc(t, "c * c", columns)
+			if number, ok := columns["c"].Decimal(); ok && number.NumDigits() > maxDigits {
+				maxDigits = number.NumDigits()
+			}
+		}
+		if !columns["c"].IsNull() {
+			t.Errorf("deep squaring chain = %v, want a null cell", columns["c"])
+		}
+		if maxDigits > maxDecimalDigits {
+			t.Errorf("a value survived with %d digits, over the %d ceiling", maxDigits, maxDecimalDigits)
+		}
+	})
+
+	t.Run("a large-exponent chain collapses to null instead of wrapping the int32 exponent", func(t *testing.T) {
+		columns := map[string]Value{"c": evalSrc(t, "1e308", map[string]Value{})}
+		for i := 0; i < 40; i++ {
+			columns["c"] = evalSrc(t, "c * c", columns)
+			if columns["c"].IsNull() {
+				return // collapsed before it could wrap to a wrong number — the guard working
+			}
+		}
+		t.Fatalf("a 1e308 squaring chain never collapsed: %v", columns["c"])
+	})
+}
+
 // A zero divisor must yield an empty cell. shopspring panics on this, so the
 // guard is the only thing standing between a report with a zero count and a
 // crashed request.

--- a/api/internal/reporting/mutation-check.sh
+++ b/api/internal/reporting/mutation-check.sh
@@ -323,12 +323,22 @@ add 'null-operand-reads-as-zero' 'eval.go' \
 '	leftNumber, _ := left.Decimal()
 	rightNumber, _ := right.Decimal()'
 
+# TestEvalArithmetic_BoundsMagnitude / TestRun_BoundsRunawayArithmeticGrowth —
+# without the coefficient guard a squaring chain doubles its big.Int without limit.
+# Both tests check the size ceiling *inside* the growth loop (and the Run chain is
+# kept short), so a removed guard trips a normal assertion at a small intermediate
+# rather than exhausting the test process's memory.
+add 'digit-guard-removed' 'eval.go' \
+'	if d.NumDigits() > maxDecimalDigits {
+		return Null()
+	}
+	if exponent := d.Exponent(); exponent > maxDecimalExponent || exponent < -maxDecimalExponent {' \
+'	if exponent := d.Exponent(); exponent > maxDecimalExponent || exponent < -maxDecimalExponent {'
+
 # TestEvalArithmetic_BoundsMagnitude — without the exponent guard a chain of
 # large-exponent literals (1e308 * 1e308 * …) climbs toward the int32 exponent
-# boundary and wraps to a silently wrong number instead of a null cell. The
-# sibling coefficient guard is exercised by the same test and by
-# TestRun_BoundsRunawayArithmeticGrowth, but removing it exhausts memory rather
-# than producing a checkable value, so it is deliberately not mutated here.
+# boundary and wraps to a silently wrong number instead of a null cell (the
+# coefficient stays tiny, so this one never risked memory).
 add 'exponent-guard-removed' 'eval.go' \
 '	if exponent := d.Exponent(); exponent > maxDecimalExponent || exponent < -maxDecimalExponent {
 		return Null()

--- a/api/internal/reporting/mutation-check.sh
+++ b/api/internal/reporting/mutation-check.sh
@@ -336,6 +336,13 @@ add 'exponent-guard-removed' 'eval.go' \
 	return Num(d)' \
 '	return Num(d)'
 
+# TestEvalArithmetic_RoundIsBounded — ROUND is the last arithmetic-producing path,
+# and it must bound its result like the rest; skipping boundedNum lets an
+# over-ceiling operand round straight through instead of collapsing to null.
+add 'round-guard-removed' 'eval.go' \
+'	return boundedNum(operand.Round(places))' \
+'	return Num(operand.Round(places))'
+
 # --- validate: the rules ----------------------------------------------------
 
 # TestValidate_Rejects/arithmetic references itself

--- a/api/internal/reporting/mutation-check.sh
+++ b/api/internal/reporting/mutation-check.sh
@@ -242,8 +242,8 @@ add 'column-format-dropped' 'engine.go' \
 
 # TestRun_MetaParamsAreCopied
 add 'meta-params-aliased' 'engine.go' \
-'			Params:         copyParams(meta.Params),' \
-'			Params:         meta.Params,'
+'			Params:      copyParams(meta.Params),' \
+'			Params:      meta.Params,'
 
 # TestRun_RecordsModeDoesNotAliasInputRows
 add 'records-label-cell-aliases-the-row' 'engine.go' \
@@ -305,13 +305,13 @@ add 'division-guard-removed' 'eval.go' \
 '		if rightNumber.IsZero() {
 			return Null()
 		}
-		return Num(leftNumber.DivRound(rightNumber, divisionScale))' \
-'		return Num(leftNumber.DivRound(rightNumber, divisionScale))'
+		return boundedNum(leftNumber.DivRound(rightNumber, divisionScale))' \
+'		return boundedNum(leftNumber.DivRound(rightNumber, divisionScale))'
 
 # TestEvalArithmetic_IgnoresDivisionPrecisionGlobal
 add 'division-reads-the-global' 'eval.go' \
-'		return Num(leftNumber.DivRound(rightNumber, divisionScale))' \
-'		return Num(leftNumber.Div(rightNumber))'
+'		return boundedNum(leftNumber.DivRound(rightNumber, divisionScale))' \
+'		return boundedNum(leftNumber.Div(rightNumber))'
 
 # TestEvalArithmetic_NullPropagates
 add 'null-operand-reads-as-zero' 'eval.go' \
@@ -322,6 +322,19 @@ add 'null-operand-reads-as-zero' 'eval.go' \
 	}' \
 '	leftNumber, _ := left.Decimal()
 	rightNumber, _ := right.Decimal()'
+
+# TestEvalArithmetic_BoundsMagnitude — without the exponent guard a chain of
+# large-exponent literals (1e308 * 1e308 * …) climbs toward the int32 exponent
+# boundary and wraps to a silently wrong number instead of a null cell. The
+# sibling coefficient guard is exercised by the same test and by
+# TestRun_BoundsRunawayArithmeticGrowth, but removing it exhausts memory rather
+# than producing a checkable value, so it is deliberately not mutated here.
+add 'exponent-guard-removed' 'eval.go' \
+'	if exponent := d.Exponent(); exponent > maxDecimalExponent || exponent < -maxDecimalExponent {
+		return Null()
+	}
+	return Num(d)' \
+'	return Num(d)'
 
 # --- validate: the rules ----------------------------------------------------
 

--- a/api/internal/services/report_service.go
+++ b/api/internal/services/report_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -350,6 +351,19 @@ func buildReportSpec(command commands.ReportRequestCommand) (reporting.ReportSpe
 
 	columns := make([]reporting.Column, 0, len(command.Columns))
 	for _, column := range command.Columns {
+		// A saved template may carry a dimension column that is currently
+		// unresolvable — a label the engine can't place on an aggregated row
+		// because its field is neither the aggregate dimension nor a grouping
+		// level. The builder greys these out and leaves them out of the request;
+		// the same projection here lets a template that stores one (so it
+		// round-trips into the builder and re-enables when the config makes it
+		// valid) still generate — with the column omitted — instead of failing
+		// the whole report. Mirrors the desktop isDimensionColumnDisabled rule
+		// and the engine's own compileLabelColumn rejection.
+		if isDisabledDimensionColumn(command, column) {
+			continue
+		}
+
 		built, err := buildReportColumn(column)
 		if err != nil {
 			return reporting.ReportSpec{}, err
@@ -364,6 +378,19 @@ func buildReportSpec(command commands.ReportRequestCommand) (reporting.ReportSpe
 		Subtotals:   command.Subtotals,
 		GrandTotals: command.GrandTotals,
 	}, nil
+}
+
+// isDisabledDimensionColumn reports whether a dimension column is unresolvable in
+// aggregate mode — its field is neither the aggregate dimension nor a grouping
+// level, so the engine cannot label an aggregated row with it. It is the
+// server-side twin of the desktop builder's isDimensionColumnDisabled: such a
+// column is projected out of the spec rather than failing the report, so a saved
+// template may retain it for round-trip fidelity.
+func isDisabledDimensionColumn(command commands.ReportRequestCommand, column commands.ReportColumn) bool {
+	if command.Detail.Mode != commands.ReportDetailAggregate || column.Kind != commands.ReportColumnDimension {
+		return false
+	}
+	return column.Field != command.Detail.By && !slices.Contains(command.GroupBy, column.Field)
 }
 
 func buildReportColumn(column commands.ReportColumn) (reporting.Column, error) {

--- a/api/internal/services/report_service_test.go
+++ b/api/internal/services/report_service_test.go
@@ -291,6 +291,66 @@ func TestReportService_BuildReportSpec(t *testing.T) {
 	}
 }
 
+func specColumnNames(spec reporting.ReportSpec) []string {
+	names := make([]string, len(spec.Columns))
+	for index, column := range spec.Columns {
+		names[index] = column.Name
+	}
+	return names
+}
+
+// A saved template may hold a dimension column that is currently unresolvable in
+// aggregate mode — its field is neither the aggregate dimension nor a grouping
+// level, which the engine would reject (ErrLabelColumnUnresolvable). buildReportSpec
+// projects it out, mirroring the builder, so the stored template still generates
+// with the column omitted rather than failing the whole report. Resolvable
+// dimension, aggregate, and formula columns are kept, and records mode drops nothing.
+func TestReportService_BuildReportSpec_ProjectsDisabledDimensionColumns(t *testing.T) {
+	t.Run("aggregate mode drops only the unresolvable dimension column", func(t *testing.T) {
+		command := commands.ReportRequestCommand{
+			GroupBy: []string{"group"},
+			Detail:  commands.ReportDetail{Mode: commands.ReportDetailAggregate, By: "category"},
+			Columns: []commands.ReportColumn{
+				{Kind: commands.ReportColumnDimension, Name: "Group", Field: "group"},       // grouped -> kept
+				{Kind: commands.ReportColumnDimension, Name: "Category", Field: "category"}, // detail.by -> kept
+				{Kind: commands.ReportColumnDimension, Name: "PaidBy", Field: "paid_by"},    // neither -> dropped
+				{Kind: commands.ReportColumnAggregate, Name: "Total", AggFunc: "SUM", Measure: "amount"},
+				{Kind: commands.ReportColumnFormula, Name: "Double", Expr: "Total + Total"},
+			},
+		}
+
+		spec, err := buildReportSpec(command)
+		if err != nil {
+			t.Fatalf("buildReportSpec: %v", err)
+		}
+
+		got := specColumnNames(spec)
+		want := []string{"Group", "Category", "Total", "Double"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("columns = %v, want %v (the unresolvable PaidBy dimension dropped)", got, want)
+		}
+	})
+
+	t.Run("records mode keeps every dimension column", func(t *testing.T) {
+		command := commands.ReportRequestCommand{
+			Detail: commands.ReportDetail{Mode: commands.ReportDetailRecords},
+			Columns: []commands.ReportColumn{
+				{Kind: commands.ReportColumnDimension, Name: "PaidBy", Field: "paid_by"},
+				{Kind: commands.ReportColumnDimension, Name: "Category", Field: "category"},
+			},
+		}
+
+		spec, err := buildReportSpec(command)
+		if err != nil {
+			t.Fatalf("buildReportSpec: %v", err)
+		}
+
+		if got := specColumnNames(spec); !reflect.DeepEqual(got, []string{"PaidBy", "Category"}) {
+			t.Errorf("records mode dropped a column: %v", got)
+		}
+	})
+}
+
 // --- DB-backed generation -------------------------------------------------
 
 // seedReportUserInGroups creates one user who is a member of every named group,

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -206,9 +206,10 @@ paths:
       summary: Preview a report
       description:
         Renders the current report configuration as HTML for the builder's live
-        preview, along with the number of receipts it covers. Runs under the
-        caller's group permissions and requires group.reports.read in every covered
-        group. The preview is a row-capped sample of the engine's own output.
+        preview, along with the number of receipts it covers. Requires the
+        app-level app.reports.read (or app.reports.readAll) and group.reports.read
+        in every covered group. The preview is a row-capped sample of the engine's
+        own output.
       operationId: previewReport
       requestBody:
         description: The report builder configuration

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -658,7 +658,12 @@ endpoint); the builder's own ad-hoc generate still gates on `app.reports.generat
     — a derived state (`isDimensionColumnDisabled` in `report-command.mapper.ts`) shown greyed in the
     columns list and **left out of the request** (`enabledReportColumns`), auto-re-enabling when the
     config makes it valid again. `report-builder` blocks preview/generate only if *no* enabled column
-    remains. Nothing is removed or auto-changed.
+    remains. Nothing is removed or auto-changed — and **Save persists every column, including disabled
+    ones** (`toReportRequestCommandForSave`, distinct from the enabled-only preview/generate
+    `toReportRequestCommand`), so a disabled column round-trips into a reopened template and self-heals
+    instead of being silently dropped. The backend applies the same projection when a stored template is
+    generated (see `api/CLAUDE.md` → "Report templates"), so a template holding a currently-disabled
+    column still generates with it omitted.
 - **Save Template**: the generate bar's secondary button (left of Generate) persists the current
   configuration. Its gate and label follow the builder's mode, driven by two inputs from
   `report-builder` (`isEditMode` + `saveButtonPermission`): on the **new** route it **creates** a

--- a/desktop/e2e/report-builder.spec.ts
+++ b/desktop/e2e/report-builder.spec.ts
@@ -8,7 +8,7 @@ import {
   uniqueName,
   withAdminApi,
 } from './helpers/provisioning';
-import { addFirstGroupToScope, addGroupToScopeByName, gotoReports, openComboboxAndPick } from './helpers/reports';
+import { addFirstGroupToScope, addGroupToScopeByName, gotoReportBuilder, openComboboxAndPick } from './helpers/reports';
 
 // The Report Builder is gated by the app-level app.reports.read permission, which
 // the seeded Legacy Admin role carries (and Legacy User does not). Run the positive
@@ -21,7 +21,7 @@ test.describe('Report Builder', () => {
   });
 
   test('admin builds a report, sees a live preview, and downloads it', async ({ page }) => {
-    await gotoReports(page);
+    await gotoReportBuilder(page);
 
     // The reports route opts into the shell's full-height frame: the content area
     // becomes a bounded flex column and the outlet drops the default p-4 padding so
@@ -50,7 +50,7 @@ test.describe('Report Builder', () => {
   });
 
   test('disables an aggregate dimension column that is neither the aggregate-by nor a grouping level', async ({ page }) => {
-    await gotoReports(page);
+    await gotoReportBuilder(page);
 
     // Scope to a group (the disable behavior is independent of the data).
     await addFirstGroupToScope(page);
@@ -72,7 +72,7 @@ test.describe('Report Builder', () => {
   });
 
   test('adds a grouping level and a filter through the shared app-select pickers', async ({ page }) => {
-    await gotoReports(page);
+    await gotoReportBuilder(page);
     await addFirstGroupToScope(page);
 
     // Grouping: the "Add grouping level…" picker is an app-select (a combobox),
@@ -137,7 +137,7 @@ test.describe('Report Builder — receipt drill-in', () => {
   });
 
   test('drills into a receipt and opens the full receipt in a new tab', async ({ page }) => {
-    await gotoReports(page);
+    await gotoReportBuilder(page);
     await addGroupToScopeByName(page, groupName);
 
     // Cover the provisioned 2024-01-01 receipt with a generous custom range (a

--- a/desktop/e2e/report-columns.spec.ts
+++ b/desktop/e2e/report-columns.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { stubTokenRefresh } from './helpers/auth';
-import { addFirstGroupToScope, gotoReports, openComboboxAndPick } from './helpers/reports';
+import { addFirstGroupToScope, gotoReportBuilder, openComboboxAndPick } from './helpers/reports';
 
 // The Report Builder is gated by app.reports.read, carried only by Legacy Admin.
 test.use({ storageState: 'e2e/.auth/admin.json' });
@@ -12,7 +12,7 @@ test.use({ storageState: 'e2e/.auth/admin.json' });
 test.describe('Report Builder — columns', () => {
   test.beforeEach(async ({ page }) => {
     await stubTokenRefresh(page);
-    await gotoReports(page);
+    await gotoReportBuilder(page);
     await addFirstGroupToScope(page);
   });
 

--- a/desktop/e2e/report-config.spec.ts
+++ b/desktop/e2e/report-config.spec.ts
@@ -1,6 +1,6 @@
 import { expect, Page, test } from '@playwright/test';
 import { stubTokenRefresh } from './helpers/auth';
-import { addFirstGroupToScope, addGroupingLevel, gotoReports, openComboboxAndPick } from './helpers/reports';
+import { addFirstGroupToScope, addGroupingLevel, gotoReportBuilder, openComboboxAndPick } from './helpers/reports';
 
 // The Report Builder is gated by app.reports.read, carried only by Legacy Admin.
 test.use({ storageState: 'e2e/.auth/admin.json' });
@@ -19,7 +19,7 @@ async function downloadOnGenerate(page: Page) {
 test.describe('Report Builder — configuration', () => {
   test.beforeEach(async ({ page }) => {
     await stubTokenRefresh(page);
-    await gotoReports(page);
+    await gotoReportBuilder(page);
     await addFirstGroupToScope(page);
     // Settle the initial preview so per-test picks start from a stable panel.
     await expect(page.getByTestId('report-receipt-count')).toBeVisible({ timeout: 20_000 });

--- a/desktop/src/reports/models/report-command.mapper.spec.ts
+++ b/desktop/src/reports/models/report-command.mapper.spec.ts
@@ -4,6 +4,7 @@ import {
   isDimensionColumnDisabled,
   ReportBuilderValue,
   toReportRequestCommand,
+  toReportRequestCommandForSave,
 } from "./report-command.mapper";
 
 function baseValue(): ReportBuilderValue {
@@ -102,6 +103,31 @@ describe("toReportRequestCommand", () => {
     ];
     const command = toReportRequestCommand(value);
     expect(command.columns.map((c) => c.name)).toEqual(["Count", "Total"]);
+  });
+});
+
+describe("toReportRequestCommandForSave", () => {
+  it("keeps every column, including a disabled (invalid) dimension column", () => {
+    // Same failing config as the generate-mapper test: aggregate by tag, group by
+    // paid_by, plus a Category dimension that reads neither. The save mapper keeps
+    // it (so it round-trips and self-heals) where the generate mapper drops it.
+    const value = baseValue();
+    value.groupBy = ["paid_by"];
+    value.detail = { mode: ReportDetail.ModeEnum.Aggregate, by: "tag" };
+    value.columns = [
+      { id: "cat", kind: ReportColumn.KindEnum.Dimension, name: "Category", label: "Category", field: "category" },
+      { id: "cnt", kind: ReportColumn.KindEnum.Aggregate, name: "Count", label: "Count", aggFunc: ReportColumn.AggFuncEnum.Count },
+      { id: "tot", kind: ReportColumn.KindEnum.Aggregate, name: "Total", label: "Total", aggFunc: ReportColumn.AggFuncEnum.Sum, measure: "amount" },
+    ];
+
+    expect(toReportRequestCommandForSave(value).columns.map((c) => c.name)).toEqual(["Category", "Count", "Total"]);
+    // The generate mapper still drops the disabled column, proving the two diverge.
+    expect(toReportRequestCommand(value).columns.map((c) => c.name)).toEqual(["Count", "Total"]);
+  });
+
+  it("matches the generate mapper when no column is disabled", () => {
+    const value = baseValue();
+    expect(toReportRequestCommandForSave(value)).toEqual(toReportRequestCommand(value));
   });
 });
 

--- a/desktop/src/reports/models/report-command.mapper.ts
+++ b/desktop/src/reports/models/report-command.mapper.ts
@@ -118,11 +118,12 @@ function toFormats(formats: Record<ReportRequestFormat, boolean>): ReportRequest
 }
 
 /**
- * Maps the builder form's value onto the ReportRequestCommand the endpoint
- * consumes. Detail `by` is only sent in aggregate mode; the document is omitted
- * when entirely empty. The same command feeds both preview and generate.
+ * Maps the builder form's value onto a ReportRequestCommand, carrying the given
+ * columns. Detail `by` is only sent in aggregate mode; the document is omitted
+ * when entirely empty. Callers choose the column set: enabled-only for
+ * preview/generate, every column for save.
  */
-export function toReportRequestCommand(value: ReportBuilderValue): ReportRequestCommand {
+function mapReportCommand(value: ReportBuilderValue, columns: ReportColumnValue[]): ReportRequestCommand {
   const detail: ReportDetail = { mode: value.detail.mode };
   if (value.detail.mode === ReportDetail.ModeEnum.Aggregate) {
     detail.by = value.detail.by;
@@ -135,7 +136,7 @@ export function toReportRequestCommand(value: ReportBuilderValue): ReportRequest
     filter: value.filter,
     groupBy: value.groupBy,
     detail,
-    columns: enabledReportColumns(value).map(toColumn),
+    columns: columns.map(toColumn),
     subtotals: value.subtotals,
     grandTotals: value.grandTotals,
     formats: toFormats(value.formats),
@@ -147,4 +148,25 @@ export function toReportRequestCommand(value: ReportBuilderValue): ReportRequest
   }
 
   return command;
+}
+
+/**
+ * The command sent to preview and generate: disabled (currently-invalid)
+ * dimension columns are excluded, because the engine rejects them. The same
+ * command feeds both preview and generate.
+ */
+export function toReportRequestCommand(value: ReportBuilderValue): ReportRequestCommand {
+  return mapReportCommand(value, enabledReportColumns(value));
+}
+
+/**
+ * The command persisted when saving a template. Unlike preview/generate it keeps
+ * *every* column, including ones currently disabled, so they round-trip back into
+ * the builder and re-enable when the config makes them valid again instead of
+ * being silently dropped. The backend applies the same disabled-column projection
+ * at generation time (buildReportSpec), so a stored template still generates with
+ * such a column omitted.
+ */
+export function toReportRequestCommandForSave(value: ReportBuilderValue): ReportRequestCommand {
+  return mapReportCommand(value, value.columns);
 }

--- a/desktop/src/reports/models/report-form.factory.spec.ts
+++ b/desktop/src/reports/models/report-form.factory.spec.ts
@@ -4,7 +4,7 @@ import { FormArray, FormBuilder } from "@angular/forms";
 import { UntilDestroy } from "@ngneat/until-destroy";
 import { FilterOperation, ReportColumn, ReportDetail, ReportPeriod, ReportRequestCommand } from "../../open-api";
 import { buildReceiptFilterForm } from "../../utils/receipt-filter";
-import { ReportBuilderValue, toReportRequestCommand } from "./report-command.mapper";
+import { ReportBuilderValue, toReportRequestCommand, toReportRequestCommandForSave } from "./report-command.mapper";
 import { buildReportFormFromCommand, readStringArray } from "./report-form.factory";
 
 // buildReceiptFilterForm wires untilDestroyed subscriptions, so it needs an
@@ -64,6 +64,40 @@ describe("buildReportFormFromCommand", () => {
     };
 
     expect(roundTrip(command)).toEqual(command);
+  });
+
+  it("preserves a disabled dimension column through a save round-trip while generate still drops it", () => {
+    // A stored template whose config holds a currently-disabled dimension column:
+    // aggregate by tag, group by paid_by, plus a Category dimension reading neither.
+    const command: ReportRequestCommand = {
+      name: "Has a disabled column",
+      groupIds: ["1"],
+      period: { preset: ReportPeriod.PresetEnum.ThisMonth },
+      filter: canonicalFilter({}),
+      groupBy: ["paid_by"],
+      detail: { mode: ReportDetail.ModeEnum.Aggregate, by: "tag" },
+      columns: [
+        { kind: ReportColumn.KindEnum.Dimension, name: "Category", label: "Category", field: "category" },
+        { kind: ReportColumn.KindEnum.Dimension, name: "Tag", label: "Tag", field: "tag" },
+        { kind: ReportColumn.KindEnum.Aggregate, name: "Total", label: "Total", aggFunc: ReportColumn.AggFuncEnum.Sum, measure: "amount" },
+      ],
+      subtotals: false,
+      grandTotals: false,
+      formats: [ReportRequestCommand.FormatsEnum.Csv],
+    };
+
+    const form = buildReportFormFromCommand(fb, host, command);
+
+    // The save mapper keeps every column, so hydrate -> save is a fixpoint: the
+    // disabled Category column survives the round-trip instead of being lost.
+    expect(toReportRequestCommandForSave(form.getRawValue() as ReportBuilderValue)).toEqual(command);
+
+    // The generate mapper still drops the disabled Category dimension (Tag is the
+    // aggregate-by, so it stays), proving the two paths diverge as intended.
+    expect(toReportRequestCommand(form.getRawValue() as ReportBuilderValue).columns.map((c) => c.name)).toEqual([
+      "Tag",
+      "Total",
+    ]);
   });
 
   it("round-trips a custom-period records command with no document and an amount BETWEEN filter", () => {

--- a/desktop/src/reports/report-builder/report-builder.component.spec.ts
+++ b/desktop/src/reports/report-builder/report-builder.component.spec.ts
@@ -197,6 +197,43 @@ describe("ReportBuilderComponent", () => {
     expect(snackbar.success).toHaveBeenCalledWith("Template updated");
   });
 
+  it("persists every column on save, including a disabled one, so a reopen self-heals", () => {
+    // The stored config carries a currently-disabled dimension column: aggregate by
+    // tag, group by paid_by, plus a Category dimension that reads neither. Save must
+    // keep it (round-trip) rather than silently dropping it. Tag (the aggregate-by)
+    // and Total stay enabled — proving only the disabled one would have been at risk.
+    const configuration: ReportRequestCommand = {
+      name: "Self-heal",
+      groupIds: ["1"],
+      period: { preset: ReportPeriod.PresetEnum.ThisMonth },
+      filter: {},
+      groupBy: ["paid_by"],
+      detail: { mode: ReportDetail.ModeEnum.Aggregate, by: "tag" },
+      columns: [
+        { kind: ReportColumn.KindEnum.Dimension, name: "Category", label: "Category", field: "category" },
+        { kind: ReportColumn.KindEnum.Dimension, name: "Tag", label: "Tag", field: "tag" },
+        { kind: ReportColumn.KindEnum.Aggregate, name: "Total", label: "Total", aggFunc: ReportColumn.AggFuncEnum.Sum, measure: "amount" },
+      ],
+      subtotals: false,
+      grandTotals: false,
+      formats: [ReportRequestCommand.FormatsEnum.Csv],
+    };
+    const template: ReportTemplate = {
+      id: 9,
+      name: "Self-heal",
+      createdAt: "2026-01-01T00:00:00Z",
+      configuration,
+      configurationVersion: 1,
+    };
+    activatedRoute.snapshot.data = { template };
+
+    const local = TestBed.createComponent(ReportBuilderComponent).componentInstance;
+    local.saveTemplate();
+
+    const savedCommand = runner.updateTemplate.mock.calls[0][1] as ReportRequestCommand;
+    expect(savedCommand.columns.map((column) => column.name)).toEqual(["Category", "Tag", "Total"]);
+  });
+
   describe("Save/Generate permission gates honor the -All variants", () => {
     // The matcher treats "…create" and "…createAll" as unrelated keys, so gating on the
     // base key alone would hide the control from a role holding only the "*All" variant.

--- a/desktop/src/reports/report-builder/report-builder.component.ts
+++ b/desktop/src/reports/report-builder/report-builder.component.ts
@@ -13,7 +13,12 @@ import { UntilDestroy } from "@ngneat/until-destroy";
 import { Store } from "@ngxs/store";
 import { EMPTY, catchError, debounceTime, finalize, startWith, switchMap, take, tap } from "rxjs";
 import { Permission, ReportPeriod, ReportRequestCommand, ReportTemplate } from "../../open-api";
-import { enabledReportColumns, ReportBuilderValue, toReportRequestCommand } from "../models/report-command.mapper";
+import {
+  enabledReportColumns,
+  ReportBuilderValue,
+  toReportRequestCommand,
+  toReportRequestCommandForSave,
+} from "../models/report-command.mapper";
 import { SnackbarService } from "../../services";
 import { AuthState } from "../../store";
 import { buildReportForm, buildReportFormFromCommand } from "../models/report-form.factory";
@@ -177,7 +182,7 @@ export class ReportBuilderComponent {
     }
     this.saving.set(true);
     const loaded = this.loadedTemplate;
-    const command = this.currentCommand();
+    const command = this.commandForSave();
     const request$ = loaded
       ? this.runner.updateTemplate(loaded.id, command)
       : this.runner.saveTemplate(command);
@@ -195,6 +200,13 @@ export class ReportBuilderComponent {
 
   private currentCommand(): ReportRequestCommand {
     return toReportRequestCommand(this.form.getRawValue() as ReportBuilderValue);
+  }
+
+  // The command persisted on save keeps every column, including currently-disabled
+  // ones, so they round-trip into the builder and self-heal; preview and generate
+  // still send enabled-only columns via currentCommand().
+  private commandForSave(): ReportRequestCommand {
+    return toReportRequestCommandForSave(this.form.getRawValue() as ReportBuilderValue);
   }
 
   private isRunnable(): boolean {


### PR DESCRIPTION
Two fixes from a pre-merge review of the reporting feature, both in this one PR (no stacking).

## HIGH — bound arithmetic magnitude (prevents an OOM crash)
Arithmetic report columns may reference one another, and the column count was uncapped, so a spec could chain squaring (`c1 = c0*c0`, `c2 = c1*c1`, …) to grow one decimal's coefficient without limit — hundreds of megabytes within ~30 tiny columns, exhausting memory during preview/generation and taking the shared API down for every tenant.

- `evalBinary` now bounds every computed value's magnitude (coefficient digit count **and** exponent), collapsing an over-large intermediate to a null cell per the engine's "correct or null, never wrong" contract. Because each column reads the previous column's already-bounded value, this transitively bounds every downstream operand; it also closes a large-exponent chain that could otherwise overflow shopspring's int32 exponent to a silently-wrong number.
- Capped the declared column count in `ReportRequestCommand` validation (clean 400 instead of a silent null).
- Tests: an end-to-end engine test (chained squaring collapses, `Run` stays cheap), eval-layer coverage of both growth modes, and a column-count validation test. Re-anchored the two division mutation-check entries onto the new call, added an `exponent-guard-removed` mutation, and fixed a pre-existing stale `meta-params` anchor — all 44 mutations caught.

Also reconciled the `api/CLAUDE.md` and swagger `/report/preview` docs with the app-level `app.reports.read`/`readAll` gate the preview endpoint enforces (was previously documented as group-scoped only).

## MED — persist disabled columns so saved templates self-heal
The builder greys out a dimension column that's currently invalid (aggregate mode, a field that isn't the aggregate dimension or a grouping level) and excludes it from preview/generate — promising in-UI that "nothing is removed, it re-enables when valid." But Save persisted that same enabled-only command, so a disabled column was silently dropped and lost on reopen.

- Frontend: split the request mapper — `toReportRequestCommand` still sends enabled-only columns for preview/generate; a new `toReportRequestCommandForSave` keeps every column, and the builder's Save/Update use it. A disabled column now round-trips into a reopened template and re-enables when the config makes it valid again.
- Backend: `buildReportSpec` projects out a disabled dimension column before running the engine (`isDisabledDimensionColumn`, mirroring the desktop rule and the engine's own `ErrLabelColumnUnresolvable`). So a stored template that carries one still generates — verbatim, including via `POST /report/template/{id}/generate` (the list's Generate) — with the column omitted instead of a 400.
- Tests: the projection (aggregate drops the unresolvable column, records keeps all); the save mapper keeps all columns while generate drops them; a save-mapper hydration round-trip preserving a disabled column; and the builder persisting every column on save.

## Verification
- Backend: full `go test ./...` green; engine `mutation-check.sh` = 45/45 caught.
- Frontend: all reports specs green (`npx jest src/reports`); production build clean (strict template typecheck).
- E2e: **fixed in this PR.** The builder-suite specs (`report-builder`/`report-config`/`report-columns`) were failing at the shared `addFirstGroupToScope` precondition — a stale-spec bug from #632, which repurposed the `gotoReports` helper to the new `/reports` templates list (moving the builder to `/reports/new` behind a new `gotoReportBuilder`) but never migrated those three specs. They now open the builder route; **all 29 report builder + list e2e tests pass**.
- Review: addressed CodeRabbit's two comments — the arithmetic-bound tests now assert against a test-local ceiling (independent of the production constant), and `evalRound` routes through the same `boundedNum` magnitude guard (+ regression test and a `round-guard-removed` mutation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Report templates now preserve disabled dimension columns when saved and reopened.
  - Preview and generation automatically omit dimension columns that can’t be resolved in aggregate mode.
  - Report requests now support up to 100 columns.
- **Bug Fixes**
  - Computed arithmetic and rounding results are now magnitude-bounded to prevent runaway numeric growth, returning null when out of bounds.
- **Documentation**
  - Updated report builder and preview docs to clarify required app-level permissions for previews and the behavior of disabled-dimension columns in aggregate mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
