### PR TITLE
Add server-side pagination for user list

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -381,8 +381,9 @@ will be dropped in a later release.
   Owner** (the group VIEWER / EDITOR / OWNER tiers; Owner = every group permission). The sets live in
   `permissions/legacy.go` (`Legacy*Keys()` helpers) and were derived from the actual handler-level
   gating, not the desktop UI presets. **Deliberate exceptions** (Legacy User omits these): `app.users.read`
-  — it gates only the admin `GET /user/` listing, which no client calls (user dropdowns read from AppData via
-  `app.account.read`), so granting it would only expose the admin "Manage Users" page to normal users; and
+  — it gates the admin user listing (the unpaged `GET /user/` **and** the paged `POST /user/getPagedUsers`
+  that the desktop "Manage Users" page reads from); user dropdowns instead read from AppData via
+  `app.account.read`, so granting it would only expose the admin "Manage Users" page to normal users; and
   `app.categories.read` / `app.tags.read` — omitted as part of the category/tag grant lock-down, since they
   gate the GLOBAL category/tag lists; normal users now get only the per-group filtered catalogs (the
   `app.categories.create` / `app.tags.create` permissions are retained for inline creation); and

--- a/api/internal/handlers/users.go
+++ b/api/internal/handlers/users.go
@@ -54,6 +54,55 @@ func GetAllUsers(w http.ResponseWriter, r *http.Request) {
 	HandleRequest(handler)
 }
 
+func GetPagedUsers(w http.ResponseWriter, r *http.Request) {
+	handler := structs.Handler{
+		ErrorMessage:   "Error retrieving users.",
+		Writer:         w,
+		Request:        r,
+		AppPermissions: []string{permissions.AppUsersRead},
+		ResponseType:   constants.ApplicationJson,
+		HandlerFunction: func(w http.ResponseWriter, r *http.Request) (int, error) {
+			command := commands.PagedRequestCommand{}
+			err := command.LoadDataFromRequest(w, r)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			vErr := command.Validate()
+			if len(vErr.Errors) > 0 {
+				structs.WriteValidatorErrorResponse(w, vErr, http.StatusBadRequest)
+				return 0, nil
+			}
+
+			userRepository := repositories.NewUserRepository(nil)
+			users, count, err := userRepository.GetPagedUsers(command)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			pagedData := structs.PagedData{}
+			data := make([]interface{}, 0)
+			for i := 0; i < len(users); i++ {
+				data = append(data, users[i])
+			}
+			pagedData.TotalCount = count
+			pagedData.Data = data
+
+			responseBytes, err := utils.MarshalResponseData(pagedData)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			w.WriteHeader(http.StatusOK)
+			w.Write(responseBytes)
+
+			return 0, nil
+		},
+	}
+
+	HandleRequest(handler)
+}
+
 func CreateUser(w http.ResponseWriter, r *http.Request) {
 	handler := structs.Handler{
 		ErrorMessage:   "Error creating user.",

--- a/api/internal/handlers/users_test.go
+++ b/api/internal/handlers/users_test.go
@@ -775,3 +775,107 @@ func TestGetAmountOwedForUserReceiptIdsCombinedWithGroupId(t *testing.T) {
 	assertOwed(t, result, 2, 10)
 	assertOwed(t, result, 4, 25)
 }
+
+func TestShouldNotAllowUserToGetPagedUsers(t *testing.T) {
+	defer tearDownUserTest()
+	reader := strings.NewReader("")
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/api", reader)
+
+	newContext := context.WithValue(r.Context(), jwtmiddleware.ContextKey{}, &validator.ValidatedClaims{CustomClaims: &structs.Claims{UserId: 1}})
+	r = r.WithContext(newContext)
+
+	GetPagedUsers(w, r)
+
+	if w.Result().StatusCode != http.StatusForbidden {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusForbidden)
+	}
+}
+
+func TestShouldNotGetPagedUsersWithBadRequest(t *testing.T) {
+	defer tearDownUserTest()
+
+	tests := map[string]struct {
+		input  commands.PagedRequestCommand
+		expect int
+	}{
+		"badOrderBy": {
+			input:  commands.PagedRequestCommand{Page: 1, PageSize: 50, OrderBy: "badOrderBy", SortDirection: "asc"},
+			expect: http.StatusInternalServerError,
+		},
+		"badSortDirection": {
+			input:  commands.PagedRequestCommand{Page: 1, PageSize: 50, OrderBy: "username", SortDirection: "badSortDirection"},
+			expect: http.StatusBadRequest,
+		},
+		"badPage": {
+			input:  commands.PagedRequestCommand{Page: -1, PageSize: 50, OrderBy: "username", SortDirection: "asc"},
+			expect: http.StatusBadRequest,
+		},
+		"badPageSize": {
+			input:  commands.PagedRequestCommand{Page: 1, PageSize: -2, OrderBy: "username", SortDirection: "asc"},
+			expect: http.StatusBadRequest,
+		},
+		"valid": {
+			input:  commands.PagedRequestCommand{Page: 1, PageSize: 25, OrderBy: "username", SortDirection: "asc"},
+			expect: http.StatusOK,
+		},
+	}
+
+	grantAllAppPerms(t, 1)
+
+	for name, test := range tests {
+		bytes, _ := json.Marshal(test.input)
+		reader := strings.NewReader(string(bytes))
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("POST", "/api", reader)
+
+		newContext := context.WithValue(r.Context(), jwtmiddleware.ContextKey{}, &validator.ValidatedClaims{CustomClaims: &structs.Claims{UserId: 1}})
+		r = r.WithContext(newContext)
+
+		GetPagedUsers(w, r)
+
+		if w.Result().StatusCode != test.expect {
+			utils.PrintTestError(t, name+" status "+strconv.Itoa(w.Result().StatusCode), test.expect)
+		}
+	}
+}
+
+func TestShouldAllowAdminToGetPagedUsers(t *testing.T) {
+	defer tearDownUserTest()
+
+	// grantAllAppPerms creates user 1 with the admin role; add two more so the
+	// page returns a known, non-trivial set.
+	grantAllAppPerms(t, 1)
+	db := repositories.GetDB()
+	db.Create(&models.User{Username: "alpha", DisplayName: "alpha", Password: "password"})
+	db.Create(&models.User{Username: "beta", DisplayName: "beta", Password: "password"})
+
+	command := commands.PagedRequestCommand{Page: 1, PageSize: 25, OrderBy: "username", SortDirection: "asc"}
+	bytes, _ := json.Marshal(command)
+	reader := strings.NewReader(string(bytes))
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/api", reader)
+
+	newContext := context.WithValue(r.Context(), jwtmiddleware.ContextKey{}, &validator.ValidatedClaims{CustomClaims: &structs.Claims{UserId: 1}})
+	r = r.WithContext(newContext)
+
+	GetPagedUsers(w, r)
+
+	if w.Result().StatusCode != http.StatusOK {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusOK)
+		return
+	}
+
+	var pagedData structs.PagedData
+	if err := json.NewDecoder(w.Result().Body).Decode(&pagedData); err != nil {
+		utils.PrintTestError(t, err, "no error decoding paged data")
+		return
+	}
+
+	if pagedData.TotalCount != 3 {
+		utils.PrintTestError(t, pagedData.TotalCount, int64(3))
+	}
+	if len(pagedData.Data) != 3 {
+		utils.PrintTestError(t, len(pagedData.Data), 3)
+	}
+}

