### PR TITLE
Use ARM-native runner for Docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
       needs.detect-changes.outputs.docker == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
       - name: Get build date

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
 
   build-docker-arm64:
     needs: [test-api, test-desktop]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
       - name: Get build date


### PR DESCRIPTION
## Summary
Updates CI/CD workflows to use ARM-native GitHub Actions runners (`ubuntu-24.04-arm`) instead of the generic `ubuntu-latest` for Docker ARM64 builds. This improves build performance and reliability by running ARM builds natively on ARM hardware rather than through emulation.

## Changes
- **ci.yml**: Changed `build-docker` job runner from `ubuntu-latest` to `ubuntu-24.04-arm`
- **release.yml**: Changed `build-docker-arm64` job runner from `ubuntu-latest` to `ubuntu-24.04-arm`

## Details
Building ARM64 Docker images on x86 runners requires QEMU emulation, which is slower and can be less reliable. By using GitHub's ARM-native runners, Docker builds for ARM64 will execute natively, resulting in faster builds and better compatibility with the target platform.

https://claude.ai/code/session_01CBSsTg3i7mkW2FVkSVhUPy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ARM64 Docker builds in CI and release workflows to use a dedicated ARM64 runner.
  * Existing build, push, and release behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->