### PR TITLE
feat(reporting): Report dashboard widget (view + gated download)

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -777,6 +777,23 @@ declared on the handler as an `AnyAppPermissions` any-of and ANDed with the per-
 `group.reports.read` — so the builder's live feedback loop is reachable by exactly the users who can
 open the builder, and preview is never merely group-scoped.
 
+**`POST /api/report/template/{id}/render`** backs the **dashboard report widget** (a view-only widget
+that pins a saved template — see `desktop/CLAUDE.md` → "Reports"). It mirrors
+`GenerateReportFromTemplate` (loads the stored config server-side) but emits the same JSON
+`ReportPreviewResponse { html, receiptCount, allowedActions }` as `/preview`, with two deliberate
+differences from the builder preview: it renders the **full dataset** (`ReportService.RenderTemplateForUser`
+calls the shared `renderHTML` helper with `rowLimit = 0`, like `Generate` — **not** the capped
+`reportPreviewRowCap` sample the builder's `Preview` uses), and it **returns restricted-notice HTML at a
+normal 200** (with empty `allowedActions`) when the caller may not view the template or it was deleted,
+rather than a 403/404. That's because the widget always drops whatever HTML it gets into its sandboxed
+iframe, so there is no client-side "restricted" branch. Authorization is resolved **in the service** via
+`PermissionService.AllowedActionsForTemplate` (the single source: the base/`*All` app perms + the
+per-group ceiling + the per-template matrix); a result lacking `"read"` yields the restricted notice, and
+the returned `allowedActions` (which include `"generate"` iff the caller may generate) gate the widget's
+download button off the server result — the download itself reuses the enforcing
+`/report/template/{id}/generate`. The `restrictedReportHTML` notice and the extracted `renderHTML` helper
+(shared by `Preview` and `RenderTemplateForUser`) live in `services/report_service.go`.
+
 **Custom currency formatting.** `buildModel` loads System Settings (`SystemSettingsRepository.GetSystemSettings`,
 a get-or-create singleton) and passes the app's currency configuration — symbol, symbol position (START/END),
 thousands/decimal separators, and hide-decimal-places — through `MetaInput.Currency` (mapped by

--- a/api/internal/handlers/report.go
+++ b/api/internal/handlers/report.go
@@ -537,6 +537,49 @@ func GenerateReportFromTemplate(w http.ResponseWriter, r *http.Request) {
 	HandleRequest(handler)
 }
 
+// RenderReportTemplate renders a saved template as full-dataset HTML for the
+// dashboard report widget. It mirrors GenerateReportFromTemplate — loading the
+// stored configuration server-side — but emits a JSON { html, receiptCount,
+// allowedActions } body (the report's own rendered HTML over the full dataset)
+// instead of a downloadable file. Unlike the other template handlers it does NOT
+// use authorizeTemplateAction (which writes 403/404): when the caller may not view
+// the template, or it was deleted, the service returns restricted-notice HTML at a
+// normal 200 — the widget always drops whatever HTML it gets into its iframe.
+// AllowedActions lets the widget gate its download button off the server result.
+func RenderReportTemplate(w http.ResponseWriter, r *http.Request) {
+	handler := structs.Handler{
+		ErrorMessage: "Error rendering report template",
+		Writer:       w,
+		Request:      r,
+		ResponseType: constants.ApplicationJson,
+		HandlerFunction: func(w http.ResponseWriter, r *http.Request) (int, error) {
+			token := structs.GetClaims(r)
+			id := chi.URLParam(r, "id")
+
+			preview, err := services.NewReportService(nil).RenderTemplateForUser(token.UserId, id)
+			if err != nil {
+				var specErr *services.ReportSpecError
+				if errors.As(err, &specErr) {
+					utils.WriteCustomErrorResponse(w, "Invalid report configuration: "+specErr.Error(), http.StatusBadRequest)
+					return 0, nil
+				}
+				return http.StatusInternalServerError, err
+			}
+
+			bytes, err := utils.MarshalResponseData(preview)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			w.WriteHeader(http.StatusOK)
+			w.Write(bytes)
+			return 0, nil
+		},
+	}
+
+	HandleRequest(handler)
+}
+
 // GetReportTemplateOptions returns every report template as a lightweight
 // {id, name, groupIds} option for the role-form access matrix. It is gated on
 // app.roles.read (the admin role editor), NOT app.reports.read: the admin building a

--- a/api/internal/handlers/report.go
+++ b/api/internal/handlers/report.go
@@ -546,6 +546,17 @@ func GenerateReportFromTemplate(w http.ResponseWriter, r *http.Request) {
 // the template, or it was deleted, the service returns restricted-notice HTML at a
 // normal 200 — the widget always drops whatever HTML it gets into its iframe.
 // AllowedActions lets the widget gate its download button off the server result.
+//
+// The absent declarative permission gate (no AppPermissions/AnyAppPermissions) is
+// deliberate: authorization is enforced in the service — RenderTemplateForUser →
+// AllowedActionsForTemplate re-resolves the caller's access on every call and
+// gates the full-dataset render behind it, returning a data-free restricted notice
+// (never the report, never an existence oracle) to anyone lacking read. A hard
+// endpoint gate would refuse those callers with a 403 instead, breaking the widget's
+// always-200 "render something graceful" contract (an orphaned widget whose owner
+// was fully de-authorized would show an error box rather than the Restricted notice).
+// This mirrors the Search / GetReceipt handlers, which likewise enforce in the
+// service rather than via declarative Handler fields.
 func RenderReportTemplate(w http.ResponseWriter, r *http.Request) {
 	handler := structs.Handler{
 		ErrorMessage: "Error rendering report template",

--- a/api/internal/handlers/report_test.go
+++ b/api/internal/handlers/report_test.go
@@ -1008,3 +1008,59 @@ func TestRenderReportTemplate_RestrictedWhenTemplateAccessRevoked(t *testing.T) 
 		t.Errorf("restricted response must carry no allowedActions, got %v", preview.AllowedActions)
 	}
 }
+
+// A stored config that is valid JSON but an invalid spec (grouping by a measure) is
+// caught by the engine as a *ReportSpecError, which the handler maps to 400 — not the
+// 500 a generic failure would produce.
+func TestRenderReportTemplate_MapsInvalidSpecToBadRequest(t *testing.T) {
+	defer tearDownReportTest()
+	repositories.CreateTestGroupWithUsers()
+	grantAppPerms(t, 1, permissions.AppReportsRead)
+	grantGroupPerms(t, 1, 1, permissions.GroupReportsRead)
+	seedReportReceipt(1, 1)
+
+	// The create path stores the command verbatim (no engine validation), so an invalid
+	// spec only surfaces when the widget renders it.
+	command := commands.ReportRequestCommand{
+		Name:     "Invalid Spec",
+		GroupIds: []string{"1"},
+		Period:   commands.ReportPeriod{Preset: "this_month"},
+		GroupBy:  []string{"amount"}, // grouping by a measure is rejected by the engine
+		Detail:   commands.ReportDetail{Mode: "records"},
+		Columns:  []commands.ReportColumn{{Kind: "dimension", Name: "Name", Label: "Name", Field: "name"}},
+		Formats:  []string{"csv"},
+	}
+	template, err := repositories.NewReportTemplateRepository(nil).CreateReportTemplate(command, 1)
+	if err != nil {
+		t.Fatalf("seed invalid-spec template: %v", err)
+	}
+
+	w, r := reportTemplateIdRequest("POST", 1, fmt.Sprint(template.ID))
+	RenderReportTemplate(w, r)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+// A stored config that is not valid JSON fails to unmarshal — a generic (non-spec)
+// error the handler maps to 500. The caller can read the template, so the render
+// reaches the unmarshal.
+func TestRenderReportTemplate_MapsMalformedConfigToServerError(t *testing.T) {
+	defer tearDownReportTest()
+	repositories.CreateTestGroupWithUsers()
+	grantAppPerms(t, 1, permissions.AppReportsRead)
+	grantGroupPerms(t, 1, 1, permissions.GroupReportsRead)
+
+	db := repositories.GetDB()
+	template := models.ReportTemplate{Name: "Corrupt", Configuration: json.RawMessage("{ not json"), ConfigurationVersion: 1}
+	if err := db.Create(&template).Error; err != nil {
+		t.Fatalf("seed template: %v", err)
+	}
+	if err := db.Create(&models.ReportTemplateGroup{ReportTemplateID: template.ID, GroupID: 1}).Error; err != nil {
+		t.Fatalf("seed template group: %v", err)
+	}
+
+	w, r := reportTemplateIdRequest("POST", 1, fmt.Sprint(template.ID))
+	RenderReportTemplate(w, r)
+
+	assertStatus(t, w, http.StatusInternalServerError)
+}

--- a/api/internal/handlers/report_test.go
+++ b/api/internal/handlers/report_test.go
@@ -945,3 +945,66 @@ func TestGetReportTemplateOptions_ForbidsWithoutRolesRead(t *testing.T) {
 
 	assertStatus(t, w, http.StatusForbidden)
 }
+
+// --- Dashboard report-widget render endpoint ---
+//
+// RenderReportTemplate has no declarative permission gate by design: it enforces
+// access in the service and returns restricted-notice HTML at 200 rather than a 403,
+// so the widget always has HTML to render (see the handler doc comment). These assert
+// the two 200 outcomes; the resolution logic itself is covered in
+// services/report_render_template_test.go and services/report_authz_test.go.
+
+func TestRenderReportTemplate_RendersWhenAuthorized(t *testing.T) {
+	defer tearDownReportTest()
+	repositories.CreateTestGroupWithUsers()
+	grantAppPerms(t, 1, permissions.AppReportsRead)
+	grantGroupPerms(t, 1, 1, permissions.GroupReportsRead)
+	seeded := seedReportTemplate(t, 1, "HTTP Report")
+	seedReportReceipt(1, 1)
+
+	w, r := reportTemplateIdRequest("POST", 1, fmt.Sprint(seeded.ID))
+	RenderReportTemplate(w, r)
+
+	assertStatus(t, w, http.StatusOK)
+	if got := w.Header().Get("Content-Type"); !strings.Contains(got, constants.ApplicationJson) {
+		t.Errorf("Content-Type = %q, want %q", got, constants.ApplicationJson)
+	}
+
+	var preview services.ReportPreview
+	if err := json.Unmarshal(w.Body.Bytes(), &preview); err != nil {
+		t.Fatalf("decode preview body: %v", err)
+	}
+	if !strings.Contains(preview.Html, "<") {
+		t.Errorf("expected rendered report HTML, got %q", preview.Html)
+	}
+	if !containsString(preview.AllowedActions, "read") {
+		t.Errorf("allowedActions = %v, want read present", preview.AllowedActions)
+	}
+}
+
+// A caller who holds base app read but lacks group.reports.read in the template's
+// group cannot view it — but the widget endpoint returns the restricted notice at
+// 200 (empty allowedActions), not the 403 the GET handler would return.
+func TestRenderReportTemplate_RestrictedWhenTemplateAccessRevoked(t *testing.T) {
+	defer tearDownReportTest()
+	repositories.CreateTestGroupWithUsers()
+	grantAppPerms(t, 1, permissions.AppReportsRead)
+	grantGroupPerms(t, 1, 1, permissions.GroupView)
+	seeded := seedReportTemplate(t, 1, "HTTP Report")
+
+	w, r := reportTemplateIdRequest("POST", 1, fmt.Sprint(seeded.ID))
+	RenderReportTemplate(w, r)
+
+	assertStatus(t, w, http.StatusOK)
+
+	var preview services.ReportPreview
+	if err := json.Unmarshal(w.Body.Bytes(), &preview); err != nil {
+		t.Fatalf("decode preview body: %v", err)
+	}
+	if !strings.Contains(preview.Html, "no longer have access") {
+		t.Errorf("expected the restricted notice HTML, got %q", preview.Html)
+	}
+	if len(preview.AllowedActions) != 0 {
+		t.Errorf("restricted response must carry no allowedActions, got %v", preview.AllowedActions)
+	}
+}

--- a/api/internal/models/widget_type.go
+++ b/api/internal/models/widget_type.go
@@ -12,6 +12,7 @@ const (
 	FILTERED_RECEIPTS WidgetType = "FILTERED_RECEIPTS"
 	GROUP_ACTIVITY    WidgetType = "GROUP_ACTIVITY"
 	PIE_CHART         WidgetType = "PIE_CHART"
+	REPORT            WidgetType = "REPORT"
 )
 
 func (widgetType *WidgetType) Scan(value string) error {
@@ -23,7 +24,8 @@ func (widgetType WidgetType) Value() (driver.Value, error) {
 	if widgetType != GROUP_SUMMARY &&
 		widgetType != FILTERED_RECEIPTS &&
 		widgetType != GROUP_ACTIVITY &&
-		widgetType != PIE_CHART {
+		widgetType != PIE_CHART &&
+		widgetType != REPORT {
 		return nil, errors.New("invalid widget type")
 	}
 	return string(widgetType), nil

--- a/api/internal/routers/report.go
+++ b/api/internal/routers/report.go
@@ -20,6 +20,7 @@ func BuildReportRouter() *chi.Mux {
 	reportRouter.Put("/template/{id}", handlers.UpdateReportTemplate)
 	reportRouter.Post("/template/{id}/duplicate", handlers.DuplicateReportTemplate)
 	reportRouter.Post("/template/{id}/generate", handlers.GenerateReportFromTemplate)
+	reportRouter.Post("/template/{id}/render", handlers.RenderReportTemplate)
 	reportRouter.Delete("/template/{id}", handlers.DeleteReportTemplate)
 
 	return reportRouter

--- a/api/internal/services/report_render_template_test.go
+++ b/api/internal/services/report_render_template_test.go
@@ -141,6 +141,34 @@ func TestReportService_RenderTemplateForUser_MissingTemplateIsRestricted(t *test
 	}
 }
 
+// A stored configuration that is not valid JSON surfaces as an error (no HTML, no
+// actions) rather than a silently blank render — a corrupt template blob fails loudly.
+// The caller can read the template, so the render reaches the unmarshal.
+func TestReportService_RenderTemplateForUser_MalformedConfigIsError(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	resetAuthzCaches()
+
+	userId := seedAppUser(t, "widget-badcfg", []string{permissions.AppReportsRead})
+	groupId, _ := joinGroup(t, userId, "Household", []string{permissions.GroupReportsRead, permissions.GroupReceiptsRead})
+
+	db := repositories.GetDB()
+	template := models.ReportTemplate{Name: "Corrupt", Configuration: json.RawMessage("{ not json"), ConfigurationVersion: 1}
+	if err := db.Create(&template).Error; err != nil {
+		t.Fatalf("seed template: %v", err)
+	}
+	if err := db.Create(&models.ReportTemplateGroup{ReportTemplateID: template.ID, GroupID: groupId}).Error; err != nil {
+		t.Fatalf("seed template group: %v", err)
+	}
+
+	preview, err := NewReportService(nil).RenderTemplateForUser(userId, utils.UintToString(template.ID))
+	if err == nil {
+		t.Fatalf("expected an error for a malformed stored configuration, got none (preview=%+v)", preview)
+	}
+	if preview.Html != "" || len(preview.AllowedActions) != 0 {
+		t.Errorf("error response must carry no HTML or actions, got html=%q actions=%v", preview.Html, preview.AllowedActions)
+	}
+}
+
 // The widget renders the FULL dataset, not the row-capped builder-preview sample:
 // with more than reportPreviewRowCap receipts, the grand total sums every receipt
 // (would read short if this path reused the preview cap).

--- a/api/internal/services/report_render_template_test.go
+++ b/api/internal/services/report_render_template_test.go
@@ -1,0 +1,184 @@
+package services
+
+import (
+	"encoding/json"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"receipt-wrangler/api/internal/commands"
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/permissions"
+	"receipt-wrangler/api/internal/repositories"
+	"receipt-wrangler/api/internal/utils"
+)
+
+// seedRenderableTemplate creates a report template whose stored configuration is a
+// real ReportRequestCommand (so RenderTemplateForUser can unmarshal and render it)
+// and indexes it under groupIds.
+func seedRenderableTemplate(t *testing.T, name string, groupIds []uint, command commands.ReportRequestCommand) uint {
+	t.Helper()
+	db := repositories.GetDB()
+
+	config, err := json.Marshal(command)
+	if err != nil {
+		t.Fatalf("marshal template config: %v", err)
+	}
+	template := models.ReportTemplate{Name: name, Configuration: config, ConfigurationVersion: 1}
+	if err := db.Create(&template).Error; err != nil {
+		t.Fatalf("seed template: %v", err)
+	}
+	for _, groupId := range groupIds {
+		if err := db.Create(&models.ReportTemplateGroup{ReportTemplateID: template.ID, GroupID: groupId}).Error; err != nil {
+			t.Fatalf("seed template group: %v", err)
+		}
+	}
+	return template.ID
+}
+
+// A user who can read AND generate the template gets the rendered report HTML, the
+// true receipt count, and an AllowedActions list containing both actions (so the
+// widget shows its download button).
+func TestReportService_RenderTemplateForUser_ReadAndGenerate(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	resetAuthzCaches()
+
+	category := loadCategory(t, makeCategory(t, "Groceries"))
+	userId := seedAppUser(t, "widget-rw", []string{permissions.AppReportsRead, permissions.AppReportsGenerate})
+	groupId, _ := joinGroup(t, userId, "Household", []string{permissions.GroupReportsRead, permissions.GroupReceiptsRead})
+	createReportReceipt(t, "h1", userId, groupId, []models.Category{category})
+	createReportReceipt(t, "h2", userId, groupId, []models.Category{category})
+	templateId := seedRenderableTemplate(t, "Widget", []uint{groupId}, aggregateReportCommand("Widget", []uint{groupId}, nil))
+
+	preview, err := NewReportService(nil).RenderTemplateForUser(userId, utils.UintToString(templateId))
+	if err != nil {
+		t.Fatalf("RenderTemplateForUser: %v", err)
+	}
+
+	if preview.ReceiptCount != 2 {
+		t.Errorf("receipt count = %d, want 2", preview.ReceiptCount)
+	}
+	if !strings.Contains(preview.Html, "<h1>Widget</h1>") || !strings.Contains(preview.Html, "Groceries") {
+		t.Errorf("expected rendered report HTML with heading + category, got:\n%s", preview.Html)
+	}
+	if !slices.Contains(preview.AllowedActions, "read") || !slices.Contains(preview.AllowedActions, "generate") {
+		t.Errorf("allowedActions = %v, want read + generate", preview.AllowedActions)
+	}
+}
+
+// A user who can read but not generate still sees the rendered report, but
+// AllowedActions omits "generate" so the widget hides its download button.
+func TestReportService_RenderTemplateForUser_ReadOnlyOmitsGenerate(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	resetAuthzCaches()
+
+	category := loadCategory(t, makeCategory(t, "Groceries"))
+	userId := seedAppUser(t, "widget-ro", []string{permissions.AppReportsRead})
+	groupId, _ := joinGroup(t, userId, "Household", []string{permissions.GroupReportsRead, permissions.GroupReceiptsRead})
+	createReportReceipt(t, "h1", userId, groupId, []models.Category{category})
+	templateId := seedRenderableTemplate(t, "Widget", []uint{groupId}, aggregateReportCommand("Widget", []uint{groupId}, nil))
+
+	preview, err := NewReportService(nil).RenderTemplateForUser(userId, utils.UintToString(templateId))
+	if err != nil {
+		t.Fatalf("RenderTemplateForUser: %v", err)
+	}
+
+	if !strings.Contains(preview.Html, "<h1>Widget</h1>") {
+		t.Errorf("expected rendered report HTML, got:\n%s", preview.Html)
+	}
+	if !slices.Contains(preview.AllowedActions, "read") {
+		t.Errorf("allowedActions = %v, want read present", preview.AllowedActions)
+	}
+	if slices.Contains(preview.AllowedActions, "generate") {
+		t.Errorf("allowedActions = %v, must omit generate (no generate permission)", preview.AllowedActions)
+	}
+}
+
+// A user without view access to the template gets the restricted notice at a normal
+// success (empty count + actions), not the report and not an error — the widget just
+// renders whatever HTML it receives.
+func TestReportService_RenderTemplateForUser_DeniedReadIsRestricted(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	resetAuthzCaches()
+
+	userId := seedAppUser(t, "widget-denied", []string{permissions.AppAccountRead})
+	groupId, _ := joinGroup(t, userId, "Household", []string{permissions.GroupReportsRead, permissions.GroupReceiptsRead})
+	createReportReceipt(t, "h1", userId, groupId, nil)
+	templateId := seedRenderableTemplate(t, "Widget", []uint{groupId}, aggregateReportCommand("Widget", []uint{groupId}, nil))
+
+	preview, err := NewReportService(nil).RenderTemplateForUser(userId, utils.UintToString(templateId))
+	if err != nil {
+		t.Fatalf("RenderTemplateForUser: %v", err)
+	}
+
+	if preview.Html != restrictedReportHTML {
+		t.Errorf("expected the restricted notice, got:\n%s", preview.Html)
+	}
+	if preview.ReceiptCount != 0 || len(preview.AllowedActions) != 0 {
+		t.Errorf("restricted response must have count 0 and no actions, got count=%d actions=%v", preview.ReceiptCount, preview.AllowedActions)
+	}
+}
+
+// A deleted (or never-existent) template resolves to the restricted notice, not an
+// error, so a widget pinned to a removed template degrades gracefully.
+func TestReportService_RenderTemplateForUser_MissingTemplateIsRestricted(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	resetAuthzCaches()
+
+	userId := seedAppUser(t, "widget-missing", []string{permissions.AppReportsRead})
+
+	preview, err := NewReportService(nil).RenderTemplateForUser(userId, "999999")
+	if err != nil {
+		t.Fatalf("RenderTemplateForUser: %v", err)
+	}
+
+	if preview.Html != restrictedReportHTML {
+		t.Errorf("expected the restricted notice for a missing template, got:\n%s", preview.Html)
+	}
+}
+
+// The widget renders the FULL dataset, not the row-capped builder-preview sample:
+// with more than reportPreviewRowCap receipts, the grand total sums every receipt
+// (would read short if this path reused the preview cap).
+func TestReportService_RenderTemplateForUser_RendersFullDataset(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	resetAuthzCaches()
+
+	userId := seedAppUser(t, "widget-full", []string{permissions.AppReportsRead})
+	groupId, _ := joinGroup(t, userId, "Household", []string{permissions.GroupReportsRead, permissions.GroupReceiptsRead})
+
+	const receiptCount = reportPreviewRowCap + 1 // one past the preview cap
+	receipts := make([]models.Receipt, receiptCount)
+	for i := range receipts {
+		receipts[i] = models.Receipt{
+			Name:         "r" + strconv.Itoa(i),
+			Amount:       decimal.NewFromInt(100),
+			Date:         time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC),
+			PaidByUserID: userId,
+			GroupId:      groupId,
+			Status:       models.OPEN,
+		}
+	}
+	if err := repositories.GetDB().CreateInBatches(receipts, 200).Error; err != nil {
+		t.Fatalf("seed receipts: %v", err)
+	}
+	templateId := seedRenderableTemplate(t, "Full", []uint{groupId}, aggregateReportCommand("Full", []uint{groupId}, nil))
+
+	preview, err := NewReportService(nil).RenderTemplateForUser(userId, utils.UintToString(templateId))
+	if err != nil {
+		t.Fatalf("RenderTemplateForUser: %v", err)
+	}
+
+	if preview.ReceiptCount != receiptCount {
+		t.Errorf("receipt count = %d, want %d", preview.ReceiptCount, receiptCount)
+	}
+	// 1001 receipts * 100 = 100,100 (the full total). A capped render would sum only
+	// the first 1000 → 100,000, which does not contain "100,100".
+	if !strings.Contains(preview.Html, "100,100") {
+		t.Errorf("widget render must include the full dataset (grand total 100,100), got:\n%s", preview.Html)
+	}
+}

--- a/api/internal/services/report_service.go
+++ b/api/internal/services/report_service.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"slices"
@@ -44,10 +46,14 @@ type GeneratedReport struct {
 
 // ReportPreview is the rendered HTML for the live builder preview plus the true
 // number of receipts the current configuration covers (reported even when the
-// rendered sample is capped).
+// rendered sample is capped). AllowedActions is populated only by the dashboard
+// report-widget render path (RenderTemplateForUser) — it carries the actions the
+// caller may perform on the template so the widget can gate its download button;
+// the builder's own Preview leaves it nil (omitted).
 type ReportPreview struct {
-	Html         string `json:"html"`
-	ReceiptCount int    `json:"receiptCount"`
+	Html           string   `json:"html"`
+	ReceiptCount   int      `json:"receiptCount"`
+	AllowedActions []string `json:"allowedActions,omitempty"`
 }
 
 // reportPreviewRowCap bounds how many receipt rows a preview feeds to the engine.
@@ -100,7 +106,15 @@ func (service ReportService) Generate(userId uint, command commands.ReportReques
 // (reportPreviewRowCap). The same per-group authorization as Generate is the
 // caller's responsibility.
 func (service ReportService) Preview(userId uint, command commands.ReportRequestCommand) (ReportPreview, error) {
-	build, err := service.buildModel(userId, command, time.Now(), reportPreviewRowCap)
+	return service.renderHTML(userId, command, reportPreviewRowCap)
+}
+
+// renderHTML runs the shared engine pipeline and renders the report as HTML. It
+// backs both the row-capped builder preview (rowLimit = reportPreviewRowCap) and
+// the dashboard report widget, which renders the full dataset (rowLimit = 0, like
+// Generate). ReceiptCount is always the true pre-cap total.
+func (service ReportService) renderHTML(userId uint, command commands.ReportRequestCommand, rowLimit int) (ReportPreview, error) {
+	build, err := service.buildModel(userId, command, time.Now(), rowLimit)
 	if err != nil {
 		return ReportPreview{}, err
 	}
@@ -111,6 +125,77 @@ func (service ReportService) Preview(userId uint, command commands.ReportRequest
 	}
 
 	return ReportPreview{Html: string(html), ReceiptCount: build.receiptCount}, nil
+}
+
+// restrictedReportHTML is the self-contained document the report widget renders in
+// place of a report when the caller may not view the pinned template (access
+// revoked, or the template was deleted). It inlines all styling and references no
+// external resources or scripts, so it renders inside the widget's sandboxed
+// iframe (sandbox="allow-same-origin", scripts disabled) exactly like real report
+// output.
+const restrictedReportHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<style>
+  html, body { margin: 0; height: 100%; }
+  body {
+    display: flex; align-items: center; justify-content: center;
+    min-height: 260px; padding: 24px; box-sizing: border-box;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    color: #5f6368; text-align: center;
+  }
+  .notice { max-width: 360px; }
+  .notice__icon { font-size: 40px; line-height: 1; margin-bottom: 12px; }
+  .notice__title { font-size: 16px; font-weight: 600; color: #3c4043; margin: 0 0 6px; }
+  .notice__body { font-size: 13px; margin: 0; }
+</style>
+</head>
+<body>
+  <div class="notice">
+    <div class="notice__icon" aria-hidden="true">&#128274;</div>
+    <p class="notice__title">Restricted</p>
+    <p class="notice__body">You no longer have access to this report.</p>
+  </div>
+</body>
+</html>`
+
+// RenderTemplateForUser renders a saved report template as full-dataset HTML for
+// the dashboard report widget, re-resolving the caller's access to the template on
+// every call. Unlike the builder's Preview it feeds the full dataset to the engine
+// (no row cap) so the widget shows the complete report, and — because the widget
+// always renders whatever HTML it gets back — a revoked/deleted template yields the
+// restrictedReportHTML notice at a normal 200 (empty AllowedActions) rather than an
+// error. AllowedActions carries the actions the caller may perform on the template
+// so the widget can gate its download button off the server result.
+func (service ReportService) RenderTemplateForUser(userId uint, templateId string) (ReportPreview, error) {
+	template, err := repositories.NewReportTemplateRepository(service.TX).GetReportTemplateById(templateId)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ReportPreview{Html: restrictedReportHTML}, nil
+		}
+		return ReportPreview{}, err
+	}
+
+	actions, err := NewPermissionService(service.TX).AllowedActionsForTemplate(userId, template.ID)
+	if err != nil {
+		return ReportPreview{}, err
+	}
+	if !slices.Contains(actions, "read") {
+		return ReportPreview{Html: restrictedReportHTML}, nil
+	}
+
+	var command commands.ReportRequestCommand
+	if err := json.Unmarshal(template.Configuration, &command); err != nil {
+		return ReportPreview{}, err
+	}
+
+	preview, err := service.renderHTML(userId, command, 0)
+	if err != nil {
+		return ReportPreview{}, err
+	}
+	preview.AllowedActions = actions
+	return preview, nil
 }
 
 // reportBuild is the engine output plus the render inputs both Generate and

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -494,6 +494,42 @@ paths:
       security:
         - bearerAuth: [ ]
         - apiKeyAuth: [ ]
+  /report/template/{id}/render:
+    post:
+      tags:
+        - Report
+      summary: Render a saved template as HTML for the dashboard report widget
+      description:
+        Renders a saved report template by id as a self-contained HTML document
+        over the full dataset (unlike /report/preview, which caps the sample) for
+        the dashboard report widget, loading the stored configuration server-side.
+        Re-resolves the caller's access on every call; when the caller may not view
+        the template (or it was deleted) a restricted-notice HTML document is
+        returned at 200 with empty allowedActions, so the widget always has HTML to
+        render. allowedActions carries the actions the caller may perform (drives
+        the widget's download button).
+      operationId: renderReportTemplate
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: Id of the report template to render
+      responses:
+        200:
+          description: The rendered report (or restricted notice) HTML
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReportPreviewResponse"
+        400:
+          $ref: "#/components/responses/BadRequest"
+        500:
+          $ref: "#/components/responses/Internal"
+      security:
+        - bearerAuth: [ ]
+        - apiKeyAuth: [ ]
   /category/{categoryName}:
     parameters:
       - in: path
@@ -3542,6 +3578,7 @@ components:
         - "FILTERED_RECEIPTS"
         - "GROUP_ACTIVITY"
         - "PIE_CHART"
+        - "REPORT"
     ChartGrouping:
       type: string
       enum:
@@ -6103,6 +6140,15 @@ components:
         receiptCount:
           type: integer
           description: The number of receipts the current configuration covers.
+        allowedActions:
+          type: array
+          description: >-
+            The actions the requesting user may perform on the template
+            (read, generate, update, delete, duplicate), resolved per user and
+            populated only by the dashboard report-widget render endpoint. Drives
+            the widget's download button.
+          items:
+            type: string
     ReportTemplate:
       allOf:
         - $ref: "#/components/schemas/BaseModel"

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -709,6 +709,30 @@ endpoint); the builder's own ad-hoc generate still gates on `app.reports.generat
   the same flag for any future full-bleed page. The report name appears as the rendered heading when
   Document → Title is left blank (the engine falls back to the report name).
 
+### Report dashboard widget
+
+A **view-only** dashboard widget (`WidgetType.Report`, `src/dashboard/report-widget/`) that pins a saved
+report template and renders its HTML inside a **sandboxed `<iframe srcdoc>`** (`sandbox="allow-same-origin"`,
+scripts disabled; `bypassSecurityTrustHtml`) — the same technique as the builder preview, but the widget
+copies the ~10-line idiom locally rather than reusing the builder-coupled `ReportPreviewPanelComponent`.
+The widget stores only `{ reportTemplateId }` in its configuration blob and calls
+`ReportRunnerService.renderTemplate(id)` → `POST /report/template/{id}/render` (see `api/CLAUDE.md`), which
+renders the **full dataset** (not the capped builder preview) and re-resolves access server-side.
+
+- **Restricted state is backend-driven**: a revoked/deleted template comes back as restricted-notice HTML
+  at 200, which the widget renders like any other HTML — there is no special client "restricted" branch
+  (only a generic error state for a network failure or a missing `reportTemplateId`). The report renders
+  in a height-capped, internally-scrolling stage so a long report doesn't blow out the tile.
+- **Download button** (`data-testid="report-widget-download"`): shown **only when** the server-returned
+  `allowedActions` include `"generate"` — gated purely on the server result, **never** re-AND-ed with a
+  client `*hasAppPermission` (same rule as the templates-list row buttons). It calls
+  `ReportRunnerService.downloadTemplateById(id)` (resolve template → `generateFromTemplateById`, the
+  enforcing `/report/template/{id}/generate` path).
+- **Authoring** (`dashboard-form`): the **Report** widget-type option is filtered out unless the user holds
+  `app.reports.read`/`readAll` (`availableWidgetTypeOptions`), and its config is a single template picker
+  (`app-select`) whose options come from `ReportService.getReportTemplates` — server-filtered to the
+  caller's viewable templates (`reportTemplateOptions`, loaded in `ngOnInit`, `catchError`→empty).
+
 ## Testing Requirements
 
 **All new code must have accompanying unit tests.**

--- a/desktop/src/dashboard/constants/widget-options.ts
+++ b/desktop/src/dashboard/constants/widget-options.ts
@@ -17,5 +17,9 @@ export const widgetTypeOptions: FormOption[] = [
   {
     value: WidgetType.PieChart,
     displayValue: "Pie Chart",
+  },
+  {
+    value: WidgetType.Report,
+    displayValue: "Report",
   }
 ];

--- a/desktop/src/dashboard/dashboard-form/dashboard-form.component.html
+++ b/desktop/src/dashboard/dashboard-form/dashboard-form.component.html
@@ -56,7 +56,7 @@
         [inputFormControl]="
                       form | formGet : 'widgets.' + i + '.widgetType'
                     "
-        [options]="widgetTypeOptions"
+        [options]="availableWidgetTypeOptions()"
       ></app-select>
       <ng-container
         [ngSwitch]="widgets.controls[i].value.widgetType"
@@ -101,6 +101,17 @@
               (formCommand)="handleFormCommand($event)"
             ></app-receipt-filter>
           </app-form-section>
+        </ng-container>
+        <ng-container *ngSwitchCase="WidgetType.Report">
+          <app-select
+            label="Report"
+            optionValueKey="id"
+            optionDisplayKey="name"
+            [inputFormControl]="
+              form | formGet : 'widgets.' + i + '.configuration.reportTemplateId'
+            "
+            [options]="reportTemplateOptions()"
+          ></app-select>
         </ng-container>
       </ng-container>
       <app-dialog-footer

--- a/desktop/src/dashboard/dashboard-form/dashboard-form.component.spec.ts
+++ b/desktop/src/dashboard/dashboard-form/dashboard-form.component.spec.ts
@@ -1,5 +1,5 @@
 import { provideHttpClientTesting } from "@angular/common/http/testing";
-import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
+import { CUSTOM_ELEMENTS_SCHEMA, provideZonelessChangeDetection } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ReactiveFormsModule } from "@angular/forms";
 import { MatDialog, MatDialogRef } from "@angular/material/dialog";
@@ -28,6 +28,7 @@ describe("DashboardFormComponent", () => {
         PipesModule,
         ReactiveFormsModule],
     providers: [
+        provideZonelessChangeDetection(),
         DashboardService,
         MatDialog,
         {

--- a/desktop/src/dashboard/dashboard-form/dashboard-form.component.spec.ts
+++ b/desktop/src/dashboard/dashboard-form/dashboard-form.component.spec.ts
@@ -6,7 +6,7 @@ import { MatDialog, MatDialogRef } from "@angular/material/dialog";
 import { MatSnackBarModule } from "@angular/material/snack-bar";
 import { NgxsModule, Store } from "@ngxs/store";
 import { of } from "rxjs";
-import { Dashboard, DashboardService } from "../../open-api";
+import { Dashboard, DashboardService, ReportService, WidgetType } from "../../open-api";
 import { PipesModule } from "../../pipes";
 import { SnackbarService } from "../../services";
 import { EditableListComponent } from "../../shared-ui/editable-list/editable-list.component";
@@ -122,5 +122,56 @@ describe("DashboardFormComponent", () => {
       widgets: [],
     } as any);
     expect(snackbarSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers the Report widget type and loads viewable templates when the user can read reports", () => {
+    const listSpy = jest
+      .spyOn(TestBed.inject(ReportService), "getReportTemplates")
+      .mockReturnValue(
+        of({ data: [{ id: 3, name: "Monthly" }], totalCount: 1 } as any)
+      );
+    store.reset({
+      groups: { selectedGroupId: "1" },
+      auth: { appPermissions: ["app.reports.read"] },
+    });
+
+    component.ngOnInit();
+
+    expect(
+      component.availableWidgetTypeOptions().some((o) => o.value === WidgetType.Report)
+    ).toBe(true);
+    expect(listSpy).toHaveBeenCalledTimes(1);
+    expect(component.reportTemplateOptions()).toEqual([{ id: 3, name: "Monthly" }]);
+  });
+
+  it("hides the Report widget type and skips the template load without report-read", () => {
+    const listSpy = jest.spyOn(TestBed.inject(ReportService), "getReportTemplates");
+    store.reset({
+      groups: { selectedGroupId: "1" },
+      auth: { appPermissions: [] },
+    });
+
+    component.ngOnInit();
+
+    expect(
+      component.availableWidgetTypeOptions().some((o) => o.value === WidgetType.Report)
+    ).toBe(false);
+    expect(listSpy).not.toHaveBeenCalled();
+  });
+
+  it("builds a required reportTemplateId control for a Report widget", () => {
+    store.reset({
+      groups: { selectedGroupId: "1" },
+      auth: { appPermissions: ["app.reports.read"] },
+    });
+    component.ngOnInit();
+
+    component.addWidget();
+    const widget = component.widgets.at(0);
+    widget.get("widgetType")?.setValue(WidgetType.Report);
+
+    const configuration = widget.get("configuration");
+    expect(configuration?.get("reportTemplateId")).toBeTruthy();
+    expect(configuration?.get("reportTemplateId")?.valid).toBe(false); // required, still empty
   });
 });

--- a/desktop/src/dashboard/dashboard-form/dashboard-form.component.ts
+++ b/desktop/src/dashboard/dashboard-form/dashboard-form.component.ts
@@ -1,12 +1,13 @@
-import { Component, OnInit, ViewEncapsulation, computed, viewChildren, viewChild } from "@angular/core";
+import { Component, OnInit, ViewEncapsulation, computed, signal, viewChildren, viewChild } from "@angular/core";
 import { FormArray, FormBuilder, FormGroup, Validators } from "@angular/forms";
 import { MatDialogRef } from "@angular/material/dialog";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { Store } from "@ngxs/store";
-import { take, tap } from "rxjs";
+import { catchError, of, take, tap } from "rxjs";
 import { ReceiptFilterComponent } from "src/shared-ui/receipt-filter/receipt-filter.component";
+import { FormOption } from "../../interfaces/form-option.interface";
 import { BaseFormComponent } from "../../form/index";
-import { Category, ChartGrouping, Dashboard, DashboardService, Tag, Widget, WidgetType } from "../../open-api";
+import { Category, ChartGrouping, Dashboard, DashboardService, PagedRequestCommand, Permission, ReportService, ReportTemplate, SortDirection, Tag, Widget, WidgetType } from "../../open-api";
 import { SnackbarService } from "../../services";
 import { EditableListComponent } from "../../shared-ui/editable-list/editable-list.component";
 import { AuthState, GroupState } from "../../store";
@@ -56,6 +57,26 @@ export class DashboardFormComponent extends BaseFormComponent implements OnInit 
       : this.store.selectSnapshot(AuthState.groupTags(groupId));
   });
 
+  // Only offer the Report widget type to users who can view report templates —
+  // otherwise the template picker would be empty. Resolved through the AuthState
+  // selector, exactly like the report builder / templates-list gate.
+  private readonly canSelectReport = this.store.selectSignal(
+    AuthState.hasAnyAppPermission([
+      Permission.AppReportsRead,
+      Permission.AppReportsReadAll,
+    ])
+  );
+
+  public readonly availableWidgetTypeOptions = computed<FormOption[]>(() =>
+    this.canSelectReport()
+      ? widgetTypeOptions
+      : widgetTypeOptions.filter((option) => option.value !== WidgetType.Report)
+  );
+
+  // The templates the user may view, as determined by the API (the list endpoint is
+  // server-filtered to the caller's visible templates) — the Report widget's picker.
+  public readonly reportTemplateOptions = signal<{ id: number; name: string }[]>([]);
+
   public get widgets(): FormArray {
     return this.form.get("widgets") as FormArray;
   }
@@ -65,6 +86,7 @@ export class DashboardFormComponent extends BaseFormComponent implements OnInit 
     private formBuilder: FormBuilder,
     private store: Store,
     private snackbarService: SnackbarService,
+    private reportService: ReportService,
     private matDialogRef: MatDialogRef<DashboardFormComponent>
   ) {
     super();
@@ -74,6 +96,35 @@ export class DashboardFormComponent extends BaseFormComponent implements OnInit 
   public ngOnInit(): void {
     this.originalWidgets = Array.from(this.dashboard?.widgets ?? []);
     this.initForm();
+    if (this.canSelectReport()) {
+      this.loadReportTemplates();
+    }
+  }
+
+  // Populate the Report widget's template picker from the server-filtered list, so
+  // the choices are exactly the templates the user may view. A read failure yields
+  // an empty picker rather than an error (the user can still add other widgets).
+  private loadReportTemplates(): void {
+    const command: PagedRequestCommand = {
+      page: 1,
+      pageSize: 200,
+      orderBy: "name",
+      sortDirection: SortDirection.Asc,
+    };
+    this.reportService
+      .getReportTemplates(command)
+      .pipe(
+        take(1),
+        catchError(() => of({ data: [], totalCount: 0 })),
+        tap((paged) => {
+          const templates = (paged.data ?? []) as unknown as ReportTemplate[];
+          this.reportTemplateOptions.set(
+            templates.map((template) => ({ id: template.id, name: template.name }))
+          );
+        }),
+        untilDestroyed(this)
+      )
+      .subscribe();
   }
 
   public initForm(): void {
@@ -106,6 +157,13 @@ export class DashboardFormComponent extends BaseFormComponent implements OnInit 
           configuration: this.buildPieChartConfigForm(widget.configuration),
         });
         break;
+      case WidgetType.Report:
+        formGroup = this.formBuilder.group({
+          name: [widget.name, Validators.required],
+          widgetType: [widget.widgetType, Validators.required],
+          configuration: this.buildReportConfigForm(widget.configuration),
+        });
+        break;
       default:
         formGroup = this.formBuilder.group({
           name: [widget.name, Validators.required],
@@ -125,6 +183,9 @@ export class DashboardFormComponent extends BaseFormComponent implements OnInit 
           } else if (widgetType === WidgetType.PieChart) {
             formGroup.removeControl("configuration");
             formGroup.addControl("configuration", this.buildPieChartConfigForm({}));
+          } else if (widgetType === WidgetType.Report) {
+            formGroup.removeControl("configuration");
+            formGroup.addControl("configuration", this.buildReportConfigForm({}));
           } else {
             formGroup.removeControl("configuration");
           }
@@ -138,6 +199,12 @@ export class DashboardFormComponent extends BaseFormComponent implements OnInit 
     return this.formBuilder.group({
       chartGrouping: [config?.chartGrouping ?? ChartGrouping.Categories, Validators.required],
       filter: buildReceiptFilterForm(config?.filter ?? {}, this),
+    });
+  }
+
+  private buildReportConfigForm(config: any): FormGroup {
+    return this.formBuilder.group({
+      reportTemplateId: [config?.reportTemplateId ?? null, Validators.required],
     });
   }
 

--- a/desktop/src/dashboard/dashboard.module.ts
+++ b/desktop/src/dashboard/dashboard.module.ts
@@ -24,6 +24,7 @@ import { DashboardComponent } from "./dashboard/dashboard.component";
 import { FilteredReceiptsComponent } from "./filtered-receipts/filtered-receipts.component";
 import { GroupDashboardsComponent } from "./group-dashboards/group-dashboards.component";
 import { PieChartComponent } from "./pie-chart/pie-chart.component";
+import { ReportWidgetComponent } from "./report-widget/report-widget.component";
 import { WidgetTypePipe } from "./widget-type.pipe";
 
 @NgModule({
@@ -46,6 +47,7 @@ import { WidgetTypePipe } from "./widget-type.pipe";
     MatChipsModule,
     MatListModule,
     PieChartComponent,
+    ReportWidgetComponent,
     PipesModule,
     PipesModule,
     ReactiveFormsModule,

--- a/desktop/src/dashboard/dashboard/dashboard.component.html
+++ b/desktop/src/dashboard/dashboard/dashboard.component.html
@@ -1,35 +1,37 @@
 <div class="container-fluid">
   <div class="row g-3">
-    <div class="d-block widget col-12 col-md-6 col-lg-4 col-xxl-3" *ngFor="let widget of selectedDashboard()?.widgets">
-      <ng-container [ngSwitch]="widget.widgetType">
-        <ng-container *ngSwitchCase="widgetType.GroupSummary">
-          <app-summary-card
-            [headerText]="widget.name ?? 'Receipt Summary'"
-            [groupId]="selectedDashboard()?.groupId ?? ''"
-          ></app-summary-card>
+    @for (widget of selectedDashboard()?.widgets; track widget.id) {
+      <div class="d-block widget col-12 col-md-6 col-lg-4 col-xxl-3">
+        <ng-container [ngSwitch]="widget.widgetType">
+          <ng-container *ngSwitchCase="widgetType.GroupSummary">
+            <app-summary-card
+              [headerText]="widget.name ?? 'Receipt Summary'"
+              [groupId]="selectedDashboard()?.groupId ?? ''"
+            ></app-summary-card>
+          </ng-container>
+          <ng-container *ngSwitchCase="widgetType.FilteredReceipts">
+            <app-filtered-receipts
+              [widget]="widget"
+              [groupId]="selectedDashboard()?.groupId"
+            ></app-filtered-receipts>
+          </ng-container>
+          <ng-container *ngSwitchCase="widgetType.GroupActivity">
+            <app-activity
+              [widget]="widget"
+              [groupId]="selectedDashboard()?.groupId"
+            ></app-activity>
+          </ng-container>
+          <ng-container *ngSwitchCase="widgetType.PieChart">
+            <app-pie-chart
+              [widget]="widget"
+              [groupId]="selectedDashboard()?.groupId"
+            ></app-pie-chart>
+          </ng-container>
+          <ng-container *ngSwitchCase="widgetType.Report">
+            <app-report-widget [widget]="widget"></app-report-widget>
+          </ng-container>
         </ng-container>
-        <ng-container *ngSwitchCase="widgetType.FilteredReceipts">
-          <app-filtered-receipts
-            [widget]="widget"
-            [groupId]="selectedDashboard()?.groupId"
-          ></app-filtered-receipts>
-        </ng-container>
-        <ng-container *ngSwitchCase="widgetType.GroupActivity">
-          <app-activity
-            [widget]="widget"
-            [groupId]="selectedDashboard()?.groupId"
-          ></app-activity>
-        </ng-container>
-        <ng-container *ngSwitchCase="widgetType.PieChart">
-          <app-pie-chart
-            [widget]="widget"
-            [groupId]="selectedDashboard()?.groupId"
-          ></app-pie-chart>
-        </ng-container>
-        <ng-container *ngSwitchCase="widgetType.Report">
-          <app-report-widget [widget]="widget"></app-report-widget>
-        </ng-container>
-      </ng-container>
-    </div>
+      </div>
+    }
   </div>
 </div>

--- a/desktop/src/dashboard/dashboard/dashboard.component.html
+++ b/desktop/src/dashboard/dashboard/dashboard.component.html
@@ -26,6 +26,9 @@
             [groupId]="selectedDashboard()?.groupId"
           ></app-pie-chart>
         </ng-container>
+        <ng-container *ngSwitchCase="widgetType.Report">
+          <app-report-widget [widget]="widget"></app-report-widget>
+        </ng-container>
       </ng-container>
     </div>
   </div>

--- a/desktop/src/dashboard/dashboard/dashboard.component.spec.ts
+++ b/desktop/src/dashboard/dashboard/dashboard.component.spec.ts
@@ -6,10 +6,10 @@ import { MatDialogModule } from "@angular/material/dialog";
 import { MatListModule } from "@angular/material/list";
 import { ActivatedRoute, Params } from "@angular/router";
 import { NgxsModule, Store } from "@ngxs/store";
-import { BehaviorSubject } from "rxjs";
+import { BehaviorSubject, of } from "rxjs";
 import { PipesModule } from "src/pipes/pipes.module";
 import { DashboardState } from "src/store/dashboard.state";
-import { ApiModule, Dashboard } from "../../open-api";
+import { ApiModule, Dashboard, UserService, Widget, WidgetType } from "../../open-api";
 import { SummaryCardComponent } from "../../shared-ui/summary-card/summary-card.component";
 import { GroupState } from "../../store";
 import { DashboardRoutingModule } from "../dashboard-routing.module";
@@ -101,5 +101,59 @@ describe("DashboardComponent", () => {
     component.ngOnInit();
 
     expect(component.selectedDashboard()).toEqual(dashboards[1]);
+  });
+
+  // Regression: every widget used to double-fetch on load. The `dashboards` slice
+  // emits twice (the cached replay, then the resolver's refetch with brand-new
+  // widget object references but the SAME widget id), and the widget loop had no
+  // track key, so emission 2 destroyed and recreated every widget → each re-ran its
+  // init fetch. `@for ... track widget.id` keeps the instance, so it does not
+  // re-fetch. Proven here with the (non-report) GROUP_SUMMARY widget, whose effect
+  // calls UserService.getAmountOwedForUser.
+  it("fetches a widget's data only once when the dashboards slice re-emits with the same widget id", () => {
+    const owedSpy = jest
+      .spyOn(TestBed.inject(UserService), "getAmountOwedForUser")
+      .mockReturnValue(of({}) as any);
+
+    // A fresh dashboard + fresh widget object each call (new references), same id.
+    const summaryDashboards = (): { [groupId: string]: Dashboard[] } => ({
+      "1": [
+        {
+          id: 1,
+          userId: 1,
+          name: "Summary",
+          groupId: 1,
+          widgets: [
+            {
+              id: 10,
+              dashboardId: 1,
+              widgetType: WidgetType.GroupSummary,
+              name: "S",
+            } as Widget,
+          ],
+        } as Dashboard,
+      ],
+    });
+
+    // Emission 1 — the cached dashboard mounts the summary widget → one fetch.
+    store.reset({
+      ...store.snapshot(),
+      groups: { selectedGroupId: "1", selectedDashboardId: "1" },
+      dashboards: { dashboards: summaryDashboards() },
+    });
+    fixture.detectChanges();
+
+    expect(owedSpy).toHaveBeenCalledTimes(1);
+
+    // Emission 2 — the resolver's refetch replaces the slice with new object
+    // references (same widget id 10). The widget must NOT re-fetch.
+    store.reset({
+      ...store.snapshot(),
+      groups: { selectedGroupId: "1", selectedDashboardId: "1" },
+      dashboards: { dashboards: summaryDashboards() },
+    });
+    fixture.detectChanges();
+
+    expect(owedSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/desktop/src/dashboard/dashboard/dashboard.component.spec.ts
+++ b/desktop/src/dashboard/dashboard/dashboard.component.spec.ts
@@ -110,7 +110,7 @@ describe("DashboardComponent", () => {
   // init fetch. `@for ... track widget.id` keeps the instance, so it does not
   // re-fetch. Proven here with the (non-report) GROUP_SUMMARY widget, whose effect
   // calls UserService.getAmountOwedForUser.
-  it("fetches a widget's data only once when the dashboards slice re-emits with the same widget id", () => {
+  it("fetches a widget's data only once when the dashboards slice re-emits with the same widget id", async () => {
     const owedSpy = jest
       .spyOn(TestBed.inject(UserService), "getAmountOwedForUser")
       .mockReturnValue(of({}) as any);
@@ -136,12 +136,15 @@ describe("DashboardComponent", () => {
     });
 
     // Emission 1 — the cached dashboard mounts the summary widget → one fetch.
+    // The summary card fetches from a constructor effect, so flush effects and let
+    // the fixture stabilize before asserting the spy count (zoneless CD).
     store.reset({
       ...store.snapshot(),
       groups: { selectedGroupId: "1", selectedDashboardId: "1" },
       dashboards: { dashboards: summaryDashboards() },
     });
-    fixture.detectChanges();
+    TestBed.flushEffects();
+    await fixture.whenStable();
 
     expect(owedSpy).toHaveBeenCalledTimes(1);
 
@@ -152,7 +155,8 @@ describe("DashboardComponent", () => {
       groups: { selectedGroupId: "1", selectedDashboardId: "1" },
       dashboards: { dashboards: summaryDashboards() },
     });
-    fixture.detectChanges();
+    TestBed.flushEffects();
+    await fixture.whenStable();
 
     expect(owedSpy).toHaveBeenCalledTimes(1);
   });

--- a/desktop/src/dashboard/report-widget/report-widget.component.html
+++ b/desktop/src/dashboard/report-widget/report-widget.component.html
@@ -1,0 +1,42 @@
+<app-card cardStyle="dashboard-card">
+  <ng-container header>
+    <div class="d-flex justify-content-between align-items-center">
+      <h3>{{ widget().name || 'Report' }}</h3>
+      @if (canDownload()) {
+        <app-button
+          matButtonType="iconButton"
+          color="accent"
+          icon="download"
+          tooltip="Download report"
+          data-testid="report-widget-download"
+          [disabled]="isDownloading()"
+          (clicked)="download()"
+        ></app-button>
+      }
+    </div>
+  </ng-container>
+  <ng-container content>
+    <div class="report-widget__stage">
+      @if (isLoading()) {
+        <div class="report-widget__loading" data-testid="report-widget-loading">
+          <mat-icon>autorenew</mat-icon>
+        </div>
+      } @else if (hasError()) {
+        <div class="report-widget__placeholder" data-testid="report-widget-error">
+          <mat-icon>error_outline</mat-icon>
+          <span>Couldn't load this report.</span>
+        </div>
+      } @else {
+        <iframe
+          #frame
+          class="report-widget__frame"
+          title="Report"
+          sandbox="allow-same-origin"
+          [style.height.px]="frameHeight()"
+          [srcdoc]="safeHtml()"
+          (load)="onFrameLoad(frame)"
+        ></iframe>
+      }
+    </div>
+  </ng-container>
+</app-card>

--- a/desktop/src/dashboard/report-widget/report-widget.component.scss
+++ b/desktop/src/dashboard/report-widget/report-widget.component.scss
@@ -1,6 +1,7 @@
 .report-widget {
   &__stage {
     position: relative;
+
     // The report renders its full dataset; cap the visible area and scroll so a long
     // report never blows out the dashboard tile.
     max-height: 360px;

--- a/desktop/src/dashboard/report-widget/report-widget.component.scss
+++ b/desktop/src/dashboard/report-widget/report-widget.component.scss
@@ -1,0 +1,39 @@
+.report-widget {
+  &__stage {
+    position: relative;
+    // The report renders its full dataset; cap the visible area and scroll so a long
+    // report never blows out the dashboard tile.
+    max-height: 360px;
+    overflow: auto;
+  }
+
+  &__frame {
+    display: block;
+    width: 100%;
+    border: 0;
+  }
+
+  &__loading,
+  &__placeholder {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    min-height: 160px;
+    color: var(--bs-secondary-color, #6c757d);
+  }
+
+  &__loading mat-icon {
+    animation: report-widget-spin 1s linear infinite;
+  }
+}
+
+@keyframes report-widget-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/desktop/src/dashboard/report-widget/report-widget.component.spec.ts
+++ b/desktop/src/dashboard/report-widget/report-widget.component.spec.ts
@@ -1,10 +1,10 @@
 import { provideHttpClient, withInterceptorsFromDi } from "@angular/common/http";
 import { provideHttpClientTesting } from "@angular/common/http/testing";
-import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
+import { CUSTOM_ELEMENTS_SCHEMA, provideZonelessChangeDetection } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
 import { provideRouter } from "@angular/router";
-import { Subject, of } from "rxjs";
+import { Subject, of, throwError } from "rxjs";
 import { ReportPreviewResponse, Widget, WidgetType } from "../../open-api";
 import { ReportRunnerService } from "../../reports/services/report-runner.service";
 import { ReportWidgetComponent } from "./report-widget.component";
@@ -25,9 +25,7 @@ describe("ReportWidgetComponent", () => {
     fixture = TestBed.createComponent(ReportWidgetComponent);
     component = fixture.componentInstance;
     fixture.componentRef.setInput("widget", w);
-    fixture.detectChanges();
     await fixture.whenStable();
-    fixture.detectChanges();
   }
 
   beforeEach(async () => {
@@ -37,6 +35,7 @@ describe("ReportWidgetComponent", () => {
       imports: [ReportWidgetComponent],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
       providers: [
+        provideZonelessChangeDetection(),
         { provide: ReportRunnerService, useValue: runner },
         provideRouter([]),
         provideHttpClient(withInterceptorsFromDi()),
@@ -90,6 +89,42 @@ describe("ReportWidgetComponent", () => {
     expect(fixture.debugElement.query(By.css('[data-testid="report-widget-error"]'))).toBeTruthy();
   });
 
+  it("shows an error state when the render request fails", async () => {
+    runner.renderTemplate.mockReturnValue(throwError(() => new Error("boom")));
+
+    await setup(widget(5));
+
+    expect(component.hasError()).toBe(true);
+    expect(component.isLoading()).toBe(false);
+    expect(fixture.debugElement.query(By.css('[data-testid="report-widget-error"]'))).toBeTruthy();
+    expect(fixture.debugElement.query(By.css("iframe"))).toBeNull();
+  });
+
+  it("ignores a slow render for a swapped-out template (stale result cannot win)", async () => {
+    const first = new Subject<ReportPreviewResponse>(); // template 5 — never resolves until later
+    const second: ReportPreviewResponse = { html: "<p>seven</p>", receiptCount: 1, allowedActions: ["read", "generate"] };
+    runner.renderTemplate.mockImplementation((id: number) => (id === 5 ? first : of(second)));
+
+    await setup(widget(5));
+    expect(component.isLoading()).toBe(true);
+
+    // Swap the pinned template while template 5's request is still pending.
+    fixture.componentRef.setInput("widget", widget(7));
+    await fixture.whenStable();
+
+    // The new template resolved synchronously.
+    expect(component.html()).toBe("<p>seven</p>");
+    expect(component.allowedActions()).toEqual(["read", "generate"]);
+
+    // The stale template-5 request now emits — its subscription was cancelled on the
+    // swap, so it must not overwrite the current report or its permissions.
+    first.next({ html: "<p>five</p>", receiptCount: 9, allowedActions: [] });
+    await fixture.whenStable();
+
+    expect(component.html()).toBe("<p>seven</p>");
+    expect(component.allowedActions()).toEqual(["read", "generate"]);
+  });
+
   it("shows the download button only when allowedActions include generate, and downloads on click", async () => {
     const response: ReportPreviewResponse = { html: "<p>report</p>", receiptCount: 2, allowedActions: ["read", "generate"] };
     runner.renderTemplate.mockReturnValue(of(response));
@@ -102,5 +137,18 @@ describe("ReportWidgetComponent", () => {
 
     component.download();
     expect(runner.downloadTemplateById).toHaveBeenCalledWith(7);
+  });
+
+  it("resets the downloading flag when the download fails", async () => {
+    const response: ReportPreviewResponse = { html: "<p>report</p>", receiptCount: 2, allowedActions: ["read", "generate"] };
+    runner.renderTemplate.mockReturnValue(of(response));
+    runner.downloadTemplateById.mockReturnValue(throwError(() => new Error("download failed")));
+
+    await setup(widget(7));
+
+    component.download();
+    await fixture.whenStable();
+
+    expect(component.isDownloading()).toBe(false);
   });
 });

--- a/desktop/src/dashboard/report-widget/report-widget.component.spec.ts
+++ b/desktop/src/dashboard/report-widget/report-widget.component.spec.ts
@@ -25,6 +25,7 @@ describe("ReportWidgetComponent", () => {
     fixture = TestBed.createComponent(ReportWidgetComponent);
     component = fixture.componentInstance;
     fixture.componentRef.setInput("widget", w);
+    TestBed.flushEffects();
     await fixture.whenStable();
   }
 
@@ -110,6 +111,7 @@ describe("ReportWidgetComponent", () => {
 
     // Swap the pinned template while template 5's request is still pending.
     fixture.componentRef.setInput("widget", widget(7));
+    TestBed.flushEffects();
     await fixture.whenStable();
 
     // The new template resolved synchronously.
@@ -119,6 +121,7 @@ describe("ReportWidgetComponent", () => {
     // The stale template-5 request now emits — its subscription was cancelled on the
     // swap, so it must not overwrite the current report or its permissions.
     first.next({ html: "<p>five</p>", receiptCount: 9, allowedActions: [] });
+    TestBed.flushEffects();
     await fixture.whenStable();
 
     expect(component.html()).toBe("<p>seven</p>");

--- a/desktop/src/dashboard/report-widget/report-widget.component.spec.ts
+++ b/desktop/src/dashboard/report-widget/report-widget.component.spec.ts
@@ -1,0 +1,106 @@
+import { provideHttpClient, withInterceptorsFromDi } from "@angular/common/http";
+import { provideHttpClientTesting } from "@angular/common/http/testing";
+import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
+import { provideRouter } from "@angular/router";
+import { Subject, of } from "rxjs";
+import { ReportPreviewResponse, Widget, WidgetType } from "../../open-api";
+import { ReportRunnerService } from "../../reports/services/report-runner.service";
+import { ReportWidgetComponent } from "./report-widget.component";
+
+describe("ReportWidgetComponent", () => {
+  let fixture: ComponentFixture<ReportWidgetComponent>;
+  let component: ReportWidgetComponent;
+  let runner: { renderTemplate: jest.Mock; downloadTemplateById: jest.Mock };
+
+  const widget = (reportTemplateId?: number): Widget => ({
+    id: 1,
+    name: "My Report",
+    widgetType: WidgetType.Report,
+    configuration: reportTemplateId === undefined ? {} : { reportTemplateId },
+  });
+
+  async function setup(w: Widget): Promise<void> {
+    fixture = TestBed.createComponent(ReportWidgetComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput("widget", w);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  beforeEach(async () => {
+    runner = { renderTemplate: jest.fn(), downloadTemplateById: jest.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [ReportWidgetComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        { provide: ReportRunnerService, useValue: runner },
+        provideRouter([]),
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+      ],
+    }).compileComponents();
+  });
+
+  it("renders the returned report HTML in a sandboxed iframe", async () => {
+    const response: ReportPreviewResponse = { html: "<p>report</p>", receiptCount: 3, allowedActions: ["read"] };
+    runner.renderTemplate.mockReturnValue(of(response));
+
+    await setup(widget(5));
+
+    expect(runner.renderTemplate).toHaveBeenCalledWith(5);
+    expect(component.html()).toBe("<p>report</p>");
+    expect(component.isLoading()).toBe(false);
+    const iframe = fixture.debugElement.query(By.css("iframe"));
+    expect(iframe).toBeTruthy();
+    expect(iframe.attributes["sandbox"]).toBe("allow-same-origin");
+  });
+
+  it("shows the loading spinner while the render is in flight", async () => {
+    runner.renderTemplate.mockReturnValue(new Subject<ReportPreviewResponse>()); // never emits
+
+    await setup(widget(5));
+
+    expect(component.isLoading()).toBe(true);
+    expect(fixture.debugElement.query(By.css('[data-testid="report-widget-loading"]'))).toBeTruthy();
+    expect(fixture.debugElement.query(By.css("iframe"))).toBeNull();
+  });
+
+  it("renders whatever HTML comes back for the restricted case and hides the download button", async () => {
+    const restricted: ReportPreviewResponse = { html: "<html>restricted</html>", receiptCount: 0, allowedActions: [] };
+    runner.renderTemplate.mockReturnValue(of(restricted));
+
+    await setup(widget(5));
+
+    // No special "restricted" branch — the widget just renders the HTML it was given.
+    expect(component.html()).toBe("<html>restricted</html>");
+    expect(fixture.debugElement.query(By.css("iframe"))).toBeTruthy();
+    expect(component.canDownload()).toBe(false);
+    expect(fixture.debugElement.query(By.css('[data-testid="report-widget-download"]'))).toBeNull();
+  });
+
+  it("shows an error state and does not call the API when no template is pinned", async () => {
+    await setup(widget(undefined));
+
+    expect(runner.renderTemplate).not.toHaveBeenCalled();
+    expect(component.hasError()).toBe(true);
+    expect(fixture.debugElement.query(By.css('[data-testid="report-widget-error"]'))).toBeTruthy();
+  });
+
+  it("shows the download button only when allowedActions include generate, and downloads on click", async () => {
+    const response: ReportPreviewResponse = { html: "<p>report</p>", receiptCount: 2, allowedActions: ["read", "generate"] };
+    runner.renderTemplate.mockReturnValue(of(response));
+    runner.downloadTemplateById.mockReturnValue(of(new Blob()));
+
+    await setup(widget(7));
+
+    expect(component.canDownload()).toBe(true);
+    expect(fixture.debugElement.query(By.css('[data-testid="report-widget-download"]'))).toBeTruthy();
+
+    component.download();
+    expect(runner.downloadTemplateById).toHaveBeenCalledWith(7);
+  });
+});

--- a/desktop/src/dashboard/report-widget/report-widget.component.ts
+++ b/desktop/src/dashboard/report-widget/report-widget.component.ts
@@ -1,0 +1,114 @@
+import { CommonModule } from "@angular/common";
+import { ChangeDetectionStrategy, Component, DestroyRef, computed, effect, inject, input, signal } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { MatIconModule } from "@angular/material/icon";
+import { DomSanitizer, SafeHtml } from "@angular/platform-browser";
+import { EMPTY, catchError, finalize, tap } from "rxjs";
+import { ButtonModule } from "../../button/index";
+import { Widget } from "../../open-api";
+import { ReportRunnerService } from "../../reports/services/report-runner.service";
+import { SharedUiModule } from "../../shared-ui/shared-ui.module";
+
+/**
+ * A view-only dashboard widget that renders a saved report template's HTML, exactly
+ * as the report preview does — a sandboxed iframe (scripts disabled) fed the engine
+ * output. The pinned template is stored as `{ reportTemplateId }` in the widget
+ * configuration; the server renders the FULL dataset and re-resolves access on every
+ * load, so when the user's access is revoked (or the template is deleted) the
+ * endpoint returns restricted-notice HTML at 200 — the widget always drops whatever
+ * HTML it gets into the iframe, no special "restricted" branch. A download button
+ * shows only when the server-computed allowedActions include "generate".
+ */
+@Component({
+  selector: "app-report-widget",
+  templateUrl: "./report-widget.component.html",
+  styleUrls: ["./report-widget.component.scss"],
+  standalone: true,
+  imports: [CommonModule, SharedUiModule, ButtonModule, MatIconModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ReportWidgetComponent {
+  public readonly widget = input.required<Widget>();
+
+  private readonly runner = inject(ReportRunnerService);
+  private readonly sanitizer = inject(DomSanitizer);
+  private readonly destroyRef = inject(DestroyRef);
+
+  public readonly html = signal<string>("");
+  public readonly allowedActions = signal<string[]>([]);
+  public readonly isLoading = signal<boolean>(true);
+  public readonly hasError = signal<boolean>(false);
+  public readonly isDownloading = signal<boolean>(false);
+  public readonly frameHeight = signal<number>(320);
+
+  public readonly reportTemplateId = computed<number | undefined>(() => {
+    const config = this.widget()?.configuration as { reportTemplateId?: number } | undefined;
+    return config?.reportTemplateId ?? undefined;
+  });
+
+  // Gate the download button purely on the server-computed allowedActions (which
+  // already bake in the base/"*All" report permissions, the per-group ceiling, and
+  // the per-template matrix) — never AND-ed with a client permission check.
+  public readonly canDownload = computed<boolean>(
+    () => !!this.reportTemplateId() && this.allowedActions().includes("generate")
+  );
+
+  public readonly safeHtml = computed<SafeHtml>(() =>
+    this.sanitizer.bypassSecurityTrustHtml(this.html())
+  );
+
+  constructor() {
+    // Load whenever the pinned template changes (the effect tracks the
+    // widget-config-derived id). Replaces ngOnChanges for this input-watching load.
+    effect(() => this.load(this.reportTemplateId()));
+  }
+
+  /** Sizes the iframe to its content; the stage caps the height and scrolls. */
+  public onFrameLoad(iframe: HTMLIFrameElement): void {
+    const doc = iframe.contentDocument;
+    if (doc?.documentElement) {
+      this.frameHeight.set(doc.documentElement.scrollHeight + 8);
+    }
+  }
+
+  public download(): void {
+    const id = this.reportTemplateId();
+    if (!id || this.isDownloading()) {
+      return;
+    }
+    this.isDownloading.set(true);
+    this.runner
+      .downloadTemplateById(id)
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        catchError(() => EMPTY), // the HTTP interceptor surfaces the failure toast
+        finalize(() => this.isDownloading.set(false))
+      )
+      .subscribe();
+  }
+
+  private load(id: number | undefined): void {
+    if (!id) {
+      this.isLoading.set(false);
+      this.hasError.set(true);
+      return;
+    }
+    this.isLoading.set(true);
+    this.hasError.set(false);
+    this.runner
+      .renderTemplate(id)
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        tap((response) => {
+          this.html.set(response.html ?? "");
+          this.allowedActions.set(response.allowedActions ?? []);
+        }),
+        catchError(() => {
+          this.hasError.set(true);
+          return EMPTY;
+        }),
+        finalize(() => this.isLoading.set(false))
+      )
+      .subscribe();
+  }
+}

--- a/desktop/src/dashboard/report-widget/report-widget.component.ts
+++ b/desktop/src/dashboard/report-widget/report-widget.component.ts
@@ -3,7 +3,7 @@ import { ChangeDetectionStrategy, Component, DestroyRef, computed, effect, injec
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { MatIconModule } from "@angular/material/icon";
 import { DomSanitizer, SafeHtml } from "@angular/platform-browser";
-import { EMPTY, catchError, finalize, tap } from "rxjs";
+import { EMPTY, Subscription, catchError, finalize, tap } from "rxjs";
 import { ButtonModule } from "../../button/index";
 import { Widget } from "../../open-api";
 import { ReportRunnerService } from "../../reports/services/report-runner.service";
@@ -60,7 +60,13 @@ export class ReportWidgetComponent {
   constructor() {
     // Load whenever the pinned template changes (the effect tracks the
     // widget-config-derived id). Replaces ngOnChanges for this input-watching load.
-    effect(() => this.load(this.reportTemplateId()));
+    // onCleanup cancels the prior render before the next one starts (and on destroy),
+    // so a slower in-flight request for the old template can never overwrite the new
+    // one — takeUntilDestroyed alone only cancels on destroy, not on re-run.
+    effect((onCleanup) => {
+      const subscription = this.load(this.reportTemplateId());
+      onCleanup(() => subscription?.unsubscribe());
+    });
   }
 
   /** Sizes the iframe to its content; the stage caps the height and scrolls. */
@@ -87,7 +93,13 @@ export class ReportWidgetComponent {
       .subscribe();
   }
 
-  private load(id: number | undefined): void {
+  private load(id: number | undefined): Subscription | undefined {
+    // Clear the previous template's output up front so a swap can't briefly show the
+    // old report or (worse) enable download using the old template's authorization
+    // result while the new one loads.
+    this.html.set("");
+    this.allowedActions.set([]);
+
     if (!id) {
       this.isLoading.set(false);
       this.hasError.set(true);
@@ -95,7 +107,7 @@ export class ReportWidgetComponent {
     }
     this.isLoading.set(true);
     this.hasError.set(false);
-    this.runner
+    return this.runner
       .renderTemplate(id)
       .pipe(
         takeUntilDestroyed(this.destroyRef),

--- a/desktop/src/dashboard/widget-type.pipe.spec.ts
+++ b/desktop/src/dashboard/widget-type.pipe.spec.ts
@@ -1,8 +1,18 @@
+import { WidgetType } from "../open-api";
 import { WidgetTypePipe } from './widget-type.pipe';
 
 describe('WidgetTypePipe', () => {
+  const pipe = new WidgetTypePipe();
+
   it('create an instance', () => {
-    const pipe = new WidgetTypePipe();
     expect(pipe).toBeTruthy();
+  });
+
+  it('maps each widget type to its display label', () => {
+    expect(pipe.transform(WidgetType.GroupSummary)).toBe("Group Summary");
+    expect(pipe.transform(WidgetType.FilteredReceipts)).toBe("Filtered Receipts");
+    expect(pipe.transform(WidgetType.GroupActivity)).toBe("Activity");
+    expect(pipe.transform(WidgetType.PieChart)).toBe("Pie Chart");
+    expect(pipe.transform(WidgetType.Report)).toBe("Report");
   });
 });

--- a/desktop/src/dashboard/widget-type.pipe.ts
+++ b/desktop/src/dashboard/widget-type.pipe.ts
@@ -16,6 +16,8 @@ export class WidgetTypePipe implements PipeTransform {
         return "Activity";
       case WidgetType.PieChart:
         return "Pie Chart";
+      case WidgetType.Report:
+        return "Report";
     }
 
     return "";

--- a/desktop/src/open-api/api/report.service.ts
+++ b/desktop/src/open-api/api/report.service.ts
@@ -734,7 +734,7 @@ export class ReportService {
 
     /**
      * Preview a report
-     * Renders the current report configuration as HTML for the builder\&#39;s live preview, along with the number of receipts it covers. Runs under the caller\&#39;s group permissions and requires group.reports.read in every covered group. The preview is a row-capped sample of the engine\&#39;s own output.
+     * Renders the current report configuration as HTML for the builder\&#39;s live preview, along with the number of receipts it covers. Requires the app-level app.reports.read (or app.reports.readAll) and group.reports.read in every covered group. The preview is a row-capped sample of the engine\&#39;s own output.
      * @param reportRequestCommand The report builder configuration
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -810,6 +810,84 @@ export class ReportService {
             {
                 context: localVarHttpContext,
                 body: reportRequestCommand,
+                responseType: <any>responseType_,
+                withCredentials: this.configuration.withCredentials,
+                headers: localVarHeaders,
+                observe: observe,
+                transferCache: localVarTransferCache,
+                reportProgress: reportProgress
+            }
+        );
+    }
+
+    /**
+     * Render a saved template as HTML for the dashboard report widget
+     * Renders a saved report template by id as a self-contained HTML document over the full dataset (unlike /report/preview, which caps the sample) for the dashboard report widget, loading the stored configuration server-side. Re-resolves the caller\&#39;s access on every call; when the caller may not view the template (or it was deleted) a restricted-notice HTML document is returned at 200 with empty allowedActions, so the widget always has HTML to render. allowedActions carries the actions the caller may perform (drives the widget\&#39;s download button).
+     * @param id Id of the report template to render
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
+     */
+    public renderReportTemplate(id: number, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<ReportPreviewResponse>;
+    public renderReportTemplate(id: number, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<ReportPreviewResponse>>;
+    public renderReportTemplate(id: number, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<ReportPreviewResponse>>;
+    public renderReportTemplate(id: number, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
+        if (id === null || id === undefined) {
+            throw new Error('Required parameter id was null or undefined when calling renderReportTemplate.');
+        }
+
+        let localVarHeaders = this.defaultHeaders;
+
+        let localVarCredential: string | undefined;
+        // authentication (apiKeyAuth) required
+        localVarCredential = this.configuration.lookupCredential('apiKeyAuth');
+        if (localVarCredential) {
+            localVarHeaders = localVarHeaders.set('Authorization', localVarCredential);
+        }
+
+        // authentication (bearerAuth) required
+        localVarCredential = this.configuration.lookupCredential('bearerAuth');
+        if (localVarCredential) {
+            localVarHeaders = localVarHeaders.set('Authorization', 'Bearer ' + localVarCredential);
+        }
+
+        let localVarHttpHeaderAcceptSelected: string | undefined = options && options.httpHeaderAccept;
+        if (localVarHttpHeaderAcceptSelected === undefined) {
+            // to determine the Accept header
+            const httpHeaderAccepts: string[] = [
+                'application/json'
+            ];
+            localVarHttpHeaderAcceptSelected = this.configuration.selectHeaderAccept(httpHeaderAccepts);
+        }
+        if (localVarHttpHeaderAcceptSelected !== undefined) {
+            localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
+        }
+
+        let localVarHttpContext: HttpContext | undefined = options && options.context;
+        if (localVarHttpContext === undefined) {
+            localVarHttpContext = new HttpContext();
+        }
+
+        let localVarTransferCache: boolean | undefined = options && options.transferCache;
+        if (localVarTransferCache === undefined) {
+            localVarTransferCache = true;
+        }
+
+
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
+            }
+        }
+
+        let localVarPath = `/report/template/${this.configuration.encodeParam({name: "id", value: id, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: undefined})}/render`;
+        return this.httpClient.request<ReportPreviewResponse>('post', `${this.configuration.basePath}${localVarPath}`,
+            {
+                context: localVarHttpContext,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/desktop/src/open-api/model/reportPreviewResponse.ts
+++ b/desktop/src/open-api/model/reportPreviewResponse.ts
@@ -18,5 +18,9 @@ export interface ReportPreviewResponse {
      * The number of receipts the current configuration covers.
      */
     receiptCount: number;
+    /**
+     * The actions the requesting user may perform on the template (read, generate, update, delete, duplicate), resolved per user and populated only by the dashboard report-widget render endpoint. Drives the widget\'s download button.
+     */
+    allowedActions?: Array<string>;
 }
 

--- a/desktop/src/open-api/model/widgetType.ts
+++ b/desktop/src/open-api/model/widgetType.ts
@@ -9,12 +9,13 @@
  */
 
 
-export type WidgetType = 'GROUP_SUMMARY' | 'FILTERED_RECEIPTS' | 'GROUP_ACTIVITY' | 'PIE_CHART';
+export type WidgetType = 'GROUP_SUMMARY' | 'FILTERED_RECEIPTS' | 'GROUP_ACTIVITY' | 'PIE_CHART' | 'REPORT';
 
 export const WidgetType = {
     GroupSummary: 'GROUP_SUMMARY' as WidgetType,
     FilteredReceipts: 'FILTERED_RECEIPTS' as WidgetType,
     GroupActivity: 'GROUP_ACTIVITY' as WidgetType,
-    PieChart: 'PIE_CHART' as WidgetType
+    PieChart: 'PIE_CHART' as WidgetType,
+    Report: 'REPORT' as WidgetType
 };
 

--- a/desktop/src/reports/services/report-runner.service.spec.ts
+++ b/desktop/src/reports/services/report-runner.service.spec.ts
@@ -46,6 +46,7 @@ describe("ReportRunnerService", () => {
     deleteReportTemplate: jest.Mock;
     generateReport: jest.Mock;
     generateReportFromTemplate: jest.Mock;
+    renderReportTemplate: jest.Mock;
   };
   let service: ReportRunnerService;
 
@@ -60,6 +61,7 @@ describe("ReportRunnerService", () => {
       deleteReportTemplate: jest.fn(() => of(undefined)),
       generateReport: jest.fn(() => of(new Blob())),
       generateReportFromTemplate: jest.fn(() => of(new Blob())),
+      renderReportTemplate: jest.fn(() => of({ html: "", receiptCount: 0 })),
     };
     TestBed.configureTestingModule({
       providers: [
@@ -115,5 +117,28 @@ describe("ReportRunnerService", () => {
     service.generateFromTemplateById(template).subscribe();
     expect(reportService.generateReportFromTemplate).toHaveBeenCalledWith(7);
     expect(downloadFile).toHaveBeenCalledWith(expect.any(Blob), "Run.pdf");
+  });
+
+  it("renderTemplate delegates to renderReportTemplate", () => {
+    service.renderTemplate(9).subscribe();
+    expect(reportService.renderReportTemplate).toHaveBeenCalledWith(9);
+  });
+
+  it("downloadTemplateById resolves the template then generates + downloads by id", () => {
+    reportService.getReportTemplate.mockReturnValue(
+      of({
+        id: 9,
+        name: "Widget",
+        createdAt: "2026-01-01T00:00:00Z",
+        configuration: command("Widget", ["csv"]),
+        configurationVersion: 1,
+      })
+    );
+
+    service.downloadTemplateById(9).subscribe();
+
+    expect(reportService.getReportTemplate).toHaveBeenCalledWith(9);
+    expect(reportService.generateReportFromTemplate).toHaveBeenCalledWith(9);
+    expect(downloadFile).toHaveBeenCalledWith(expect.any(Blob), "Widget.csv");
   });
 });

--- a/desktop/src/reports/services/report-runner.service.ts
+++ b/desktop/src/reports/services/report-runner.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, inject } from "@angular/core";
-import { Observable, tap } from "rxjs";
+import { Observable, switchMap, tap } from "rxjs";
 import {
   PagedData,
   PagedRequestCommand,
@@ -34,6 +34,27 @@ export class ReportRunnerService {
   /** Renders the current configuration to preview HTML + the covered receipt count. */
   public preview(command: ReportRequestCommand): Observable<ReportPreviewResponse> {
     return this.reportService.previewReport(command);
+  }
+
+  /**
+   * Renders a saved template by id as full-dataset HTML for the dashboard report
+   * widget. The server loads the stored configuration, re-resolves the caller's
+   * access, and returns restricted-notice HTML (with empty allowedActions) when the
+   * caller may no longer view it — so the widget always has HTML to render.
+   */
+  public renderTemplate(id: number): Observable<ReportPreviewResponse> {
+    return this.reportService.renderReportTemplate(id);
+  }
+
+  /**
+   * Downloads a saved template by id: resolves the template (for the download
+   * filename) then runs it through the enforcing generate endpoint. Reused by the
+   * report widget's download button; the server 403s if the caller cannot generate.
+   */
+  public downloadTemplateById(id: number): Observable<Blob> {
+    return this.getTemplate(id).pipe(
+      switchMap((template) => this.generateFromTemplateById(template))
+    );
   }
 
   /** Saves the current configuration as a new reusable report template. */


### PR DESCRIPTION
## Summary

Adds a **view-only Report dashboard widget** that pins a saved report template and drops its rendered HTML into the dashboard tile — the same sandboxed-iframe rendering as the report preview, but over the **full dataset** (not the row-capped builder sample). The pinned template is chosen from the templates the user can view (server-filtered), and a **download button** appears only when the user is permitted to generate that template.

## Backend

- New `WidgetType` value `REPORT` (schema-less `configuration` stores `{ reportTemplateId }`; no DB migration).
- New `POST /report/template/{id}/render` → `{ html, receiptCount, allowedActions }`:
  - Loads the stored configuration **server-side** (the client never sends it), mirroring `/template/{id}/generate`.
  - Re-resolves the caller's access via `PermissionService.AllowedActionsForTemplate` (base/`*All` app perms + per-group ceiling + per-template matrix — the single source of truth).
  - Renders the **full dataset** (`renderHTML` with `rowLimit = 0`, like generate) — distinct from the row-capped builder `/preview`.
  - When the caller may no longer view the template (or it was deleted), returns **restricted-notice HTML at 200** with empty `allowedActions`, so a widget whose access is later revoked degrades gracefully instead of erroring.
- Extracts a shared `renderHTML` helper (used by both `Preview` and the new `RenderTemplateForUser`); `Preview` behavior is unchanged.

## Desktop

- `app-report-widget` renders the returned HTML in a `sandbox="allow-same-origin"` iframe (scripts disabled), height-capped and internally scrolling so a long report doesn't blow out the tile.
- **Download button** shown only when the server-returned `allowedActions` include `"generate"` — gated purely on the server result, never re-AND-ed with a client permission check. Download reuses the enforcing `/template/{id}/generate` path.
- `dashboard-form` offers the **Report** widget type only to users who can read reports, and sources its template picker from the server-filtered viewable-template list.

## Testing

- **Backend:** `RenderTemplateForUser` unit tests (read+generate, read-only omits generate, denied → restricted, missing → restricted, and full-dataset with >1000 receipts). Full `go test ./...` green.
- **Desktop:** `report-widget`, `dashboard-form` (Report case + gating), `widget-type.pipe`, and `report-runner.service` specs; production `ng build` green.
- **Live end-to-end** against a running stack: admin render → real report HTML + full `allowedActions`; non-admin render → restricted-notice HTML at 200 with no `allowedActions` and no report data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new dashboard **Report** widget type to pin and display saved report templates.
  * Added a server-rendered template rendering endpoint that returns full HTML and receipt totals, including a restricted-notice HTML payload at HTTP 200 when access isn’t allowed.
  * Added permission-gated downloads: the widget shows the download button only when the returned `allowedActions` includes `"generate"`.
* **Documentation**
  * Updated API and widget documentation for the render/download contract and restricted behavior.
* **Tests**
  * Added coverage for authorized vs restricted rendering, full-dataset correctness, malformed configs, and widget download/render behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->