--- a/api/internal/repositories/users.go
+++ b/api/internal/repositories/users.go
@@ -1,6 +1,7 @@
 package repositories
 
 import (
+	"errors"
 	"receipt-wrangler/api/internal/commands"
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/permissions"
@@ -182,6 +183,41 @@ func (repository UserRepository) GetAllUserViews() ([]structs.UserView, error) {
 	}
 
 	return users, nil
+}
+
+func (repository UserRepository) GetPagedUsers(command commands.PagedRequestCommand) ([]structs.UserView, int64, error) {
+	db := repository.GetDB()
+	var results []structs.UserView
+	var count int64
+
+	query := db.Model(&models.User{})
+
+	err := query.Count(&count).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	validColumn := repository.isUserSortColumn(command.OrderBy)
+	if !validColumn {
+		return nil, 0, errors.New("invalid column: " + command.OrderBy)
+	}
+
+	query = repository.Sort(query, command.OrderBy, command.SortDirection)
+	query = query.Scopes(repository.Paginate(command.Page, command.PageSize))
+
+	err = query.Find(&results).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return results, count, nil
+}
+
+func (repository UserRepository) isUserSortColumn(orderBy string) bool {
+	return orderBy == "username" ||
+		orderBy == "display_name" ||
+		orderBy == "created_at" ||
+		orderBy == "updated_at"
 }
 
 func (repository UserRepository) GetUserById(userId uint) (structs.UserView, error) {

--- a/api/internal/repositories/users_test.go
+++ b/api/internal/repositories/users_test.go
@@ -424,3 +424,128 @@ func validateGroup(t *testing.T, group models.Group, id uint, userId uint) {
 	}
 
 }
+
+func pagedUsersCommand(orderBy string, direction commands.SortDirection) commands.PagedRequestCommand {
+	return commands.PagedRequestCommand{
+		Page:          1,
+		PageSize:      10,
+		OrderBy:       orderBy,
+		SortDirection: direction,
+	}
+}
+
+func createUserWithUsername(username string) {
+	GetDB().Create(&models.User{
+		Username:    username,
+		DisplayName: username,
+		Password:    "Password",
+	})
+}
+
+func TestGetPagedUsers_ReturnsRowsAndCount(t *testing.T) {
+	defer TruncateTestDb()
+
+	createUserWithUsername("beta")
+	createUserWithUsername("alpha")
+
+	repository := NewUserRepository(nil)
+	users, count, err := repository.GetPagedUsers(pagedUsersCommand("username", commands.ASCENDING))
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+
+	if count != 2 {
+		utils.PrintTestError(t, count, int64(2))
+	}
+	if len(users) != 2 {
+		utils.PrintTestError(t, len(users), 2)
+		return
+	}
+	// Ascending username order.
+	if users[0].Username != "alpha" || users[1].Username != "beta" {
+		utils.PrintTestError(t, []string{users[0].Username, users[1].Username}, []string{"alpha", "beta"})
+	}
+}
+
+func TestGetPagedUsers_SecondPage(t *testing.T) {
+	defer TruncateTestDb()
+
+	createUserWithUsername("a")
+	createUserWithUsername("b")
+	createUserWithUsername("c")
+
+	command := pagedUsersCommand("username", commands.ASCENDING)
+	command.Page = 2
+	command.PageSize = 2
+
+	users, count, err := NewUserRepository(nil).GetPagedUsers(command)
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+
+	// Count is the unpaged total.
+	if count != 3 {
+		utils.PrintTestError(t, count, int64(3))
+	}
+	if len(users) != 1 {
+		utils.PrintTestError(t, len(users), 1)
+		return
+	}
+	if users[0].Username != "c" {
+		utils.PrintTestError(t, users[0].Username, "c")
+	}
+}
+
+func TestGetPagedUsers_EmptyReturnsZeroCount(t *testing.T) {
+	defer TruncateTestDb()
+
+	users, count, err := NewUserRepository(nil).GetPagedUsers(pagedUsersCommand("username", commands.ASCENDING))
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+	if count != 0 {
+		utils.PrintTestError(t, count, int64(0))
+	}
+	if len(users) != 0 {
+		utils.PrintTestError(t, len(users), 0)
+	}
+}
+
+func TestGetPagedUsers_RejectsInvalidColumn(t *testing.T) {
+	defer TruncateTestDb()
+
+	// An order-by outside the allow-list is rejected rather than interpolated as raw SQL.
+	_, _, err := NewUserRepository(nil).GetPagedUsers(pagedUsersCommand("password", commands.ASCENDING))
+	if err == nil {
+		utils.PrintTestError(t, nil, "an invalid column error")
+	}
+}
+
+func TestGetPagedUsers_SortsByAllowedColumns(t *testing.T) {
+	defer TruncateTestDb()
+
+	createUserWithUsername("alpha")
+	createUserWithUsername("beta")
+
+	repository := NewUserRepository(nil)
+
+	// username is covered above; display_name, created_at and updated_at must also
+	// execute through Sort/Find without error (they are on the allow-list but were
+	// never exercised).
+	for _, column := range []string{"display_name", "created_at", "updated_at"} {
+		users, count, err := repository.GetPagedUsers(pagedUsersCommand(column, commands.DESCENDING))
+		if err != nil {
+			utils.PrintTestError(t, err, "no error sorting by "+column)
+			return
+		}
+		if count != 2 {
+			utils.PrintTestError(t, count, int64(2))
+		}
+		if len(users) != 2 {
+			utils.PrintTestError(t, len(users), 2)
+		}
+	}
+}

