### PR TITLE
Add end-to-end ingest tests for QuickScan and Magic Fill

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -799,8 +799,8 @@ a real paid-by and status — neither field is ever null/empty**. This is why th
   to the granted catalog, but a crafted request could otherwise attach a category/tag the caller can't
   see.
 - **End-to-end ingest tests** (`services/quick_scan_ingest_test.go`): the AI is mocked at the HTTP
-  transport layer (a mutable-body httptest server, reusing `newMockOllamaServerForService` /
-  `ollamaBody` / `seedReceiptImagePipeline` from `ai_test.go` / `receipt_image_test.go`), a controlled
+  transport layer (a new mutable-body httptest server `newMutableOllamaServer` + `ollamaReceiptResponse`,
+  reusing `seedReceiptImagePipeline` from `receipt_image_test.go`), a controlled
   receipt JSON is driven through the real `ReceiptService.QuickScan`, and the persisted receipt is read
   back via `GetFullyLoadedReceiptById` to prove **every** field survives — name/amount/date/paid-by/
   status, receipt- and item-level categories/tags, items (amount / status / `chargedToUserId` /

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -798,6 +798,19 @@ a real paid-by and status — neither field is ever null/empty**. This is why th
   and admin-bypass callers are a no-op). This closes a write bypass: the UI picker already limits picks
   to the granted catalog, but a crafted request could otherwise attach a category/tag the caller can't
   see.
+- **End-to-end ingest tests** (`services/quick_scan_ingest_test.go`): the AI is mocked at the HTTP
+  transport layer (a mutable-body httptest server, reusing `newMockOllamaServerForService` /
+  `ollamaBody` / `seedReceiptImagePipeline` from `ai_test.go` / `receipt_image_test.go`), a controlled
+  receipt JSON is driven through the real `ReceiptService.QuickScan`, and the persisted receipt is read
+  back via `GetFullyLoadedReceiptById` to prove **every** field survives — name/amount/date/paid-by/
+  status, receipt- and item-level categories/tags, items (amount / status / `chargedToUserId` /
+  `isTaxed` / linked items), comments, and all five custom-field value types. This pins the
+  AI→`CreateReceipt` contract (which passes items/comments/customFields through untouched, so a future
+  prompt emitting them just works), plus the paid-by/status backfill, the category/tag merge, refunds
+  (negative amounts), and the all-or-nothing failure path (bad item status / invalid JSON persist
+  nothing). Note: `UpsertReceiptCommand.Validate` deliberately does **not** validate `CustomFields`
+  (unlike categories/tags/items/comments), so a custom-field value is persisted unchecked — the test
+  is the only guard against a regression that silently drops or mis-columns it.
 
 ## Reporting Engine (`internal/reporting`)
 

