### PR TITLE
feat(reporting): mobile view-only Report dashboard widget + e2e

### DIFF
--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -213,9 +213,28 @@ permission model exactly.
   emit `"aggFunc":""`. **Keep this omitempty on the API side; any future generated-client regen must
   keep the enum tolerant / the field omitted**, or every real report (dimension/formula columns) shows
   invisible rows in the mobile list.
+- **Dashboard report widget (view-only):** the fifth dashboard widget type, `REPORT`, ported from
+  desktop's `desktop/src/dashboard/report-widget/`. `lib/groups/widgets/dashboard_widgets/report_widget.dart`
+  pins a saved template (reads `configuration.reportTemplateId` from the widget's untyped config blob),
+  asks the server to render the **full dataset** (`POST /report/template/{id}/render` →
+  `renderReportTemplate` → `ReportPreviewResponse { html, receiptCount, allowedActions }`), and drops the
+  self-contained HTML into a **WebView** — the same rendering path as `report_preview_screen.dart` (JS
+  disabled, spinner cleared on `onPageFinished`). A revoked/deleted template returns restricted-notice HTML
+  at 200 with empty `allowedActions`, so there is no client "restricted" branch. Wired into the widget-type
+  `switch` in `group_dashboard.dart` (bounded by the shared `SizedBox(height: widgetHeight)` so the report
+  scrolls inside the tile). The **Download** button is gated **only** on the render response's
+  `allowedActions.contains('generate')` (never AND-ed with a client permission — same contract as
+  `report_list_item.dart`); on tap it fetches the template then reuses the existing
+  `generateAndSaveReport` share helper, mirroring desktop's `downloadTemplateById` (get template →
+  generate). Authoring stays desktop-only. This required a **mobile client regen** to pick up
+  `WidgetType.REPORT`, `renderReportTemplate`, and `allowedActions` on `ReportPreviewResponse` — **no
+  swagger change** was needed (the spec already carried all three; the mobile client was simply stale).
 - **Tests:** `test/widgets/report_list_item_test.dart` (the `allowedActions` row-gating contract),
-  `test/widgets/top_app_bar_reports_menu_test.dart` (menu-entry gate), `test/reports/report_filename_test.dart`
-  (filename derivation), and `reportsReadRedirect` cases in `test/guards/permission_guard_test.dart`.
+  `test/widgets/report_widget_test.dart` (the dashboard widget's pure `reportTemplateIdFromConfig`
+  extraction + `reportWidgetCanDownload` gate — the WebView render path is not widget-testable, matching
+  `report_preview_screen.dart`), `test/widgets/top_app_bar_reports_menu_test.dart` (menu-entry gate),
+  `test/reports/report_filename_test.dart` (filename derivation), and `reportsReadRedirect` cases in
+  `test/guards/permission_guard_test.dart`.
   Shared builders in `test/helpers/report_test_helpers.dart`. **E2E:** `integration_test/reports_list_test.dart`
   drives the list view — seeds a template via the new `createReportTemplate` fixture and asserts the row
   renders (the omitempty regression guard), the empty state, and the avatar-menu gate; the

--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -246,8 +246,14 @@ permission model exactly.
   (**with the fixture user's own jwt** — `getDashboardsForUserByGroup` filters on `user_id`, so an
   admin-owned dashboard would be invisible to the viewer), enters the group, and asserts the `ReportWidget`
   mounts, the WebView renders (success branch, no error placeholder, spinner clears), and the server-gated
-  Download button shows. **iOS/Android only** (`skip: Platform.isLinux`) — `webview_flutter` has no Linux
-  desktop implementation, so the Linux `run-e2e.sh` runner can't mount the widget.
+  Download button shows. Three `testWidgets` share a `seedAndOpenReportDashboard` helper — the positive path
+  plus two **deny** cases that pin down the widget's rejection contract (the render endpoint never 403s; a
+  denied caller gets restricted-notice HTML at 200 with empty `allowedActions`, so denial shows up as the
+  Download button being withheld, never an error): (a) a user with `app.reports.read` but **not** generate →
+  the report still renders but the Download button is `findsNothing`; (b) a Legacy Viewer with no
+  `app.reports.*` and no `group.reports.read` → the restricted-notice HTML renders gracefully with no
+  Download. **iOS/Android only** (`skip: Platform.isLinux`) — `webview_flutter` has no Linux desktop
+  implementation, so the Linux `run-e2e.sh` runner can't mount the widget.
 
 ## Development Notes
 

--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -240,6 +240,14 @@ permission model exactly.
   renders (the omitempty regression guard), the empty state, and the avatar-menu gate; the
   `provisionUserWithAppPermissions` fixture (inverse of `provisionUserWithoutAppPermission`) grants
   `app.reports.read`/`readAll`. Preview/generate/delete are out of the e2e scope.
+  `integration_test/report_dashboard_widget_test.dart` drives the **dashboard report widget** end-to-end:
+  it provisions a user (`app.reports.read`/`readAll`/`generate`/`generateAll` + Legacy Owner group), seeds
+  a template, then seeds a dashboard holding a `REPORT` widget via the new `createDashboard` fixture
+  (**with the fixture user's own jwt** — `getDashboardsForUserByGroup` filters on `user_id`, so an
+  admin-owned dashboard would be invisible to the viewer), enters the group, and asserts the `ReportWidget`
+  mounts, the WebView renders (success branch, no error placeholder, spinner clears), and the server-gated
+  Download button shows. **iOS/Android only** (`skip: Platform.isLinux`) — `webview_flutter` has no Linux
+  desktop implementation, so the Linux `run-e2e.sh` runner can't mount the widget.
 
 ## Development Notes
 

--- a/mobile/api/.openapi-generator/FILES
+++ b/mobile/api/.openapi-generator/FILES
@@ -317,13 +317,3 @@ lib/src/model/widget.dart
 lib/src/model/widget_type.dart
 lib/src/serializers.dart
 pubspec.yaml
-test/report_api_test.dart
-test/report_column_test.dart
-test/report_detail_test.dart
-test/report_document_test.dart
-test/report_period_test.dart
-test/report_preview_response_test.dart
-test/report_request_command_test.dart
-test/report_template_grant_test.dart
-test/report_template_option_test.dart
-test/report_template_test.dart