--- a/api/internal/routers/user.go
+++ b/api/internal/routers/user.go
@@ -12,6 +12,7 @@ func BuildUserRouter() *chi.Mux {
 
 	// Authenticated routes
 	userRouter.With(middleware.UnifiedAuthMiddleware).Get("/", handlers.GetAllUsers)
+	userRouter.With(middleware.UnifiedAuthMiddleware).Post("/getPagedUsers", handlers.GetPagedUsers)
 	userRouter.With(middleware.UnifiedAuthMiddleware, middleware.SetGeneralBodyData("updateProfileCommand", commands.UpdateProfileCommand{})).Put("/updateUserProfile", handlers.UpdateUserProfile)
 	userRouter.With(middleware.UnifiedAuthMiddleware, middleware.SetUserData, middleware.ValidateUserData(true)).Post("/", handlers.CreateUser)
 	userRouter.With(middleware.UnifiedAuthMiddleware, middleware.SetUserData).Put("/{id}", handlers.UpdateUser)

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -1938,6 +1938,36 @@ paths:
       security:
         - bearerAuth: [ ]
         - apiKeyAuth: [ ]
+  /user/getPagedUsers:
+    post:
+      tags:
+        - User
+      summary: Gets paged users
+      description: This will return paged users
+      operationId: getPagedUsers
+      requestBody:
+        description: Paging and sorting data
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PagedRequestCommand"
+      responses:
+        200:
+          description: Paged users
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PagedData"
+        500:
+          $ref: "#/components/responses/Internal"
+        400:
+          $ref: "#/components/responses/BadRequest"
+        403:
+          $ref: "#/components/responses/Forbidden"
+      security:
+        - bearerAuth: [ ]
+        - apiKeyAuth: [ ]
   /user/{userId}:
     put:
       tags:
@@ -4614,6 +4644,7 @@ components:
               - $ref: "#/components/schemas/Activity"
               - $ref: "#/components/schemas/CustomField"
               - $ref: "#/components/schemas/ReportTemplate"
+              - $ref: "#/components/schemas/UserView"
         totalCount:
           type: integer
     FeatureConfig:

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -239,6 +239,16 @@ gated by `appPermissionGuard` requiring `app.roles.read` (see **Permission-based
     `AuthState.hasGroupPermission`), mirroring the backend `UpdateGroup` guard (see `api/CLAUDE.md` →
     "Group member management"). They default to enabled in **create** mode (no group yet; the creator
     becomes owner). This is UI-only; the server re-enforces on every request.
+- **Manage Users is a server-paged `app-table`:** the admin user-list (`src/user/user-list/`) follows
+  the standard paginated-table pattern (`BaseTableComponent` + `UserTableService` + the NGXS
+  `UserTableState`, mirroring the groups/roles list pages) and reads a page at a time from
+  `UserService.getPagedUsers` (`POST /user/getPagedUsers`) — it no longer wraps `UserState.users` in a
+  client-side `MatTableDataSource`. Server-sortable columns use the DB column names as their
+  `matColumnDef` (`username`, `display_name`, `created_at`, `updated_at`); the client-resolved **Role**
+  column is non-sortable. CRUD row actions refetch via `getTableData()` after the mutation, and delete /
+  bulk-delete still dispatch `RemoveUser` / `RemoveUsers` so the `UserState` cache (consumed by the
+  role-editor & report-builder paid-by pickers, `user-autocomplete`, the `user` pipe, etc.) stays in
+  sync. `UserState` itself is unchanged and still bootstrap-loaded from AppData for those other consumers.
 - **Permission-based UI gating.** The UI gates on the user's effective permissions, mirroring the
   backend's enforcement. Permissions are delivered on **AppData** (`appPermissions: string[]` and
   `groupPermissions: { [groupId]: string[] }`) and stored in `AuthState` via the dedicated

--- a/desktop/src/app/app.config.ts
+++ b/desktop/src/app/app.config.ts
@@ -37,6 +37,7 @@ import { SystemEmailTaskTableState } from "../store/system-email-task-table.stat
 import { SystemSettingsState } from "../store/system-settings.state";
 import { SystemTaskTableState } from "../store/system-task-table.state";
 import { TagTableState } from "../store/tag-table.state";
+import { UserTableState } from "../store/user-table.state";
 import { UserState } from "../store/user.state";
 import { environment } from "src/environments/environment.development";
 
@@ -61,6 +62,7 @@ const ngxsStates = [
   SystemSettingsState,
   SystemTaskTableState,
   TagTableState,
+  UserTableState,
   UserState,
 ];
 
@@ -84,6 +86,7 @@ const ngxsStorageKeys = [
   "systemSettings",
   "systemTaskTable",
   "tagTable",
+  "userTable",
   "users",
 ];
 

--- a/desktop/src/open-api/api/user.service.ts
+++ b/desktop/src/open-api/api/user.service.ts
@@ -27,6 +27,10 @@ import { DeleteAccountCommand } from '../model/deleteAccountCommand';
 // @ts-ignore
 import { InternalErrorResponse } from '../model/internalErrorResponse';
 // @ts-ignore
+import { PagedData } from '../model/pagedData';
+// @ts-ignore
+import { PagedRequestCommand } from '../model/pagedRequestCommand';
+// @ts-ignore
 import { ResetPasswordCommand } from '../model/resetPasswordCommand';
 // @ts-ignore
 import { UpdateProfileCommand } from '../model/updateProfileCommand';
