### PR TITLE
Add Claude Code sandbox setup playbooks for all components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,34 @@ flutter build ios                 # Build iOS app
 
 See `mobile/CLAUDE.md` for Flutter architecture, Provider state management, and navigation.
 
+## Running in the Claude Code Web/Cloud Sandbox
+
+When running this app inside the **Claude Code web (cloud) sandbox**, the stock "just run it" commands
+above do **not** work out of the box, and the setup must be redone from scratch **every session**
+(the container is ephemeral — the built ImageMagick, Redis, the DB, and node_modules are all lost
+when the session ends). Two component-specific playbooks capture the exact, verified steps — read
+them instead of rediscovering:
+
+- **Backend:** `api/CLAUDE.md` → "Running in the Claude Code Web/Cloud Sandbox"
+- **Frontend:** `desktop/CLAUDE.md` → "Running in the Claude Code Web/Cloud Sandbox"
+
+**Root cause of the friction:** the sandbox base image is **Ubuntu 24.04 (Noble)**, whereas the
+project's Docker images / setup scripts assume **Debian** (`golang:1.25-trixie`, `bullseye`). The big
+one is ImageMagick: the Go API's `imagick.v3` CGO binding needs **ImageMagick 7**, but Ubuntu only
+ships ImageMagick **6** and has no IM7 package — so `set-up-dependencies.sh` can't provide it and IM7
+has to be **built from source**. Redis is installed but not started, and Tesseract/ImageMagick native
+dev libs must be installed by hand.
+
+**Run order & quick orientation:**
+1. Backend (`:8081`) first — start Redis, install Tesseract libs, build IM7 from source, then
+   `go run main.go` from `api/` with SQLite + local-Redis env vars.
+2. Frontend (`:4200`) second — `npm install` then `npm start`; it only *proxies* to the backend, so
+   the API must already be up.
+3. Log in with the auto-created default admin **`admin` / `admin`**; login lands on
+   `/dashboard/group/<id>`.
+4. To drive the UI / take screenshots, use Playwright against the **pre-installed** Chromium at
+   `/opt/pw-browsers/chromium` (do not `playwright install`) — details in `desktop/CLAUDE.md`.
+
 ## Critical Cross-Component Considerations
 
 ### API Changes Workflow

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -13,6 +13,87 @@ Receipt Wrangler API is a Go-based backend service for a receipt management and 
 - `go run main.go` - Run the application directly
 - `./set-up-dependencies.sh` - Install system dependencies (tesseract, ImageMagick, Chromium, Python deps)
 
