### PR TITLE
fix(mobile): recover iOS launch render freeze on 120Hz devices (#617)

### DIFF
--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -388,6 +388,50 @@ applies `kotlin-android` itself and uses the legacy `kotlinOptions {}` DSL (work
 2.1.0); its `getPictures(noOfPages:)` API — the only call the app uses (`lib/utils/scan.dart`) —
 is identical.
 
+**Related: `sentry_flutter` pins Kotlin `languageVersion 1.6`.** `sentry_flutter` **8.14.2**'s
+`android/build.gradle` hardcodes `kotlinOptions { languageVersion = "1.6" }`, which the project's
+Kotlin **2.2.x** toolchain (above) rejects at compile time — `flutter build apk --release` fails at
+`:sentry_flutter:compileReleaseKotlin` with *"Language version 1.6 is no longer supported; please,
+use version 1.8 or greater"*. iOS uses a different toolchain and never hits this. The fix (root
+`android/build.gradle`) is a `subprojects { if (sp.name == 'sentry_flutter') { sp.afterEvaluate {
+tasks.withType(KotlinCompile).configureEach { compilerOptions { languageVersion / apiVersion .set(
+KOTLIN_1_8) } } } } }` block — scoped to that one module (via `afterEvaluate` so it overrides the
+module's own `kotlinOptions`), so every other subproject keeps its own language version. The block
+is a no-op / removable once `sentry_flutter` is upgraded past the 1.6 pin (9.x drops it, but 9.x
+needs a newer Dart SDK than this app currently targets).
+
+### Crash & error reporting (GlitchTip) + the iOS launch-freeze fix
+
+**Crash reporting** is via `sentry_flutter` → a self-hosted **GlitchTip** (Sentry-compatible)
+backend, wired in `lib/service/crash_reporting.dart`. It is **opt-out (on by default)** and
+**privacy-hardened**: `sendDefaultPii=false`, no screenshots / view-hierarchy / print breadcrumbs,
+`tracesSampleRate=0`, `enableAutoSessionTracking=false` (GlitchTip has no sessions), no `setUser`.
+`main()` only calls `SentryFlutter.init` when `isCrashReportingEnabled()` (a `SharedPreferences`
+flag, default true); the **opt-out toggle** ("Crash & error reporting") lives in
+`UserProfileScreen` and flips it live via `setCrashReportingEnabled` (`SentryFlutter.init` /
+`Sentry.close()`). The app has **zero** other analytics/tracking SDKs. `sentry_flutter` is pinned at
+**8.14.2** (9.x needs a newer Dart SDK); its Android Kotlin pin needs the gradle override documented
+above.
+
+**iOS launch-freeze fix (GitHub #617).** On iOS the Flutter engine pauses rendering while the app is
+`inactive`, and on **iOS 26.x with 120Hz ProMotion displays** (iPhone 17 / Air) it doesn't reliably
+resume — the first frame is painted at transient launch window metrics (wrong size/orientation) and
+then never repaints, so the UI freezes "half-rotated / unpainted." The fix (`lib/main.dart`):
+- **No launch-time permission request.** The old fire-and-forget `requestPermissions()` in
+  `initState` popped a camera dialog (→ `inactive` → freeze) *and* collided with in-context requests.
+  Camera is now requested by the scanner itself; photo-library access is requested at the
+  `Gal.putImageBytes` save sites (`receipt_app_bar_action_builder.dart`,
+  `receipt_image_app_bar.dart`). `requestPermissions()` is kept (uncalled) because a unit test
+  covers it.
+- **A forced-frame pump** (`nudgeFrames()`): bumps an invisible `ValueNotifier` (hosted in
+  `MaterialApp.builder`) **and** calls `WidgetsBinding.instance.scheduleForcedFrame()` each tick for
+  ~3s — the forced call bypasses the engine's "frames disabled while inactive" gate. It fires from
+  three points: a **launch** `addPostFrameCallback` (cold launch delivers no `resumed`), on
+  **`didChangeMetrics`** while a 6s launch window is open (re-flows the stale frame the moment the
+  window geometry settles), and on lifecycle **`resumed`** (app-switcher / scan-camera returns). It
+  **early-returns unless `defaultTargetPlatform == TargetPlatform.iOS`**, so Android/desktop and the
+  test suites are unaffected.
+
 ### QR-scan the server URL (login)
 
 The "Connect to Server" screen (`lib/auth/set-homeserver-url/screens/set_homeserver_url.dart`, route

--- a/mobile/android/build.gradle
+++ b/mobile/android/build.gradle
@@ -39,6 +39,28 @@ subprojects { sp ->
     }
 }
 
+// sentry_flutter (8.14.2) pins Kotlin `languageVersion = "1.6"` in its
+// android/build.gradle, which this project's Kotlin 2.2.x toolchain (bumped for
+// cunning_document_scanner 2.3.0, see settings.gradle) rejects at compile time:
+// "Language version 1.6 is no longer supported; please, use version 1.8 or
+// greater". Force that one module's Kotlin compile tasks up to the supported
+// floor. Scoped to sentry_flutter (via afterEvaluate, so it overrides the
+// module's own kotlinOptions) so every other subproject keeps its own language
+// version. If sentry_flutter is upgraded past the 1.6 pin, this block is a no-op
+// and can be removed.
+subprojects { sp ->
+    if (sp.name == 'sentry_flutter') {
+        sp.afterEvaluate {
+            sp.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+                compilerOptions {
+                    languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_8)
+                    apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_8)
+                }
+            }
+        }
+    }
+}
+
 tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/mobile/ios/Podfile.lock
+++ b/mobile/ios/Podfile.lock
@@ -17,9 +17,21 @@ PODS:
   - mobile_scanner (7.0.0):
     - Flutter
     - FlutterMacOS
+  - package_info_plus (0.4.5):
+    - Flutter
   - permission_handler_apple (9.4.8):
     - Flutter
+  - Sentry/HybridSDK (8.46.0)
+  - sentry_flutter (8.14.2):
+    - Flutter
+    - FlutterMacOS
+    - Sentry/HybridSDK (= 8.46.0)
+  - share_plus (0.0.1):
+    - Flutter
   - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - webview_flutter_wkwebview (0.0.1):
     - Flutter
     - FlutterMacOS
 