@@ -693,6 +697,94 @@ export class UserService {
         return this.httpClient.request<AppData>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                responseType: <any>responseType_,
+                withCredentials: this.configuration.withCredentials,
+                headers: localVarHeaders,
+                observe: observe,
+                transferCache: localVarTransferCache,
+                reportProgress: reportProgress
+            }
+        );
+    }
+
+    /**
+     * Gets paged users
+     * This will return paged users
+     * @param pagedRequestCommand Paging and sorting data
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
+     */
+    public getPagedUsers(pagedRequestCommand: PagedRequestCommand, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<PagedData>;
+    public getPagedUsers(pagedRequestCommand: PagedRequestCommand, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<PagedData>>;
+    public getPagedUsers(pagedRequestCommand: PagedRequestCommand, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<PagedData>>;
+    public getPagedUsers(pagedRequestCommand: PagedRequestCommand, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
+        if (pagedRequestCommand === null || pagedRequestCommand === undefined) {
+            throw new Error('Required parameter pagedRequestCommand was null or undefined when calling getPagedUsers.');
+        }
+
+        let localVarHeaders = this.defaultHeaders;
+
+        let localVarCredential: string | undefined;
+        // authentication (apiKeyAuth) required
+        localVarCredential = this.configuration.lookupCredential('apiKeyAuth');
+        if (localVarCredential) {
+            localVarHeaders = localVarHeaders.set('Authorization', localVarCredential);
+        }
+
+        // authentication (bearerAuth) required
+        localVarCredential = this.configuration.lookupCredential('bearerAuth');
+        if (localVarCredential) {
+            localVarHeaders = localVarHeaders.set('Authorization', 'Bearer ' + localVarCredential);
+        }
+
+        let localVarHttpHeaderAcceptSelected: string | undefined = options && options.httpHeaderAccept;
+        if (localVarHttpHeaderAcceptSelected === undefined) {
+            // to determine the Accept header
+            const httpHeaderAccepts: string[] = [
+                'application/json'
+            ];
+            localVarHttpHeaderAcceptSelected = this.configuration.selectHeaderAccept(httpHeaderAccepts);
+        }
+        if (localVarHttpHeaderAcceptSelected !== undefined) {
+            localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
+        }
+
+        let localVarHttpContext: HttpContext | undefined = options && options.context;
+        if (localVarHttpContext === undefined) {
+            localVarHttpContext = new HttpContext();
+        }
+
+        let localVarTransferCache: boolean | undefined = options && options.transferCache;
+        if (localVarTransferCache === undefined) {
+            localVarTransferCache = true;
+        }
+
+
+        // to determine the Content-Type header
+        const consumes: string[] = [
+            'application/json'
+        ];
+        const httpContentTypeSelected: string | undefined = this.configuration.selectHeaderContentType(consumes);
+        if (httpContentTypeSelected !== undefined) {
+            localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
+        }
+
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
+            }
+        }
+
+        let localVarPath = `/user/getPagedUsers`;
+        return this.httpClient.request<PagedData>('post', `${this.configuration.basePath}${localVarPath}`,
+            {
+                context: localVarHttpContext,
+                body: pagedRequestCommand,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/desktop/src/open-api/model/pagedDataDataInner.ts
+++ b/desktop/src/open-api/model/pagedDataDataInner.ts
@@ -14,6 +14,7 @@ import { Category } from './category';
 import { ReportRequestCommand } from './reportRequestCommand';
 import { ReportTemplate } from './reportTemplate';
 import { Activity } from './activity';
+import { UserView } from './userView';
 import { ReceiptProcessingSettings } from './receiptProcessingSettings';
 import { Item } from './item';
 import { GroupReceiptSettings } from './groupReceiptSettings';
@@ -158,9 +159,9 @@ export interface PagedDataDataInner {
      */
     port?: string;
     /**
-     * IMAP username
+     * User\'s username used to login
      */
-    username?: string;
+    username: string;
     /**
      * IMAP password
      */
@@ -180,6 +181,22 @@ export interface PagedDataDataInner {
      * The actions the requesting user may perform on this template (read, generate, update, delete, duplicate), resolved per user and populated only on the list response. Drives the row action buttons.
      */
     allowedActions?: Array<string>;
+    /**
+     * Default avatar color
+     */
+    defaultAvatarColor?: string;
+    /**
+     * Display name
+     */
+    displayName: string;
+    /**
+     * Is dummy user
+     */
+    isDummyUser: boolean;
+    /**
+     * Id of the modern app role assigned to the user
+     */
+    appRoleId?: number;
 }
 export namespace PagedDataDataInner {
 }

--- a/desktop/src/store/user-table.state.actions.ts
+++ b/desktop/src/store/user-table.state.actions.ts
@@ -1,0 +1,25 @@
+import { SortDirection } from "@angular/material/sort";
+
+export class SetPage {
+  static readonly type = "[UserListComponent] Set Page";
+
+  constructor(public page: number) {}
+}
+
+export class SetPageSize {
+  static readonly type = "[UserListComponent] Set Page Size";
+
+  constructor(public pageSize: number) {}
+}
+
+export class SetOrderBy {
+  static readonly type = "[UserListComponent] Set Order By";
+
+  constructor(public orderBy: string) {}
+}
+
+export class SetSortDirection {
+  static readonly type = "[UserListComponent] Set Sort Direction";
+
+  constructor(public sortDirection: SortDirection) {}
+}

--- a/desktop/src/store/user-table.state.ts
+++ b/desktop/src/store/user-table.state.ts
@@ -1,0 +1,55 @@
+import { Injectable } from "@angular/core";
+import { Action, State, StateContext } from "@ngxs/store";
+import { PagedTableInterface } from "src/interfaces/paged-table.interface";
+import { SortDirection } from "../open-api";
+import { PagedTableState } from "./paged-table.state";
+import { SetOrderBy, SetPage, SetPageSize, SetSortDirection } from "./user-table.state.actions";
+
+@State<PagedTableInterface>({
+  name: "userTable",
+  defaults: {
+    page: 1,
+    pageSize: 50,
+    orderBy: "username",
+    sortDirection: SortDirection.Asc,
+  },
+})
+@Injectable()
+export class UserTableState extends PagedTableState {
+  @Action(SetPage)
+  setPage({ patchState }: StateContext<PagedTableInterface>, payload: SetPage) {
+    patchState({
+      page: payload.page,
+    });
+  }
+
+  @Action(SetPageSize)
+  setPageSize(
+    { patchState }: StateContext<PagedTableInterface>,
+    payload: SetPageSize
+  ) {
+    patchState({
+      pageSize: payload.pageSize,
+    });
+  }
+
+  @Action(SetOrderBy)
+  setOrderBy(
+    { patchState }: StateContext<PagedTableInterface>,
+    payload: SetOrderBy
+  ) {
+    patchState({
+      orderBy: payload.orderBy,
+    });
+  }
+
+  @Action(SetSortDirection)
+  setSortDirection(
+    { patchState }: StateContext<PagedTableInterface>,
+    payload: SetSortDirection
+  ) {
+    patchState({
+      sortDirection: payload.sortDirection,
+    });
+  }
+}

--- a/desktop/src/user/user-list/user-list.component.html
+++ b/desktop/src/user/user-list/user-list.component.html
@@ -23,6 +23,12 @@
       [columns]="columns"
       [displayedColumns]="displayedColumns"
       [selectionCheckboxes]="true"
+      [pagination]="true"
+      [length]="totalCount()"
+      [page]="((baseTableService.page$ | async) || 1) - 1"
+      [pageSize]="(baseTableService.pageSize$ | async) || 50"
+      (sorted)="sorted($event)"
+      (pageChange)="pageChanged($event)"
     ></app-table>
   </div>
 </div>

--- a/desktop/src/user/user-list/user-list.component.html
+++ b/desktop/src/user/user-list/user-list.component.html
@@ -25,8 +25,8 @@
       [selectionCheckboxes]="true"
       [pagination]="true"
       [length]="totalCount()"
-      [page]="((baseTableService.page$ | async) || 1) - 1"
-      [pageSize]="(baseTableService.pageSize$ | async) || 50"
+      [page]="(page() || 1) - 1"
+      [pageSize]="pageSize() || 50"
       (sorted)="sorted($event)"
       (pageChange)="pageChanged($event)"
     ></app-table>

--- a/desktop/src/user/user-list/user-list.component.spec.ts
+++ b/desktop/src/user/user-list/user-list.component.spec.ts
@@ -4,9 +4,10 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { MatDialogModule } from "@angular/material/dialog";
 import { MatSnackBarModule } from "@angular/material/snack-bar";
 import { NgxsModule } from "@ngxs/store";
+import { of } from "rxjs";
 import { TableModule } from "src/table/table.module";
 import { DirectivesModule } from "../../directives";
-import { ApiModule } from "../../open-api";
+import { ApiModule, UserService } from "../../open-api";
 import { AuthState } from "../../store";
 import { UserTableState } from "../../store/user-table.state";
 import { UserListComponent } from "./user-list.component";
@@ -36,5 +37,26 @@ describe("UserListComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should fetch a page from the backend and set datasource + total count", () => {
+    const serviceSpy = jest.spyOn(TestBed.inject(UserService), "getPagedUsers");
+    serviceSpy.mockReturnValue(
+      of({
+        data: [{ id: 1, username: "admin" }],
+        totalCount: 1,
+      } as any)
+    );
+
+    component.getTableData();
+
+    expect(serviceSpy).toHaveBeenCalledWith({
+      page: 1,
+      pageSize: 50,
+      orderBy: "username",
+      sortDirection: "asc",
+    });
+    expect(component.totalCount()).toBe(1);
+    expect(component.dataSource().data.length).toBe(1);
   });
 });

--- a/desktop/src/user/user-list/user-list.component.spec.ts
+++ b/desktop/src/user/user-list/user-list.component.spec.ts
@@ -1,5 +1,5 @@
 import { provideHttpClientTesting } from "@angular/common/http/testing";
-import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
+import { CUSTOM_ELEMENTS_SCHEMA, provideZonelessChangeDetection } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { MatDialogModule } from "@angular/material/dialog";
 import { MatSnackBarModule } from "@angular/material/snack-bar";
@@ -8,6 +8,7 @@ import { TableModule } from "src/table/table.module";
 import { DirectivesModule } from "../../directives";
 import { ApiModule } from "../../open-api";
 import { AuthState } from "../../store";
+import { UserTableState } from "../../store/user-table.state";
 import { UserListComponent } from "./user-list.component";
 import { provideHttpClient, withInterceptorsFromDi } from "@angular/common/http";
 
@@ -23,9 +24,9 @@ describe("UserListComponent", () => {
         DirectivesModule,
         MatDialogModule,
         MatSnackBarModule,
-        NgxsModule.forRoot([AuthState]),
+        NgxsModule.forRoot([AuthState, UserTableState]),
         TableModule],
-    providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
+    providers: [provideZonelessChangeDetection(), provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
 }).compileComponents();
 
     fixture = TestBed.createComponent(UserListComponent);

--- a/desktop/src/user/user-list/user-list.component.spec.ts
+++ b/desktop/src/user/user-list/user-list.component.spec.ts
@@ -1,17 +1,20 @@
+import { provideHttpClient, withInterceptorsFromDi } from "@angular/common/http";
 import { provideHttpClientTesting } from "@angular/common/http/testing";
 import { CUSTOM_ELEMENTS_SCHEMA, provideZonelessChangeDetection } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
-import { MatDialogModule } from "@angular/material/dialog";
+import { MatDialog, MatDialogModule } from "@angular/material/dialog";
+import { PageEvent } from "@angular/material/paginator";
 import { MatSnackBarModule } from "@angular/material/snack-bar";
+import { Sort } from "@angular/material/sort";
+import { MatTableDataSource } from "@angular/material/table";
 import { NgxsModule } from "@ngxs/store";
-import { of } from "rxjs";
+import { config, of, throwError } from "rxjs";
 import { TableModule } from "src/table/table.module";
 import { DirectivesModule } from "../../directives";
-import { ApiModule, UserService } from "../../open-api";
+import { ApiModule, User, UserService } from "../../open-api";
 import { AuthState } from "../../store";
 import { UserTableState } from "../../store/user-table.state";
 import { UserListComponent } from "./user-list.component";
-import { provideHttpClient, withInterceptorsFromDi } from "@angular/common/http";
 
 describe("UserListComponent", () => {
   let component: UserListComponent;
@@ -35,18 +38,17 @@ describe("UserListComponent", () => {
     // fixture.detectChanges();
   });
 
+  const mockPagedUsers = () =>
+    jest.spyOn(TestBed.inject(UserService), "getPagedUsers").mockReturnValue(
+      of({ data: [{ id: 1, username: "admin" }], totalCount: 1 } as any)
+    );
+
   it("should create", () => {
     expect(component).toBeTruthy();
   });
 
   it("should fetch a page from the backend and set datasource + total count", () => {
-    const serviceSpy = jest.spyOn(TestBed.inject(UserService), "getPagedUsers");
-    serviceSpy.mockReturnValue(
-      of({
-        data: [{ id: 1, username: "admin" }],
-        totalCount: 1,
-      } as any)
-    );
+    const serviceSpy = mockPagedUsers();
 
     component.getTableData();
 
@@ -58,5 +60,85 @@ describe("UserListComponent", () => {
     });
     expect(component.totalCount()).toBe(1);
     expect(component.dataSource().data.length).toBe(1);
+  });
+
+  it("should refetch with the new 1-based page and page size on page change", () => {
+    const serviceSpy = mockPagedUsers();
+
+    component.pageChanged({ pageIndex: 2, pageSize: 15 } as PageEvent);
+
+    expect(serviceSpy).toHaveBeenCalledWith({
+      page: 3, // pageIndex + 1
+      pageSize: 15,
+      orderBy: "username",
+      sortDirection: "asc",
+    });
+  });
+
+  it("should refetch with the requested column and direction on sort", () => {
+    const serviceSpy = mockPagedUsers();
+
+    component.sorted({ active: "display_name", direction: "desc" } as Sort);
+
+    expect(serviceSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: "display_name", sortDirection: "desc" })
+    );
+  });
+
+  it("should refetch with a cleared sort direction", () => {
+    const serviceSpy = mockPagedUsers();
+
+    component.sorted({ active: "username", direction: "" } as Sort);
+
+    expect(serviceSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: "username", sortDirection: "" })
+    );
+  });
+
+  it("should refetch the current page after deleting a user", () => {
+    const serviceSpy = mockPagedUsers();
+    const deleteSpy = jest
+      .spyOn(TestBed.inject(UserService), "deleteUserById")
+      .mockReturnValue(of({} as any));
+
+    // A user other than the (undefined) current user, so the delete guard passes.
+    component.dataSource.set(
+      new MatTableDataSource<User>([{ id: 5, username: "victim" } as User])
+    );
+
+    jest
+      .spyOn(TestBed.inject(MatDialog), "open")
+      .mockReturnValue({ afterClosed: () => of(true), componentInstance: {} } as any);
+
+    component.deleteUser(0);
+
+    expect(deleteSpy).toHaveBeenCalledWith(5);
+    expect(serviceSpy).toHaveBeenCalled(); // refetch
+  });
+
+  it("should not corrupt datasource/total count when the fetch errors", () => {
+    // getTableData delegates errors to the global HTTP interceptor (no component
+    // handler), so RxJS reports the error asynchronously. Swallow that rethrow with
+    // fake timers + a no-op onUnhandledError so the assertion stays deterministic.
+    jest.useFakeTimers();
+    const previousHandler = config.onUnhandledError;
+    config.onUnhandledError = () => {};
+
+    try {
+      const serviceSpy = jest
+        .spyOn(TestBed.inject(UserService), "getPagedUsers")
+        .mockReturnValue(throwError(() => new Error("boom")) as any);
+
+      component.getTableData();
+
+      expect(serviceSpy).toHaveBeenCalled();
+      expect(component.totalCount()).toBe(0);
+      expect(component.dataSource().data.length).toBe(0);
+
+      jest.runOnlyPendingTimers();
+    } finally {
+      config.onUnhandledError = previousHandler;
+      jest.useRealTimers();
+    }
   });
 });