--- a/api/internal/services/quick_scan_ingest_test.go
+++ b/api/internal/services/quick_scan_ingest_test.go
@@ -1,0 +1,750 @@
+package services
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"receipt-wrangler/api/internal/commands"
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/repositories"
+	"receipt-wrangler/api/internal/structs"
+	"receipt-wrangler/api/internal/utils"
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+// These tests exercise the full "AI response -> created receipt" path: a controlled AI JSON body is
+// fed through the real ReceiptService.QuickScan (the only place an AI response reaches CreateReceipt)
+// and the persisted receipt is read back through the deep-preload GetFullyLoadedReceiptById to prove
+// that every field survives - name, amount, date, paid-by, status, categories, tags, receipt items
+// (amount / status / chargedToUserId / isTaxed / per-item categories+tags / linked items), comments,
+// and custom-field values of all five value types. If a future prompt starts emitting these fields,
+// these tests prove the plumbing already persists them; a regression that silently drops a field
+// fails here.
+//
+// The AI is mocked at the HTTP transport layer (see ai_test.go) via a server whose body is set AFTER
+// the pipeline is seeded, so fixtures can reference the seeded user's real id without guessing.
+
+// newMutableOllamaServer serves whatever *body points at, at request time. Unlike
+// newMockOllamaServerForService (fixed body) this lets a test seed the graph first, learn the seeded
+// user's id, then set the AI response referencing that id - the request only fires later, inside
+// QuickScan.
+func newMutableOllamaServer(t *testing.T, body *string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(*body))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// ollamaReceiptResponse wraps a receipt JSON string as the message.content of an Ollama chat
+// response, JSON-escaping it so quotes/newlines in the receipt JSON can't break the envelope.
+func ollamaReceiptResponse(t *testing.T, receiptJSON string) string {
+	t.Helper()
+	envelope := map[string]any{
+		"model":      "test",
+		"created_at": "2024-01-01T00:00:00Z",
+		"message":    map[string]any{"role": "assistant", "content": receiptJSON},
+		"done":       true,
+	}
+	bytes, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("marshal ollama envelope: %v", err)
+	}
+	return string(bytes)
+}
+
+// writeQuickScanTempFile writes the shared JPG fixture to a temp file and returns its path, mirroring
+// what handlers.QuickScan hands ReceiptService.QuickScan.
+func writeQuickScanTempFile(t *testing.T) string {
+	t.Helper()
+	jpg, err := os.ReadFile(filepath.Join(testApiRoot(), "testing", "test.jpg"))
+	if err != nil {
+		t.Fatalf("read jpg fixture: %v", err)
+	}
+	path, err := repositories.NewFileRepository(nil).WriteTempFile(jpg)
+	if err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	t.Cleanup(func() { os.Remove(path) })
+	return path
+}
+
+// seededCustomFields carries the ids of the custom fields (one per value type) seeded for a test so
+// the AI-response fixture can reference them.
+type seededCustomFields struct {
+	textId, dateId, selectId, optionId, currencyId, booleanId uint
+}
+
+func seedQuickScanCustomFields(t *testing.T) seededCustomFields {
+	t.Helper()
+	db := repositories.GetDB()
+
+	text := models.CustomField{Name: "Text Field", Type: models.TEXT}
+	date := models.CustomField{Name: "Date Field", Type: models.DATE}
+	selectField := models.CustomField{Name: "Select Field", Type: models.SELECT}
+	currency := models.CustomField{Name: "Currency Field", Type: models.CURRENCY}
+	boolean := models.CustomField{Name: "Boolean Field", Type: models.BOOLEAN}
+	for _, field := range []*models.CustomField{&text, &date, &selectField, &currency, &boolean} {
+		if err := db.Create(field).Error; err != nil {
+			t.Fatalf("seed custom field: %v", err)
+		}
+	}
+
+	option := models.CustomFieldOption{Value: "Option A", CustomFieldId: selectField.ID}
+	if err := db.Create(&option).Error; err != nil {
+		t.Fatalf("seed custom field option: %v", err)
+	}
+
+	return seededCustomFields{
+		textId:     text.ID,
+		dateId:     date.ID,
+		selectId:   selectField.ID,
+		optionId:   option.ID,
+		currencyId: currency.ID,
+		booleanId:  boolean.ID,
+	}
+}
+
+// runQuickScan seeds the receipt-image pipeline + categories (ids 1-3) + tags (ids 1-2), points a
+// mock AI at the JSON built from the seeded user/group, and drives ReceiptService.QuickScan. The
+// aiJSONFor callback runs after seeding so it can reference the seeded user's real id; paidByArg is
+// the QuickScan paid-by argument (the handler-resolved default), resolved from the seeded user too.
+func runQuickScan(
+	t *testing.T,
+	paidByArg func(user models.User) uint,
+	status models.ReceiptStatus,
+	categoryPicks []uint,
+	tagPicks []uint,
+	aiJSONFor func(user models.User, group models.Group) string,
+) (models.Receipt, models.User, models.Group, error) {
+	t.Helper()
+
+	var body string
+	server := newMutableOllamaServer(t, &body)
+	user, group, _ := seedReceiptImagePipeline(t, server.URL)
+	repositories.CreateTestCategories()
+	createTestTags()
+
+	body = ollamaReceiptResponse(t, aiJSONFor(user, group))
+	tempPath := writeQuickScanTempFile(t)
+
+	paidBy := uint(0)
+	if paidByArg != nil {
+		paidBy = paidByArg(user)
+	}
+
+	receipt, err := NewReceiptService(nil).QuickScan(
+		&structs.Claims{UserId: user.ID},
+		paidBy,
+		group.ID,
+		status,
+		categoryPicks,
+		tagPicks,
+		tempPath,
+		"test.jpg",
+		"test-task",
+	)
+	return receipt, user, group, err
+}
+
+func hasCategoryId(categories []models.Category, id uint) bool {
+	for _, category := range categories {
+		if category.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func hasTagId(tags []models.Tag, id uint) bool {
+	for _, tag := range tags {
+		if tag.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func findItemByName(items []models.Item, name string) (models.Item, bool) {
+	for _, item := range items {
+		if item.Name == name {
+			return item, true
+		}
+	}
+	return models.Item{}, false
+}
+
+func findCustomFieldValue(values []models.CustomFieldValue, customFieldId uint) (models.CustomFieldValue, bool) {
+	for _, value := range values {
+		if value.CustomFieldId == customFieldId {
+			return value, true
+		}
+	}
+	return models.CustomFieldValue{}, false
+}
+
+// fullReceiptAiJSON is a maximal receipt the AI could return: every persistable field populated,
+// including nested linked items, item-level categories/tags, comments, and one custom-field value per
+// type. The %d placeholders are: paidByUserId, item.chargedToUserId, comment.userId, then the five
+// custom-field ids (with the select option id between the select field id and the currency field id).
+const fullReceiptAiJSON = `{
+	"name": "Full Receipt",
+	"amount": 100.00,
+	"date": "2024-05-01T00:00:00Z",
+	"paidByUserId": %d,
+	"status": "OPEN",
+	"categories": [{"id": 1, "name": "test"}, {"id": 2, "name": "test2"}],
+	"tags": [{"id": 1, "name": "tag-a"}],
+	"receiptItems": [
+		{
+			"name": "Widget",
+			"amount": 40.00,
+			"status": "OPEN",
+			"chargedToUserId": %d,
+			"isTaxed": true,
+			"categories": [{"id": 1, "name": "test"}],
+			"tags": [{"id": 1, "name": "tag-a"}],
+			"linkedItems": [
+				{"name": "Sub Widget", "amount": 10.00, "status": "OPEN", "categories": [{"id": 2, "name": "test2"}], "tags": [{"id": 2, "name": "tag-b"}]}
+			]
+		},
+		{"name": "Gadget", "amount": 25.00, "status": "RESOLVED", "isTaxed": false}
+	],
+	"comments": [{"comment": "Looks good", "userId": %d}],
+	"customFields": [
+		{"customFieldId": %d, "stringValue": "hello world"},
+		{"customFieldId": %d, "dateValue": "2024-06-15T00:00:00Z"},
+		{"customFieldId": %d, "selectValue": %d},
+		{"customFieldId": %d, "currencyValue": 12.34},
+		{"customFieldId": %d, "booleanValue": true}
+	]
+}`
+
+// TestQuickScan_PersistsEveryField is the anti-drop centerpiece: a maximal AI response is created
+// through QuickScan and every scalar and nested association is asserted on the read-back receipt.
+func TestQuickScan_PersistsEveryField(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	cf := seedQuickScanCustomFields(t)
+
+	created, user, group, err := runQuickScan(
+		t,
+		func(u models.User) uint { return 0 }, // AI provides paid-by; no backfill
+		models.OPEN,
+		nil,
+		nil,
+		func(u models.User, g models.Group) string {
+			return fmt.Sprintf(
+				fullReceiptAiJSON,
+				u.ID, u.ID, u.ID,
+				cf.textId, cf.dateId, cf.selectId, cf.optionId, cf.currencyId, cf.booleanId,
+			)
+		},
+	)
+	if err != nil {
+		utils.PrintTestError(t, err, "no error creating receipt from AI response")
+		return
+	}
+
+	receipt, err := repositories.NewReceiptRepository(nil).GetFullyLoadedReceiptById(utils.UintToString(created.ID))
+	if err != nil {
+		utils.PrintTestError(t, err, "no error reading receipt back")
+		return
+	}
+
+	// Scalars.
+	if receipt.Name != "Full Receipt" {
+		utils.PrintTestError(t, receipt.Name, "Full Receipt")
+	}
+	if !receipt.Amount.Equal(decimal.NewFromInt(100)) {
+		utils.PrintTestError(t, receipt.Amount.String(), "100")
+	}
+	if receipt.Date.UTC().Format("2006-01-02") != "2024-05-01" {
+		utils.PrintTestError(t, receipt.Date.UTC().Format("2006-01-02"), "2024-05-01")
+	}
+	if receipt.PaidByUserID != user.ID {
+		utils.PrintTestError(t, receipt.PaidByUserID, user.ID)
+	}
+	if receipt.Status != models.OPEN {
+		utils.PrintTestError(t, receipt.Status, models.OPEN)
+	}
+	if receipt.GroupId != group.ID {
+		utils.PrintTestError(t, receipt.GroupId, group.ID)
+	}
+
+	// Receipt-level categories & tags.
+	if len(receipt.Categories) != 2 || !hasCategoryId(receipt.Categories, 1) || !hasCategoryId(receipt.Categories, 2) {
+		utils.PrintTestError(t, receipt.Categories, "categories 1 and 2")
+	}
+	if len(receipt.Tags) != 1 || !hasTagId(receipt.Tags, 1) {
+		utils.PrintTestError(t, receipt.Tags, "tag 1")
+	}
+
+	// Items (linked items are filtered out of the top level, so 2 parents remain).
+	if len(receipt.ReceiptItems) != 2 {
+		utils.PrintTestError(t, len(receipt.ReceiptItems), 2)
+		return
+	}
+
+	widget, ok := findItemByName(receipt.ReceiptItems, "Widget")
+	if !ok {
+		utils.PrintTestError(t, receipt.ReceiptItems, "an item named Widget")
+		return
+	}
+	if !widget.Amount.Equal(decimal.NewFromInt(40)) {
+		utils.PrintTestError(t, widget.Amount.String(), "40")
+	}
+	if widget.Status != models.ITEM_OPEN {
+		utils.PrintTestError(t, widget.Status, models.ITEM_OPEN)
+	}
+	if widget.ChargedToUserId == nil || *widget.ChargedToUserId != user.ID {
+		utils.PrintTestError(t, widget.ChargedToUserId, user.ID)
+	}
+	if !widget.IsTaxed {
+		utils.PrintTestError(t, widget.IsTaxed, true)
+	}
+	if len(widget.Categories) != 1 || !hasCategoryId(widget.Categories, 1) {
+		utils.PrintTestError(t, widget.Categories, "item category 1")
+	}
+	if len(widget.Tags) != 1 || !hasTagId(widget.Tags, 1) {
+		utils.PrintTestError(t, widget.Tags, "item tag 1")
+	}
+
+	// Linked item under Widget, with its own categories/tags.
+	if len(widget.LinkedItems) != 1 {
+		utils.PrintTestError(t, len(widget.LinkedItems), 1)
+		return
+	}
+	sub := widget.LinkedItems[0]
+	if sub.Name != "Sub Widget" {
+		utils.PrintTestError(t, sub.Name, "Sub Widget")
+	}
+	if !sub.Amount.Equal(decimal.NewFromInt(10)) {
+		utils.PrintTestError(t, sub.Amount.String(), "10")
+	}
+	if len(sub.Categories) != 1 || !hasCategoryId(sub.Categories, 2) {
+		utils.PrintTestError(t, sub.Categories, "linked item category 2")
+	}
+	if len(sub.Tags) != 1 || !hasTagId(sub.Tags, 2) {
+		utils.PrintTestError(t, sub.Tags, "linked item tag 2")
+	}
+
+	gadget, ok := findItemByName(receipt.ReceiptItems, "Gadget")
+	if !ok {
+		utils.PrintTestError(t, receipt.ReceiptItems, "an item named Gadget")
+		return
+	}
+	if !gadget.Amount.Equal(decimal.NewFromInt(25)) {
+		utils.PrintTestError(t, gadget.Amount.String(), "25")
+	}
+	if gadget.Status != models.ITEM_RESOLVED {
+		utils.PrintTestError(t, gadget.Status, models.ITEM_RESOLVED)
+	}
+	if gadget.IsTaxed {
+		utils.PrintTestError(t, gadget.IsTaxed, false)
+	}
+	if gadget.ChargedToUserId != nil {
+		utils.PrintTestError(t, gadget.ChargedToUserId, "nil charged-to")
+	}
+
+	// Comment.
+	if len(receipt.Comments) != 1 {
+		utils.PrintTestError(t, len(receipt.Comments), 1)
+		return
+	}
+	if receipt.Comments[0].Comment != "Looks good" {
+		utils.PrintTestError(t, receipt.Comments[0].Comment, "Looks good")
+	}
+	if receipt.Comments[0].UserId == nil || *receipt.Comments[0].UserId != user.ID {
+		utils.PrintTestError(t, receipt.Comments[0].UserId, user.ID)
+	}
+
+	// Custom-field values: each must land in the right column with the right field id, and nothing
+	// else. Even though Validate ignores custom fields, they must persist unchanged.
+	if len(receipt.CustomFields) != 5 {
+		utils.PrintTestError(t, len(receipt.CustomFields), 5)
+		return
+	}
+
+	if text, ok := findCustomFieldValue(receipt.CustomFields, cf.textId); !ok {
+		utils.PrintTestError(t, receipt.CustomFields, "a value for the text field")
+	} else if text.StringValue == nil || *text.StringValue != "hello world" {
+		utils.PrintTestError(t, text.StringValue, "hello world")
+	} else if text.CustomField.Type != models.TEXT {
+		utils.PrintTestError(t, text.CustomField.Type, models.TEXT)
+	}
+
+	if date, ok := findCustomFieldValue(receipt.CustomFields, cf.dateId); !ok {
+		utils.PrintTestError(t, receipt.CustomFields, "a value for the date field")
+	} else if date.DateValue == nil || date.DateValue.UTC().Format("2006-01-02") != "2024-06-15" {
+		utils.PrintTestError(t, date.DateValue, "2024-06-15")
+	}
+
+	if selectValue, ok := findCustomFieldValue(receipt.CustomFields, cf.selectId); !ok {
+		utils.PrintTestError(t, receipt.CustomFields, "a value for the select field")
+	} else if selectValue.SelectValue == nil || *selectValue.SelectValue != cf.optionId {
+		utils.PrintTestError(t, selectValue.SelectValue, cf.optionId)
+	} else if len(selectValue.CustomField.Options) != 1 {
+		utils.PrintTestError(t, selectValue.CustomField.Options, "one preloaded option")
+	}
+
+	if currency, ok := findCustomFieldValue(receipt.CustomFields, cf.currencyId); !ok {
+		utils.PrintTestError(t, receipt.CustomFields, "a value for the currency field")
+	} else if currency.CurrencyValue == nil || !currency.CurrencyValue.Equal(decimal.RequireFromString("12.34")) {
+		utils.PrintTestError(t, currency.CurrencyValue, "12.34")
+	}
+
+	if boolean, ok := findCustomFieldValue(receipt.CustomFields, cf.booleanId); !ok {
+		utils.PrintTestError(t, receipt.CustomFields, "a value for the boolean field")
+	} else if boolean.BooleanValue == nil || *boolean.BooleanValue != true {
+		utils.PrintTestError(t, boolean.BooleanValue, true)
+	}
+}
+
+// TestQuickScan_BackfillsPaidByAndStatusWhenAiOmitsThem proves QuickScan fills the paid-by/status
+// from its arguments (the group's resolved defaults) when the AI omits them.
+func TestQuickScan_BackfillsPaidByAndStatusWhenAiOmitsThem(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	created, user, _, err := runQuickScan(
+		t,
+		func(u models.User) uint { return u.ID }, // handler-resolved default paid-by
+		models.NEEDS_ATTENTION,
+		nil,
+		nil,
+		func(u models.User, g models.Group) string {
+			return `{"name": "No Payer", "amount": 12.50, "date": "2024-03-03T00:00:00Z"}`
+		},
+	)
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+
+	receipt, err := repositories.NewReceiptRepository(nil).GetFullyLoadedReceiptById(utils.UintToString(created.ID))
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+	if receipt.PaidByUserID != user.ID {
+		utils.PrintTestError(t, receipt.PaidByUserID, user.ID)
+	}
+	if receipt.Status != models.NEEDS_ATTENTION {
+		utils.PrintTestError(t, receipt.Status, models.NEEDS_ATTENTION)
+	}
+}
+
+// TestQuickScan_KeepsAiPaidByAndStatusWhenPresent proves an AI-supplied paid-by/status is not
+// overwritten by the QuickScan default arguments.
+func TestQuickScan_KeepsAiPaidByAndStatusWhenPresent(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	created, user, _, err := runQuickScan(
+		t,
+		func(u models.User) uint { return u.ID }, // default paid-by (should be ignored)
+		models.OPEN,                              // default status (should be ignored)
+		nil,
+		nil,
+		func(u models.User, g models.Group) string {
+			return fmt.Sprintf(
+				`{"name": "Has Payer", "amount": 5.00, "date": "2024-02-02T00:00:00Z", "paidByUserId": %d, "status": "RESOLVED"}`,
+				u.ID,
+			)
+		},
+	)
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+
+	receipt, err := repositories.NewReceiptRepository(nil).GetFullyLoadedReceiptById(utils.UintToString(created.ID))
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+	if receipt.PaidByUserID != user.ID {
+		utils.PrintTestError(t, receipt.PaidByUserID, user.ID)
+	}
+	if receipt.Status != models.RESOLVED {
+		utils.PrintTestError(t, receipt.Status, models.RESOLVED)
+	}
+}
+
+// TestQuickScan_MergesUserCategoryAndTagPicksWithAi proves the user's per-file category/tag picks are
+// unioned (deduped by id) with the AI-assigned ones, with names resolved so validation passes.
+func TestQuickScan_MergesUserCategoryAndTagPicksWithAi(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	created, _, _, err := runQuickScan(
+		t,
+		func(u models.User) uint { return u.ID },
+		models.OPEN,
+		[]uint{2, 3}, // user category picks
+		[]uint{2},    // user tag pick
+		func(u models.User, g models.Group) string {
+			// AI assigns category 1 and tag 1 (with names, as required by validation).
+			return `{"name": "Merge", "amount": 9.99, "date": "2024-01-01T00:00:00Z", "categories": [{"id": 1, "name": "test"}], "tags": [{"id": 1, "name": "tag-a"}]}`
+		},
+	)
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+
+	receipt, err := repositories.NewReceiptRepository(nil).GetFullyLoadedReceiptById(utils.UintToString(created.ID))
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+	if len(receipt.Categories) != 3 ||
+		!hasCategoryId(receipt.Categories, 1) ||
+		!hasCategoryId(receipt.Categories, 2) ||
+		!hasCategoryId(receipt.Categories, 3) {
+		utils.PrintTestError(t, receipt.Categories, "categories 1,2,3 unioned")
+	}
+	if len(receipt.Tags) != 2 || !hasTagId(receipt.Tags, 1) || !hasTagId(receipt.Tags, 2) {
+		utils.PrintTestError(t, receipt.Tags, "tags 1,2 unioned")
+	}
+}
+
+// TestQuickScan_RefundNegativeAmountsPersist proves a refund (negative receipt and item amounts)
+// round-trips - the item's abs amount is still <= the receipt's abs amount, so validation passes.
+func TestQuickScan_RefundNegativeAmountsPersist(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	created, _, _, err := runQuickScan(
+		t,
+		func(u models.User) uint { return u.ID },
+		models.OPEN,
+		nil,
+		nil,
+		func(u models.User, g models.Group) string {
+			return `{"name": "Refund", "amount": -30.00, "date": "2024-04-04T00:00:00Z", "receiptItems": [{"name": "Returned", "amount": -30.00, "status": "OPEN"}]}`
+		},
+	)
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+
+	receipt, err := repositories.NewReceiptRepository(nil).GetFullyLoadedReceiptById(utils.UintToString(created.ID))
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+	if !receipt.Amount.Equal(decimal.NewFromInt(-30)) {
+		utils.PrintTestError(t, receipt.Amount.String(), "-30")
+	}
+	if len(receipt.ReceiptItems) != 1 {
+		utils.PrintTestError(t, len(receipt.ReceiptItems), 1)
+		return
+	}
+	if !receipt.ReceiptItems[0].Amount.Equal(decimal.NewFromInt(-30)) {
+		utils.PrintTestError(t, receipt.ReceiptItems[0].Amount.String(), "-30")
+	}
+}
+
+// TestQuickScan_MinimalReceiptCreatesNoSpuriousAssociations proves a bare AI response (only
+// name/amount/date) persists with the backfilled paid-by/status and no invented associations.
+func TestQuickScan_MinimalReceiptCreatesNoSpuriousAssociations(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	created, user, _, err := runQuickScan(
+		t,
+		func(u models.User) uint { return u.ID },
+		models.OPEN,
+		nil,
+		nil,
+		func(u models.User, g models.Group) string {
+			return `{"name": "Bare", "amount": 1.00, "date": "2024-07-07T00:00:00Z"}`
+		},
+	)
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+
+	receipt, err := repositories.NewReceiptRepository(nil).GetFullyLoadedReceiptById(utils.UintToString(created.ID))
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+	if receipt.Name != "Bare" {
+		utils.PrintTestError(t, receipt.Name, "Bare")
+	}
+	if receipt.PaidByUserID != user.ID {
+		utils.PrintTestError(t, receipt.PaidByUserID, user.ID)
+	}
+	if receipt.Status != models.OPEN {
+		utils.PrintTestError(t, receipt.Status, models.OPEN)
+	}
+	if len(receipt.ReceiptItems) != 0 {
+		utils.PrintTestError(t, len(receipt.ReceiptItems), 0)
+	}
+	if len(receipt.Categories) != 0 {
+		utils.PrintTestError(t, len(receipt.Categories), 0)
+	}
+	if len(receipt.Tags) != 0 {
+		utils.PrintTestError(t, len(receipt.Tags), 0)
+	}
+	if len(receipt.Comments) != 0 {
+		utils.PrintTestError(t, len(receipt.Comments), 0)
+	}
+	if len(receipt.CustomFields) != 0 {
+		utils.PrintTestError(t, len(receipt.CustomFields), 0)
+	}
+}
+
+// TestQuickScan_MissingItemStatusFailsAndPersistsNothing proves receipt validation runs on the
+// AI-built command: an item missing its (required) status fails the whole quick scan, and no receipt
+// row is written (all-or-nothing).
+func TestQuickScan_MissingItemStatusFailsAndPersistsNothing(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	_, _, _, err := runQuickScan(
+		t,
+		func(u models.User) uint { return u.ID },
+		models.OPEN,
+		nil,
+		nil,
+		func(u models.User, g models.Group) string {
+			// Item has no status -> UpsertItemCommand.Validate fails.
+			return `{"name": "Bad Item", "amount": 20.00, "date": "2024-08-08T00:00:00Z", "receiptItems": [{"name": "No Status", "amount": 5.00}]}`
+		},
+	)
+	if err == nil {
+		utils.PrintTestError(t, nil, "a validation error")
+	}
+
+	// Only receipts created through CreateReceipt carry a created_by; the pipeline's seeded baseline
+	// receipt leaves it NULL. Zero here means the failed scan wrote nothing.
+	if count := quickScanCreatedReceiptCount(); count != 0 {
+		utils.PrintTestError(t, count, int64(0))
+	}
+}
+
+// TestQuickScan_InvalidAiJsonReturnsError proves a non-JSON AI response surfaces as an error from
+// QuickScan and persists nothing.
+func TestQuickScan_InvalidAiJsonReturnsError(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	_, _, _, err := runQuickScan(
+		t,
+		func(u models.User) uint { return u.ID },
+		models.OPEN,
+		nil,
+		nil,
+		func(u models.User, g models.Group) string {
+			return `this is not json`
+		},
+	)
+	if err == nil {
+		utils.PrintTestError(t, nil, "a JSON parse error")
+	}
+
+	if count := quickScanCreatedReceiptCount(); count != 0 {
+		utils.PrintTestError(t, count, int64(0))
+	}
+}
+
+// quickScanCreatedReceiptCount counts receipts written through CreateReceipt (which stamps
+// created_by), excluding the pipeline's seeded baseline receipt (created_by NULL). It is the "nothing
+// was persisted" probe for the failure-path tests.
+func quickScanCreatedReceiptCount() int64 {
+	var count int64
+	repositories.GetDB().Model(&models.Receipt{}).Where("created_by IS NOT NULL").Count(&count)
+	return count
+}
+
+// TestMagicFill_ParsesAllReceiptFields isolates the deserialization layer: a maximal AI response is
+// parsed by MagicFillFromImage and the returned UpsertReceiptCommand is asserted to carry every
+// field, so a failure localizes to parse (this test) vs. persist (the QuickScan tests). It also
+// covers cleanResponse stripping a ```json code fence (the common LLM wrapping).
+func TestMagicFill_ParsesAllReceiptFields(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	cf := seedQuickScanCustomFields(t)
+
+	var body string
+	server := newMutableOllamaServer(t, &body)
+	user, group, _ := seedReceiptImagePipeline(t, server.URL)
+
+	receiptJSON := "```json\n" + fmt.Sprintf(
+		fullReceiptAiJSON,
+		user.ID, user.ID, user.ID,
+		cf.textId, cf.dateId, cf.selectId, cf.optionId, cf.currencyId, cf.booleanId,
+	) + "\n```" // code fence exercises cleanResponse
+	body = ollamaReceiptResponse(t, receiptJSON)
+
+	jpg, err := os.ReadFile(filepath.Join(testApiRoot(), "testing", "test.jpg"))
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+
+	command, _, err := MagicFillFromImage(
+		commands.MagicFillCommand{ImageData: jpg},
+		utils.UintToString(group.ID),
+		user.ID,
+	)
+	if err != nil {
+		utils.PrintTestError(t, err, "no error parsing AI response")
+		return
+	}
+
+	if command.Name != "Full Receipt" {
+		utils.PrintTestError(t, command.Name, "Full Receipt")
+	}
+	if !command.Amount.Equal(decimal.NewFromInt(100)) {
+		utils.PrintTestError(t, command.Amount.String(), "100")
+	}
+	if len(command.Categories) != 2 {
+		utils.PrintTestError(t, len(command.Categories), 2)
+	}
+	if len(command.Tags) != 1 {
+		utils.PrintTestError(t, len(command.Tags), 1)
+	}
+	if len(command.Items) != 2 {
+		utils.PrintTestError(t, len(command.Items), 2)
+		return
+	}
+	if len(command.Comments) != 1 {
+		utils.PrintTestError(t, len(command.Comments), 1)
+	}
+	if len(command.CustomFields) != 5 {
+		utils.PrintTestError(t, len(command.CustomFields), 5)
+	}
+
+	// Nested fields on the first item survive the parse.
+	widget, ok := findUpsertItemByName(command.Items, "Widget")
+	if !ok {
+		utils.PrintTestError(t, command.Items, "an item named Widget")
+		return
+	}
+	if widget.ChargedToUserId == nil || *widget.ChargedToUserId != user.ID {
+		utils.PrintTestError(t, widget.ChargedToUserId, user.ID)
+	}
+	if !widget.IsTaxed {
+		utils.PrintTestError(t, widget.IsTaxed, true)
+	}
+	if len(widget.LinkedItems) != 1 {
+		utils.PrintTestError(t, len(widget.LinkedItems), 1)
+	}
+}
+
+func findUpsertItemByName(items []commands.UpsertItemCommand, name string) (commands.UpsertItemCommand, bool) {
+	for _, item := range items {
+		if item.Name == name {
+			return item, true
+		}
+	}
+	return commands.UpsertItemCommand{}, false
+}

--- a/api/internal/services/quick_scan_ingest_test.go
+++ b/api/internal/services/quick_scan_ingest_test.go
@@ -447,16 +447,25 @@ func TestQuickScan_BackfillsPaidByAndStatusWhenAiOmitsThem(t *testing.T) {
 func TestQuickScan_KeepsAiPaidByAndStatusWhenPresent(t *testing.T) {
 	defer repositories.TruncateTestDb()
 
-	created, user, _, err := runQuickScan(
+	var aiPayerId uint
+	created, _, _, err := runQuickScan(
 		t,
 		func(u models.User) uint { return u.ID }, // default paid-by (should be ignored)
 		models.OPEN,                              // default status (should be ignored)
 		nil,
 		nil,
 		func(u models.User, g models.Group) string {
+			// A second, distinct user for the AI paid-by so the assertion fails if
+			// QuickScan drops the AI value and falls back to the default arg (the
+			// seeded user). Same-user ids would pass either way.
+			aiPayer := models.User{Username: "ai-payer", Password: "p", DisplayName: "x"}
+			if err := repositories.GetDB().Create(&aiPayer).Error; err != nil {
+				t.Fatalf("seed ai payer: %v", err)
+			}
+			aiPayerId = aiPayer.ID
 			return fmt.Sprintf(
 				`{"name": "Has Payer", "amount": 5.00, "date": "2024-02-02T00:00:00Z", "paidByUserId": %d, "status": "RESOLVED"}`,
-				u.ID,
+				aiPayer.ID,
 			)
 		},
 	)
@@ -470,8 +479,8 @@ func TestQuickScan_KeepsAiPaidByAndStatusWhenPresent(t *testing.T) {
 		utils.PrintTestError(t, err, "no error")
 		return
 	}
-	if receipt.PaidByUserID != user.ID {
-		utils.PrintTestError(t, receipt.PaidByUserID, user.ID)
+	if receipt.PaidByUserID != aiPayerId {
+		utils.PrintTestError(t, receipt.PaidByUserID, aiPayerId)
 	}
 	if receipt.Status != models.RESOLVED {
 		utils.PrintTestError(t, receipt.Status, models.RESOLVED)

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -647,6 +647,32 @@ helpers `withAdminApi` + `apiDeleteUserByName` / `apiDeleteGroupById` / `apiDele
     with the flag injected on, a **Legacy Editor** member (holds `group.receipts.quick-scan`) sees the button
     while the Viewer — same user, same flag — does not.
 
+## Magic Fill (receipt form)
+
+Distinct from Quick Scan (which creates a receipt entirely server-side): the ✨ **Magic Fill** button on the
+receipt form (`src/receipts/receipt-form/`, `magicFill()` → `patchMagicValues`) calls
+`POST /receiptImage/magicFill`, which returns the backend's fully-parsed `UpsertReceiptCommand`, and patches
+it **into the form** for the user to review before saving. `patchMagicValues` ingests the **whole** receipt —
+name/amount/date/paid-by/status, categories/tags, `receiptItems` (items **and** shares — items with a
+`chargedToUserId` — plus nested `linkedItems` and per-item categories/tags), `customFields`, and `comments` —
+reusing the form's existing builders (`buildItemForm`, `buildCustomOptionFormGroup`, and the comments child's
+`buildCommentFormGroup`) so `this.form.value` round-trips into `UpsertReceiptCommand` on submit with nothing
+dropped. Each field is reported filled (and named in the success toast, via a friendly-label map) **only when
+it actually changes the form**, so an empty or unmatched value never claims a phantom fill. Guarded by
+`receipt-form.component.spec.ts` → `describe("magicFill — full receipt ingest")`.
+
+Two cross-component seams support this (each with its own focused spec):
+- **Paid-by display:** `patchValue` updates the `paidByUserId` control but not the autocomplete's shown text
+  (the single-select display is seeded from the control only once on init), so
+  `AutocomleteComponent.syncSingleDisplay()` re-seeds it after the patch.
+- **Comments:** the `app-receipt-comments` child owns the comments array and is **mode-aware**, so Magic Fill
+  hands them to `ReceiptCommentsComponent.addMagicFilledComments()` — add mode collects them for the create
+  submit; edit mode POSTs each via `CommentService` because the receipt-**update** path does not persist
+  comments (they're individual resources — see `api/CLAUDE.md` → `UpdateReceipt`).
+- **Custom fields** reference a field by id only (the magic-fill response carries no field definition), so a
+  value whose `customFieldId` isn't in the loaded catalog pool is skipped, and adding one flips its
+  manage-fields menu entry to selected via an immutable array replace (zoneless CD).
+
 ## Reports (Report Builder)
 
 The **Report Builder** (`src/reports/`) is a two-pane screen for building and downloading receipt

--- a/desktop/src/autocomplete/autocomlete/autocomlete.component.spec.ts
+++ b/desktop/src/autocomplete/autocomlete/autocomlete.component.spec.ts
@@ -82,6 +82,26 @@ describe("AutocomleteComponent", () => {
     expect(result).toEqual([]);
   });
 
+  it("re-seeds the single-select display from inputFormControl on syncSingleDisplay", () => {
+    component.multiple = false;
+    component.inputFormControl.setValue(42);
+    component.filterFormControl.setValue("");
+
+    component.syncSingleDisplay();
+
+    expect(component.filterFormControl.value).toEqual(42);
+  });
+
+  it("leaves the display untouched on syncSingleDisplay in multiple mode", () => {
+    component.multiple = true;
+    component.inputFormControl = new FormArray([new FormControl(1)]) as any;
+    component.filterFormControl.setValue("stale");
+
+    component.syncSingleDisplay();
+
+    expect(component.filterFormControl.value).toEqual("stale");
+  });
+
   it("should set the selected option value to the inputFormControl in single mode", () => {
     component.multiple = false;
     component.optionValueKey = "value";

--- a/desktop/src/autocomplete/autocomlete/autocomlete.component.ts
+++ b/desktop/src/autocomplete/autocomlete/autocomlete.component.ts
@@ -94,6 +94,18 @@ export class AutocomleteComponent
     this.filterFormControl.setValue(this.inputFormControl.value);
   }
 
+  // Re-seeds the single-select display from the current inputFormControl value.
+  // The visible field is driven by filterFormControl (rendered via displayWith)
+  // and is otherwise only seeded once in ngOnInit, so a programmatic value change
+  // (e.g. a parent form.patchValue) updates the value but not the shown text.
+  // Callers invoke this after such a change to refresh the display. No-op in
+  // multiple mode, which renders selections as chips from inputFormControl.
+  public syncSingleDisplay(): void {
+    if (!this.multiple) {
+      this.initSingleAutocomplete();
+    }
+  }
+
   public _filter(value: string): any[] {
     value = value ?? "";
     const filterValue = value.toString()?.toLowerCase();

--- a/desktop/src/receipts/receipt-comments/receipt-comments.component.spec.ts
+++ b/desktop/src/receipts/receipt-comments/receipt-comments.component.spec.ts
@@ -174,6 +174,77 @@ describe("ReceiptCommentsComponent", () => {
     expect(component.canDeleteComments()).toEqual(false);
   });
 
+  it("collects magic-filled comments and emits them in add mode", () => {
+    const emitSpy = jest.spyOn(component.commentsUpdated, "emit");
+    store.reset({ auth: { userId: 1 } });
+    fixture.componentRef.setInput("mode", FormMode.add);
+    fixture.componentRef.setInput("receiptId", 3);
+    component.ngOnInit();
+
+    component.addMagicFilledComments([
+      { comment: "from ai", userId: 9 } as any,
+      { comment: "second" } as any,
+    ]);
+
+    expect(component.commentsArray.length).toEqual(2);
+    expect(component.commentsArray.at(0).value).toEqual({
+      comment: "from ai",
+      userId: 9,
+      receiptId: 3,
+    });
+    // buildCommentFormGroup defaults userId to the logged-in user when absent
+    expect(component.commentsArray.at(1).value).toEqual({
+      comment: "second",
+      userId: 1,
+      receiptId: 3,
+    });
+    expect(emitSpy).toHaveBeenCalledWith(component.commentsArray);
+  });
+
+  it("posts each magic-filled comment individually in edit mode", () => {
+    const addSpy = jest.spyOn(TestBed.inject(CommentService), "addComment");
+    addSpy.mockReturnValue(
+      of({
+        id: 8,
+        userId: 1,
+        receiptId: 2,
+        comment: "from ai",
+        createdAt: "",
+        updatedAt: "",
+      }) as any
+    );
+    const emitSpy = jest.spyOn(component.commentsUpdated, "emit");
+    store.reset({ auth: { userId: 1 } });
+    fixture.componentRef.setInput("mode", FormMode.edit);
+    fixture.componentRef.setInput("receiptId", 2);
+    component.ngOnInit();
+
+    component.addMagicFilledComments([{ comment: "from ai", userId: 9 } as any]);
+
+    // Server assigns the author, so the POST carries the logged-in user, not the input userId
+    expect(addSpy).toHaveBeenCalledWith({
+      comment: "from ai",
+      userId: 1,
+      receiptId: 2,
+    });
+    expect(component.commentsArray.length).toEqual(1);
+    expect(component.internalComments().length).toEqual(1);
+    expect(component.internalComments()[0].id).toEqual(8);
+    // Edit-mode comments are individual resources, not part of the form submit
+    expect(emitSpy).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when there are no magic-filled comments", () => {
+    const emitSpy = jest.spyOn(component.commentsUpdated, "emit");
+    fixture.componentRef.setInput("mode", FormMode.add);
+    component.ngOnInit();
+
+    component.addMagicFilledComments([]);
+
+    expect(component.commentsArray.length).toEqual(0);
+    expect(emitSpy).not.toHaveBeenCalled();
+  });
+
   it("should send api call if form is valid and is in edit mode", () => {
     const spy = jest.spyOn(TestBed.inject(CommentService), "addComment");
     spy.mockReturnValue(

--- a/desktop/src/receipts/receipt-comments/receipt-comments.component.ts
+++ b/desktop/src/receipts/receipt-comments/receipt-comments.component.ts
@@ -104,6 +104,45 @@ export class ReceiptCommentsComponent implements OnInit {
     }
   }
 
+  // Ingests comments produced by magic fill. Mirrors addComment's per-mode
+  // handling: in add mode the comments ride the receipt-create submit (collect
+  // in the array + emit so the parent form picks them up), while in edit mode
+  // comments are individual resources the receipt-update submit ignores, so each
+  // is POSTed via CommentService just like a manually added edit-mode comment.
+  public addMagicFilledComments(comments: Comment[]): void {
+    const magicComments = comments ?? [];
+    if (magicComments.length === 0) {
+      return;
+    }
+
+    const mode = this.mode();
+    if (mode === FormMode.add) {
+      magicComments.forEach((comment) => {
+        this.commentsArray.push(this.buildCommentFormGroup(comment));
+      });
+      this.commentsUpdated.emit(this.commentsArray);
+    } else if (mode === FormMode.edit) {
+      magicComments.forEach((comment) => {
+        const newComment = {
+          comment: comment.comment,
+          userId: Number.parseInt(this.store.selectSnapshot(AuthState.userId)),
+          receiptId: this.receiptId(),
+        } as any;
+
+        this.commentService
+          .addComment(newComment)
+          .pipe(
+            take(1),
+            tap((createdComment: Comment) => {
+              this.internalComments.update((existing) => [...existing, createdComment]);
+              this.commentsArray.push(this.buildCommentFormGroup(newComment));
+            })
+          )
+          .subscribe();
+      });
+    }
+  }
+
   public deleteComment(index: number): void {
     switch (this.mode()) {
       case FormMode.edit:

--- a/desktop/src/receipts/receipt-form/receipt-form.component.spec.ts
+++ b/desktop/src/receipts/receipt-form/receipt-form.component.spec.ts
@@ -300,6 +300,14 @@ describe("ReceiptFormComponent", () => {
   // backend can return (paid-by, status, items, shares, custom fields, comments),
   // not just the header fields, and drops nothing on the way into the form.
   describe("magicFill — full receipt ingest", () => {
+    // A test below overrides the timezone offset for a deterministic date
+    // assertion; capture the real one (before any test runs) and restore it so
+    // the override can't leak into later tests.
+    const originalGetTimezoneOffset = Date.prototype.getTimezoneOffset;
+    afterEach(() => {
+      Date.prototype.getTimezoneOffset = originalGetTimezoneOffset;
+    });
+
     function stubCarousel(index = 0): void {
       Object.defineProperty(component, "carouselComponent", {
         value: () => ({ currentlyShownImageIndex: index }),
@@ -685,6 +693,40 @@ describe("ReceiptFormComponent", () => {
         "Existing Item",
         "New Item",
       ]);
+    });
+
+    it("does not duplicate a category the receipt already carries", () => {
+      component.images.set([{ id: 1 } as any]);
+      routeDataSubject.next({
+        mode: FormMode.edit,
+        customFields: [],
+        receipt: {
+          id: 5,
+          name: "R",
+          amount: "100.00",
+          categories: [{ id: 1, name: "existing cat" }],
+          customFields: [],
+        } as any,
+      });
+      component.mode = FormMode.edit;
+      stubCarousel();
+      component.categories = [{ id: 1, name: "existing cat" } as any];
+
+      const magicReceipt = { categories: [{ id: 1 }] } as any;
+
+      mockMagicFill(magicReceipt);
+      const errorSpy = spyError();
+
+      component.magicFill();
+
+      // The already-present category is not appended a second time, and since
+      // nothing new was added the fill reports empty (error toast).
+      expect(component.form.getRawValue().categories).toEqual([
+        { id: 1, name: "existing cat" },
+      ]);
+      expect(errorSpy).toHaveBeenCalledWith(
+        "Could not find any values to fill! Try reuploading a clearer image."
+      );
     });
 
     it("round-trips negative refund amounts on the receipt and items", () => {

--- a/desktop/src/receipts/receipt-form/receipt-form.component.spec.ts
+++ b/desktop/src/receipts/receipt-form/receipt-form.component.spec.ts
@@ -2,7 +2,7 @@ import { provideHttpClient, withInterceptorsFromDi } from "@angular/common/http"
 import { provideHttpClientTesting } from "@angular/common/http/testing";
 import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
-import { ReactiveFormsModule } from "@angular/forms";
+import { ReactiveFormsModule, Validators } from "@angular/forms";
 import { MatDialogModule } from "@angular/material/dialog";
 import { MatSnackBarModule } from "@angular/material/snack-bar";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
@@ -11,7 +11,7 @@ import { BehaviorSubject, of } from "rxjs";
 import { FormMode } from "src/enums/form-mode.enum";
 import { PipesModule } from "src/pipes/pipes.module";
 import { SharedUiModule } from "src/shared-ui/shared-ui.module";
-import { ApiModule, ReceiptImageService, ReceiptStatus } from "../../open-api";
+import { ApiModule, CustomFieldType, ReceiptImageService, ReceiptStatus } from "../../open-api";
 import { SnackbarService } from "../../services";
 import { QueueMode } from "../../services/receipt-queue.service";
 import { StoreModule } from "../../store/store.module";
@@ -294,5 +294,452 @@ describe("ReceiptFormComponent", () => {
     expect(component.originalReceipt?.id).toEqual(2);
     expect(component.form.get("name")?.value).toEqual("Duplicate");
     expect(component.editLink).toEqual("/receipts/2/edit");
+  });
+
+  // Full-receipt magic-fill ingest: proves the form takes in every field the
+  // backend can return (paid-by, status, items, shares, custom fields, comments),
+  // not just the header fields, and drops nothing on the way into the form.
+  describe("magicFill — full receipt ingest", () => {
+    function stubCarousel(index = 0): void {
+      Object.defineProperty(component, "carouselComponent", {
+        value: () => ({ currentlyShownImageIndex: index }),
+        configurable: true,
+      });
+    }
+
+    function stubItemAndShareLists(): { setItems: jest.Mock; setUserItemMap: jest.Mock } {
+      const setItems = jest.fn();
+      const setUserItemMap = jest.fn();
+      Object.defineProperty(component, "itemListComponent", {
+        value: () => ({ setItems }),
+        configurable: true,
+      });
+      Object.defineProperty(component, "shareListComponent", {
+        value: () => ({ setUserItemMap }),
+        configurable: true,
+      });
+      return { setItems, setUserItemMap };
+    }
+
+    function stubCommentsComponent(): { addMagicFilledComments: jest.Mock } {
+      const addMagicFilledComments = jest.fn();
+      Object.defineProperty(component, "receiptCommentsComponent", {
+        value: () => ({ addMagicFilledComments }),
+        configurable: true,
+      });
+      return { addMagicFilledComments };
+    }
+
+    function stubPaidByAutocomplete(): { syncSingleDisplay: jest.Mock } {
+      const syncSingleDisplay = jest.fn();
+      Object.defineProperty(component, "paidByAutocomplete", {
+        value: () => ({ autocompleteComponent: () => ({ syncSingleDisplay }) }),
+        configurable: true,
+      });
+      return { syncSingleDisplay };
+    }
+
+    function mockMagicFill(magicReceipt: any): jest.SpyInstance {
+      return jest
+        .spyOn(TestBed.inject(ReceiptImageService), "magicFillReceipt")
+        .mockReturnValue(of(magicReceipt));
+    }
+
+    function spySuccess(): jest.SpyInstance {
+      return jest.spyOn(TestBed.inject(SnackbarService), "success").mockReturnValue(undefined);
+    }
+
+    function spyError(): jest.SpyInstance {
+      return jest.spyOn(TestBed.inject(SnackbarService), "error").mockReturnValue(undefined);
+    }
+
+    const customFieldDefs = [
+      { id: 1, name: "Text Field", type: CustomFieldType.Text },
+      { id: 2, name: "Date Field", type: CustomFieldType.Date },
+      { id: 3, name: "Select Field", type: CustomFieldType.Select },
+      { id: 4, name: "Currency Field", type: CustomFieldType.Currency },
+      { id: 5, name: "Boolean Field", type: CustomFieldType.Boolean },
+    ] as any[];
+
+    it("ingests every field of a full magic-filled receipt", () => {
+      // Fix the timezone offset so the date assertion is deterministic.
+      Date.prototype.getTimezoneOffset = () => 0;
+      component.images.set([{ id: 1 } as any]);
+      routeDataSubject.next({ mode: FormMode.edit, customFields: customFieldDefs });
+      component.mode = FormMode.edit;
+
+      stubCarousel();
+      const { setItems, setUserItemMap } = stubItemAndShareLists();
+      const { addMagicFilledComments } = stubCommentsComponent();
+      const { syncSingleDisplay } = stubPaidByAutocomplete();
+
+      component.categories = [
+        { id: 1, name: "category" } as any,
+        { id: 2, name: "category2" } as any,
+      ];
+      component.tags = [
+        { id: 1, name: "tag" } as any,
+        { id: 2, name: "tag2" } as any,
+      ];
+
+      const magicReceipt = {
+        name: "Full Receipt",
+        amount: "100.00",
+        date: "2023-08-05T00:00:00.000Z",
+        paidByUserId: 7,
+        status: ReceiptStatus.NeedsAttention,
+        categories: [{ id: 1 }],
+        tags: [{ id: 2 }],
+        receiptItems: [
+          {
+            name: "Regular Item",
+            amount: "40.00",
+            status: "OPEN",
+            IsTaxed: true,
+            categories: [{ id: 5, name: "item cat" }],
+            tags: [{ id: 6, name: "item tag" }],
+          },
+          {
+            name: "Shared Item",
+            amount: "20.00",
+            status: "OPEN",
+            chargedToUserId: 7,
+            linkedItems: [
+              { name: "Linked", amount: "10.00", status: "OPEN", chargedToUserId: 7 },
+            ],
+          },
+        ],
+        customFields: [
+          { customFieldId: 1, stringValue: "hello" },
+          { customFieldId: 2, dateValue: "2023-08-05T00:00:00.000Z" },
+          { customFieldId: 3, selectValue: 42 },
+          { customFieldId: 4, currencyValue: "9.99" },
+          { customFieldId: 5, booleanValue: true },
+        ],
+        comments: [{ comment: "auto comment", userId: 7 }],
+      } as any;
+
+      mockMagicFill(magicReceipt);
+      const successSpy = spySuccess();
+
+      component.magicFill();
+
+      const value = component.form.getRawValue();
+
+      // Scalars
+      expect(value.name).toEqual("Full Receipt");
+      expect(value.amount).toEqual("100.00");
+      expect(value.date).toEqual(new Date("2023-08-05T00:00:00.000Z"));
+      expect(value.paidByUserId).toEqual(7);
+      expect(value.status).toEqual(ReceiptStatus.NeedsAttention);
+      expect(syncSingleDisplay).toHaveBeenCalled();
+
+      // Categories/tags matched from the pool by id
+      expect(value.categories).toEqual([component.categories[0]]);
+      expect(value.tags).toEqual([component.tags[1]]);
+
+      // Items (regular + share + linked + per-item cats/tags + taxed)
+      expect(value.receiptItems.length).toEqual(2);
+      const regular = value.receiptItems[0];
+      expect(regular.name).toEqual("Regular Item");
+      expect(regular.amount).toEqual("40.00");
+      expect(regular.status).toEqual("OPEN");
+      expect(regular.isTaxed).toEqual(true);
+      expect(regular.chargedToUserId).toBeFalsy();
+      expect(regular.categories).toEqual([{ id: 5, name: "item cat" }]);
+      expect(regular.tags).toEqual([{ id: 6, name: "item tag" }]);
+      expect(regular.linkedItems).toEqual([]);
+
+      const shared = value.receiptItems[1];
+      expect(shared.name).toEqual("Shared Item");
+      expect(shared.chargedToUserId).toEqual(7);
+      expect(shared.linkedItems.length).toEqual(1);
+      expect(shared.linkedItems[0].name).toEqual("Linked");
+      expect(shared.linkedItems[0].chargedToUserId).toEqual(7);
+
+      expect(setItems).toHaveBeenCalled();
+      expect(setUserItemMap).toHaveBeenCalled();
+
+      // Custom fields land in the type-specific column
+      expect(value.customFields.length).toEqual(5);
+      const byId = (id: number) => value.customFields.find((c: any) => c.customFieldId === id);
+      expect(byId(1).stringValue).toEqual("hello");
+      expect(byId(2).dateValue).toEqual("2023-08-05T00:00:00.000Z");
+      expect(byId(3).selectValue).toEqual(42);
+      expect(byId(4).currencyValue).toEqual("9.99");
+      expect(byId(5).booleanValue).toEqual(true);
+      // Manage-fields menu entries flip to selected
+      customFieldDefs.forEach((def) => {
+        const menuItem = component.customFieldsStatefulMenuItems.find(
+          (m) => m.value === def.id.toString()
+        );
+        expect(menuItem?.selected).toBe(true);
+      });
+
+      // Comments handed to the (mode-aware) comments child
+      expect(addMagicFilledComments).toHaveBeenCalledWith(magicReceipt.comments);
+
+      // Snackbar lists every filled field with reader-friendly labels
+      expect(successSpy).toHaveBeenCalledWith(
+        "Magic fill successfully filled name, amount, date, paid by, status, categories, tags, items, custom fields, comments from selected image!",
+        { duration: 10000 }
+      );
+    });
+
+    it("treats items with a chargedToUserId as shares and excludes them from the item total", () => {
+      component.images.set([{ id: 1 } as any]);
+      component.ngOnInit();
+      component.mode = FormMode.edit;
+      stubCarousel();
+      stubItemAndShareLists();
+
+      const magicReceipt = {
+        name: "Items",
+        amount: "100.00",
+        date: "2023-08-05T00:00:00.000Z",
+        receiptItems: [
+          { name: "Regular", amount: "40.00", status: "OPEN" },
+          { name: "Share", amount: "20.00", status: "OPEN", chargedToUserId: 9 },
+        ],
+      } as any;
+
+      mockMagicFill(magicReceipt);
+      spySuccess();
+
+      component.magicFill();
+
+      // Only the non-share item counts toward the receipt item total
+      expect((component as any).calculateItemsTotal()).toEqual(40);
+      // The share carries a required chargedToUserId validator; the regular item does not
+      const shareControl = component.receiptItemsFormArray.at(1).get("chargedToUserId");
+      const regularControl = component.receiptItemsFormArray.at(0).get("chargedToUserId");
+      expect(shareControl?.hasValidator(Validators.required)).toBe(true);
+      expect(regularControl?.hasValidator(Validators.required)).toBe(false);
+    });
+
+    it("fills nothing and shows an error when the response is all defaults/empty", () => {
+      component.images.set([{ id: 1 } as any]);
+      component.ngOnInit();
+      component.mode = FormMode.edit;
+      stubCarousel();
+
+      const originalData = {
+        name: "kept name",
+        amount: "482.32",
+        paidByUserId: 3,
+        status: ReceiptStatus.Open,
+      } as any;
+      component.form.patchValue(originalData);
+
+      const magicReceipt = {
+        name: "",
+        amount: "0",
+        date: "0001-01-01T00:00:00Z",
+        paidByUserId: 0,
+        status: "",
+        categories: [],
+        tags: [],
+        receiptItems: [],
+        customFields: [],
+        comments: [],
+      } as any;
+
+      mockMagicFill(magicReceipt);
+      const errorSpy = spyError();
+
+      component.magicFill();
+
+      const value = component.form.getRawValue();
+      expect(value.name).toEqual("kept name");
+      expect(value.amount).toEqual("482.32");
+      expect(value.paidByUserId).toEqual(3);
+      expect(value.status).toEqual(ReceiptStatus.Open);
+      expect(value.receiptItems).toEqual([]);
+      expect(value.customFields).toEqual([]);
+      expect(errorSpy).toHaveBeenCalledWith(
+        "Could not find any values to fill! Try reuploading a clearer image."
+      );
+    });
+
+    it("fills only the fields present and labels just those in the snackbar", () => {
+      component.images.set([{ id: 1 } as any]);
+      component.ngOnInit();
+      component.mode = FormMode.edit;
+      stubCarousel();
+      stubItemAndShareLists();
+
+      component.form.patchValue({ name: "untouched", amount: "5.00" });
+
+      const magicReceipt = {
+        receiptItems: [{ name: "Only Item", amount: "3.00", status: "OPEN" }],
+      } as any;
+
+      mockMagicFill(magicReceipt);
+      const successSpy = spySuccess();
+
+      component.magicFill();
+
+      const value = component.form.getRawValue();
+      expect(value.name).toEqual("untouched");
+      expect(value.amount).toEqual("5.00");
+      expect(value.receiptItems.length).toEqual(1);
+      expect(successSpy).toHaveBeenCalledWith(
+        "Magic fill successfully filled items from selected image!",
+        { duration: 10000 }
+      );
+    });
+
+    it("skips custom field values whose field is not in the catalog pool", () => {
+      component.images.set([{ id: 1 } as any]);
+      routeDataSubject.next({ mode: FormMode.edit, customFields: [customFieldDefs[0]] });
+      component.mode = FormMode.edit;
+      stubCarousel();
+
+      const magicReceipt = {
+        name: "CF",
+        amount: "1.00",
+        date: "2023-08-05T00:00:00.000Z",
+        customFields: [{ customFieldId: 999, stringValue: "orphan" }],
+      } as any;
+
+      mockMagicFill(magicReceipt);
+      const successSpy = spySuccess();
+
+      component.magicFill();
+
+      expect(component.customFieldsFormArray.length).toEqual(0);
+      // "custom fields" is absent from the snackbar since nothing was ingested
+      expect(successSpy).toHaveBeenCalledWith(
+        "Magic fill successfully filled name, amount, date from selected image!",
+        { duration: 10000 }
+      );
+    });
+
+    it("does not duplicate a custom field the receipt already carries a value for", () => {
+      component.images.set([{ id: 1 } as any]);
+      routeDataSubject.next({
+        mode: FormMode.edit,
+        customFields: [customFieldDefs[0]],
+        receipt: {
+          id: 5,
+          name: "R",
+          amount: "1.00",
+          customFields: [{ customFieldId: 1, stringValue: "existing" }],
+        } as any,
+      });
+      component.mode = FormMode.edit;
+      stubCarousel();
+
+      const magicReceipt = {
+        name: "CF",
+        amount: "1.00",
+        date: "2023-08-05T00:00:00.000Z",
+        customFields: [{ customFieldId: 1, stringValue: "new value" }],
+      } as any;
+
+      mockMagicFill(magicReceipt);
+      spySuccess();
+
+      component.magicFill();
+
+      expect(component.customFieldsFormArray.length).toEqual(1);
+      expect(component.customFieldsFormArray.at(0).value.stringValue).toEqual("existing");
+    });
+
+    it("appends magic-filled items and categories onto existing ones", () => {
+      component.images.set([{ id: 1 } as any]);
+      routeDataSubject.next({
+        mode: FormMode.edit,
+        customFields: [],
+        receipt: {
+          id: 5,
+          name: "R",
+          amount: "100.00",
+          categories: [{ id: 1, name: "existing cat" }],
+          receiptItems: [{ name: "Existing Item", amount: "10.00", status: "OPEN" }],
+          customFields: [],
+        } as any,
+      });
+      component.mode = FormMode.edit;
+      stubCarousel();
+      stubItemAndShareLists();
+      component.categories = [
+        { id: 1, name: "existing cat" } as any,
+        { id: 2, name: "new cat" } as any,
+      ];
+
+      const magicReceipt = {
+        categories: [{ id: 2 }],
+        receiptItems: [{ name: "New Item", amount: "15.00", status: "OPEN" }],
+      } as any;
+
+      mockMagicFill(magicReceipt);
+      spySuccess();
+
+      component.magicFill();
+
+      const value = component.form.getRawValue();
+      expect(value.categories).toEqual([
+        { id: 1, name: "existing cat" },
+        { id: 2, name: "new cat" },
+      ]);
+      expect(value.receiptItems.map((i: any) => i.name)).toEqual([
+        "Existing Item",
+        "New Item",
+      ]);
+    });
+
+    it("round-trips negative refund amounts on the receipt and items", () => {
+      component.images.set([{ id: 1 } as any]);
+      component.ngOnInit();
+      component.mode = FormMode.edit;
+      stubCarousel();
+      stubItemAndShareLists();
+
+      const magicReceipt = {
+        name: "Refund",
+        amount: "-50.00",
+        date: "2023-08-05T00:00:00.000Z",
+        receiptItems: [{ name: "Refunded", amount: "-50.00", status: "OPEN" }],
+      } as any;
+
+      mockMagicFill(magicReceipt);
+      spySuccess();
+
+      component.magicFill();
+
+      const value = component.form.getRawValue();
+      expect(value.amount).toEqual("-50.00");
+      expect(value.receiptItems[0].amount).toEqual("-50.00");
+    });
+
+    it("skips paid-by when the backend returns the unset sentinel (0)", () => {
+      component.images.set([{ id: 1 } as any]);
+      component.ngOnInit();
+      component.mode = FormMode.edit;
+      stubCarousel();
+      const { syncSingleDisplay } = stubPaidByAutocomplete();
+      component.form.patchValue({ paidByUserId: 4 });
+
+      const magicReceipt = {
+        name: "No Payer",
+        amount: "1.00",
+        date: "2023-08-05T00:00:00.000Z",
+        paidByUserId: 0,
+      } as any;
+
+      mockMagicFill(magicReceipt);
+      const successSpy = spySuccess();
+
+      component.magicFill();
+
+      // Existing paid-by preserved, display not refreshed, not listed in the snackbar
+      expect(component.form.getRawValue().paidByUserId).toEqual(4);
+      expect(syncSingleDisplay).not.toHaveBeenCalled();
+      expect(successSpy).toHaveBeenCalledWith(
+        "Magic fill successfully filled name, amount, date from selected image!",
+        { duration: 10000 }
+      );
+    });
   });
 });

--- a/desktop/src/receipts/receipt-form/receipt-form.component.spec.ts
+++ b/desktop/src/receipts/receipt-form/receipt-form.component.spec.ts
@@ -395,7 +395,6 @@ describe("ReceiptFormComponent", () => {
             name: "Regular Item",
             amount: "40.00",
             status: "OPEN",
-            IsTaxed: true,
             categories: [{ id: 5, name: "item cat" }],
             tags: [{ id: 6, name: "item tag" }],
           },
@@ -444,7 +443,6 @@ describe("ReceiptFormComponent", () => {
       expect(regular.name).toEqual("Regular Item");
       expect(regular.amount).toEqual("40.00");
       expect(regular.status).toEqual("OPEN");
-      expect(regular.isTaxed).toEqual(true);
       expect(regular.chargedToUserId).toBeFalsy();
       expect(regular.categories).toEqual([{ id: 5, name: "item cat" }]);
       expect(regular.tags).toEqual([{ id: 6, name: "item tag" }]);

--- a/desktop/src/receipts/receipt-form/receipt-form.component.ts
+++ b/desktop/src/receipts/receipt-form/receipt-form.component.ts
@@ -798,17 +798,23 @@ export class ReceiptFormComponent implements OnInit {
   }
 
   // Appends the magic-filled categories/tags that resolve to an entry in the
-  // available pool. Returns whether any were added, so an empty or unmatched
-  // response doesn't report a phantom fill.
+  // available pool and aren't already on the receipt (edit mode can re-return an
+  // existing selection, which the picker itself would dedupe). Returns whether
+  // any were added, so an empty/unmatched/all-duplicate response doesn't report a
+  // phantom fill.
   private handleCategoryAndTagMagicFill(
     formKey: "categories" | "tags",
     value: Category[] | Tag[],
     arrayToFilter: Category[] | Tag[]
   ): boolean {
-    const itemsToPush = (arrayToFilter as any[]).filter((item) =>
-      value.map((foundItem) => foundItem.id)?.includes(item.id)
-    );
     const itemsFormArray = this.form.get(formKey) as FormArray;
+    const existingIds = new Set(
+      itemsFormArray.controls.map((control) => control.value?.id)
+    );
+    const magicIds = value.map((foundItem) => foundItem.id);
+    const itemsToPush = (arrayToFilter as any[]).filter(
+      (item) => magicIds.includes(item.id) && !existingIds.has(item.id)
+    );
     itemsToPush.forEach((c) => {
       itemsFormArray.push(this.formBuilder.control(c));
     });

--- a/desktop/src/receipts/receipt-form/receipt-form.component.ts
+++ b/desktop/src/receipts/receipt-form/receipt-form.component.ts
@@ -38,6 +38,7 @@ import { StatefulMenuItem } from "../../standalone/components/filtered-stateful-
 import { AuthState, FeatureConfigState, GroupState, UserState } from "../../store";
 import { downloadFile } from "../../utils/file";
 import { ItemListComponent } from "../item-list/item-list.component";
+import { ReceiptCommentsComponent } from "../receipt-comments/receipt-comments.component";
 import { ShareListComponent } from "../share-list/share-list.component";
 
 
@@ -57,6 +58,10 @@ export class ReceiptFormComponent implements OnInit {
   public readonly shareListComponent = viewChild.required(ShareListComponent);
 
   public readonly itemListComponent = viewChild.required(ItemListComponent);
+
+  // Optional: the comments child only renders when the group doesn't hide
+  // comments (see the @if in the template), so this query may be empty.
+  public readonly receiptCommentsComponent = viewChild(ReceiptCommentsComponent);
 
   public readonly uploadImageComponent = viewChild.required(UploadImageComponent);
 
@@ -594,58 +599,192 @@ export class ReceiptFormComponent implements OnInit {
   }
 
   private patchMagicValues(magicReceipt: Receipt): void {
+    // A field is only reported as filled when it actually changes the form, so
+    // an empty/unmatched value never claims a phantom fill. Scalars come first,
+    // then each association through the form's existing builders (amount is
+    // patched before items so item validators see the filled receipt total).
+    const filledKeys: string[] = [];
+
+    this.patchMagicScalars(magicReceipt, filledKeys);
+
+    if (
+      this.handleCategoryAndTagMagicFill(
+        "categories",
+        magicReceipt?.categories ?? [],
+        this.categories
+      )
+    ) {
+      filledKeys.push("categories");
+    }
+    if (
+      this.handleCategoryAndTagMagicFill(
+        "tags",
+        magicReceipt?.tags ?? [],
+        this.tags
+      )
+    ) {
+      filledKeys.push("tags");
+    }
+    if (this.patchMagicItems(magicReceipt)) {
+      filledKeys.push("receiptItems");
+    }
+    if (this.patchMagicCustomFields(magicReceipt)) {
+      filledKeys.push("customFields");
+    }
+    if (this.patchMagicComments(magicReceipt)) {
+      filledKeys.push("comments");
+    }
+
+    this.showMagicFillResult(filledKeys);
+  }
+
+  // Patches the scalar fields. Each is skipped when the backend value is unset:
+  // the `value && value !== default` guard covers both the falsy sentinels
+  // (name "", paidByUserId 0, status "") and the truthy ones (amount "0", the
+  // zero date). status routes through the default branch.
+  private patchMagicScalars(magicReceipt: Receipt, filledKeys: string[]): void {
     const keysWithDefaults = {
       name: "",
       amount: "0",
       date: "0001-01-01T00:00:00Z",
-      categories: null,
-      tags: null,
+      paidByUserId: 0,
+      status: "",
     } as any;
-    const validKeys: string[] = [];
     Object.keys(keysWithDefaults).forEach((key) => {
       let value = (magicReceipt as any)[key] as string | Date;
       if (value && value !== keysWithDefaults[key]) {
         switch (key) {
-          case "categories":
-            this.handleCategoryAndTagMagicFill(
-              key,
-              magicReceipt?.categories ?? [],
-              this.categories
-            );
-            break;
-          case "tags":
-            this.handleCategoryAndTagMagicFill(
-              key,
-              magicReceipt?.tags ?? [],
-              this.tags
-            );
-            break;
           case "date":
             value = this.handleDateMagicFill(value as string);
             this.form.patchValue({
               date: value,
             });
             break;
+          case "paidByUserId":
+            this.patchMagicValue(key, magicReceipt);
+            // patchValue updates the control but not the autocomplete's shown
+            // text, which is seeded from the control only once on init.
+            this.paidByAutocomplete()?.autocompleteComponent()?.syncSingleDisplay();
+            break;
           default:
             this.patchMagicValue(key, magicReceipt);
         }
 
-        validKeys.push(key);
+        filledKeys.push(key);
       }
     });
+  }
 
-    if (validKeys.length > 0) {
-      const successString = `Magic fill successfully filled ${validKeys.join(
-        ", "
-      )} from selected image!`;
-      this.snackbarService.success(successString, {
-        duration: 10000,
-      });
-    } else {
+  // Appends magic-filled items (and shares — items with a chargedToUserId) onto
+  // the receiptItems array using the same builder the form uses elsewhere, which
+  // also nests linkedItems and per-item categories/tags. Returns whether any were
+  // added.
+  private patchMagicItems(magicReceipt: Receipt): boolean {
+    const items = magicReceipt.receiptItems ?? [];
+    if (items.length === 0) {
+      return false;
+    }
+
+    items.forEach((item) => {
+      const itemForm = buildItemForm(
+        item,
+        this.originalReceipt?.id?.toString(),
+        !!item.chargedToUserId,
+        this.syncAmountWithItems
+      );
+      this.receiptItemsFormArray.push(itemForm);
+    });
+    this.refreshComponentsAndSync();
+    return true;
+  }
+
+  // Appends magic-filled custom field values. The magic-fill response carries no
+  // field definition, so a value is only ingested when its field is in the loaded
+  // catalog pool (otherwise it can't be rendered or edited); a field the receipt
+  // already has a value for is skipped to avoid duplicates. Returns whether any
+  // were added.
+  private patchMagicCustomFields(magicReceipt: Receipt): boolean {
+    const values = magicReceipt.customFields ?? [];
+    if (values.length === 0) {
+      return false;
+    }
+
+    let filledAny = false;
+    values.forEach((value) => {
+      const definition = this.customFields.find(
+        (field) => field.id === value.customFieldId
+      );
+      if (!definition) {
+        return;
+      }
+
+      const alreadyPresent = this.customFieldsFormArray.controls.some(
+        (control) => control.value?.["customFieldId"] === value.customFieldId
+      );
+      if (alreadyPresent) {
+        return;
+      }
+
+      this.customFieldsFormArray.push(this.buildCustomOptionFormGroup(value));
+      this.markCustomFieldMenuItemSelected(value.customFieldId);
+      filledAny = true;
+    });
+    return filledAny;
+  }
+
+  // Flips the manage-fields menu entry to selected so the newly added custom
+  // field renders, using an immutable array replace (required under zoneless CD,
+  // mirroring customFieldChanged).
+  private markCustomFieldMenuItemSelected(customFieldId: number): void {
+    const menuValue = customFieldId.toString();
+    const index = this.customFieldsStatefulMenuItems.findIndex(
+      (item) => item.value === menuValue
+    );
+    if (index === -1) {
+      return;
+    }
+
+    const updated = Array.from(this.customFieldsStatefulMenuItems);
+    updated[index] = { ...updated[index], selected: true };
+    this.customFieldsStatefulMenuItems = updated;
+  }
+
+  // Hands magic-filled comments to the comments child, which owns them and is
+  // mode-aware (add mode collects them for the create submit; edit mode POSTs
+  // each as an individual resource). Returns whether the child handled them.
+  private patchMagicComments(magicReceipt: Receipt): boolean {
+    const comments = magicReceipt.comments ?? [];
+    const commentsComponent = this.receiptCommentsComponent();
+    if (comments.length === 0 || !commentsComponent) {
+      return false;
+    }
+
+    commentsComponent.addMagicFilledComments(comments);
+    return true;
+  }
+
+  private showMagicFillResult(filledKeys: string[]): void {
+    if (filledKeys.length === 0) {
       this.snackbarService.error(
         "Could not find any values to fill! Try reuploading a clearer image."
       );
+      return;
     }
+
+    // Map the raw form keys of the added fields to reader-friendly labels; the
+    // existing scalar keys map to themselves.
+    const labels: { [key: string]: string } = {
+      paidByUserId: "paid by",
+      receiptItems: "items",
+      customFields: "custom fields",
+    };
+    const filledLabels = filledKeys.map((key) => labels[key] ?? key);
+    const successString = `Magic fill successfully filled ${filledLabels.join(
+      ", "
+    )} from selected image!`;
+    this.snackbarService.success(successString, {
+      duration: 10000,
+    });
   }
 
   private patchMagicValue(key: string, magicReceipt: Receipt): void {
@@ -658,11 +797,14 @@ export class ReceiptFormComponent implements OnInit {
     return this.formatMagicFilledDate(value);
   }
 
+  // Appends the magic-filled categories/tags that resolve to an entry in the
+  // available pool. Returns whether any were added, so an empty or unmatched
+  // response doesn't report a phantom fill.
   private handleCategoryAndTagMagicFill(
     formKey: "categories" | "tags",
     value: Category[] | Tag[],
     arrayToFilter: Category[] | Tag[]
-  ): void {
+  ): boolean {
     const itemsToPush = (arrayToFilter as any[]).filter((item) =>
       value.map((foundItem) => foundItem.id)?.includes(item.id)
     );
@@ -670,6 +812,7 @@ export class ReceiptFormComponent implements OnInit {
     itemsToPush.forEach((c) => {
       itemsFormArray.push(this.formBuilder.control(c));
     });
+    return itemsToPush.length > 0;
   }
 
   private formatMagicFilledDate(date: string): Date {


### PR DESCRIPTION
## Summary
Adds comprehensive end-to-end tests for the AI-powered receipt ingest pipeline, covering both server-side QuickScan and client-side Magic Fill. These tests verify that every persistable receipt field survives the full ingest-and-roundtrip cycle, serving as regression guards against silent field drops.

## Key Changes

### Backend (api/)
- **New test file**: `services/quick_scan_ingest_test.go` (750 lines)
  - `TestQuickScan_PersistsEveryField`: Maximal receipt with all scalar fields, nested associations (items, linked items, comments), per-item categories/tags, and custom field values of all five types (text, date, select, currency, boolean)
  - `TestQuickScan_BackfillsPaidByAndStatusWhenAiOmitsThem`: Verifies QuickScan fills paid-by/status from arguments when AI omits them
  - `TestQuickScan_KeepsAiPaidByAndStatusWhenPresent`: Proves AI-supplied values aren't overwritten by defaults
  - `TestQuickScan_MergesUserCategoryAndTagPicksWithAi`: Union deduplication of user picks and AI assignments
  - `TestQuickScan_RefundNegativeAmountsPersist`: Negative amounts (refunds) round-trip correctly
  - `TestQuickScan_MinimalReceiptCreatesNoSpuriousAssociations`: Bare AI response doesn't invent associations
  - `TestQuickScan_MissingItemStatusFailsAndPersistsNothing`: Validation failures are all-or-nothing
  - `TestQuickScan_InvalidAiJsonReturnsError`: Malformed AI responses surface as errors
- Helper functions for mutable Ollama server, temp file handling, and custom field seeding

### Frontend (desktop/)
- **receipt-form.component.ts**: Refactored `patchMagicValues()` to handle full receipt ingest
  - `patchMagicScalars()`: Handles name, amount, date, paid-by, status with proper default detection
  - `patchMagicItems()`: Appends items/shares with nested linked items and per-item categories/tags
  - `patchMagicCustomFields()`: Ingests custom field values, skipping orphaned fields and duplicates
  - `patchMagicComments()`: Routes comments to the comments child component
  - `showMagicFillResult()`: Generates user-friendly snackbar listing only fields actually filled
  - Paid-by autocomplete synced after patching to update displayed text

- **receipt-form.component.spec.ts**: 450+ lines of new tests
  - Full receipt ingest with every field type
  - Share detection (chargedToUserId) and item-total exclusion
  - Empty/default response handling (no spurious fills)
  - Partial fills with accurate snackbar labeling
  - Custom field catalog filtering and duplicate prevention

- **receipt-comments.component.ts**: New `addMagicFilledComments()` method
  - Add mode: collects comments in array, emits for parent form submission
  - Edit mode: POSTs each comment individually via CommentService

- **receipt-comments.component.spec.ts**: Tests for magic-filled comment handling in both modes

- **autocomlete.component.ts**: New `syncSingleDisplay()` method to re-seed single-select display from control value (used by Magic Fill to update paid-by autocomplete text after patching)

- **autocomlete.component.spec.ts**: Test for `syncSingleDisplay()` behavior

### Documentation
- **api/CLAUDE.md**: Added "End-to-end ingest tests" section documenting the test strategy
- **desktop/CLAUDE.md**: Added "Magic Fill (receipt form)" section explaining the feature and its relationship to Quick Scan

## Notable Implementation Details

- **Mutable Ollama server**: Tests seed the graph first, learn the seeded user's ID, then set the AI response referencing that ID — the request only fires later inside QuickScan
- **Field

https://claude.ai/code/session_0199Abyj9EvGZA6iq6SX5EA9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Magic Fill now ingests fully parsed receipt data into the receipt form, including items/shares, categories/tags, custom fields, paid-by/status, and comments.
  * Added receipt-form support to apply magic-filled comments and synchronize autocomplete display in single-select mode.

* **Improvements**
  * Magic Fill reports only the fields actually populated.
  * Better handling for refunds and negative amounts, including validation of failure cases (invalid/incomplete data won’t save partial receipts).

* **Documentation**
  * Expanded Quick Scan and Magic Fill guidance.

* **Tests**
  * Added end-to-end Quick Scan ingest coverage and expanded desktop unit tests for Magic Fill ingestion and comments behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->