+### Running in the Claude Code Web/Cloud Sandbox
+
+> Playbook for booting the API in the Claude Code web (cloud) sandbox from a **fresh session**.
+> Everything below is ephemeral — the container is rebuilt each session, so these steps must be
+> re-run every time. Follow them top-to-bottom and the server comes up on `:8081` in ~2 min.
+
+**Why the normal path doesn't just work.** The sandbox base image is **Ubuntu 24.04 (Noble)**, but
+the project's Docker images (and `set-up-dependencies.sh`) assume **Debian** (`golang:1.25-trixie` /
+`bullseye`). Two consequences:
+- The CGO binding `gopkg.in/gographics/imagick.v3` needs **ImageMagick 7**'s MagickWand API. Ubuntu's
+  repos only ship ImageMagick **6** (`libmagickwand-dev` = IM6) and have no IM7 package, so
+  `set-up-dependencies.sh`'s `libmagickwand-7.q16-dev` isn't installable and the Go build fails to
+  link. **IM7 must be built from source.**
+- `set-up-dependencies.sh` also installs heavy Python (torch, easyocr) used only by the **IMAP email
+  client**, not the Go server. **Skip it** — install just the native libs below.
+
+**Step 1 — Start Redis** (installed but not running by default):
+```bash
+redis-server --daemonize yes --save "" --appendonly no
+redis-cli ping   # -> PONG
+```
+
+**Step 2 — Install Tesseract + build tooling** (apt, these IM6-free packages are all in Ubuntu's repos):
+```bash
+apt-get update -qq
+apt-get install -y build-essential pkg-config libtesseract-dev libleptonica-dev tesseract-ocr-eng
+```
+
+**Step 3 — Install ImageMagick 7 delegate dev libs** (needed before configuring IM7):
+```bash
+apt-get install -y libpng-dev libjpeg-turbo8-dev libtiff-dev libwebp-dev libheif-dev libde265-dev ghostscript libtool
+```
+
+**Step 4 — Build & install ImageMagick 7 from source** (the `imagemagick.org/archive` tarball 404s —
+clone from GitHub instead):
+```bash
+cd <scratchpad>            # build outside the repo
+git clone --depth 1 https://github.com/ImageMagick/ImageMagick.git
+cd ImageMagick
+./configure --prefix=/usr/local --with-heic=yes --with-jpeg=yes --with-png=yes \
+            --with-tiff=yes --with-webp=yes --with-gslib=yes --disable-docs --without-magick-plus-plus
+make -j"$(nproc)"          # ~1-2 min
+make install
+ldconfig                   # <-- the key step
+```
+`ldconfig` is what makes both the Go build and the running server find the new libs: `/usr/local/lib`
+is already listed in `/etc/ld.so.conf.d/libc.conf`, so after `ldconfig`, `pkg-config --modversion
+MagickWand` resolves `7.1.2` from the **default** path and `libMagickWand-7.Q16HDRI.so` is in the
+loader cache. You do **not** need `PKG_CONFIG_PATH` or `LD_LIBRARY_PATH` once `ldconfig` has run
+(fallbacks if it somehow didn't: `PKG_CONFIG_PATH=/usr/local/lib/pkgconfig` for the build,
+`LD_LIBRARY_PATH=/usr/local/lib` for the run). Verify: `magick -version` shows `7.1.2 ... Q16-HDRI`.
+
+**Step 5 — Run the Go server from the `api/` directory** (paths like `logs/` and `./sqlite/` are
+relative to the working directory, so cwd **must** be `api/`):
+```bash
+cd /home/user/receipt-wrangler/api
+DB_ENGINE=sqlite DB_FILENAME=wrangler.db \
+ENCRYPTION_KEY=dev-encryption-key SECRET_KEY=dev-secret-key \
+REDIS_HOST=127.0.0.1 REDIS_PORT=6379 \
+go run main.go            # (or build once: `go build -o /tmp/rw-api . && /tmp/rw-api`)
+```
+- `ENCRYPTION_KEY` / `SECRET_KEY` just need to be **non-empty** (`config.CheckRequiredEnvironmentVariables`
+  fatals on empty) — throwaway dev values are fine.
+- Gotcha: `dev/switch-to-sqlite.sh` exports `REDIS_HOST=redis` (the docker-compose service name). For a
+  **local** Redis you must override it to `127.0.0.1`, or the connection fails at startup.
+- Ready when the log prints `Listening on port 8081`. Smoke test: `curl localhost:8081/api/featureConfig`
+  → `200`.
+
+**Logging in.** First startup auto-creates a default admin **`admin` / `admin`** (in any env except
+`-env test`; see `CreateUserIfNoneExist`). The login endpoint is **`POST /api/login/`** (not
+`/api/auth/login`); add `?tokensInBody=true` to get the JWT in the response body:
+```bash
+curl -X POST 'localhost:8081/api/login/?tokensInBody=true' \
+  -H 'Content-Type: application/json' -d '{"username":"admin","password":"admin"}'
+```
+
+**Not needed to boot the server (skip in the sandbox):** the Python/torch/easyocr install, and the
+ImageMagick PDF-policy edit in `set-up-dependencies.sh` (it targets `/etc/ImageMagick-7/policy.xml`; a
+source build's policy is at `/usr/local/etc/ImageMagick-7/policy.xml` and doesn't block PDF by
+default). Those only matter for exercising email-OCR / PDF-receipt processing, not for a running API.
+
 ### Testing
 - `go test -v ./...` - Run all Go tests with verbose output
 - `go test -coverprofile=coverage.out -covermode=atomic -v ./...` - Run tests with coverage

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -19,6 +19,49 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Development server uses proxy configuration in `proxy.conf.json` to route API calls to backend
 - Angular CLI configuration in `angular.json`
 
+### Running in the Claude Code Web/Cloud Sandbox
+
+> Playbook for booting the desktop app in the Claude Code web (cloud) sandbox from a **fresh session**.
+> Everything is ephemeral — re-run these each session. See `api/CLAUDE.md` →
+> "Running in the Claude Code Web/Cloud Sandbox" for the backend, and the root `CLAUDE.md` for the
+> shared root-cause / run-order notes.
+
+1. **Backend first.** The dev server only *proxies* `/api` → `localhost:8081`; it does not start the
+   API. Bring the Go backend up first (see `api/CLAUDE.md`).
+2. **`npm install`** — first run, node_modules isn't present.
+   - **Lockfile gotcha:** the sandbox's npm (10.9.7) rewrites `package-lock.json`, stripping the
+     `"libc"` platform-hint fields from optional platform deps. This is **metadata drift only** — no
+     packages/versions change. Do **not** commit it: `git restore desktop/package-lock.json` to keep
+     the tree clean.
+3. **`npm start`** — serves on `0.0.0.0:4200`, proxying `/api` → `:8081` (`proxy.conf.json`). First
+   compile is ~30–60s; ready when the log shows `➜  Local:   http://localhost:4200/`. Verify the proxy:
+   `curl localhost:4200/api/featureConfig` → `200`.
+4. **Log in as `admin` / `admin`** (the backend's auto-created default admin). Login lands on
+   `/dashboard/group/<id>` ("All Dashboards", empty on a fresh DB).
+
+**Driving the UI / screenshots with Playwright in the sandbox.** `@playwright/test` is pinned to
+`1.59.1`, which expects Chromium build **1217**, but the sandbox pre-installs build **1194** at
+`/opt/pw-browsers/chromium` (`PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers`). Do **not** run
+`playwright install` / `npm run e2e:install` (the download is blocked and pointless). Instead launch
+Chromium by explicit path:
+```js
+const { chromium } = require('@playwright/test');
+const browser = await chromium.launch({
+  headless: true,
+  executablePath: '/opt/pw-browsers/chromium',   // pre-installed 1194, ignore the 1217 mismatch
+});
+```
+Run a standalone script (one that lives outside `desktop/`) with
+`NODE_PATH=/home/user/receipt-wrangler/desktop/node_modules node script.js` so `require('@playwright/test')`
+resolves. Scripted login flow (selectors from `e2e/helpers/auth.ts`):
+```js
+await page.goto('http://localhost:4200/auth/login');
+await page.getByLabel('Username').fill('admin');
+await page.getByLabel('Password').fill('admin');
+await page.getByRole('button', { name: 'Login' }).click();
+await page.waitForURL(/\/dashboard\/group\/\d+/);
+```
+
 ## Code Architecture
 
 ### Application Structure
@@ -431,7 +474,9 @@ End-to-end tests live in `e2e/` and use **Playwright**. They drive the real Angu
 
 ### Running locally
 
-1. **One-time:** install browsers — `npm run e2e:install`.
+1. **One-time:** install browsers — `npm run e2e:install`. (In the Claude Code web sandbox the browser
+   is pre-installed and `e2e:install` is blocked — use the `executablePath: '/opt/pw-browsers/chromium'`
+   workaround from "Running in the Claude Code Web/Cloud Sandbox" above instead.)
 2. **One-time:** sign up the two e2e accounts against your local DB. The **first** signup is auto-promoted to admin, so order matters. With the API running, go to `http://localhost:4200/auth/sign-up` and create:
    - Admin first: username `e2e-admin`, password `e2e-admin-password`
    - Then user: username `e2e-user`, password `e2e-user-password`


### PR DESCRIPTION
## Summary
Added comprehensive setup and troubleshooting documentation for running Receipt Wrangler in the Claude Code web (cloud) sandbox environment. The sandbox uses Ubuntu 24.04 (Noble) instead of the project's standard Debian base, requiring special handling for ImageMagick 7 and other dependencies.

## Key Changes

- **api/CLAUDE.md**: Added "Running in the Claude Code Web/Cloud Sandbox" section with step-by-step playbook covering:
  - Root cause analysis (Ubuntu 24.04 vs. Debian, ImageMagick 6 vs. 7 mismatch)
  - Redis startup
  - Tesseract and build tooling installation
  - ImageMagick 7 delegate libraries
  - Building ImageMagick 7 from source with proper `ldconfig` configuration
  - Go server startup with SQLite + local Redis environment variables
  - Default admin login credentials and verification steps

- **desktop/CLAUDE.md**: Added "Running in the Claude Code Web/Cloud Sandbox" section with:
  - Backend-first dependency (API must run on :8081 before frontend)
  - `npm install` with lockfile gotcha (npm 10.9.7 rewrites `package-lock.json`)
  - Dev server startup on :4200 with API proxy configuration
  - Playwright/Chromium workaround (use pre-installed build 1194 at `/opt/pw-browsers/chromium` instead of downloading)
  - Scripted login flow example using Playwright selectors

- **CLAUDE.md** (root): Added "Running in the Claude Code Web/Cloud Sandbox" section with:
  - High-level overview and root cause explanation
  - Cross-component run order (backend first, then frontend)
  - Quick orientation for login and UI automation
  - Links to component-specific playbooks

- **desktop/CLAUDE.md**: Updated e2e testing section to note the Playwright browser pre-installation workaround in the sandbox

## Notable Implementation Details

- The ImageMagick 7 build from source is the critical blocker — Ubuntu's repos only ship IM6, so `set-up-dependencies.sh` fails. The playbook clones from GitHub and builds with delegates (PNG, JPEG, TIFF, WebP, HEIC, Ghostscript).
- `ldconfig` is emphasized as the key step to make both the Go build and runtime find the new ImageMagick libraries without needing `PKG_CONFIG_PATH` or `LD_LIBRARY_PATH` overrides.
- Redis is pre-installed in the sandbox but not running — must be started with `redis-server --daemonize yes`.
- The Playwright/Chromium mismatch (test expects 1217, sandbox has 1194) is documented as metadata-only and safe to ignore with an explicit `executablePath`.
- All steps are marked as ephemeral — must be re-run each session since the container is rebuilt.

https://claude.ai/code/session_01VbSiPMxb5VxoDQnSGAzaET