--- a/desktop/src/user/user-list/user-list.component.ts
+++ b/desktop/src/user/user-list/user-list.component.ts
@@ -1,32 +1,39 @@
-import { AfterViewInit, Component, inject, signal, TemplateRef, viewChild } from "@angular/core";
-import { toSignal } from "@angular/core/rxjs-interop";
+import { AfterViewInit, Component, inject, TemplateRef, viewChild } from "@angular/core";
+import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import { MatDialog } from "@angular/material/dialog";
-import { MatTableDataSource } from "@angular/material/table";
-import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { Store } from "@ngxs/store";
 import { take, tap } from "rxjs";
 import { DEFAULT_HOST_CLASS } from "src/constants";
 import { DEFAULT_DIALOG_CONFIG } from "src/constants/dialog.constant";
+import { PagedTableInterface } from "src/interfaces/paged-table.interface";
 import { ConfirmationDialogComponent } from "src/shared-ui/confirmation-dialog/confirmation-dialog.component";
 import { TableColumn } from "src/table/table-column.interface";
 import { TableComponent } from "src/table/table/table.component";
 import { BulkUserDeleteCommand, Permission, PermissionScope, Role, RoleService, User, UserService } from "../../open-api";
 import { loadAssignableRoles } from "../../roles/role-loading.util";
 import { SnackbarService } from "../../services";