@@ -32,8 +44,16 @@ DEPENDENCIES:
   - gal (from `.symlinks/plugins/gal/darwin`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - mobile_scanner (from `.symlinks/plugins/mobile_scanner/darwin`)
+  - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
+  - sentry_flutter (from `.symlinks/plugins/sentry_flutter/ios`)
+  - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/darwin`)
+
+SPEC REPOS:
+  trunk:
+    - Sentry
 
 EXTERNAL SOURCES:
   cunning_document_scanner:
@@ -52,10 +72,18 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
   mobile_scanner:
     :path: ".symlinks/plugins/mobile_scanner/darwin"
+  package_info_plus:
+    :path: ".symlinks/plugins/package_info_plus/ios"
   permission_handler_apple:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
+  sentry_flutter:
+    :path: ".symlinks/plugins/sentry_flutter/ios"
+  share_plus:
+    :path: ".symlinks/plugins/share_plus/ios"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
+  webview_flutter_wkwebview:
+    :path: ".symlinks/plugins/webview_flutter_wkwebview/darwin"
 
 SPEC CHECKSUMS:
   cunning_document_scanner: 59087b3be88cf7e719fbc9d29b7278a8b2ee93d7
@@ -66,8 +94,13 @@ SPEC CHECKSUMS:
   gal: 6a522c75909f1244732d4596d11d6a2f86ff37a5
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
   mobile_scanner: 77265f3dc8d580810e91849d4a0811a90467ed5e
+  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
   permission_handler_apple: ee2fe0fd04551b304eb002714ff067c371c822ed
+  Sentry: da60d980b197a46db0b35ea12cb8f39af48d8854
+  sentry_flutter: 2df8b0aab7e4aba81261c230cbea31c82a62dd1b
+  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
   shared_preferences_foundation: 5086985c1d43c5ba4d5e69a4e8083a389e2909e6
+  webview_flutter_wkwebview: 29eb20d43355b48fe7d07113835b9128f84e3af4
 
 PODFILE CHECKSUM: 86fbc43373838e2352931d7236d3be98a7843d3a
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:go_router/go_router.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:provider/provider.dart';
 import 'package:receipt_wrangler_mobile/auth/login/screens/auth_screen.dart';
 import 'package:receipt_wrangler_mobile/groups/nav/group/group_app_bar.dart';
@@ -34,8 +36,8 @@ import 'package:receipt_wrangler_mobile/search/screens/search_screen.dart';
 import 'package:receipt_wrangler_mobile/search/widgets/searchbar.dart';
 import 'package:receipt_wrangler_mobile/services/token_refresh_service.dart';
 import 'package:receipt_wrangler_mobile/shared/widgets/circular_loading_progress.dart';
+import 'package:receipt_wrangler_mobile/service/crash_reporting.dart';
 import 'package:receipt_wrangler_mobile/shared/widgets/screen_wrapper.dart';
-import 'package:receipt_wrangler_mobile/utils/permissions.dart';
 
 import 'package:receipt_wrangler_mobile/profile/screens/user_profile_screen.dart';
 
@@ -45,11 +47,19 @@ import 'models/custom_field_model.dart';
 import 'models/system_settings_model.dart';
 
 void main() async {
-  var widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
+  final widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
   FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
   await GlobalSharedPreferences.initialize();
 
-  runApp(buildApp());
+  // Crash/error reporting is opt-out (on by default). When disabled we don't
+  // initialize Sentry at all, so nothing runs. SentryFlutter.init also installs
+  // the FlutterError/PlatformDispatcher error handlers that report uncaught
+  // exceptions.
+  if (isCrashReportingEnabled()) {
+    await SentryFlutter.init(configureSentry, appRunner: () => runApp(buildApp()));
+  } else {
+    runApp(buildApp());
+  }
 }
 
 /// Builds the production widget tree (providers + root app widget).
@@ -209,9 +219,12 @@ class ReceiptWrangler extends StatefulWidget {
   State<ReceiptWrangler> createState() => _ReceiptWrangler();
 }
 
-class _ReceiptWrangler extends State<ReceiptWrangler> {
+class _ReceiptWrangler extends State<ReceiptWrangler>
+    with WidgetsBindingObserver {
   late final AppLifecycleListener _lifecycleListener;
   Timer? _refreshTimer;
+  Timer? _launchWindowTimer;
+  bool _inLaunchWindow = true;
   late Future<bool> _initFuture;
   bool _initialized = false;
 
@@ -237,18 +250,48 @@ class _ReceiptWrangler extends State<ReceiptWrangler> {
   void initState() {
     super.initState();
 
+    WidgetsBinding.instance.addObserver(this);
     _lifecycleListener = AppLifecycleListener(onStateChange: _onStateChanged);
 
-    requestPermissions();
+    // NOTE: camera/photo permissions are intentionally NOT requested here.
+    // Requesting at launch makes the app go `inactive` (system dialog), and on
+    // iOS the Flutter engine pauses rendering while inactive — on iOS 26.x it
+    // doesn't reliably resume, leaving the UI frozen (GitHub #617). Permissions
+    // are now requested in-context: the scanner requests camera itself, and the
+    // save-to-gallery flow requests photo access at the point of use.
     FlutterNativeSplash.remove();
+
+    // Cold launch itself passes through `inactive`, and iOS can paint the first
+    // frame at transient launch metrics (wrong size/orientation) and then stop
+    // producing frames — the UI is stuck on that stale, "half-rotated/unpainted"
+    // frame (GitHub #617, seen on 120Hz iPhone 17 / Air devices even with no
+    // permission dialog). Force repaints from the very first frame so the
+    // pipeline re-latches and the layout re-flows to the real geometry.
+    // `didChangeMetrics` re-arms this while the window is still settling.
+    WidgetsBinding.instance.addPostFrameCallback((_) => nudgeFrames());
+    _launchWindowTimer =
+        Timer(const Duration(seconds: 6), () => _inLaunchWindow = false);
   }
 
   @override
   void dispose() {
     _refreshTimer?.cancel();
+    _launchWindowTimer?.cancel();
+    _frameNudgeTimer?.cancel();
+    WidgetsBinding.instance.removeObserver(this);
     _lifecycleListener.dispose();
 
     super.dispose();
+  }
+
+  @override
+  void didChangeMetrics() {
+    super.didChangeMetrics();
+    // A metrics change during the launch window means the window geometry just
+    // settled; force a repaint so a stale first frame re-flows to the real
+    // size/orientation. Gated to the launch window so ordinary keyboard
+    // show/hide later doesn't trigger a burst. (GitHub #617.)
+    if (_inLaunchWindow) nudgeFrames();
   }
 
   @override
@@ -316,6 +359,19 @@ class _ReceiptWrangler extends State<ReceiptWrangler> {
         useMaterial3: true,
       ),
       routerConfig: _router,
+      // Hosts an invisible repaint pump (see [nudgeFrames]) so the app can
+      // force frames after returning from an inactive state and recover from
+      // the iOS render-pause freeze (GitHub #617).
+      builder: (context, child) => Stack(
+        textDirection: TextDirection.ltr,
+        children: [
+          child ?? const SizedBox.shrink(),
+          ValueListenableBuilder<int>(
+            valueListenable: _frameNudge,
+            builder: (_, __, ___) => const SizedBox.shrink(),
+          ),
+        ],
+      ),
     );
   }
 
@@ -349,16 +405,45 @@ class _ReceiptWrangler extends State<ReceiptWrangler> {
     }
   }
 
-  void _onDetached() => print('detached');
+  void _onDetached() {}
 
   void _onResumed() async {
-    print("resumed");
+    // Recover from the iOS render-pause freeze after an inactive transition.
+    nudgeFrames();
     await TokenRefreshService().refreshTokens(force: true);
   }
 
-  void _onInactive() => print('inactive');
+  void _onInactive() {}
 
-  void _onHidden() => print('hidden');
+  void _onHidden() {}
 
-  void _onPaused() => print('paused');
+  void _onPaused() {}
+}
+
+/// Ticked by [nudgeFrames] to force the render pipeline to produce frames.
+final ValueNotifier<int> _frameNudge = ValueNotifier<int>(0);
+Timer? _frameNudgeTimer;
+
+/// The iOS Flutter engine pauses rendering while the app is `inactive` — a cold
+/// launch, a system permission dialog, the app switcher, an incoming call — and
+/// on iOS 26.x it doesn't reliably resume, leaving the UI frozen on its last
+/// (sometimes wrong-geometry) frame. For a short window this both bumps
+/// [_frameNudge] (marking the tree dirty) and calls
+/// [SchedulerBinding.scheduleForcedFrame] each tick: the forced call bypasses
+/// the engine's "frames disabled while inactive" gate, which a plain notifier
+/// bump does not — that re-latches the display link and unfreezes the UI.
+/// (GitHub #617 / flutter/engine#17396.)
+///
+/// iOS-only: a no-op on Android/desktop (and under the test suites, where
+/// `defaultTargetPlatform` is not iOS) so nothing else is affected.
+void nudgeFrames() {
+  if (defaultTargetPlatform != TargetPlatform.iOS) return;
+  _frameNudgeTimer?.cancel();
+  var ticks = 0;
+  WidgetsBinding.instance.scheduleForcedFrame();
+  _frameNudgeTimer = Timer.periodic(const Duration(milliseconds: 100), (t) {
+    _frameNudge.value++;
+    WidgetsBinding.instance.scheduleForcedFrame();
+    if (++ticks >= 30) t.cancel(); // ~3s
+  });
 }

--- a/mobile/lib/profile/screens/user_profile_screen.dart
+++ b/mobile/lib/profile/screens/user_profile_screen.dart
@@ -4,8 +4,8 @@ import 'package:go_router/go_router.dart';
 import 'package:openapi/openapi.dart' as api;
 import 'package:provider/provider.dart';
 import 'package:receipt_wrangler_mobile/client/client.dart';
-import 'package:receipt_wrangler_mobile/service/crash_reporting.dart';
 import 'package:receipt_wrangler_mobile/models/auth_model.dart';
+import 'package:receipt_wrangler_mobile/profile/widgets/crash_reporting_toggle.dart';
 import 'package:receipt_wrangler_mobile/profile/widgets/delete_account_dialog.dart';
 import 'package:receipt_wrangler_mobile/shared/widgets/screen_wrapper.dart';
 import 'package:receipt_wrangler_mobile/shared/widgets/top_app_bar.dart';
@@ -59,7 +59,7 @@ class UserProfileScreen extends StatelessWidget {
               'Privacy',
               style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
             ),
-            const _CrashReportingToggle(),
+            const CrashReportingToggle(),
             const SizedBox(height: 24),
             Container(
               width: double.infinity,
@@ -104,46 +104,6 @@ class UserProfileScreen extends StatelessWidget {
           ],
         ),
       ),
-    );
-  }
-}
-
-/// Opt-out toggle for crash & error reporting (on by default). Flips Sentry on
-/// the fly via [setCrashReportingEnabled] — no restart.
-class _CrashReportingToggle extends StatefulWidget {
-  const _CrashReportingToggle();
-
-  @override
-  State<_CrashReportingToggle> createState() => _CrashReportingToggleState();
-}
-
-class _CrashReportingToggleState extends State<_CrashReportingToggle> {
-  late bool _enabled = isCrashReportingEnabled();
-
-  @override
-  Widget build(BuildContext context) {
-    return SwitchListTile(
-      contentPadding: EdgeInsets.zero,
-      value: _enabled,
-      title: const Text('Crash & error reporting'),
-      subtitle: const Text(
-        'Sends anonymous crash and error reports so bugs can be fixed. No '
-        'personal data, no usage tracking, no advertising. You can turn this '
-        'off anytime.',
-      ),
-      onChanged: (value) async {
-        final previous = _enabled;
-        setState(() => _enabled = value);
-        try {
-          await setCrashReportingEnabled(value);
-        } catch (_) {
-          // Toggling the SDK failed — revert the switch so it keeps matching
-          // the persisted preference / actual SDK state, and surface the error.
-          if (!mounted) return;
-          setState(() => _enabled = previous);
-          showErrorSnackbar(context, "Couldn't update crash reporting setting");
-        }
-      },
     );
   }
 }

--- a/mobile/lib/profile/screens/user_profile_screen.dart
+++ b/mobile/lib/profile/screens/user_profile_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:openapi/openapi.dart' as api;
 import 'package:provider/provider.dart';
 import 'package:receipt_wrangler_mobile/client/client.dart';
+import 'package:receipt_wrangler_mobile/service/crash_reporting.dart';
 import 'package:receipt_wrangler_mobile/models/auth_model.dart';
 import 'package:receipt_wrangler_mobile/profile/widgets/delete_account_dialog.dart';
 import 'package:receipt_wrangler_mobile/shared/widgets/screen_wrapper.dart';
@@ -54,6 +55,12 @@ class UserProfileScreen extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             const SizedBox(height: 24),
+            const Text(
+              'Privacy',
+              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+            ),
+            const _CrashReportingToggle(),
+            const SizedBox(height: 24),
             Container(
               width: double.infinity,
               padding: const EdgeInsets.all(16),
@@ -97,6 +104,37 @@ class UserProfileScreen extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+/// Opt-out toggle for crash & error reporting (on by default). Flips Sentry on
+/// the fly via [setCrashReportingEnabled] — no restart.
+class _CrashReportingToggle extends StatefulWidget {
+  const _CrashReportingToggle();
+
+  @override
+  State<_CrashReportingToggle> createState() => _CrashReportingToggleState();
+}
+
+class _CrashReportingToggleState extends State<_CrashReportingToggle> {
+  late bool _enabled = isCrashReportingEnabled();
+
+  @override
+  Widget build(BuildContext context) {
+    return SwitchListTile(
+      contentPadding: EdgeInsets.zero,
+      value: _enabled,
+      title: const Text('Crash & error reporting'),
+      subtitle: const Text(
+        'Sends anonymous crash and error reports so bugs can be fixed. No '
+        'personal data, no usage tracking, no advertising. You can turn this '
+        'off anytime.',
+      ),
+      onChanged: (value) async {
+        setState(() => _enabled = value);
+        await setCrashReportingEnabled(value);
+      },
     );
   }
 }

--- a/mobile/lib/profile/screens/user_profile_screen.dart
+++ b/mobile/lib/profile/screens/user_profile_screen.dart
@@ -132,8 +132,17 @@ class _CrashReportingToggleState extends State<_CrashReportingToggle> {
         'off anytime.',
       ),
       onChanged: (value) async {
+        final previous = _enabled;
         setState(() => _enabled = value);
-        await setCrashReportingEnabled(value);
+        try {
+          await setCrashReportingEnabled(value);
+        } catch (_) {
+          // Toggling the SDK failed — revert the switch so it keeps matching
+          // the persisted preference / actual SDK state, and surface the error.
+          if (!mounted) return;
+          setState(() => _enabled = previous);
+          showErrorSnackbar(context, "Couldn't update crash reporting setting");
+        }
       },
     );
   }

--- a/mobile/lib/profile/widgets/crash_reporting_toggle.dart
+++ b/mobile/lib/profile/widgets/crash_reporting_toggle.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:receipt_wrangler_mobile/service/crash_reporting.dart';
+import 'package:receipt_wrangler_mobile/utils/snackbar.dart';
+
+/// Opt-out toggle for crash & error reporting (on by default). Flips Sentry on
+/// the fly via [setCrashReportingEnabled] — no restart.
+///
+/// [readEnabled] / [setEnabled] default to the real functions; they exist as
+/// seams so the widget can be tested without touching the native Sentry SDK.
+class CrashReportingToggle extends StatefulWidget {
+  const CrashReportingToggle({
+    super.key,
+    this.readEnabled = isCrashReportingEnabled,
+    this.setEnabled = setCrashReportingEnabled,
+  });
+
+  final bool Function() readEnabled;
+  final Future<void> Function(bool) setEnabled;
+
+  @override
+  State<CrashReportingToggle> createState() => _CrashReportingToggleState();
+}
+
+class _CrashReportingToggleState extends State<CrashReportingToggle> {
+  late bool _enabled = widget.readEnabled();
+  bool _isLoading = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return SwitchListTile(
+      contentPadding: EdgeInsets.zero,
+      value: _enabled,
+      // Disabled while a toggle is in flight so a rapid double-tap can't start a
+      // second concurrent SDK init/close (a null onChanged disables the switch).
+      onChanged: _isLoading ? null : _onChanged,
+      title: const Text('Crash & error reporting'),
+      subtitle: const Text(
+        'Sends anonymous crash and error reports so bugs can be fixed. No '
+        'personal data, no usage tracking, no advertising. You can turn this '
+        'off anytime.',
+      ),
+    );
+  }
+
+  Future<void> _onChanged(bool value) async {
+    final previous = _enabled;
+    setState(() {
+      _enabled = value;
+      _isLoading = true;
+    });
+    try {
+      await widget.setEnabled(value);
+    } catch (_) {
+      // Toggling the SDK failed — revert the switch so it keeps matching the
+      // persisted preference / actual SDK state, and surface the error.
+      if (mounted) {
+        setState(() => _enabled = previous);
+        showErrorSnackbar(context, "Couldn't update crash reporting setting");
+      }
+    } finally {
+      if (mounted) setState(() => _isLoading = false);
+    }
+  }
+}

--- a/mobile/lib/receipts/nav/receipt_app_bar_action_builder.dart
+++ b/mobile/lib/receipts/nav/receipt_app_bar_action_builder.dart
@@ -152,36 +152,43 @@ class ReceiptAppBarActionBuilder {
 
   Future downloadImage() async {
     loadingModel.setIsLoading(true);
-    var receiptImage = getCurrentlySelectedImage();
-    if (receiptImage == null) {
-      return;
+    try {
+      var receiptImage = getCurrentlySelectedImage();
+      if (receiptImage == null) {
+        return;
+      }
+
+      var imageResponse = await OpenApiClient.client
+          .getReceiptImageApi()
+          .downloadReceiptImageById(receiptImageId: receiptImage.id);
+
+      var imageBytes = imageResponse.data;
+      if (imageBytes == null) {
+        return;
+      }
+
+      // Gal.requestAccess() returns false when the user denies gallery access;
+      // bail out instead of falling through to a putImageBytes that would throw.
+      if (!await Gal.requestAccess()) {
+        if (context.mounted) {
+          showErrorSnackbar(context, "Gallery access denied");
+        }
+        return;
+      }
+
+      await Gal.putImageBytes(imageBytes);
+      if (context.mounted) {
+        showSuccessSnackbar(context, "Image saved to gallery",
+            action: SnackBarAction(
+                label: "Open", onPressed: () async => await Gal.open()));
+      }
+    } catch (e) {
+      if (context.mounted) {
+        showErrorSnackbar(context, "Failed to save image to gallery");
+      }
+    } finally {
+      loadingModel.setIsLoading(false);
     }
-
-    var imageResponse = await OpenApiClient.client
-        .getReceiptImageApi()
-        .downloadReceiptImageById(receiptImageId: receiptImage.id);
-
-    var imageBytes = imageResponse.data;
-
-    if (imageBytes == null) {
-      loadingModel.setIsLoading(false);
-      return;
-    }
-
-    await Gal.requestAccess();
-    await Gal.putImageBytes(imageBytes).then((value) {
-      var snackbarAction = SnackBarAction(
-        label: "Open",
-        onPressed: () async => await Gal.open(),
-      );
-
-      showSuccessSnackbar(context, "Image saved to gallery",
-          action: snackbarAction);
-      loadingModel.setIsLoading(false);
-    }).catchError((e) {
-      showErrorSnackbar(context, "Failed to save image to gallery");
-      loadingModel.setIsLoading(false);
-    });
   }
 
   List<PopupMenuEntry> _buildViewAppBarMenuOptions() {

--- a/mobile/lib/receipts/nav/receipt_app_bar_action_builder.dart
+++ b/mobile/lib/receipts/nav/receipt_app_bar_action_builder.dart
@@ -1,6 +1,5 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
-import 'package:gal/gal.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openapi/openapi.dart' as api;
 import 'package:provider/provider.dart';
@@ -14,6 +13,7 @@ import '../../enums/upload_method.dart';
 import '../../interfaces/upload_multipart_file_data.dart';
 import '../../models/loading_model.dart';
 import '../../models/receipt_model.dart';
+import '../../shared/functions/receipt_image_gallery.dart';
 import '../../shared/widgets/receipt_edit_popup_menu.dart';
 import '../../utils/forms.dart';
 import '../../utils/scan.dart';
@@ -151,44 +151,11 @@ class ReceiptAppBarActionBuilder {
   }
 
   Future downloadImage() async {
-    loadingModel.setIsLoading(true);
-    try {
-      var receiptImage = getCurrentlySelectedImage();
-      if (receiptImage == null) {
-        return;
-      }
-
-      var imageResponse = await OpenApiClient.client
-          .getReceiptImageApi()
-          .downloadReceiptImageById(receiptImageId: receiptImage.id);
-
-      var imageBytes = imageResponse.data;
-      if (imageBytes == null) {
-        return;
-      }
-
-      // Gal.requestAccess() returns false when the user denies gallery access;
-      // bail out instead of falling through to a putImageBytes that would throw.
-      if (!await Gal.requestAccess()) {
-        if (context.mounted) {
-          showErrorSnackbar(context, "Gallery access denied");
-        }
-        return;
-      }
-
-      await Gal.putImageBytes(imageBytes);
-      if (context.mounted) {
-        showSuccessSnackbar(context, "Image saved to gallery",
-            action: SnackBarAction(
-                label: "Open", onPressed: () async => await Gal.open()));
-      }
-    } catch (e) {
-      if (context.mounted) {
-        showErrorSnackbar(context, "Failed to save image to gallery");
-      }
-    } finally {
-      loadingModel.setIsLoading(false);
+    var receiptImage = getCurrentlySelectedImage();
+    if (receiptImage == null) {
+      return;
     }
+    await saveReceiptImageToGallery(context, loadingModel, receiptImage.id);
   }
 
   List<PopupMenuEntry> _buildViewAppBarMenuOptions() {

--- a/mobile/lib/receipts/nav/receipt_app_bar_action_builder.dart
+++ b/mobile/lib/receipts/nav/receipt_app_bar_action_builder.dart
@@ -168,6 +168,7 @@ class ReceiptAppBarActionBuilder {
       return;
     }
 
+    await Gal.requestAccess();
     await Gal.putImageBytes(imageBytes).then((value) {
       var snackbarAction = SnackBarAction(
         label: "Open",

--- a/mobile/lib/receipts/widgets/receipt_image_app_bar.dart
+++ b/mobile/lib/receipts/widgets/receipt_image_app_bar.dart
@@ -139,37 +139,44 @@ class ReceiptImageAppBar extends StatelessWidget implements PreferredSizeWidget 
   Future _downloadImage(BuildContext context, ReceiptModel receiptModel) async {
     final loadingModel = Provider.of<LoadingModel>(context, listen: false);
     loadingModel.setIsLoading(true);
-    
-    var receiptImage = _getCurrentlySelectedImage(receiptModel);
-    if (receiptImage == null) {
-      return;
+
+    try {
+      var receiptImage = _getCurrentlySelectedImage(receiptModel);
+      if (receiptImage == null) {
+        return;
+      }
+
+      var imageResponse = await OpenApiClient.client
+          .getReceiptImageApi()
+          .downloadReceiptImageById(receiptImageId: receiptImage.id);
+
+      var imageBytes = imageResponse.data;
+      if (imageBytes == null) {
+        return;
+      }
+
+      // Gal.requestAccess() returns false when the user denies gallery access;
+      // bail out instead of falling through to a putImageBytes that would throw.
+      if (!await Gal.requestAccess()) {
+        if (context.mounted) {
+          showErrorSnackbar(context, "Gallery access denied");
+        }
+        return;
+      }
+
+      await Gal.putImageBytes(imageBytes);
+      if (context.mounted) {
+        showSuccessSnackbar(context, "Image saved to gallery",
+            action: SnackBarAction(
+                label: "Open", onPressed: () async => await Gal.open()));
+      }
+    } catch (e) {
+      if (context.mounted) {
+        showErrorSnackbar(context, "Failed to save image to gallery");
+      }
+    } finally {
+      loadingModel.setIsLoading(false);
     }
-
-    var imageResponse = await OpenApiClient.client
-        .getReceiptImageApi()
-        .downloadReceiptImageById(receiptImageId: receiptImage.id);
-
-    var imageBytes = imageResponse.data;
-
-    if (imageBytes == null) {
-      loadingModel.setIsLoading(false);
-      return;
-    }
-
-    await Gal.requestAccess();
-    await Gal.putImageBytes(imageBytes).then((value) {
-      var snackbarAction = SnackBarAction(
-        label: "Open",
-        onPressed: () async => await Gal.open(),
-      );
-
-      showSuccessSnackbar(context, "Image saved to gallery",
-          action: snackbarAction);
-      loadingModel.setIsLoading(false);
-    }).catchError((e) {
-      showErrorSnackbar(context, "Failed to save image to gallery");
-      loadingModel.setIsLoading(false);
-    });
   }
 
   PopupMenuEntry _buildDeleteButton(BuildContext context, ReceiptModel receiptModel) {

--- a/mobile/lib/receipts/widgets/receipt_image_app_bar.dart
+++ b/mobile/lib/receipts/widgets/receipt_image_app_bar.dart
@@ -156,6 +156,7 @@ class ReceiptImageAppBar extends StatelessWidget implements PreferredSizeWidget 
       return;
     }
 
+    await Gal.requestAccess();
     await Gal.putImageBytes(imageBytes).then((value) {
       var snackbarAction = SnackBarAction(
         label: "Open",

--- a/mobile/lib/receipts/widgets/receipt_image_app_bar.dart
+++ b/mobile/lib/receipts/widgets/receipt_image_app_bar.dart
@@ -1,6 +1,5 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
-import 'package:gal/gal.dart';
 import 'package:openapi/openapi.dart' as api;
 import 'package:provider/provider.dart';
 import 'package:receipt_wrangler_mobile/enums/form_state.dart';
@@ -13,6 +12,7 @@ import '../../enums/upload_method.dart';
 import '../../interfaces/upload_multipart_file_data.dart';
 import '../../models/loading_model.dart';
 import '../../models/receipt_model.dart';
+import '../../shared/functions/receipt_image_gallery.dart';
 import '../../shared/widgets/receipt_edit_popup_menu.dart';
 import '../../utils/scan.dart';
 import '../../utils/snackbar.dart';
@@ -138,45 +138,11 @@ class ReceiptImageAppBar extends StatelessWidget implements PreferredSizeWidget 
 
   Future _downloadImage(BuildContext context, ReceiptModel receiptModel) async {
     final loadingModel = Provider.of<LoadingModel>(context, listen: false);
-    loadingModel.setIsLoading(true);
-
-    try {
-      var receiptImage = _getCurrentlySelectedImage(receiptModel);
-      if (receiptImage == null) {
-        return;
-      }
-
-      var imageResponse = await OpenApiClient.client
-          .getReceiptImageApi()
-          .downloadReceiptImageById(receiptImageId: receiptImage.id);
-
-      var imageBytes = imageResponse.data;
-      if (imageBytes == null) {
-        return;
-      }
-
-      // Gal.requestAccess() returns false when the user denies gallery access;
-      // bail out instead of falling through to a putImageBytes that would throw.
-      if (!await Gal.requestAccess()) {
-        if (context.mounted) {
-          showErrorSnackbar(context, "Gallery access denied");
-        }
-        return;
-      }
-
-      await Gal.putImageBytes(imageBytes);
-      if (context.mounted) {
-        showSuccessSnackbar(context, "Image saved to gallery",
-            action: SnackBarAction(
-                label: "Open", onPressed: () async => await Gal.open()));
-      }
-    } catch (e) {
-      if (context.mounted) {
-        showErrorSnackbar(context, "Failed to save image to gallery");
-      }
-    } finally {
-      loadingModel.setIsLoading(false);
+    var receiptImage = _getCurrentlySelectedImage(receiptModel);
+    if (receiptImage == null) {
+      return;
     }
+    await saveReceiptImageToGallery(context, loadingModel, receiptImage.id);
   }
 
   PopupMenuEntry _buildDeleteButton(BuildContext context, ReceiptModel receiptModel) {

--- a/mobile/lib/service/crash_reporting.dart
+++ b/mobile/lib/service/crash_reporting.dart
@@ -33,10 +33,12 @@ void configureSentry(SentryFlutterOptions options) {
 /// Toggle crash reporting at runtime (opt-out; default on). Effective
 /// immediately — no restart.
 Future<void> setCrashReportingEnabled(bool enabled) async {
-  await GlobalSharedPreferences.instance.setBool(kCrashReportingKey, enabled);
+  // Apply the SDK change first, then persist — a failed init/close must not
+  // leave the stored preference out of sync with what the SDK is actually doing.
   if (enabled) {
     await SentryFlutter.init(configureSentry);
   } else {
     await Sentry.close();
   }
+  await GlobalSharedPreferences.instance.setBool(kCrashReportingKey, enabled);
 }

--- a/mobile/lib/service/crash_reporting.dart
+++ b/mobile/lib/service/crash_reporting.dart
@@ -1,0 +1,42 @@
+import 'package:receipt_wrangler_mobile/persistence/global_shared_preferences.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+/// Privacy-respecting crash & error reporting via GlitchTip (Sentry-compatible).
+///
+/// - Reports crashes / uncaught exceptions / native hangs only — no behavioral
+///   analytics, no ads, no advertising IDs.
+/// - No PII: `sendDefaultPii = false` (no IP), never calls `setUser`, no
+///   screenshots/view-hierarchy, and app logs are not turned into breadcrumbs.
+/// - Opt-out: on by default, but the user can disable it live from the profile
+///   screen ([setCrashReportingEnabled]) — `Sentry.close()` stops the whole SDK
+///   (Dart + native) immediately; re-enabling re-inits it, no app restart.
+const String kCrashReportingKey = 'crashReportingEnabled';
+
+const String _dsn =
+    'https://167ea649143c46418671b1597dfd8a9b@app.glitchtip.com/25926';
+
+/// Whether the user has crash reporting enabled (default: true / opted-in).
+bool isCrashReportingEnabled() =>
+    GlobalSharedPreferences.instance.getBool(kCrashReportingKey) ?? true;
+
+/// Shared, privacy-hardened Sentry configuration.
+void configureSentry(SentryFlutterOptions options) {
+  options.dsn = _dsn;
+  options.sendDefaultPii = false; // no IP address / no PII
+  options.enableAutoSessionTracking = false; // GlitchTip has no sessions
+  options.enablePrintBreadcrumbs = false; // don't turn app logs into breadcrumbs
+  options.attachScreenshot = false; // never capture screen contents
+  options.attachViewHierarchy = false;
+  options.tracesSampleRate = 0.0; // crash/error reporting only, no perf tracing
+}
+
+/// Toggle crash reporting at runtime (opt-out; default on). Effective
+/// immediately — no restart.
+Future<void> setCrashReportingEnabled(bool enabled) async {
+  await GlobalSharedPreferences.instance.setBool(kCrashReportingKey, enabled);
+  if (enabled) {
+    await SentryFlutter.init(configureSentry);
+  } else {
+    await Sentry.close();
+  }
+}

--- a/mobile/lib/shared/functions/receipt_image_gallery.dart
+++ b/mobile/lib/shared/functions/receipt_image_gallery.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:gal/gal.dart';
+import 'package:receipt_wrangler_mobile/client/client.dart';
+import 'package:receipt_wrangler_mobile/models/loading_model.dart';
+import 'package:receipt_wrangler_mobile/utils/snackbar.dart';
+
+/// Downloads receipt image [receiptImageId] and saves it to the device gallery,
+/// driving the [loadingModel] spinner and surfacing success / access-denied /
+/// failure via snackbars. Shared by the two receipt image app bars so the flow
+/// stays in one place.
+Future<void> saveReceiptImageToGallery(
+    BuildContext context, LoadingModel loadingModel, int receiptImageId) async {
+  loadingModel.setIsLoading(true);
+  try {
+    final imageResponse = await OpenApiClient.client
+        .getReceiptImageApi()
+        .downloadReceiptImageById(receiptImageId: receiptImageId);
+
+    final imageBytes = imageResponse.data;
+    if (imageBytes == null) {
+      return;
+    }
+
+    // Gal.requestAccess() returns false when the user denies gallery access;
+    // bail out instead of falling through to a putImageBytes that would throw.
+    if (!await Gal.requestAccess()) {
+      if (context.mounted) {
+        showErrorSnackbar(context, "Gallery access denied");
+      }
+      return;
+    }
+
+    await Gal.putImageBytes(imageBytes);
+    if (context.mounted) {
+      showSuccessSnackbar(context, "Image saved to gallery",
+          action: SnackBarAction(
+              label: "Open", onPressed: () async => await Gal.open()));
+    }
+  } catch (e) {
+    if (context.mounted) {
+      showErrorSnackbar(context, "Failed to save image to gallery");
+    }
+  } finally {
+    loadingModel.setIsLoading(false);
+  }
+}

--- a/mobile/linux/flutter/generated_plugin_registrant.cc
+++ b/mobile/linux/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <file_selector_linux/file_selector_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
+#include <sentry_flutter/sentry_flutter_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
@@ -17,6 +18,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
+  g_autoptr(FlPluginRegistrar) sentry_flutter_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "SentryFlutterPlugin");
+  sentry_flutter_plugin_register_with_registrar(sentry_flutter_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/mobile/linux/flutter/generated_plugins.cmake
+++ b/mobile/linux/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
   flutter_secure_storage_linux
+  sentry_flutter
   url_launcher_linux
 )
 

--- a/mobile/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/mobile/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,6 +9,8 @@ import file_selector_macos
 import flutter_secure_storage_darwin
 import gal
 import mobile_scanner
+import package_info_plus
+import sentry_flutter
 import share_plus
 import shared_preferences_foundation
 import webview_flutter_wkwebview
@@ -18,6 +20,8 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   GalPlugin.register(with: registry.registrar(forPlugin: "GalPlugin"))
   MobileScannerPlugin.register(with: registry.registrar(forPlugin: "MobileScannerPlugin"))
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  SentryFlutterPlugin.register(with: registry.registrar(forPlugin: "SentryFlutterPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   WebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "WebViewFlutterPlugin"))

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -739,6 +739,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  package_info_plus:
+    dependency: transitive
+    description:
+      name: package_info_plus
+      sha256: "127e1751e37ffb2ff4658beeaca77bad0c27bf5f932bd3a501c2296926d4b481"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.2.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: db762cb2f4f25ee60fb6359773861b0f199e00b90d237bd85a76a1e806b46ef4
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   path:
     dependency: transitive
     description:
@@ -963,6 +979,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  sentry:
+    dependency: transitive
+    description:
+      name: sentry
+      sha256: "599701ca0693a74da361bc780b0752e1abc98226cf5095f6b069648116c896bb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.14.2"
+  sentry_flutter:
+    dependency: "direct main"
+    description:
+      name: sentry_flutter
+      sha256: "5ba2cf40646a77d113b37a07bd69f61bb3ec8a73cbabe5537b05a7c89d2656f8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.14.2"
   share_plus:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -68,6 +68,7 @@ dependencies:
   webview_flutter: ^4.14.1
   path_provider: ^2.1.6
   share_plus: ^13.2.1
+  sentry_flutter: ^8.14.2
 
 dev_dependencies:
   flutter_test:

--- a/mobile/test/interceptors/auth_interceptor_test.dart
+++ b/mobile/test/interceptors/auth_interceptor_test.dart
@@ -34,7 +34,7 @@ class TestErrorHandler with _NoopBaseHandler
   }
 
   @override
-  void reject(DioException err) {
+  void reject(DioException err, [bool callFollowingErrorInterceptor = false]) {
     if (!_actionCompleter.isCompleted) _actionCompleter.complete('reject');
   }
 }

--- a/mobile/test/services/crash_reporting_test.dart
+++ b/mobile/test/services/crash_reporting_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:receipt_wrangler_mobile/persistence/global_shared_preferences.dart';
+import 'package:receipt_wrangler_mobile/service/crash_reporting.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    // Must run before the first getInstance(); GlobalSharedPreferences caches a
+    // single instance and has no reset, so we mutate the live instance per test.
+    SharedPreferences.setMockInitialValues({});
+    await GlobalSharedPreferences.initialize();
+  });
+
+  setUp(() async {
+    await GlobalSharedPreferences.instance.remove(kCrashReportingKey);
+  });
+
+  group('isCrashReportingEnabled', () {
+    test('defaults to true (opted in) when the preference is unset', () {
+      expect(isCrashReportingEnabled(), isTrue);
+    });
+
+    test('returns false when the preference is stored false', () async {
+      await GlobalSharedPreferences.instance.setBool(kCrashReportingKey, false);
+      expect(isCrashReportingEnabled(), isFalse);
+    });
+
+    test('returns true when the preference is stored true', () async {
+      await GlobalSharedPreferences.instance.setBool(kCrashReportingKey, true);
+      expect(isCrashReportingEnabled(), isTrue);
+    });
+  });
+
+  group('configureSentry', () {
+    test('applies the privacy-hardened configuration', () {
+      final options = SentryFlutterOptions();
+
+      configureSentry(options);
+
+      expect(options.dsn, isNotEmpty);
+      expect(options.sendDefaultPii, isFalse); // no IP / no PII
+      expect(options.enableAutoSessionTracking, isFalse); // GlitchTip: no sessions
+      expect(options.enablePrintBreadcrumbs, isFalse); // logs not turned into breadcrumbs
+      expect(options.attachScreenshot, isFalse); // never capture screen contents
+      expect(options.attachViewHierarchy, isFalse);
+      expect(options.tracesSampleRate, 0.0); // crash/error only, no perf tracing
+    });
+  });
+}

--- a/mobile/test/shared/functions/receipt_image_gallery_test.dart
+++ b/mobile/test/shared/functions/receipt_image_gallery_test.dart
@@ -1,0 +1,127 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openapi/openapi.dart' show Openapi, ReceiptImageApi;
+import 'package:receipt_wrangler_mobile/client/client.dart';
+import 'package:receipt_wrangler_mobile/models/loading_model.dart';
+import 'package:receipt_wrangler_mobile/shared/functions/receipt_image_gallery.dart';
+
+class MockOpenapi extends Mock implements Openapi {}
+
+class MockReceiptImageApi extends Mock implements ReceiptImageApi {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const galChannel = MethodChannel('gal');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  late MockOpenapi mockClient;
+  late MockReceiptImageApi mockReceiptImageApi;
+  late LoadingModel loadingModel;
+  late bool grantAccess;
+  late List<String> galCalls;
+
+  setUp(() {
+    mockClient = MockOpenapi();
+    mockReceiptImageApi = MockReceiptImageApi();
+    when(() => mockClient.getReceiptImageApi()).thenReturn(mockReceiptImageApi);
+    // The default client builds a real Openapi with a relative baseUrl that dio
+    // rejects off-Web, so install the mock for the test's lifetime (no restore).
+    OpenApiClient.client = mockClient;
+
+    loadingModel = LoadingModel();
+    grantAccess = true;
+    galCalls = [];
+    messenger.setMockMethodCallHandler(galChannel, (call) async {
+      galCalls.add(call.method);
+      if (call.method == 'requestAccess') return grantAccess;
+      if (call.method == 'hasAccess') return true;
+      return null; // putImageBytes, open
+    });
+  });
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(galChannel, null);
+  });
+
+  void stubDownload({Uint8List? data, bool throwError = false}) {
+    final call =
+        when(() => mockReceiptImageApi.downloadReceiptImageById(receiptImageId: 5));
+    if (throwError) {
+      call.thenThrow(DioException(requestOptions: RequestOptions(path: '')));
+    } else {
+      call.thenAnswer((_) async => Response<Uint8List>(
+            requestOptions: RequestOptions(path: ''),
+            statusCode: 200,
+            data: data,
+          ));
+    }
+  }
+
+  Widget host() => MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (ctx) => ElevatedButton(
+              onPressed: () =>
+                  saveReceiptImageToGallery(ctx, loadingModel, 5),
+              child: const Text('go'),
+            ),
+          ),
+        ),
+      );
+
+  Future<void> tapAndDrain(WidgetTester tester) async {
+    await tester.tap(find.text('go'));
+    await tester.pump(); // run the async body
+    await tester.pump(const Duration(milliseconds: 750)); // snackbar entrance
+  }
+
+  testWidgets('saves the image and shows a success snackbar', (tester) async {
+    stubDownload(data: Uint8List.fromList([1, 2, 3]));
+    await tester.pumpWidget(host());
+
+    await tapAndDrain(tester);
+
+    expect(galCalls, contains('putImageBytes'));
+    expect(find.text('Image saved to gallery'), findsOneWidget);
+    expect(loadingModel.isLoading, isFalse);
+  });
+
+  testWidgets('bails with a snackbar when gallery access is denied',
+      (tester) async {
+    stubDownload(data: Uint8List.fromList([1, 2, 3]));
+    grantAccess = false;
+    await tester.pumpWidget(host());
+
+    await tapAndDrain(tester);
+
+    expect(find.text('Gallery access denied'), findsOneWidget);
+    expect(galCalls.contains('putImageBytes'), isFalse);
+    expect(loadingModel.isLoading, isFalse);
+  });
+
+  testWidgets('returns quietly when the image bytes are null', (tester) async {
+    stubDownload(data: null);
+    await tester.pumpWidget(host());
+
+    await tapAndDrain(tester);
+
+    expect(find.byType(SnackBar), findsNothing);
+    expect(galCalls, isEmpty); // requestAccess is only reached after the null check
+    expect(loadingModel.isLoading, isFalse);
+  });
+
+  testWidgets('shows an error snackbar when the download fails', (tester) async {
+    stubDownload(throwError: true);
+    await tester.pumpWidget(host());
+
+    await tapAndDrain(tester);
+
+    expect(find.text('Failed to save image to gallery'), findsOneWidget);
+    expect(loadingModel.isLoading, isFalse);
+  });
+}

--- a/mobile/test/widgets/crash_reporting_toggle_test.dart
+++ b/mobile/test/widgets/crash_reporting_toggle_test.dart
@@ -1,0 +1,68 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:receipt_wrangler_mobile/profile/widgets/crash_reporting_toggle.dart';
+
+void main() {
+  Widget host(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+  SwitchListTile theSwitch(WidgetTester tester) =>
+      tester.widget<SwitchListTile>(find.byType(SwitchListTile));
+
+  testWidgets('reflects the injected initial enabled state', (tester) async {
+    await tester.pumpWidget(host(CrashReportingToggle(
+      readEnabled: () => false,
+      setEnabled: (_) async {},
+    )));
+
+    expect(theSwitch(tester).value, isFalse);
+  });
+
+  testWidgets('persists the new value via setEnabled', (tester) async {
+    bool? saved;
+    await tester.pumpWidget(host(CrashReportingToggle(
+      readEnabled: () => true,
+      setEnabled: (value) async => saved = value,
+    )));
+
+    await tester.tap(find.byType(SwitchListTile));
+    await tester.pumpAndSettle();
+
+    expect(saved, isFalse);
+    expect(theSwitch(tester).value, isFalse);
+  });
+
+  testWidgets('reverts the switch and shows a snackbar when setEnabled throws',
+      (tester) async {
+    await tester.pumpWidget(host(CrashReportingToggle(
+      readEnabled: () => true,
+      setEnabled: (_) async => throw Exception('boom'),
+    )));
+
+    await tester.tap(find.byType(SwitchListTile));
+    await tester.pump(); // let _onChanged run through its catch
+    await tester.pump(const Duration(milliseconds: 750)); // snackbar entrance
+
+    expect(theSwitch(tester).value, isTrue); // reverted to the prior value
+    expect(find.text("Couldn't update crash reporting setting"), findsOneWidget);
+  });
+
+  testWidgets('disables the switch while a toggle is in flight', (tester) async {
+    final gate = Completer<void>();
+    await tester.pumpWidget(host(CrashReportingToggle(
+      readEnabled: () => true,
+      setEnabled: (_) => gate.future,
+    )));
+
+    await tester.tap(find.byType(SwitchListTile));
+    await tester.pump(); // _isLoading = true
+
+    expect(theSwitch(tester).onChanged, isNull); // disabled mid-flight
+
+    gate.complete();
+    await tester.pumpAndSettle();
+
+    expect(theSwitch(tester).onChanged, isNotNull); // re-enabled
+  });
+}

--- a/mobile/windows/flutter/generated_plugin_registrant.cc
+++ b/mobile/windows/flutter/generated_plugin_registrant.cc
@@ -10,6 +10,7 @@
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <gal/gal_plugin_c_api.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
+#include <sentry_flutter/sentry_flutter_plugin.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
@@ -22,6 +23,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("GalPluginCApi"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
+  SentryFlutterPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SentryFlutterPlugin"));
   SharePlusWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/mobile/windows/flutter/generated_plugins.cmake
+++ b/mobile/windows/flutter/generated_plugins.cmake
@@ -7,6 +7,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_windows
   gal
   permission_handler_windows
+  sentry_flutter
   share_plus
   url_launcher_windows
 )


### PR DESCRIPTION
## Summary

Fixes the iOS launch **hard-freeze** reported in #617 — the app hangs within a few seconds of launch on the server-entry screen (cursor stops, taps do nothing; no iOS crash log because it's a UI-thread render stall, not a crash).

### Root cause
The iOS Flutter engine pauses rendering while the app is `inactive`. On **iOS 26.x with ProMotion (120 Hz) displays** it doesn't reliably resume: the first frame is painted at transient launch window metrics (wrong size/orientation) and then never repaints, so the UI freezes **"half-rotated / unpainted."** The launch-time camera-permission dialog was one trigger (it drove the app `inactive`), but the cold launch itself passes through `inactive`, so removing the dialog alone wasn't enough on 120 Hz hardware.

### Empirical device matrix (TestingBot, real devices)
| Device | Refresh | Before | After |
|---|---|---|---|
| iPhone 16 | 60 Hz | ✅ ok | ✅ ok |
| iPhone 17 | 120 Hz | ❌ freeze | ✅ ok |
| iPhone 17 Pro Max | 120 Hz | ❌ freeze | ✅ **confirmed fixed** |
| iPhone Air | 120 Hz | ❌ freeze | (expected ok) |

## The fix (`lib/main.dart`)
- **No launch-time `requestPermissions()`.** The fire-and-forget camera request at launch popped a system dialog (→ `inactive` → freeze) and also collided with in-context requests. Camera is now requested by the scanner itself; photo-library access at the two `Gal.putImageBytes` save sites (`receipt_app_bar_action_builder.dart`, `receipt_image_app_bar.dart`). `requestPermissions()` is kept (uncalled) since a unit test covers it.
- **A forced-frame pump** (`nudgeFrames()`): bumps an invisible `ValueNotifier` (hosted in `MaterialApp.builder`) **and** calls `WidgetsBinding.instance.scheduleForcedFrame()` each tick for ~3 s — the forced call bypasses the engine's "frames disabled while inactive" gate. It fires from three points: a **launch** post-frame callback (a cold launch delivers no `resumed`), on **`didChangeMetrics`** during a 6 s launch window (re-flows the stale frame the moment window geometry settles), and on lifecycle **`resumed`** (app-switcher / scan returns). It **early-returns unless `defaultTargetPlatform == TargetPlatform.iOS`**, so Android/desktop and the test suites are untouched.

## Also included
- **Crash & error reporting** via `sentry_flutter` → GlitchTip (`lib/service/crash_reporting.dart`): **opt-out, on by default**, privacy-hardened (no PII / screenshots / view-hierarchy / breadcrumbs / tracing / user), with a live **toggle in Profile**. No other analytics SDKs exist in the app.
- **`android/build.gradle`:** a scoped Kotlin-language-version override for the `sentry_flutter` module. Sentry 8.14.2 pins `languageVersion 1.6`, which this project's Kotlin 2.2.x toolchain rejects — `flutter build apk --release` was failing at `:sentry_flutter:compileReleaseKotlin`. Scoped to that one module so nothing else changes; auto-removable once Sentry is bumped past the pin. **Verified with a release APK on TestingBot.**
- **`ios/Podfile.lock` regenerated:** adds the Sentry pod, and also syncs the previously-**missing** `webview_flutter_wkwebview` / `share_plus` / `package_info_plus` pods (main's committed lock was stale relative to its own `pubspec.yaml`). Additions only — no existing pod checksums churned.
- **`test/interceptors/auth_interceptor_test.dart`:** match the fake `TestErrorHandler.reject` override to dio 5.10's new optional positional param — a pre-existing compile drift on `main` that was failing `flutter test`. Pure signature fix (behavior unchanged; production never calls `reject`).
- `CLAUDE.md` docs for all of the above.

## Testing
- `flutter analyze` — clean on touched files (only pre-existing theme deprecations).
- `flutter test` — **fully green: 220 pass, 0 fail** (the one previously-failing file, `auth_interceptor_test.dart`, is fixed in this PR).
- iOS: fix confirmed on iPhone 17 Pro Max via TestingBot. Android: release APK builds and installs on TestingBot (behavior unchanged — the pump is iOS-gated).

## Notes
- Branched off a freshly-pulled `main`.
- Version left at `2.0.0+20` — bump before the release cut if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Crash & error reporting” privacy toggle in the profile, with immediate opt-in/opt-out (no restart).
  * Enabled privacy-focused crash and error reporting across supported platforms.
  * Centralized receipt image gallery saving with consistent loading and success/error feedback.
* **Bug Fixes**
  * Improved iOS launch stability and recovery from rendering freezes.
  * Enhanced Android build compatibility for crash-reporting integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->