--- a/mobile/api/README.md
+++ b/mobile/api/README.md
@@ -143,6 +143,7 @@ Class | Method | HTTP request | Description
 [*ReportApi*](doc/ReportApi.md) | [**getReportTemplateOptions**](doc/ReportApi.md#getreporttemplateoptions) | **GET** /report/template/options | Get report template options
 [*ReportApi*](doc/ReportApi.md) | [**getReportTemplates**](doc/ReportApi.md#getreporttemplates) | **POST** /report/template/list | Get paged report templates
 [*ReportApi*](doc/ReportApi.md) | [**previewReport**](doc/ReportApi.md#previewreport) | **POST** /report/preview | Preview a report
+[*ReportApi*](doc/ReportApi.md) | [**renderReportTemplate**](doc/ReportApi.md#renderreporttemplate) | **POST** /report/template/{id}/render | Render a saved template as HTML for the dashboard report widget
 [*ReportApi*](doc/ReportApi.md) | [**updateReportTemplate**](doc/ReportApi.md#updatereporttemplate) | **PUT** /report/template/{id} | Update a report template
 [*RoleApi*](doc/RoleApi.md) | [**createRole**](doc/RoleApi.md#createrole) | **POST** /role | Create role
 [*RoleApi*](doc/RoleApi.md) | [**deleteRole**](doc/RoleApi.md#deleterole) | **DELETE** /role/{roleId} | Delete role

--- a/mobile/api/doc/ReportApi.md
+++ b/mobile/api/doc/ReportApi.md
@@ -18,6 +18,7 @@ Method | HTTP request | Description
 [**getReportTemplateOptions**](ReportApi.md#getreporttemplateoptions) | **GET** /report/template/options | Get report template options
 [**getReportTemplates**](ReportApi.md#getreporttemplates) | **POST** /report/template/list | Get paged report templates
 [**previewReport**](ReportApi.md#previewreport) | **POST** /report/preview | Preview a report
+[**renderReportTemplate**](ReportApi.md#renderreporttemplate) | **POST** /report/template/{id}/render | Render a saved template as HTML for the dashboard report widget
 [**updateReportTemplate**](ReportApi.md#updatereporttemplate) | **PUT** /report/template/{id} | Update a report template
 
 
@@ -435,6 +436,53 @@ Name | Type | Description  | Notes
 ### HTTP request headers
 
  - **Content-Type**: application/json
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **renderReportTemplate**
+> ReportPreviewResponse renderReportTemplate(id)
+
+Render a saved template as HTML for the dashboard report widget
+
+Renders a saved report template by id as a self-contained HTML document over the full dataset (unlike /report/preview, which caps the sample) for the dashboard report widget, loading the stored configuration server-side. Re-resolves the caller's access on every call; when the caller may not view the template (or it was deleted) a restricted-notice HTML document is returned at 200 with empty allowedActions, so the widget always has HTML to render. allowedActions carries the actions the caller may perform (drives the widget's download button).
+
+### Example
+```dart
+import 'package:openapi/api.dart';
+// TODO Configure API key authorization: apiKeyAuth
+//defaultApiClient.getAuthentication<ApiKeyAuth>('apiKeyAuth').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('apiKeyAuth').apiKeyPrefix = 'Bearer';
+
+final api = Openapi().getReportApi();
+final int id = 56; // int | Id of the report template to render
+
+try {
+    final response = api.renderReportTemplate(id);
+    print(response);
+} catch on DioException (e) {
+    print('Exception when calling ReportApi->renderReportTemplate: $e\n');
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **id** | **int**| Id of the report template to render | 
+
+### Return type
+
+[**ReportPreviewResponse**](ReportPreviewResponse.md)
+
+### Authorization
+
+[apiKeyAuth](../README.md#apiKeyAuth), [bearerAuth](../README.md#bearerAuth)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
  - **Accept**: application/json
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/mobile/api/doc/ReportPreviewResponse.md
+++ b/mobile/api/doc/ReportPreviewResponse.md
@@ -10,6 +10,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **html** | **String** | The rendered report preview as a self-contained HTML document. | 
 **receiptCount** | **int** | The number of receipts the current configuration covers. | 
+**allowedActions** | **BuiltList&lt;String&gt;** | The actions the requesting user may perform on the template (read, generate, update, delete, duplicate), resolved per user and populated only by the dashboard report-widget render endpoint. Drives the widget's download button. | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/mobile/api/lib/src/api/report_api.dart
+++ b/mobile/api/lib/src/api/report_api.dart
@@ -847,6 +847,92 @@ class ReportApi {
     );
   }
 
+  /// Render a saved template as HTML for the dashboard report widget
+  /// Renders a saved report template by id as a self-contained HTML document over the full dataset (unlike /report/preview, which caps the sample) for the dashboard report widget, loading the stored configuration server-side. Re-resolves the caller&#39;s access on every call; when the caller may not view the template (or it was deleted) a restricted-notice HTML document is returned at 200 with empty allowedActions, so the widget always has HTML to render. allowedActions carries the actions the caller may perform (drives the widget&#39;s download button).
+  ///
+  /// Parameters:
+  /// * [id] - Id of the report template to render
+  /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
+  /// * [headers] - Can be used to add additional headers to the request
+  /// * [extras] - Can be used to add flags to the request
+  /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
+  /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
+  /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
+  ///
+  /// Returns a [Future] containing a [Response] with a [ReportPreviewResponse] as data
+  /// Throws [DioException] if API call or serialization fails
+  Future<Response<ReportPreviewResponse>> renderReportTemplate({ 
+    required int id,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    final _path = r'/report/template/{id}/render'.replaceAll('{' r'id' '}', encodeQueryParameter(_serializers, id, const FullType(int)).toString());
+    final _options = Options(
+      method: r'POST',
+      headers: <String, dynamic>{
+        ...?headers,
+      },
+      extra: <String, dynamic>{
+        'secure': <Map<String, String>>[
+          {
+            'type': 'apiKey',
+            'name': 'apiKeyAuth',
+            'keyName': 'Authorization',
+            'where': 'header',
+          },{
+            'type': 'http',
+            'scheme': 'bearer',
+            'name': 'bearerAuth',
+          },
+        ],
+        ...?extra,
+      },
+      validateStatus: validateStatus,
+    );
+
+    final _response = await _dio.request<Object>(
+      _path,
+      options: _options,
+      cancelToken: cancelToken,
+      onSendProgress: onSendProgress,
+      onReceiveProgress: onReceiveProgress,
+    );
+
+    ReportPreviewResponse? _responseData;
+
+    try {
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : _serializers.deserialize(
+        rawResponse,
+        specifiedType: const FullType(ReportPreviewResponse),
+      ) as ReportPreviewResponse;
+
+    } catch (error, stackTrace) {
+      throw DioException(
+        requestOptions: _response.requestOptions,
+        response: _response,
+        type: DioExceptionType.unknown,
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+
+    return Response<ReportPreviewResponse>(
+      data: _responseData,
+      headers: _response.headers,
+      isRedirect: _response.isRedirect,
+      requestOptions: _response.requestOptions,
+      redirects: _response.redirects,
+      statusCode: _response.statusCode,
+      statusMessage: _response.statusMessage,
+      extra: _response.extra,
+    );
+  }
+
   /// Update a report template
   /// Updates a saved report template in place, replacing its name and stored configuration. App-scoped (requires app.reports.update).
   ///

--- a/mobile/api/lib/src/model/report_preview_response.dart
+++ b/mobile/api/lib/src/model/report_preview_response.dart
@@ -3,6 +3,7 @@
 //
 
 // ignore_for_file: unused_element
+import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 
@@ -13,6 +14,7 @@ part 'report_preview_response.g.dart';
 /// Properties:
 /// * [html] - The rendered report preview as a self-contained HTML document.
 /// * [receiptCount] - The number of receipts the current configuration covers.
+/// * [allowedActions] - The actions the requesting user may perform on the template (read, generate, update, delete, duplicate), resolved per user and populated only by the dashboard report-widget render endpoint. Drives the widget's download button.
 @BuiltValue()
 abstract class ReportPreviewResponse implements Built<ReportPreviewResponse, ReportPreviewResponseBuilder> {
   /// The rendered report preview as a self-contained HTML document.
@@ -22,6 +24,10 @@ abstract class ReportPreviewResponse implements Built<ReportPreviewResponse, Rep
   /// The number of receipts the current configuration covers.
   @BuiltValueField(wireName: r'receiptCount')
   int get receiptCount;
+
+  /// The actions the requesting user may perform on the template (read, generate, update, delete, duplicate), resolved per user and populated only by the dashboard report-widget render endpoint. Drives the widget's download button.
+  @BuiltValueField(wireName: r'allowedActions')
+  BuiltList<String>? get allowedActions;
 
   ReportPreviewResponse._();
 
@@ -56,6 +62,13 @@ class _$ReportPreviewResponseSerializer implements PrimitiveSerializer<ReportPre
       object.receiptCount,
       specifiedType: const FullType(int),
     );
+    if (object.allowedActions != null) {
+      yield r'allowedActions';
+      yield serializers.serialize(
+        object.allowedActions,
+        specifiedType: const FullType(BuiltList, [FullType(String)]),
+      );
+    }
   }
 
   @override
@@ -92,6 +105,13 @@ class _$ReportPreviewResponseSerializer implements PrimitiveSerializer<ReportPre
             specifiedType: const FullType(int),
           ) as int;
           result.receiptCount = valueDes;
+          break;
+        case r'allowedActions':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(BuiltList, [FullType(String)]),
+          ) as BuiltList<String>;
+          result.allowedActions.replace(valueDes);
           break;
         default:
           unhandled.add(key);

--- a/mobile/api/lib/src/model/report_preview_response.g.dart
+++ b/mobile/api/lib/src/model/report_preview_response.g.dart
@@ -11,12 +11,15 @@ class _$ReportPreviewResponse extends ReportPreviewResponse {
   final String html;
   @override
   final int receiptCount;
+  @override
+  final BuiltList<String>? allowedActions;
 
   factory _$ReportPreviewResponse(
           [void Function(ReportPreviewResponseBuilder)? updates]) =>
       (ReportPreviewResponseBuilder()..update(updates))._build();
 
-  _$ReportPreviewResponse._({required this.html, required this.receiptCount})
+  _$ReportPreviewResponse._(
+      {required this.html, required this.receiptCount, this.allowedActions})
       : super._();
   @override
   ReportPreviewResponse rebuild(
@@ -32,7 +35,8 @@ class _$ReportPreviewResponse extends ReportPreviewResponse {
     if (identical(other, this)) return true;
     return other is ReportPreviewResponse &&
         html == other.html &&
-        receiptCount == other.receiptCount;
+        receiptCount == other.receiptCount &&
+        allowedActions == other.allowedActions;
   }
 
   @override
@@ -40,6 +44,7 @@ class _$ReportPreviewResponse extends ReportPreviewResponse {
     var _$hash = 0;
     _$hash = $jc(_$hash, html.hashCode);
     _$hash = $jc(_$hash, receiptCount.hashCode);
+    _$hash = $jc(_$hash, allowedActions.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -48,7 +53,8 @@ class _$ReportPreviewResponse extends ReportPreviewResponse {
   String toString() {
     return (newBuiltValueToStringHelper(r'ReportPreviewResponse')
           ..add('html', html)
-          ..add('receiptCount', receiptCount))
+          ..add('receiptCount', receiptCount)
+          ..add('allowedActions', allowedActions))
         .toString();
   }
 }
@@ -65,6 +71,12 @@ class ReportPreviewResponseBuilder
   int? get receiptCount => _$this._receiptCount;
   set receiptCount(int? receiptCount) => _$this._receiptCount = receiptCount;
 
+  ListBuilder<String>? _allowedActions;
+  ListBuilder<String> get allowedActions =>
+      _$this._allowedActions ??= ListBuilder<String>();
+  set allowedActions(ListBuilder<String>? allowedActions) =>
+      _$this._allowedActions = allowedActions;
+
   ReportPreviewResponseBuilder() {
     ReportPreviewResponse._defaults(this);
   }
@@ -74,6 +86,7 @@ class ReportPreviewResponseBuilder
     if ($v != null) {
       _html = $v.html;
       _receiptCount = $v.receiptCount;
+      _allowedActions = $v.allowedActions?.toBuilder();
       _$v = null;
     }
     return this;
@@ -93,13 +106,27 @@ class ReportPreviewResponseBuilder
   ReportPreviewResponse build() => _build();
 
   _$ReportPreviewResponse _build() {
-    final _$result = _$v ??
-        _$ReportPreviewResponse._(
-          html: BuiltValueNullFieldError.checkNotNull(
-              html, r'ReportPreviewResponse', 'html'),
-          receiptCount: BuiltValueNullFieldError.checkNotNull(
-              receiptCount, r'ReportPreviewResponse', 'receiptCount'),
-        );
+    _$ReportPreviewResponse _$result;
+    try {
+      _$result = _$v ??
+          _$ReportPreviewResponse._(
+            html: BuiltValueNullFieldError.checkNotNull(
+                html, r'ReportPreviewResponse', 'html'),
+            receiptCount: BuiltValueNullFieldError.checkNotNull(
+                receiptCount, r'ReportPreviewResponse', 'receiptCount'),
+            allowedActions: _allowedActions?.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'allowedActions';
+        _allowedActions?.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'ReportPreviewResponse', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }

--- a/mobile/api/lib/src/model/upsert_widget_command.dart
+++ b/mobile/api/lib/src/model/upsert_widget_command.dart
@@ -26,7 +26,7 @@ abstract class UpsertWidgetCommand implements Built<UpsertWidgetCommand, UpsertW
   /// Type of widget
   @BuiltValueField(wireName: r'widgetType')
   WidgetType get widgetType;
-  // enum widgetTypeEnum {  GROUP_SUMMARY,  FILTERED_RECEIPTS,  GROUP_ACTIVITY,  PIE_CHART,  };
+  // enum widgetTypeEnum {  GROUP_SUMMARY,  FILTERED_RECEIPTS,  GROUP_ACTIVITY,  PIE_CHART,  REPORT,  };
 
   /// Configuration of widget
   @BuiltValueField(wireName: r'configuration')

--- a/mobile/api/lib/src/model/widget.dart
+++ b/mobile/api/lib/src/model/widget.dart
@@ -47,7 +47,7 @@ abstract class Widget implements Built<Widget, WidgetBuilder> {
   /// Type of widget
   @BuiltValueField(wireName: r'widgetType')
   WidgetType? get widgetType;
-  // enum widgetTypeEnum {  GROUP_SUMMARY,  FILTERED_RECEIPTS,  GROUP_ACTIVITY,  PIE_CHART,  };
+  // enum widgetTypeEnum {  GROUP_SUMMARY,  FILTERED_RECEIPTS,  GROUP_ACTIVITY,  PIE_CHART,  REPORT,  };
 
   /// Configuration of widget
   @BuiltValueField(wireName: r'configuration')

--- a/mobile/api/lib/src/model/widget_type.dart
+++ b/mobile/api/lib/src/model/widget_type.dart
@@ -19,6 +19,8 @@ class WidgetType extends EnumClass {
   static const WidgetType GROUP_ACTIVITY = _$GROUP_ACTIVITY;
   @BuiltValueEnumConst(wireName: r'PIE_CHART')
   static const WidgetType PIE_CHART = _$PIE_CHART;
+  @BuiltValueEnumConst(wireName: r'REPORT')
+  static const WidgetType REPORT = _$REPORT;
 
   static Serializer<WidgetType> get serializer => _$widgetTypeSerializer;
 

--- a/mobile/api/lib/src/model/widget_type.g.dart
+++ b/mobile/api/lib/src/model/widget_type.g.dart
@@ -10,6 +10,7 @@ const WidgetType _$GROUP_SUMMARY = const WidgetType._('GROUP_SUMMARY');
 const WidgetType _$FILTERED_RECEIPTS = const WidgetType._('FILTERED_RECEIPTS');
 const WidgetType _$GROUP_ACTIVITY = const WidgetType._('GROUP_ACTIVITY');
 const WidgetType _$PIE_CHART = const WidgetType._('PIE_CHART');
+const WidgetType _$REPORT = const WidgetType._('REPORT');
 
 WidgetType _$valueOf(String name) {
   switch (name) {
@@ -21,6 +22,8 @@ WidgetType _$valueOf(String name) {
       return _$GROUP_ACTIVITY;
     case 'PIE_CHART':
       return _$PIE_CHART;
+    case 'REPORT':
+      return _$REPORT;
     default:
       throw ArgumentError(name);
   }
@@ -31,6 +34,7 @@ final BuiltSet<WidgetType> _$values = BuiltSet<WidgetType>(const <WidgetType>[
   _$FILTERED_RECEIPTS,
   _$GROUP_ACTIVITY,
   _$PIE_CHART,
+  _$REPORT,
 ]);
 
 class _$WidgetTypeMeta {
@@ -39,6 +43,7 @@ class _$WidgetTypeMeta {
   WidgetType get FILTERED_RECEIPTS => _$FILTERED_RECEIPTS;
   WidgetType get GROUP_ACTIVITY => _$GROUP_ACTIVITY;
   WidgetType get PIE_CHART => _$PIE_CHART;
+  WidgetType get REPORT => _$REPORT;
   WidgetType valueOf(String name) => _$valueOf(name);
   BuiltSet<WidgetType> get values => _$values;
 }
@@ -56,12 +61,14 @@ class _$WidgetTypeSerializer implements PrimitiveSerializer<WidgetType> {
     'FILTERED_RECEIPTS': 'FILTERED_RECEIPTS',
     'GROUP_ACTIVITY': 'GROUP_ACTIVITY',
     'PIE_CHART': 'PIE_CHART',
+    'REPORT': 'REPORT',
   };
   static const Map<Object, String> _fromWire = const <Object, String>{
     'GROUP_SUMMARY': 'GROUP_SUMMARY',
     'FILTERED_RECEIPTS': 'FILTERED_RECEIPTS',
     'GROUP_ACTIVITY': 'GROUP_ACTIVITY',
     'PIE_CHART': 'PIE_CHART',
+    'REPORT': 'REPORT',
   };
 
   @override

--- a/mobile/api/lib/src/serializers.g.dart
+++ b/mobile/api/lib/src/serializers.g.dart
@@ -264,6 +264,9 @@ Serializers _$serializers = (Serializers().toBuilder()
           const FullType(BuiltList, const [const FullType(String)]),
           () => ListBuilder<String>())
       ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(String)]),
+          () => ListBuilder<String>())
+      ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(ReportColumn)]),
           () => ListBuilder<ReportColumn>())
       ..addBuilderFactory(

--- a/mobile/integration_test/helpers/permission_fixtures.dart
+++ b/mobile/integration_test/helpers/permission_fixtures.dart
@@ -357,6 +357,60 @@ Future<void> deleteReportTemplate(int id, {required String jwt}) async {
   }
 }
 
+/// Seeds a dashboard in [groupId] holding a single view-only `REPORT` widget that
+/// pins [reportTemplateId] (`POST /dashboard/`), and returns its id. The widget's
+/// `configuration` is the same untyped blob the desktop authors — `{reportTemplateId}`
+/// — which `report_widget.dart`'s `reportTemplateIdFromConfig` reads back.
+///
+/// Seed with the **viewing user's** jwt, not admin's: `getDashboardsForUserByGroup`
+/// filters on `user_id`, so the dashboard is only visible to its creator. The
+/// creator therefore needs `group.dashboards.create` in [groupId] (a Legacy Owner
+/// group role grants it). Clean up with [deleteDashboard].
+Future<int> createDashboard({
+  required int groupId,
+  required int reportTemplateId,
+  required String jwt,
+  required String name,
+  required String widgetName,
+}) async {
+  final res = await http
+      .post(
+        Uri.parse('${E2eEnv.baseUrl}/dashboard/'),
+        headers: _jsonAuth(jwt),
+        body: jsonEncode({
+          'name': name,
+          'groupId': groupId.toString(),
+          'widgets': [
+            {
+              'name': widgetName,
+              'widgetType': 'REPORT',
+              'configuration': {'reportTemplateId': reportTemplateId},
+            },
+          ],
+        }),
+      )
+      .timeout(const Duration(seconds: 10));
+  if (res.statusCode != 200) {
+    throw StateError('createDashboard($name) failed: '
+        'HTTP ${res.statusCode}: ${res.body}');
+  }
+  return (jsonDecode(res.body) as Map<String, dynamic>)['id'] as int;
+}
+
+/// Best-effort `DELETE /dashboard/{id}`. Swallows errors like [deleteUser].
+Future<void> deleteDashboard(int id, {required String jwt}) async {
+  try {
+    await http
+        .delete(
+          Uri.parse('${E2eEnv.baseUrl}/dashboard/$id'),
+          headers: _auth(jwt),
+        )
+        .timeout(const Duration(seconds: 10));
+  } catch (_) {
+    // best-effort cleanup
+  }
+}
+
 /// Creates a global category (categories are app-wide; group visibility is via
 /// group-role grants) and returns its id. A group role with no category grants
 /// is unrestricted, so a freshly-created category shows up in every member's

--- a/mobile/integration_test/report_dashboard_widget_test.dart
+++ b/mobile/integration_test/report_dashboard_widget_test.dart
@@ -1,0 +1,119 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:receipt_wrangler_mobile/groups/widgets/dashboard_widgets/report_widget.dart';
+import 'package:receipt_wrangler_mobile/groups/widgets/group_dashboard_wrapper.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+import 'helpers/api.dart';
+import 'helpers/login.dart';
+import 'helpers/nav.dart';
+import 'helpers/permission_fixtures.dart';
+import 'helpers/platform_mocks.dart';
+import 'helpers/pump.dart';
+
+/// E2E for the view-only Report dashboard widget: seeds a saved report template
+/// and a dashboard that pins it in a `REPORT` widget, then drives the app to the
+/// group's dashboards route and asserts the widget actually renders (WebView
+/// success branch, no error placeholder) with its server-gated Download button.
+///
+/// **iOS/Android only** (`skip: Platform.isLinux`): `webview_flutter` has no Linux
+/// desktop implementation, so the widget can't mount under the Linux runner.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    if (Platform.isLinux) {
+      installLinuxDesktopMocks();
+    }
+  });
+
+  testWidgets(
+    'report dashboard widget renders the report and shows the gated download',
+    (tester) async {
+      final adminJwt = await apiLogin();
+
+      // A user that can both open the dashboard and fully render a report: the
+      // Legacy Owner group role grants group.dashboards.read/create +
+      // group.reports.read; the app perms grant the app-scoped read/generate the
+      // render endpoint's allowedActions resolution requires.
+      final fixture = await provisionUserWithAppPermissions(
+        const [
+          'app.reports.read',
+          'app.reports.readAll',
+          'app.reports.generate',
+          'app.reports.generateAll',
+        ],
+        groupRoleName: 'Legacy Owner',
+      );
+
+      final suffix = DateTime.now().microsecondsSinceEpoch;
+
+      // Template creation needs app.reports.create (admin-only); ownership does
+      // not affect the fixture user's render access (they read via *All).
+      final templateId = await createReportTemplate(
+        groupIds: [fixture.groupId!],
+        jwt: adminJwt,
+        name: 'e2e-report-$suffix',
+      );
+      addTearDown(
+          () async => deleteReportTemplate(templateId, jwt: await apiLogin()));
+
+      // The dashboard must be OWNED by the viewing user — getDashboardsForUserByGroup
+      // filters on user_id — so seed it with the fixture user's own jwt.
+      final userJwt = await apiLoginAs(fixture.username, fixture.password);
+      final widgetName = 'e2e-report-widget-$suffix';
+      final dashboardId = await createDashboard(
+        groupId: fixture.groupId!,
+        reportTemplateId: templateId,
+        jwt: userJwt,
+        name: 'e2e-dashboard-$suffix',
+        widgetName: widgetName,
+      );
+      addTearDown(() async => deleteDashboard(
+            dashboardId,
+            jwt: await apiLoginAs(fixture.username, fixture.password),
+          ));
+
+      await loginAs(
+        tester,
+        username: fixture.username,
+        password: fixture.password,
+      );
+
+      // Legacy Owner holds group.dashboards.read, so entering the group lands on
+      // the dashboards route.
+      await enterGroup(tester, fixture.groupName!);
+      await pumpUntilFound(tester, find.byType(GroupDashboardWrapper));
+      await pumpUntilFound(tester, find.byType(ReportWidget));
+
+      // The widget's own spinner clears once the render call resolves and the
+      // WebView finishes painting the HTML.
+      final spinner = find.descendant(
+        of: find.byType(ReportWidget),
+        matching: find.byType(CircularProgressIndicator),
+      );
+      await pumpUntilGone(
+        tester,
+        spinner,
+        timeout: const Duration(seconds: 25),
+      );
+
+      // Success branch — the WebView is mounted (not the error placeholder) and
+      // the report rendered without error.
+      expect(find.byType(WebViewWidget), findsOneWidget);
+      expect(find.text("Couldn't load this report."), findsNothing);
+      expect(find.text(widgetName), findsOneWidget);
+
+      // The server-gated Download button is shown, proving allowedActions.generate
+      // flowed through from the render response.
+      expect(
+        find.byKey(const ValueKey('report-widget-download')),
+        findsOneWidget,
+      );
+    },
+    skip: Platform.isLinux, // webview_flutter has no Linux desktop implementation
+  );
+}

--- a/mobile/integration_test/report_dashboard_widget_test.dart
+++ b/mobile/integration_test/report_dashboard_widget_test.dart
@@ -14,10 +14,15 @@ import 'helpers/permission_fixtures.dart';
 import 'helpers/platform_mocks.dart';
 import 'helpers/pump.dart';
 
-/// E2E for the view-only Report dashboard widget: seeds a saved report template
-/// and a dashboard that pins it in a `REPORT` widget, then drives the app to the
-/// group's dashboards route and asserts the widget actually renders (WebView
-/// success branch, no error placeholder) with its server-gated Download button.
+/// E2E for the view-only Report dashboard widget. Seeds a saved report template
+/// and a dashboard that pins it in a `REPORT` widget, drives the app to the
+/// group's dashboards route, and asserts the widget renders — plus the two deny
+/// paths that prove rejection works for viewers without report perms.
+///
+/// The render endpoint (`POST /report/template/{id}/render`) **never 403s**: a
+/// caller lacking report access gets restricted-notice HTML at 200 with empty
+/// `allowedActions`. So the widget always renders *some* HTML, and denial shows
+/// up as the Download button being withheld — never an error branch.
 ///
 /// **iOS/Android only** (`skip: Platform.isLinux`): `webview_flutter` has no Linux
 /// desktop implementation, so the widget can't mount under the Linux runner.
@@ -30,15 +35,75 @@ void main() {
     }
   });
 
-  testWidgets(
-    'report dashboard widget renders the report and shows the gated download',
-    (tester) async {
-      final adminJwt = await apiLogin();
+  /// Seeds a report template (admin jwt) + a dashboard holding a `REPORT` widget
+  /// owned by [fixture]'s user (its jwt — `getDashboardsForUserByGroup` filters
+  /// on `user_id`), logs that user in, enters the group, and waits for the widget
+  /// to finish rendering. Returns the widget's name. Registers teardown for both
+  /// seeded rows.
+  Future<String> seedAndOpenReportDashboard(
+    WidgetTester tester,
+    PermFixture fixture,
+  ) async {
+    final adminJwt = await apiLogin();
+    final suffix = DateTime.now().microsecondsSinceEpoch;
 
-      // A user that can both open the dashboard and fully render a report: the
-      // Legacy Owner group role grants group.dashboards.read/create +
-      // group.reports.read; the app perms grant the app-scoped read/generate the
-      // render endpoint's allowedActions resolution requires.
+    // Template creation needs app.reports.create (admin-only); ownership does not
+    // affect the viewer's render access (that's resolved per-request).
+    final templateId = await createReportTemplate(
+      groupIds: [fixture.groupId!],
+      jwt: adminJwt,
+      name: 'e2e-report-$suffix',
+    );
+    addTearDown(
+        () async => deleteReportTemplate(templateId, jwt: await apiLogin()));
+
+    // The dashboard must be OWNED by the viewing user — getDashboardsForUserByGroup
+    // filters on user_id — so seed it with the fixture user's own jwt.
+    final userJwt = await apiLoginAs(fixture.username, fixture.password);
+    final widgetName = 'e2e-report-widget-$suffix';
+    final dashboardId = await createDashboard(
+      groupId: fixture.groupId!,
+      reportTemplateId: templateId,
+      jwt: userJwt,
+      name: 'e2e-dashboard-$suffix',
+      widgetName: widgetName,
+    );
+    addTearDown(() async => deleteDashboard(
+          dashboardId,
+          jwt: await apiLoginAs(fixture.username, fixture.password),
+        ));
+
+    await loginAs(
+      tester,
+      username: fixture.username,
+      password: fixture.password,
+    );
+
+    // The group role holds group.dashboards.read, so entering the group lands on
+    // the dashboards route (no redirect).
+    await enterGroup(tester, fixture.groupName!);
+    await pumpUntilFound(tester, find.byType(GroupDashboardWrapper));
+    await pumpUntilFound(tester, find.byType(ReportWidget));
+
+    // The widget's own spinner clears once the render call resolves and the
+    // WebView finishes painting the HTML.
+    final spinner = find.descendant(
+      of: find.byType(ReportWidget),
+      matching: find.byType(CircularProgressIndicator),
+    );
+    await pumpUntilGone(tester, spinner, timeout: const Duration(seconds: 25));
+
+    return widgetName;
+  }
+
+  final downloadButton = find.byKey(const ValueKey('report-widget-download'));
+
+  testWidgets(
+    'renders the report and shows the gated download for a full-access user',
+    (tester) async {
+      // Legacy Owner group role → group.dashboards.read/create + group.reports.read;
+      // the app perms grant the app-scoped read + generate the render endpoint's
+      // allowedActions resolution requires.
       final fixture = await provisionUserWithAppPermissions(
         const [
           'app.reports.read',
@@ -49,71 +114,56 @@ void main() {
         groupRoleName: 'Legacy Owner',
       );
 
-      final suffix = DateTime.now().microsecondsSinceEpoch;
+      final widgetName = await seedAndOpenReportDashboard(tester, fixture);
 
-      // Template creation needs app.reports.create (admin-only); ownership does
-      // not affect the fixture user's render access (they read via *All).
-      final templateId = await createReportTemplate(
-        groupIds: [fixture.groupId!],
-        jwt: adminJwt,
-        name: 'e2e-report-$suffix',
-      );
-      addTearDown(
-          () async => deleteReportTemplate(templateId, jwt: await apiLogin()));
-
-      // The dashboard must be OWNED by the viewing user — getDashboardsForUserByGroup
-      // filters on user_id — so seed it with the fixture user's own jwt.
-      final userJwt = await apiLoginAs(fixture.username, fixture.password);
-      final widgetName = 'e2e-report-widget-$suffix';
-      final dashboardId = await createDashboard(
-        groupId: fixture.groupId!,
-        reportTemplateId: templateId,
-        jwt: userJwt,
-        name: 'e2e-dashboard-$suffix',
-        widgetName: widgetName,
-      );
-      addTearDown(() async => deleteDashboard(
-            dashboardId,
-            jwt: await apiLoginAs(fixture.username, fixture.password),
-          ));
-
-      await loginAs(
-        tester,
-        username: fixture.username,
-        password: fixture.password,
-      );
-
-      // Legacy Owner holds group.dashboards.read, so entering the group lands on
-      // the dashboards route.
-      await enterGroup(tester, fixture.groupName!);
-      await pumpUntilFound(tester, find.byType(GroupDashboardWrapper));
-      await pumpUntilFound(tester, find.byType(ReportWidget));
-
-      // The widget's own spinner clears once the render call resolves and the
-      // WebView finishes painting the HTML.
-      final spinner = find.descendant(
-        of: find.byType(ReportWidget),
-        matching: find.byType(CircularProgressIndicator),
-      );
-      await pumpUntilGone(
-        tester,
-        spinner,
-        timeout: const Duration(seconds: 25),
-      );
-
-      // Success branch — the WebView is mounted (not the error placeholder) and
-      // the report rendered without error.
+      // Success branch: WebView mounted (not the error placeholder), report rendered.
       expect(find.byType(WebViewWidget), findsOneWidget);
       expect(find.text("Couldn't load this report."), findsNothing);
       expect(find.text(widgetName), findsOneWidget);
-
-      // The server-gated Download button is shown, proving allowedActions.generate
-      // flowed through from the render response.
-      expect(
-        find.byKey(const ValueKey('report-widget-download')),
-        findsOneWidget,
-      );
+      // Download shown — allowedActions.generate flowed through from the render.
+      expect(downloadButton, findsOneWidget);
     },
     skip: Platform.isLinux, // webview_flutter has no Linux desktop implementation
+  );
+
+  testWidgets(
+    'hides the download when the user can view but not generate',
+    (tester) async {
+      // Read (+ Legacy Owner's group.reports.read) but NO generate: the report
+      // renders fully, yet the download action must be withheld.
+      final fixture = await provisionUserWithAppPermissions(
+        const ['app.reports.read', 'app.reports.readAll'],
+        groupRoleName: 'Legacy Owner',
+      );
+
+      await seedAndOpenReportDashboard(tester, fixture);
+
+      // The real report still renders (not restricted) — read is granted...
+      expect(find.byType(WebViewWidget), findsOneWidget);
+      expect(find.text("Couldn't load this report."), findsNothing);
+      // ...but the Download button is rejected: no generate in allowedActions.
+      expect(downloadButton, findsNothing);
+    },
+    skip: Platform.isLinux,
+  );
+
+  testWidgets(
+    'renders the restricted notice and no download for a user without report perms',
+    (tester) async {
+      // Legacy Viewer group role holds group.dashboards.read/create (so the
+      // dashboard opens and the user can seed their own) but no group.reports.read,
+      // and the default Legacy User app role has no app.reports.* at all.
+      final fixture = await provisionPermUser(roleName: 'Legacy Viewer');
+
+      await seedAndOpenReportDashboard(tester, fixture);
+
+      // The render returns restricted-notice HTML at 200, so the widget still
+      // renders gracefully (no error branch, no crash)...
+      expect(find.byType(WebViewWidget), findsOneWidget);
+      expect(find.text("Couldn't load this report."), findsNothing);
+      // ...with the Download button hidden (empty allowedActions).
+      expect(downloadButton, findsNothing);
+    },
+    skip: Platform.isLinux,
   );
 }

--- a/mobile/lib/groups/widgets/dashboard_widgets/report_widget.dart
+++ b/mobile/lib/groups/widgets/dashboard_widgets/report_widget.dart
@@ -1,0 +1,194 @@
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/json_object.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:openapi/openapi.dart' as api;
+import 'package:receipt_wrangler_mobile/reports/functions/report_actions.dart';
+import 'package:receipt_wrangler_mobile/utils/snackbar.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+import '../../../client/client.dart';
+import '../constants/text_styles.dart';
+
+/// Reads the pinned report template id from a dashboard widget's untyped
+/// `configuration` blob (`{ reportTemplateId: <int> }`, authored on desktop).
+/// Returns null when the key is absent or not a number, which the widget
+/// surfaces as an error state.
+int? reportTemplateIdFromConfig(BuiltMap<String, JsonObject?>? config) {
+  final value = config?['reportTemplateId'];
+  if (value == null) return null;
+  try {
+    return value.asNum.toInt();
+  } catch (_) {
+    return null;
+  }
+}
+
+/// Whether the widget should show its Download button, gated **only** on the
+/// server-computed [allowedActions] (never AND-ed with a client permission
+/// check) — the same contract `report_list_item.dart` uses. Download reuses the
+/// enforcing generate path, so `generate` is the gating action.
+bool reportWidgetCanDownload(BuiltList<String>? allowedActions) =>
+    allowedActions?.contains('generate') ?? false;
+
+/// View-only dashboard widget that pins a saved report template and renders it,
+/// mirroring the desktop report widget (`desktop/src/dashboard/report-widget/`).
+/// It asks the server to render the whole template
+/// (`POST /report/template/{id}/render`) and drops the returned self-contained
+/// HTML into a WebView — the same rendering path as the report preview screen.
+/// A Download button is shown **only** when the server's `allowedActions`
+/// includes `generate` (never AND-ed with a client permission check), matching
+/// desktop and `report_list_item.dart`.
+class ReportWidget extends StatefulWidget {
+  const ReportWidget({super.key, required this.dashboardWidget});
+
+  final api.Widget dashboardWidget;
+
+  @override
+  State<ReportWidget> createState() => _ReportWidgetState();
+}
+
+class _ReportWidgetState extends State<ReportWidget> {
+  static const _errorMessage = "Couldn't load this report.";
+
+  late final WebViewController _controller;
+  int? _templateId;
+  bool _loading = true;
+  bool _downloading = false;
+  String? _error;
+  BuiltList<String>? _allowedActions;
+
+  bool get _canDownload => reportWidgetCanDownload(_allowedActions);
+
+  @override
+  void initState() {
+    super.initState();
+    _templateId = reportTemplateIdFromConfig(widget.dashboardWidget.configuration);
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.disabled)
+      ..setBackgroundColor(Colors.white)
+      ..setNavigationDelegate(NavigationDelegate(
+        // Clear the spinner only once the page has finished painting, not when
+        // loadHtmlString returns (which resolves before the WebView renders) —
+        // otherwise the report flashes blank while it lays out.
+        onPageFinished: (_) {
+          if (mounted) setState(() => _loading = false);
+        },
+      ));
+    _load();
+  }
+
+  Future<void> _load() async {
+    final id = _templateId;
+    if (id == null) {
+      setState(() {
+        _loading = false;
+        _error = _errorMessage;
+      });
+      return;
+    }
+    try {
+      final response =
+          await OpenApiClient.client.getReportApi().renderReportTemplate(id: id);
+      if (!mounted) return;
+      final data = response.data;
+      setState(() => _allowedActions = data?.allowedActions);
+      // A revoked/deleted template comes back as restricted-notice HTML at 200
+      // with empty allowedActions, so we always have HTML to render and never
+      // need a client-side "restricted" branch. _loading is cleared by the
+      // controller's onPageFinished once the HTML has rendered.
+      await _controller.loadHtmlString(data?.html ?? '');
+    } on DioException catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _error = _errorMessage;
+      });
+      showApiErrorSnackbar(context, e);
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _error = _errorMessage;
+      });
+    }
+  }
+
+  /// Fetches the full template (for its filename/config) then reuses the shared
+  /// generate-and-share helper — the same path desktop's `downloadTemplateById`
+  /// takes (get template → generate). The gate above is server-authoritative;
+  /// the generate call re-enforces per-template access, so a stale button at
+  /// worst 403s.
+  Future<void> _download(int id) async {
+    if (_downloading) return;
+    setState(() => _downloading = true);
+    try {
+      final template =
+          (await OpenApiClient.client.getReportApi().getReportTemplate(id: id))
+              .data;
+      if (template != null && mounted) {
+        await generateAndSaveReport(context, template);
+      }
+    } on DioException catch (e) {
+      if (mounted) showApiErrorSnackbar(context, e);
+    } finally {
+      if (mounted) setState(() => _downloading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 10),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Expanded(
+              child: Text(
+                widget.dashboardWidget.name ?? 'Report',
+                style: dashboardWidgetNameStyle,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            if (_canDownload)
+              IconButton(
+                key: const ValueKey('report-widget-download'),
+                icon: const Icon(Icons.download),
+                tooltip: 'Download',
+                onPressed:
+                    _downloading ? null : () => _download(_templateId!),
+              ),
+          ],
+        ),
+        const SizedBox(height: 10),
+        Expanded(child: _buildContent()),
+      ],
+    );
+  }
+
+  Widget _buildContent() {
+    if (_error != null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.error_outline, size: 32),
+            const SizedBox(height: 8),
+            Text(_error!),
+          ],
+        ),
+      );
+    }
+    // The WebView stays mounted so it can load/paint while the spinner overlays
+    // it; the spinner is cleared by onPageFinished once the content is visible.
+    return Stack(
+      children: [
+        WebViewWidget(controller: _controller),
+        if (_loading) const Center(child: CircularProgressIndicator()),
+      ],
+    );
+  }
+}

--- a/mobile/lib/groups/widgets/group_dashboard.dart
+++ b/mobile/lib/groups/widgets/group_dashboard.dart
@@ -4,6 +4,7 @@ import 'package:openapi/openapi.dart' as api;
 import 'package:receipt_wrangler_mobile/groups/widgets/dashboard_widgets/group_activities.dart';
 import 'package:receipt_wrangler_mobile/groups/widgets/dashboard_widgets/group_summary.dart';
 import 'package:receipt_wrangler_mobile/groups/widgets/dashboard_widgets/pie_chart.dart';
+import 'package:receipt_wrangler_mobile/groups/widgets/dashboard_widgets/report_widget.dart';
 
 import 'dashboard_widgets/filtered_receipts.dart';
 
@@ -88,6 +89,14 @@ class _GroupDashboard extends State<GroupDashboard> {
             widgets.add(SizedBox(
               height: widgetHeight,
               child: DashboardPieChart(
+                dashboardWidget: widget,
+              ),
+            ));
+            break;
+          case api.WidgetType.REPORT:
+            widgets.add(SizedBox(
+              height: widgetHeight,
+              child: ReportWidget(
                 dashboardWidget: widget,
               ),
             ));

--- a/mobile/test/widgets/report_widget_test.dart
+++ b/mobile/test/widgets/report_widget_test.dart
@@ -1,0 +1,76 @@
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/json_object.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:receipt_wrangler_mobile/groups/widgets/dashboard_widgets/report_widget.dart';
+
+// The WebView render path is exercised on-device, not in a widget test — the
+// webview_flutter platform channel is unavailable under flutter_test (which is
+// why report_preview_screen.dart likewise has no widget test). These tests pin
+// the two WebView-free pieces of logic the widget depends on: reading the
+// pinned template id out of the untyped config blob, and the server-driven
+// download gate.
+void main() {
+  BuiltMap<String, JsonObject?> config(Map<String, JsonObject?> entries) =>
+      BuiltMap<String, JsonObject?>(entries);
+
+  group('reportTemplateIdFromConfig', () {
+    test('reads an integer reportTemplateId', () {
+      expect(
+        reportTemplateIdFromConfig(config({'reportTemplateId': JsonObject(7)})),
+        7,
+      );
+    });
+
+    test('truncates a numeric (double) reportTemplateId to an int', () {
+      // JSON numbers arrive as num; ids are whole but tolerate a double form.
+      expect(
+        reportTemplateIdFromConfig(
+            config({'reportTemplateId': JsonObject(7.0)})),
+        7,
+      );
+    });
+
+    test('returns null when the key is absent', () {
+      expect(
+        reportTemplateIdFromConfig(config({'chartGrouping': JsonObject('X')})),
+        isNull,
+      );
+    });
+
+    test('returns null for a null config', () {
+      expect(reportTemplateIdFromConfig(null), isNull);
+    });
+
+    test('returns null when the value is not a number', () {
+      expect(
+        reportTemplateIdFromConfig(
+            config({'reportTemplateId': JsonObject('nope')})),
+        isNull,
+      );
+    });
+  });
+
+  group('reportWidgetCanDownload', () {
+    test('true when allowedActions contains generate', () {
+      expect(
+        reportWidgetCanDownload(BuiltList<String>(['read', 'generate'])),
+        isTrue,
+      );
+    });
+
+    test('false when allowedActions omits generate', () {
+      expect(
+        reportWidgetCanDownload(BuiltList<String>(['read'])),
+        isFalse,
+      );
+    });
+
+    test('false for empty allowedActions', () {
+      expect(reportWidgetCanDownload(BuiltList<String>()), isFalse);
+    });
+
+    test('false for null allowedActions', () {
+      expect(reportWidgetCanDownload(null), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## What

Ports the desktop **Report dashboard widget** (`desktop/src/dashboard/report-widget/`) to the Flutter app as the fifth view-only dashboard widget type, `REPORT`. It pins a saved report template, renders the template's full-dataset **HTML** from `POST /report/template/{id}/render` in a WebView (the same rendering path as the existing report preview screen), and shows a **Download** button gated **only** on the render response's `allowedActions.contains('generate')` — reusing the existing `generateAndSaveReport` share helper (fetch template → generate), mirroring desktop's `downloadTemplateById`. Authoring stays desktop-only.

## No swagger change — just a stale client

`api/swagger.yml` already carried the render endpoint, `WidgetType.REPORT`, and `ReportPreviewResponse.allowedActions`; the mobile Dart client was simply out of date. Regenerated it with the pinned `openapi-generator` 7.10.0 + `build_runner` (re-applying the two documented dart-dio default-value patches), which brought in all three additively.

## Changes

- **`report_widget.dart`** — new view-only widget: reads `configuration.reportTemplateId`, renders the HTML in a WebView, gated Download button. Extracts two pure, testable helpers (`reportTemplateIdFromConfig`, `reportWidgetCanDownload`).
- **`group_dashboard.dart`** — added the `REPORT` case to the widget-type switch (bounded `SizedBox` like the other widgets).
- **Regenerated `mobile/api/`** client (report render method + `allowedActions` + `WidgetType.REPORT`).
- **Docs** — `mobile/CLAUDE.md` updated under the reporting slice.

## Tests

- **Unit** (`test/widgets/report_widget_test.dart`): the pure `reportTemplateIdFromConfig` extraction and `reportWidgetCanDownload` gate. The WebView render path isn't widget-testable (matching `report_preview_screen.dart`).
- **E2E** (`integration_test/report_dashboard_widget_test.dart`): seeds a template + a dashboard holding a `REPORT` widget (new `createDashboard`/`deleteDashboard` fixtures — seeded with the **viewing user's** jwt since `getDashboardsForUserByGroup` filters on `user_id`), enters the group, and asserts the widget mounts, the WebView renders (success branch, no error placeholder, spinner clears), and the gated Download button shows. **`skip: Platform.isLinux`** — `webview_flutter` has no Linux desktop implementation.

## Verification

- `flutter analyze` clean on touched files; full `flutter test` green (196 pass, 1 pre-existing unrelated `auth_interceptor_test` failure).
- E2E **verified green on the iOS Simulator** (iPhone 17 Pro) against the local API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added view-only “Report” dashboard widgets to mobile.
  - Widgets render saved report templates as self-contained HTML in a WebView, with loading/error handling.
  - Download is now server-controlled and only shown when the user is permitted.

- **Documentation**
  - Added documentation for the report template render API and the widget’s permission-driven download behavior.

- **Tests**
  - Added unit tests for template-id parsing and download gating.
  - Added mobile E2E tests validating successful rendering and download visibility/withholding across permission scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->