-import { AuthState, RemoveUser, RemoveUsers, UserState } from "../../store";
+import { BaseTableService } from "../../services/base-table.service";
+import { BaseTableComponent } from "../../shared-ui/base-table/base-table.component";
+import { AuthState, RemoveUser, RemoveUsers } from "../../store";
 import { DummyUserConversionDialogComponent } from "../dummy-user-conversion-dialog/dummy-user-conversion-dialog.component";
 import { ResetPasswordComponent } from "../reset-password/reset-password.component";
 import { UserFormComponent } from "../user-form/user-form.component";
+import { UserTableService } from "./user-table.service";
 
-@UntilDestroy()
 @Component({
     selector: "app-user-list",
     templateUrl: "./user-list.component.html",
     styleUrls: ["./user-list.component.scss"],
     host: DEFAULT_HOST_CLASS,
+    providers: [
+        {
+            provide: BaseTableService,
+            useClass: UserTableService
+        }
+    ],
     standalone: false
 })
-export class UserListComponent implements AfterViewInit {
+export class UserListComponent extends BaseTableComponent<User> implements AfterViewInit {
   protected readonly Permission = Permission;
   protected readonly PermissionScope = PermissionScope;
 
@@ -46,12 +53,6 @@ export class UserListComponent implements AfterViewInit {
 
   public readonly table = viewChild.required(TableComponent);
 
-  public displayedColumns: string[] = [];
-
-  public columns: TableColumn[] = [];
-
-  public dataSource = signal(new MatTableDataSource<User>([]));
-
   // Roles resolve each user's appRoleId to a role name. The request is skipped
   // unless the caller holds app.roles.read (otherwise the 403 would log them
   // out — see loadAssignableRoles); the cell then renders blank.
@@ -63,20 +64,19 @@ export class UserListComponent implements AfterViewInit {
   public hasSelectedUsers: boolean = false;
 
   constructor(
+    public override baseTableService: BaseTableService,
     private matDialog: MatDialog,
     private snackbarService: SnackbarService,
     private store: Store,
     private userService: UserService
-  ) {}
-
-  public ngAfterViewInit(): void {
-    this.initTable();
-    this.setupSelectionListener();
+  ) {
+    super(baseTableService);
   }
 
-  private initTable(): void {
+  public ngAfterViewInit(): void {
     this.setColumns();
-    this.setDataSource();
+    this.getTableData();
+    this.setupSelectionListener();
   }
 
   private setColumns(): void {
@@ -90,25 +90,25 @@ export class UserListComponent implements AfterViewInit {
 
       {
         columnHeader: "Displayname",
-        matColumnDef: "displayName",
+        matColumnDef: "display_name",
         template: this.displaynameCell(),
         sortable: true,
       },
       {
         columnHeader: "Role",
-        matColumnDef: "appRole",
+        matColumnDef: "app_role",
         template: this.appRoleCell(),
-        sortable: true,
+        sortable: false,
       },
       {
         columnHeader: "Created At",
-        matColumnDef: "createdAt",
+        matColumnDef: "created_at",
         template: this.createdAtCell(),
         sortable: true,
       },
       {
         columnHeader: "Updated At",
-        matColumnDef: "updatedAt",
+        matColumnDef: "updated_at",
         template: this.updatedAtCell(),
         sortable: true,
       },
@@ -123,33 +123,22 @@ export class UserListComponent implements AfterViewInit {
     this.displayedColumns = [
       "select",
       "username",
-      "displayName",
-      "appRole",
-      "createdAt",
-      "updatedAt",
+      "display_name",
+      "app_role",
+      "created_at",
+      "updated_at",
       "actions",
     ];
-  }
 
-  private setDataSource(): void {
-    this.store
-      .select(UserState.users)
-      .pipe(
-        untilDestroyed(this),
-        tap(() => {
-          const ds = new MatTableDataSource<User>(
-            this.store.selectSnapshot(UserState.users)
-          );
-          ds.sort = this.table().sort();
-          this.dataSource.set(ds);
-        })
-      )
-      .subscribe();
+    this.setInitialSortedColumn(
+      this.baseTableService.getPagedRequestCommand() as PagedTableInterface,
+      this.columns
+    );
   }
 
   private setupSelectionListener(): void {
-    this.table().selection.changed
-      .pipe(untilDestroyed(this))
+    this.table()
+      .selection.changed.pipe(takeUntilDestroyed())
       .subscribe(() => {
         this.updateSelectionState();
       });
@@ -169,7 +158,7 @@ export class UserListComponent implements AfterViewInit {
 
     dialogRef.afterClosed().subscribe((refresh) => {
       if (refresh) {
-        this.dataSource.set(new MatTableDataSource<User>(this.store.selectSnapshot(UserState.users)));
+        this.getTableData();
       }
     });
   }
@@ -193,11 +182,11 @@ export class UserListComponent implements AfterViewInit {
   }
 
   public deleteUser(index: number) {
-    const users = this.store.selectSnapshot(UserState.users);
+    const users = this.dataSource().data;
     const userId = this.store.selectSnapshot(AuthState.userId);
     const user = users[index];
 
-    if (users[index].id.toString() !== userId) {
+    if (user.id.toString() !== userId) {
       const dialogRef = this.matDialog.open(
         ConfirmationDialogComponent,
         DEFAULT_DIALOG_CONFIG
@@ -215,9 +204,7 @@ export class UserListComponent implements AfterViewInit {
               tap(() => {
                 this.snackbarService.success("User successfully deleted");
                 this.store.dispatch(new RemoveUser(user.id.toString()));
-                this.dataSource.set(new MatTableDataSource<User>(
-                  this.store.selectSnapshot(UserState.users)
-                ));
+                this.getTableData();
               })
             )
             .subscribe();
@@ -229,9 +216,9 @@ export class UserListComponent implements AfterViewInit {
   public bulkDeleteUsers(): void {
     const selectedUsers = this.table().selection.selected;
     const currentUserId = this.store.selectSnapshot(AuthState.userId);
-    
+
     const usersToDelete = selectedUsers.filter(user => user.id.toString() !== currentUserId);
-    
+
     if (usersToDelete.length === 0) {
       this.snackbarService.error("Cannot delete current user or no valid users selected");
       return;
@@ -260,7 +247,7 @@ export class UserListComponent implements AfterViewInit {
               this.snackbarService.success(`${usersToDelete.length} user(s) successfully deleted`);
               this.store.dispatch(new RemoveUsers(bulkDeleteCommand.userIds));
               this.table().selection.clear();
-              this.dataSource.set(new MatTableDataSource<User>(this.store.selectSnapshot(UserState.users)));
+              this.getTableData();
             })
           )
           .subscribe();

--- a/desktop/src/user/user-list/user-list.component.ts
+++ b/desktop/src/user/user-list/user-list.component.ts
@@ -15,6 +15,7 @@ import { SnackbarService } from "../../services";
 import { BaseTableService } from "../../services/base-table.service";
 import { BaseTableComponent } from "../../shared-ui/base-table/base-table.component";
 import { AuthState, RemoveUser, RemoveUsers } from "../../store";
+import { UserTableState } from "../../store/user-table.state";
 import { DummyUserConversionDialogComponent } from "../dummy-user-conversion-dialog/dummy-user-conversion-dialog.component";
 import { ResetPasswordComponent } from "../reset-password/reset-password.component";
 import { UserFormComponent } from "../user-form/user-form.component";
@@ -38,6 +39,11 @@ export class UserListComponent extends BaseTableComponent<User> implements After
   protected readonly PermissionScope = PermissionScope;
 
   userId = this.store.selectSignal(AuthState.userId);
+
+  // Signal-backed pagination state (per desktop guideline: selectSignal over | async).
+  public readonly page = this.store.selectSignal(UserTableState.page);
+
+  public readonly pageSize = this.store.selectSignal(UserTableState.pageSize);
 
   public readonly usernameCell = viewChild.required<TemplateRef<any>>("usernameCell");
 

--- a/desktop/src/user/user-list/user-list.component.ts
+++ b/desktop/src/user/user-list/user-list.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, inject, TemplateRef, viewChild } from "@angular/core";
+import { AfterViewInit, Component, DestroyRef, inject, TemplateRef, viewChild } from "@angular/core";
 import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import { MatDialog } from "@angular/material/dialog";
 import { Store } from "@ngxs/store";
@@ -62,6 +62,8 @@ export class UserListComponent extends BaseTableComponent<User> implements After
   );
 
   public hasSelectedUsers: boolean = false;
+
+  private readonly destroyRef = inject(DestroyRef);
 
   constructor(
     public override baseTableService: BaseTableService,
@@ -138,7 +140,7 @@ export class UserListComponent extends BaseTableComponent<User> implements After
 
   private setupSelectionListener(): void {
     this.table()
-      .selection.changed.pipe(takeUntilDestroyed())
+      .selection.changed.pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
         this.updateSelectionState();
       });

--- a/desktop/src/user/user-list/user-table.service.ts
+++ b/desktop/src/user/user-list/user-table.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from "@angular/core";
+import { Sort, SortDirection } from "@angular/material/sort";
+import { Store } from "@ngxs/store";
+import { Observable } from "rxjs";
+import { PagedData, PagedRequestCommand, UserService } from "../../open-api";
+import { BaseTableService } from "../../services/base-table.service";
+import { UserTableState } from "../../store/user-table.state";
+import { SetOrderBy, SetPage, SetPageSize, SetSortDirection } from "../../store/user-table.state.actions";
+
+@Injectable({
+  providedIn: "root"
+})
+export class UserTableService extends BaseTableService {
+  override page$: Observable<number>;
+
+  override pageSize$: Observable<number>;
+
+  constructor(
+    private store: Store,
+    private userService: UserService
+  ) {
+    super();
+
+    this.page$ = this.store.select(UserTableState.page);
+    this.pageSize$ = this.store.select(UserTableState.pageSize);
+  }
+
+  public setPage(page: number): void {
+    this.store.dispatch(new SetPage(page));
+  }
+
+  public setPageSize(pageSize: number): void {
+    this.store.dispatch(new SetPageSize(pageSize));
+  }
+
+  public setOrderBy(orderBy: Sort): void {
+    this.store.dispatch(new SetOrderBy(orderBy.active));
+  }
+
+  public setSortDirection(sortDirection: SortDirection): void {
+    this.store.dispatch(new SetSortDirection(sortDirection));
+  }
+
+  public getPagedRequestCommand(): PagedRequestCommand {
+    return this.store.selectSnapshot(UserTableState.state);
+  }
+
+  public getPagedData(): Observable<PagedData> {
+    return this.userService.getPagedUsers(this.getPagedRequestCommand());
+  }
+}


### PR DESCRIPTION
## Summary
Implement server-side pagination for the user management list, replacing the in-memory pagination with a backend-driven paged query system. This improves scalability for large user bases and aligns the user list with the existing paginated-table pattern used elsewhere in the application.

## Key Changes

### Backend (API)
- **New endpoint** `POST /user/getPagedUsers` in `api/internal/handlers/users.go` that accepts a `PagedRequestCommand` with pagination and sorting parameters
- **Repository method** `GetPagedUsers()` in `api/internal/repositories/users.go` that:
  - Validates sort columns against an allowlist (`username`, `display_name`, `created_at`, `updated_at`) to prevent SQL injection
  - Returns both the paged result set and total count for pagination UI
  - Applies GORM scopes for sorting and pagination
- **Comprehensive test coverage** in `api/internal/repositories/users_test.go` and `api/internal/handlers/users_test.go` validating:
  - Correct row ordering and pagination
  - Empty result handling
  - Invalid column rejection
  - All allowed sort columns execute without error
  - Permission enforcement (admin-only access)
  - Request validation (page, pageSize, sortDirection)
- **OpenAPI spec** updated in `api/swagger.yml` with the new endpoint definition

### Frontend (Angular)
- **New NGXS state** `UserTableState` in `desktop/src/store/user-table.state.ts` managing pagination state (page, pageSize, orderBy, sortDirection)
- **New service** `UserTableService` in `desktop/src/user/user-list/user-table.service.ts` extending `BaseTableService` to:
  - Dispatch state actions for pagination changes
  - Call the new `getPagedUsers()` API method
  - Provide observables for reactive state binding
- **Refactored component** `UserListComponent` to:
  - Extend `BaseTableComponent<User>` for standard paginated-table behavior
  - Replace in-memory `MatTableDataSource` with server-driven pagination
  - Update column definitions to use snake_case API field names (`display_name`, `created_at`, `updated_at`, `app_role`)
  - Remove `@UntilDestroy()` decorator in favor of `DestroyRef` + `takeUntilDestroyed()`
  - Bind table pagination controls to service state
- **Generated API client** updated with `getPagedUsers()` method in `desktop/src/open-api/api/user.service.ts`
- **Updated test** `user-list.component.spec.ts` with new state provider and pagination test case
- **Documentation** in `desktop/CLAUDE.md` noting the user list now follows the standard paginated-table pattern

## Implementation Details
- Sort column validation uses an allowlist pattern to prevent SQL injection vulnerabilities
- Total count is returned separately from the paged result set, enabling accurate pagination UI
- The backend enforces `app.users.read` permission; non-admins receive a 403 Forbidden response
- Request validation occurs before database queries (page ≥ 1, pageSize > 0, valid sortDirection)
- Column name mapping aligns frontend snake_case API fields with backend database schema

https://claude.ai/code/session_01VCBC5PbYnTRk5nx7X8X8Ym

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-side pagination and sorting to the Manage Users table.
  * Manage Users now fetches data via a new paged users API and shows the correct total count.
  * Sorting is supported for username/display name and created/updated timestamps (role column is no longer sortable).
* **Bug Fixes**
  * Added validation for invalid pagination and sorting parameters.
  * User list refreshes correctly after user create/update/delete actions.
* **Documentation**
  * Corrected permission documentation for paged user retrieval.
* **Tests**
  * Added coverage for authorization, validation, sorting, and paged results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->