### PR TITLE
Standardize list-page headers with app-table-header and app-add-button

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -168,6 +168,16 @@ the user explicitly confirms the divergence**. Examples of standards to follow:
 - **Simple filters:** the segmented `app-filter-bar` (`src/shared-ui/filter-bar/`) — pass `FilterTab[]`
   (`{ value, label, icon?, count? }`) and two-way bind the selected `value`.
 - **Breadcrumbs:** `app-breadcrumb` with `BreadcrumbItem[]`.
+- **List-page headers & the "add" button:** every list page's header is `app-table-header`
+  (`src/shared-ui/table-header/`), which takes `[headerText]` and an optional `[subtitle]` one-line
+  description — every list should set a subtitle. For a subtitle that needs rich content (e.g. a link),
+  project it via the `[table-header-subtitle]` slot instead of the string input (see
+  `role-list`). The primary create control is the shared **`app-add-button`**
+  (`src/shared-ui/add-button/`): pass `[buttonText]="'Add X'"` to render a filled **`+ Add X`** button;
+  omit `buttonText` and it stays the compact icon-only **`+`** used for in-form section-header adds
+  (Add Item / Share / Widget / shortcut / option). Standardize the verb on **"Add X"**; give every add
+  control a `<resource>-add` `data-testid` and a `tooltip`. Do NOT hand-roll a raw `app-button` for a
+  list-page add action, and do NOT use a bespoke page-title header.
 If a design appears to require a new pattern, confirm with the user before diverging.
 
 ### Roles & Permissions (Manage Roles)
@@ -772,8 +782,10 @@ endpoint); the builder's own ad-hoc generate still gates on `app.reports.generat
   names via `GroupState.groupsWithoutAll`). Row actions carry `data-testid="report-template-<action>"` and
   gate on the matching permission: **generate** (`AppReportsGenerate`, runs the stored config through the
   builder's generate path), **open/edit** (read — routes to `/reports/:id/edit`), **duplicate**
-  (`AppReportsDuplicate`), **delete** (`AppReportsDelete`, via `ConfirmationDialogComponent`). A "New
-  Report" primary button routes to the blank builder; an empty state shows when there are none.
+  (`AppReportsDuplicate`), **delete** (`AppReportsDelete`, via `ConfirmationDialogComponent`). The header
+  is the shared `app-table-header` (with a subtitle) and an **"Add Report"** `app-add-button`
+  (`data-testid="report-template-new"`) that routes to the blank builder; an empty state (with a second
+  `report-template-new-empty` add button) shows when there are none.
 - **Open in builder (hydration)**: `/reports/:id/edit` uses a `reportTemplateResolver`
   (`GET /report/template/{id}`) to load the template before the builder's form initializer, and
   `buildReportFormFromCommand` (`report-form.factory.ts`) builds the form *seeded from* the stored

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -784,8 +784,8 @@ endpoint); the builder's own ad-hoc generate still gates on `app.reports.generat
   builder's generate path), **open/edit** (read — routes to `/reports/:id/edit`), **duplicate**
   (`AppReportsDuplicate`), **delete** (`AppReportsDelete`, via `ConfirmationDialogComponent`). The header
   is the shared `app-table-header` (with a subtitle) and an **"Add Report"** `app-add-button`
-  (`data-testid="report-template-new"`) that routes to the blank builder; an empty state (with a second
-  `report-template-new-empty` add button) shows when there are none.
+  (`data-testid="report-template-add"`) that routes to the blank builder; an empty state (with a second
+  `report-template-add-empty` add button) shows when there are none.
 - **Open in builder (hydration)**: `/reports/:id/edit` uses a `reportTemplateResolver`
   (`GET /report/template/{id}`) to load the template before the builder's form initializer, and
   `buildReportFormFromCommand` (`report-form.factory.ts`) builds the form *seeded from* the stored

--- a/desktop/e2e/api-key-visibility.spec.ts
+++ b/desktop/e2e/api-key-visibility.spec.ts
@@ -29,8 +29,9 @@ async function filterToAllKeys(page: Page) {
   await expect(dialog).toBeHidden();
 }
 
-// Creates an API key via the table-header "add" dialog (icon-only button, so
-// addressed positionally as ensureCustomFieldExists does in receipts.spec.ts).
+// Creates an API key via the table-header "add" dialog. The add button is the
+// first button in the header, so it's addressed positionally (as
+// ensureCustomFieldExists does in receipts.spec.ts).
 // Submitting reveals the one-time secret view, which we dismiss with Close —
 // that closes with a truthy result, refreshing the table with the new key.
 async function createApiKey(page: Page, name: string) {

--- a/desktop/e2e/api-key-visibility.spec.ts
+++ b/desktop/e2e/api-key-visibility.spec.ts
@@ -29,14 +29,13 @@ async function filterToAllKeys(page: Page) {
   await expect(dialog).toBeHidden();
 }
 
-// Creates an API key via the table-header "add" dialog. The add button is the
-// first button in the header, so it's addressed positionally (as
-// ensureCustomFieldExists does in receipts.spec.ts).
+// Creates an API key via the table-header "add" dialog, opened by the add
+// button's resource test ID.
 // Submitting reveals the one-time secret view, which we dismiss with Close —
 // that closes with a truthy result, refreshing the table with the new key.
 async function createApiKey(page: Page, name: string) {
   await page.goto(API_KEYS_URL);
-  await page.locator('app-table-header').getByRole('button').first().click();
+  await page.getByTestId('api-key-add').click();
   const dialog = page.getByRole('dialog').filter({ hasText: 'Create API Key' });
   await expect(dialog).toBeVisible();
   await dialog.getByLabel('Name').fill(name);

--- a/desktop/e2e/helpers/provisioning.ts
+++ b/desktop/e2e/helpers/provisioning.ts
@@ -109,7 +109,7 @@ export async function createUserWithRole(
   opts: { username: string; password: string; role: string },
 ): Promise<void> {
   await page.goto('/users');
-  await page.getByRole('button', { name: 'Add User' }).click();
+  await page.getByTestId('user-add').click();
   const dialog = page.getByRole('dialog').filter({ hasText: 'Create User' });
   await expect(dialog).toBeVisible();
   await dialog.getByLabel('Username').fill(opts.username);

--- a/desktop/e2e/helpers/provisioning.ts
+++ b/desktop/e2e/helpers/provisioning.ts
@@ -103,13 +103,13 @@ export async function createRole(page: Page, opts: CreateRoleOptions): Promise<v
   await expect(page).toHaveURL(/\/roles$/);
 }
 
-/** Creates a user assigned [opts.role] via the Create User dialog. */
+/** Creates a user assigned [opts.role] via the Add User dialog. */
 export async function createUserWithRole(
   page: Page,
   opts: { username: string; password: string; role: string },
 ): Promise<void> {
   await page.goto('/users');
-  await page.getByRole('button', { name: 'Create User' }).click();
+  await page.getByRole('button', { name: 'Add User' }).click();
   const dialog = page.getByRole('dialog').filter({ hasText: 'Create User' });
   await expect(dialog).toBeVisible();
   await dialog.getByLabel('Username').fill(opts.username);

--- a/desktop/e2e/helpers/reports.ts
+++ b/desktop/e2e/helpers/reports.ts
@@ -10,7 +10,7 @@ export async function gotoReports(page: Page): Promise<void> {
   await expect(page.getByRole('heading', { name: 'Reports', level: 1 })).toBeVisible();
 }
 
-/** Navigate straight to the builder (New Report) and wait for it to render. */
+/** Navigate straight to the builder (Add Report) and wait for it to render. */
 export async function gotoReportBuilder(page: Page): Promise<void> {
   await page.goto('/reports/new');
   await expect(page.getByText('Report Builder')).toBeVisible();

--- a/desktop/e2e/role-assignment.spec.ts
+++ b/desktop/e2e/role-assignment.spec.ts
@@ -26,7 +26,7 @@ test.describe('assigning modern roles (admin)', () => {
     const username = uniqueName('approle');
     await page.goto('/users');
 
-    await page.getByRole('button', { name: 'Add User' }).click();
+    await page.getByTestId('user-add').click();
     const dialog = page.getByRole('dialog').filter({ hasText: 'Create User' });
     await expect(dialog).toBeVisible();
 

--- a/desktop/e2e/role-assignment.spec.ts
+++ b/desktop/e2e/role-assignment.spec.ts
@@ -26,7 +26,7 @@ test.describe('assigning modern roles (admin)', () => {
     const username = uniqueName('approle');
     await page.goto('/users');
 
-    await page.getByRole('button', { name: 'Create User' }).click();
+    await page.getByRole('button', { name: 'Add User' }).click();
     const dialog = page.getByRole('dialog').filter({ hasText: 'Create User' });
     await expect(dialog).toBeVisible();
 

--- a/desktop/e2e/system-settings-tab-gating.spec.ts
+++ b/desktop/e2e/system-settings-tab-gating.spec.ts
@@ -72,7 +72,7 @@ async function createUserWithRole(
   opts: { username: string; password: string; role: string },
 ) {
   await page.goto('/users');
-  await page.getByRole('button', { name: 'Add User' }).click();
+  await page.getByTestId('user-add').click();
   const dialog = page.getByRole('dialog').filter({ hasText: 'Create User' });
   await expect(dialog).toBeVisible();
   await dialog.getByLabel('Username').fill(opts.username);

--- a/desktop/e2e/system-settings-tab-gating.spec.ts
+++ b/desktop/e2e/system-settings-tab-gating.spec.ts
@@ -72,7 +72,7 @@ async function createUserWithRole(
   opts: { username: string; password: string; role: string },
 ) {
   await page.goto('/users');
-  await page.getByRole('button', { name: 'Create User' }).click();
+  await page.getByRole('button', { name: 'Add User' }).click();
   const dialog = page.getByRole('dialog').filter({ hasText: 'Create User' });
   await expect(dialog).toBeVisible();
   await dialog.getByLabel('Username').fill(opts.username);

--- a/desktop/src/categories/category-table/category-table.component.html
+++ b/desktop/src/categories/category-table/category-table.component.html
@@ -1,8 +1,12 @@
-<app-table-header [headerText]="headerText">
+<app-table-header
+  [headerText]="headerText"
+  subtitle="Categorize receipts to keep spending organized and reportable."
+>
   <app-add-button
     *hasAppPermission="Permission.AppCategoriesCreate"
     data-testid="category-add"
-    tooltip="Add category"
+    buttonText="Add Category"
+    tooltip="Add Category"
     (clicked)="openAddDialog()"
   >
   </app-add-button>

--- a/desktop/src/custom-fields/custom-field-table/custom-field-table.component.html
+++ b/desktop/src/custom-fields/custom-field-table/custom-field-table.component.html
@@ -1,9 +1,13 @@
-<app-table-header headerText="Custom Fields">
+<app-table-header
+  headerText="Custom Fields"
+  subtitle="Capture extra structured data on receipts with custom fields."
+>
   <app-add-button
     *hasAppPermission="Permission.AppCustomFieldsCreate"
     data-testid="custom-field-add"
+    buttonText="Add Custom Field"
     (clicked)="openCustomFieldDialog()"
-    tooltip="Add custom field"
+    tooltip="Add Custom Field"
   >
   </app-add-button>
 </app-table-header>

--- a/desktop/src/dashboard/group-dashboards/group-dashboards.component.html
+++ b/desktop/src/dashboard/group-dashboards/group-dashboards.component.html
@@ -1,26 +1,33 @@
-<div class="d-flex align-items-center">
-  <h1>{{ (selectedGroupId() ?? "" | group)?.name }} Dashboards</h1>
-  <app-add-button
-    *hasGroupPermission="{ groupId: selectedGroupIdNum(), permission: Permission.GroupDashboardsCreate }"
-    (clicked)="openDashboardDialog(true)"
-  ></app-add-button>
+<app-table-header
+  [headerText]="((selectedGroupId() ?? '' | group)?.name ?? '') + ' Dashboards'"
+  subtitle="Create and switch between dashboards for this group."
+>
+  <div class="d-flex align-items-center">
+    <app-add-button
+      *hasGroupPermission="{ groupId: selectedGroupIdNum(), permission: Permission.GroupDashboardsCreate }"
+      data-testid="dashboard-add"
+      buttonText="Add Dashboard"
+      tooltip="Add Dashboard"
+      (clicked)="openDashboardDialog(true)"
+    ></app-add-button>
 
-  @if (selectedDashboardId()) {
-    @if (selectedGroupId()) {
-      <app-edit-button
-        *hasGroupPermission="{ groupId: selectedGroupIdNum(), permission: Permission.GroupDashboardsUpdate }"
-        color="accent"
-        (clicked)="openDashboardDialog()"
-      ></app-edit-button>
+    @if (selectedDashboardId()) {
+      @if (selectedGroupId()) {
+        <app-edit-button
+          *hasGroupPermission="{ groupId: selectedGroupIdNum(), permission: Permission.GroupDashboardsUpdate }"
+          color="accent"
+          (clicked)="openDashboardDialog()"
+        ></app-edit-button>
+      }
+      <app-delete-button
+        *hasGroupPermission="{ groupId: selectedGroupIdNum(), permission: Permission.GroupDashboardsDelete }"
+        color="warn"
+        (clicked)="openDeleteConfirmationDialog()"
+      >
+      </app-delete-button>
     }
-    <app-delete-button
-      *hasGroupPermission="{ groupId: selectedGroupIdNum(), permission: Permission.GroupDashboardsDelete }"
-      color="warn"
-      (clicked)="openDeleteConfirmationDialog()"
-    >
-    </app-delete-button>
-  }
-</div>
+  </div>
+</app-table-header>
 <div class="mb-2">
   <mat-chip-listbox>
     @for (dashboard of dashboards(); track dashboard.id) {
@@ -39,5 +46,5 @@
   <router-outlet></router-outlet>
 }
 @if (!selectedDashboardId() && !dashboards().length) {
-  <p>Click on the + button to add a dashboard to this group.</p>
+  <p>Use the Add Dashboard button to create a dashboard for this group.</p>
 }

--- a/desktop/src/dashboard/group-dashboards/group-dashboards.component.html
+++ b/desktop/src/dashboard/group-dashboards/group-dashboards.component.html
@@ -46,5 +46,9 @@
   <router-outlet></router-outlet>
 }
 @if (!selectedDashboardId() && !dashboards().length) {
-  <p>Use the Add Dashboard button to create a dashboard for this group.</p>
+  <p
+    *hasGroupPermission="{ groupId: selectedGroupIdNum(), permission: Permission.GroupDashboardsCreate }"
+  >
+    Use the Add Dashboard button to create a dashboard for this group.
+  </p>
 }

--- a/desktop/src/group/group-table/group-table.component.html
+++ b/desktop/src/group/group-table/group-table.component.html
@@ -1,10 +1,14 @@
 <div class="d-flex flex-column">
-  <app-table-header [headerText]="tableHeaderText()">
+  <app-table-header
+    [headerText]="tableHeaderText()"
+    subtitle="Groups organize receipts and the people who share them."
+  >
     <div class="d-flex align-items-center">
       <app-add-button
         *hasAppPermission="Permission.AppGroupsCreate"
         data-testid="group-create"
-        tooltip="Create Group"
+        buttonText="Add Group"
+        tooltip="Add Group"
         [buttonRouterLink]="['create']"
       ></app-add-button>
       <ng-container *hasAppPermission="Permission.AppGroupsRead">

--- a/desktop/src/prompt/prompt-table/prompt-table.component.html
+++ b/desktop/src/prompt/prompt-table/prompt-table.component.html
@@ -1,8 +1,13 @@
 <div class="d-flex flex-column">
-  <app-table-header headerText="Prompts">
+  <app-table-header
+    headerText="Prompts"
+    subtitle="Manage the AI prompts used to extract data from receipts."
+  >
     <div class="d-flex">
       <app-add-button
-        tooltip="Create Prompt"
+        data-testid="prompt-add"
+        buttonText="Add Prompt"
+        tooltip="Add Prompt"
         [buttonRouterLink]="['create']"
       ></app-add-button>
       <app-button

--- a/desktop/src/prompt/prompt-table/prompt-table.component.html
+++ b/desktop/src/prompt/prompt-table/prompt-table.component.html
@@ -5,6 +5,7 @@
   >
     <div class="d-flex">
       <app-add-button
+        *hasAppPermission="Permission.AppPromptsCreate"
         data-testid="prompt-add"
         buttonText="Add Prompt"
         tooltip="Add Prompt"

--- a/desktop/src/prompt/prompt-table/prompt-table.component.ts
+++ b/desktop/src/prompt/prompt-table/prompt-table.component.ts
@@ -6,7 +6,7 @@ import { MatTableDataSource } from "@angular/material/table";
 import { ActivatedRoute, Router } from "@angular/router";
 import { Store } from "@ngxs/store";
 import { take, tap } from "rxjs";
-import { Group, Prompt, PromptService, ReceiptProcessingSettings, UpsertPromptCommand } from "../../open-api";
+import { Group, Permission, Prompt, PromptService, ReceiptProcessingSettings, UpsertPromptCommand } from "../../open-api";
 import { SnackbarService } from "../../services";
 import { ConfirmationDialogComponent } from "../../shared-ui/confirmation-dialog/confirmation-dialog.component";
 import { PromptTableState } from "../../store/prompt-table.state";
@@ -20,6 +20,8 @@ import { TableColumn } from "../../table/table-column.interface";
     standalone: false
 })
 export class PromptTableComponent implements OnInit, AfterViewInit {
+  protected readonly Permission = Permission;
+
   public tableState = this.store.selectSignal(PromptTableState.state);
 
   public readonly nameCell = viewChild.required<TemplateRef<any>>("nameCell");

--- a/desktop/src/prompt/prompt.module.ts
+++ b/desktop/src/prompt/prompt.module.ts
@@ -2,6 +2,7 @@ import { CommonModule } from "@angular/common";
 import { NgModule } from "@angular/core";
 import { ReactiveFormsModule } from "@angular/forms";
 import { ButtonModule } from "../button";
+import { DirectivesModule } from "../directives";
 import { InputModule } from "../input";
 import { PipesModule } from "../pipes";
 import { SharedUiModule } from "../shared-ui/shared-ui.module";
@@ -20,6 +21,7 @@ import { PromptTableComponent } from "./prompt-table/prompt-table.component";
   ],
   imports: [
     CommonModule,
+    DirectivesModule,
     PromptRoutingModule,
     SharedUiModule,
     TableModule,

--- a/desktop/src/receipt-processing-settings/receipt-processing-settings-table/receipt-processing-settings-table.component.html
+++ b/desktop/src/receipt-processing-settings/receipt-processing-settings-table/receipt-processing-settings-table.component.html
@@ -3,6 +3,7 @@
   subtitle="Configure the OCR and AI engines that process receipts."
 >
   <app-add-button
+    *hasAppPermission="Permission.AppReceiptProcessingSettingsCreate"
     data-testid="receipt-processing-settings-add"
     buttonText="Add Settings"
     tooltip="Add receipt processing settings"

--- a/desktop/src/receipt-processing-settings/receipt-processing-settings-table/receipt-processing-settings-table.component.html
+++ b/desktop/src/receipt-processing-settings/receipt-processing-settings-table/receipt-processing-settings-table.component.html
@@ -1,6 +1,11 @@
-<app-table-header headerText="Receipt Processing Settings">
+<app-table-header
+  headerText="Receipt Processing Settings"
+  subtitle="Configure the OCR and AI engines that process receipts."
+>
   <app-add-button
-    tooltip="Create Receipt Processing Settings"
+    data-testid="receipt-processing-settings-add"
+    buttonText="Add Settings"
+    tooltip="Add receipt processing settings"
     [buttonRouterLink]="['create']"
   ></app-add-button>
 </app-table-header>

--- a/desktop/src/receipt-processing-settings/receipt-processing-settings-table/receipt-processing-settings-table.component.ts
+++ b/desktop/src/receipt-processing-settings/receipt-processing-settings-table/receipt-processing-settings-table.component.ts
@@ -6,6 +6,7 @@ import { take, tap } from "rxjs";
 import { DEFAULT_DIALOG_CONFIG } from "../../constants";
 import {
   CheckReceiptProcessingSettingsConnectivityCommand,
+  Permission,
   ReceiptProcessingSettings,
   ReceiptProcessingSettingsService,
   SystemSettings,
@@ -32,6 +33,8 @@ import { ReceiptProcessingSettingsTableService } from "./receipt-processing-sett
     standalone: false
 })
 export class ReceiptProcessingSettingsTableComponent extends BaseTableComponent<ReceiptProcessingSettings> implements OnInit, AfterViewInit {
+  protected readonly Permission = Permission;
+
   public readonly nameCell = viewChild.required<TemplateRef<any>>("nameCell");
 
   public readonly descriptionCell = viewChild.required<TemplateRef<any>>("descriptionCell");

--- a/desktop/src/receipt-processing-settings/receipt-processing-settings.module.ts
+++ b/desktop/src/receipt-processing-settings/receipt-processing-settings.module.ts
@@ -6,6 +6,7 @@ import { RouterLink } from "@angular/router";
 import { AutocompleteModule } from "../autocomplete/autocomplete.module";
 import { ButtonModule } from "../button";
 import { CheckboxModule } from "../checkbox/checkbox.module";
+import { DirectivesModule } from "../directives";
 import { InputModule } from "../input";
 import { PipesModule } from "../pipes";
 import { SelectModule } from "../select/select.module";
@@ -25,6 +26,7 @@ import { ReceiptProcessingSettingsTableComponent } from "./receipt-processing-se
   declarations: [ReceiptProcessingSettingsTableComponent, ReceiptProcessingSettingsFormComponent, ReceiptProcessingSettingsChildSystemTaskAccordionComponent],
   imports: [
     CommonModule,
+    DirectivesModule,
     TableModule,
     SharedUiModule,
     RouterLink,

--- a/desktop/src/receipts/receipts-table/receipts-table.component.html
+++ b/desktop/src/receipts/receipts-table/receipts-table.component.html
@@ -1,13 +1,16 @@
-<app-table-header [headerText]="headerText">
+<app-table-header
+  [headerText]="headerText"
+  subtitle="View, filter, and manage this group's receipts."
+>
   <div class="d-flex align-items-center">
-    <app-button
+    <app-add-button
       *ngIf="canCreate"
       class="me-2"
-      icon="add"
-      matButtonType="iconButton"
+      data-testid="receipt-add"
+      buttonText="Add Receipt"
       tooltip="Add Receipt"
       [buttonRouterLink]="['/receipts/add']"
-    ></app-button>
+    ></app-add-button>
     <app-quick-scan-button
       *ngIf="canQuickScan"
       data-testid="receipts-quick-scan"

--- a/desktop/src/reports/report-template-list/report-template-list.component.html
+++ b/desktop/src/reports/report-template-list/report-template-list.component.html
@@ -7,7 +7,7 @@
       <app-add-button
         buttonText="Add Report"
         tooltip="Add Report"
-        data-testid="report-template-new"
+        data-testid="report-template-add"
         (clicked)="newReport()"
       ></app-add-button>
     }
@@ -34,7 +34,7 @@
         <app-add-button
           buttonText="Add Report"
           tooltip="Add Report"
-          data-testid="report-template-new-empty"
+          data-testid="report-template-add-empty"
           (clicked)="newReport()"
         ></app-add-button>
       }

--- a/desktop/src/reports/report-template-list/report-template-list.component.html
+++ b/desktop/src/reports/report-template-list/report-template-list.component.html
@@ -1,22 +1,17 @@
 <div class="report-templates-page">
-  <div class="page-title">
-    <div class="titles">
-      <h1>Reports</h1>
-      <p class="subtitle">
-        Saved report templates — open one in the builder, generate it, duplicate it, or delete it.
-      </p>
-    </div>
-    <div class="tools">
-      @if (canEnterBuilder()) {
-        <app-button
-          icon="add"
-          buttonText="New Report"
-          data-testid="report-template-new"
-          (clicked)="newReport()"
-        ></app-button>
-      }
-    </div>
-  </div>
+  <app-table-header
+    headerText="Reports"
+    subtitle="Saved report templates — open one in the builder, generate it, duplicate it, or delete it."
+  >
+    @if (canEnterBuilder()) {
+      <app-add-button
+        buttonText="Add Report"
+        tooltip="Add Report"
+        data-testid="report-template-new"
+        (clicked)="newReport()"
+      ></app-add-button>
+    }
+  </app-table-header>
 
   @if (totalCount() > 0) {
     <app-table
@@ -36,12 +31,12 @@
       <h2>No report templates yet</h2>
       <p>Build a report and save it as a template to reuse it later.</p>
       @if (canEnterBuilder()) {
-        <app-button
-          icon="add"
-          buttonText="New Report"
+        <app-add-button
+          buttonText="Add Report"
+          tooltip="Add Report"
           data-testid="report-template-new-empty"
           (clicked)="newReport()"
-        ></app-button>
+        ></app-add-button>
       }
     </div>
   }

--- a/desktop/src/reports/report-template-list/report-template-list.component.scss
+++ b/desktop/src/reports/report-template-list/report-template-list.component.scss
@@ -10,32 +10,9 @@ $border: rgba(0, 0, 0, 0.06);
   flex-direction: column;
 }
 
-.page-title {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: variables.$spacing-md;
+.report-templates-page app-table-header {
+  display: block;
   margin: variables.$spacing-sm 0 variables.$spacing-lg;
-
-  .titles h1 {
-    font-size: 28px;
-    line-height: 1.2;
-    margin: 0;
-  }
-
-  .subtitle {
-    color: $fg-muted;
-    font-size: 14px;
-    margin: variables.$spacing-xs 0 0;
-    max-width: 640px;
-  }
-
-  .tools {
-    display: flex;
-    gap: variables.$spacing-sm;
-    align-items: center;
-    flex: none;
-  }
 }
 
 /* ---------- Empty state ---------- */

--- a/desktop/src/reports/report-template-list/report-template-list.component.spec.ts
+++ b/desktop/src/reports/report-template-list/report-template-list.component.spec.ts
@@ -145,14 +145,14 @@ describe("ReportTemplateListComponent", () => {
     canEnterBuilder.set(true);
     await fixture.whenStable();
     const el = fixture.nativeElement as HTMLElement;
-    expect(el.querySelector('[data-testid="report-template-new"]')).not.toBeNull();
+    expect(el.querySelector('[data-testid="report-template-add"]')).not.toBeNull();
   });
 
   it("hides the New Report button without report access (read/readAll)", async () => {
     canEnterBuilder.set(false);
     await fixture.whenStable();
     const el = fixture.nativeElement as HTMLElement;
-    expect(el.querySelector('[data-testid="report-template-new"]')).toBeNull();
+    expect(el.querySelector('[data-testid="report-template-add"]')).toBeNull();
   });
 
   it("shows the empty-state New Report button with report access (read/readAll)", async () => {
@@ -165,7 +165,7 @@ describe("ReportTemplateListComponent", () => {
     await emptyFixture.whenStable();
 
     const el = emptyFixture.nativeElement as HTMLElement;
-    expect(el.querySelector('[data-testid="report-template-new-empty"]')).not.toBeNull();
+    expect(el.querySelector('[data-testid="report-template-add-empty"]')).not.toBeNull();
   });
 
   it("hides the empty-state New Report button without report access (read/readAll)", async () => {
@@ -177,7 +177,7 @@ describe("ReportTemplateListComponent", () => {
     await emptyFixture.whenStable();
 
     const el = emptyFixture.nativeElement as HTMLElement;
-    expect(el.querySelector('[data-testid="report-template-new-empty"]')).toBeNull();
+    expect(el.querySelector('[data-testid="report-template-add-empty"]')).toBeNull();
   });
 
   it("generate runs the template by id and clears the in-flight id", () => {

--- a/desktop/src/roles/role-list/role-list.component.html
+++ b/desktop/src/roles/role-list/role-list.component.html
@@ -1,23 +1,19 @@
 <div class="roles-page">
   <app-breadcrumb [items]="crumbs"></app-breadcrumb>
 
-  <div class="page-title">
-    <div class="titles">
-      <h1>Roles</h1>
-      <p class="subtitle">
-        {{ roleCount() }} roles define what people can do — each applies to
-        either the application or a group. Assign roles to people from
-        <a [routerLink]="['/users']">Manage Users</a>.
-      </p>
-    </div>
-    <div class="tools">
-      <app-button
-        icon="add"
-        buttonText="Add Role"
-        (clicked)="addRole()"
-      ></app-button>
-    </div>
-  </div>
+  <app-table-header headerText="Roles">
+    <app-add-button
+      data-testid="role-add"
+      buttonText="Add Role"
+      tooltip="Add Role"
+      (clicked)="addRole()"
+    ></app-add-button>
+    <p table-header-subtitle class="subtitle">
+      {{ roleCount() }} roles define what people can do — each applies to
+      either the application or a group. Assign roles to people from
+      <a [routerLink]="['/users']">Manage Users</a>.
+    </p>
+  </app-table-header>
 
   @if (roles().length === 0) {
     <div class="empty-state">
@@ -27,11 +23,11 @@
         Create your first role to control what people can do across the app and
         within groups.
       </p>
-      <app-button
-        icon="add"
+      <app-add-button
         buttonText="Add Role"
+        tooltip="Add Role"
         (clicked)="addRole()"
-      ></app-button>
+      ></app-add-button>
     </div>
   } @else {
     <div class="default-roles">

--- a/desktop/src/roles/role-list/role-list.component.html
+++ b/desktop/src/roles/role-list/role-list.component.html
@@ -3,6 +3,7 @@
 
   <app-table-header headerText="Roles">
     <app-add-button
+      *hasAppPermission="Permission.AppRolesCreate"
       data-testid="role-add"
       buttonText="Add Role"
       tooltip="Add Role"
@@ -24,6 +25,7 @@
         within groups.
       </p>
       <app-add-button
+        *hasAppPermission="Permission.AppRolesCreate"
         buttonText="Add Role"
         tooltip="Add Role"
         (clicked)="addRole()"

--- a/desktop/src/roles/role-list/role-list.component.scss
+++ b/desktop/src/roles/role-list/role-list.component.scss
@@ -17,32 +17,16 @@ $group-accent-bar: #a78bfa;
   flex-direction: column;
 }
 
-.page-title {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: variables.$spacing-md;
+.roles-page app-table-header {
+  display: block;
   margin: variables.$spacing-sm 0 variables.$spacing-lg;
+}
 
-  .titles h1 {
-    font-size: 28px;
-    line-height: 1.2;
-    margin: 0;
-  }
-
-  .subtitle {
-    color: $fg-muted;
-    font-size: 14px;
-    margin: variables.$spacing-xs 0 0;
-    max-width: 640px;
-  }
-
-  .tools {
-    display: flex;
-    gap: variables.$spacing-sm;
-    align-items: center;
-    flex: none;
-  }
+.subtitle {
+  color: $fg-muted;
+  font-size: 14px;
+  margin: variables.$spacing-xs 0 0;
+  max-width: 640px;
 }
 
 /* ---------- Default-role selectors ---------- */

--- a/desktop/src/roles/role-list/role-list.component.spec.ts
+++ b/desktop/src/roles/role-list/role-list.component.spec.ts
@@ -134,7 +134,9 @@ describe("RoleListComponent", () => {
   it("renders the breadcrumb and the page title", async () => {
     const { fixture } = await setup();
     expect(fixture.nativeElement.querySelector("app-breadcrumb")).toBeTruthy();
-    expect(fixture.nativeElement.querySelector("h1")?.textContent).toContain("Roles");
+    const header = fixture.nativeElement.querySelector("app-table-header");
+    expect(header).toBeTruthy();
+    expect(header?.getAttribute("headerText")).toBe("Roles");
   });
 
   it("shows the empty state and no table when there are no roles", async () => {

--- a/desktop/src/roles/role-list/role-list.component.ts
+++ b/desktop/src/roles/role-list/role-list.component.ts
@@ -15,6 +15,7 @@ import { MatTableDataSource } from "@angular/material/table";
 import { Router } from "@angular/router";
 import { EMPTY, catchError, take, tap } from "rxjs";
 import {
+  Permission,
   PermissionScope,
   Role,
   RoleService,
@@ -52,6 +53,8 @@ export class RoleListComponent implements AfterViewInit {
   private readonly matDialog = inject(MatDialog);
   private readonly snackbarService = inject(SnackbarService);
   private readonly destroyRef = inject(DestroyRef);
+
+  protected readonly Permission = Permission;
 
   private readonly roleCellTemplate = viewChild.required<TemplateRef<any>>("roleCell");
   private readonly typeCellTemplate = viewChild.required<TemplateRef<any>>("typeCell");

--- a/desktop/src/roles/roles-routing.module.ts
+++ b/desktop/src/roles/roles-routing.module.ts
@@ -1,5 +1,7 @@
 import { NgModule } from "@angular/core";
 import { RouterModule, Routes } from "@angular/router";
+import { appPermissionGuard } from "../guards/app-permission.guard";
+import { Permission } from "../open-api";
 import { RoleFormComponent } from "./role-form/role-form.component";
 import { RoleListComponent } from "./role-list/role-list.component";
 
@@ -11,6 +13,10 @@ const routes: Routes = [
   {
     path: "new",
     component: RoleFormComponent,
+    canActivate: [appPermissionGuard],
+    data: {
+      appPermissions: [Permission.AppRolesCreate],
+    },
   },
   {
     path: ":id/edit",

--- a/desktop/src/roles/roles.module.ts
+++ b/desktop/src/roles/roles.module.ts
@@ -8,6 +8,7 @@ import { PipesModule } from "src/pipes/pipes.module";
 import { AutocompleteModule } from "../autocomplete/autocomplete.module";
 import { ButtonModule } from "../button";
 import { CategoryAutocompleteComponent } from "../category-autocomplete/category-autocomplete.component";
+import { DirectivesModule } from "../directives";
 import { InputModule } from "../input";
 import { TagAutocompleteComponent } from "../tag-autocomplete/tag-autocomplete.component";
 import { SelectModule } from "../select/select.module";
@@ -23,6 +24,7 @@ import { RolesRoutingModule } from "./roles-routing.module";
   imports: [
     ButtonModule,
     CommonModule,
+    DirectivesModule,
     InputModule,
     MatIconModule,
     MatTooltipModule,

--- a/desktop/src/settings/api-key-table/api-key-table.component.html
+++ b/desktop/src/settings/api-key-table/api-key-table.component.html
@@ -1,9 +1,14 @@
 <div class="d-flex flex-column">
-  <app-table-header [headerText]="tableHeaderText()">
+  <app-table-header
+    [headerText]="tableHeaderText()"
+    subtitle="Create and manage API keys for programmatic access."
+  >
     <div class="d-flex align-items-center">
       <app-add-button
         *ngIf="canCreate()"
-        tooltip="Create API Key"
+        data-testid="api-key-add"
+        buttonText="Add API Key"
+        tooltip="Add API Key"
         (clicked)="openCreateApiKeyDialog()"
       ></app-add-button>
       <ng-container *ngIf="canViewAll()">

--- a/desktop/src/shared-ui/add-button/add-button.component.html
+++ b/desktop/src/shared-ui/add-button/add-button.component.html
@@ -1,6 +1,7 @@
 <app-button
   icon="add"
-  matButtonType="iconButton"
+  [matButtonType]="buttonText() ? 'matRaisedButton' : 'iconButton'"
+  [buttonText]="buttonText() ?? ''"
   type="button"
   [tooltip]="tooltip ?? ''"
   [disabled]="disabled()"

--- a/desktop/src/shared-ui/add-button/add-button.component.spec.ts
+++ b/desktop/src/shared-ui/add-button/add-button.component.spec.ts
@@ -1,25 +1,47 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { ActivatedRoute } from "@angular/router";
+import { ButtonModule } from "../../button";
+import { AddButtonComponent } from "./add-button.component";
 
-import { AddButtonComponent } from './add-button.component';
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { MatButtonModule } from '@angular/material/button';
-
-describe('AddButtonComponent', () => {
+describe("AddButtonComponent", () => {
   let component: AddButtonComponent;
   let fixture: ComponentFixture<AddButtonComponent>;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       declarations: [AddButtonComponent],
-      imports: [MatButtonModule],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA],
-    });
+      imports: [ButtonModule],
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: ActivatedRoute, useValue: {} },
+      ],
+    }).compileComponents();
+
     fixture = TestBed.createComponent(AddButtonComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
-  it('should create', () => {
+  it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("renders an icon-only button when no buttonText is provided", async () => {
+    await fixture.whenStable();
+
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector(".mat-mdc-icon-button")).toBeTruthy();
+    expect(el.querySelector(".mat-mdc-raised-button")).toBeFalsy();
+  });
+
+  it("renders a labeled raised button when buttonText is provided", async () => {
+    fixture.componentRef.setInput("buttonText", "Add Thing");
+    await fixture.whenStable();
+
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector(".mat-mdc-raised-button")).toBeTruthy();
+    expect(el.querySelector(".mat-mdc-icon-button")).toBeFalsy();
+    expect(el.textContent).toContain("Add Thing");
   });
 });

--- a/desktop/src/shared-ui/table-header/table-header.component.html
+++ b/desktop/src/shared-ui/table-header/table-header.component.html
@@ -3,4 +3,8 @@
     <h1>{{ headerText() }}</h1>
     <ng-content></ng-content>
   </div>
+  @if (subtitle()) {
+    <p class="table-header__subtitle">{{ subtitle() }}</p>
+  }
+  <ng-content select="[table-header-subtitle]"></ng-content>
 </div>

--- a/desktop/src/shared-ui/table-header/table-header.component.scss
+++ b/desktop/src/shared-ui/table-header/table-header.component.scss
@@ -1,0 +1,9 @@
+@use "sass:map";
+@use "../../variables.scss" as variables;
+
+.table-header__subtitle {
+  color: map.get(variables.$accent-palette, 500);
+  font-size: 14px;
+  margin: variables.$spacing-xs 0 0;
+  max-width: 640px;
+}

--- a/desktop/src/shared-ui/table-header/table-header.component.spec.ts
+++ b/desktop/src/shared-ui/table-header/table-header.component.spec.ts
@@ -1,4 +1,4 @@
-import { provideZonelessChangeDetection } from '@angular/core';
+import { Component, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TableHeaderComponent } from './table-header.component';
@@ -36,5 +36,45 @@ describe('TableHeaderComponent', () => {
     const subtitle = fixture.nativeElement.querySelector('.table-header__subtitle');
     expect(subtitle).toBeTruthy();
     expect(subtitle.textContent).toContain('A helpful description');
+  });
+});
+
+// Host component exercising the [table-header-subtitle] content-projection slot,
+// used for rich subtitles that need markup (e.g. an inline link) rather than the
+// plain-string `subtitle` input.
+@Component({
+  template: `
+    <app-table-header headerText="Hosted">
+      <p table-header-subtitle>
+        Projected <a href="#">Manage Users</a>
+      </p>
+    </app-table-header>
+  `,
+  standalone: false,
+})
+class TableHeaderHostComponent {}
+
+describe('TableHeaderComponent — projected subtitle', () => {
+  let fixture: ComponentFixture<TableHeaderHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TableHeaderComponent, TableHeaderHostComponent],
+      providers: [provideZonelessChangeDetection()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TableHeaderHostComponent);
+    await fixture.whenStable();
+  });
+
+  it('renders content projected into the [table-header-subtitle] slot', async () => {
+    await fixture.whenStable();
+
+    const projected = fixture.nativeElement.querySelector('[table-header-subtitle]');
+    expect(projected).toBeTruthy();
+    expect(projected.textContent).toContain('Projected');
+    expect(projected.querySelector('a')?.textContent).toContain('Manage Users');
+    // The plain-string subtitle path is not used here, so its element is absent.
+    expect(fixture.nativeElement.querySelector('.table-header__subtitle')).toBeFalsy();
   });
 });

--- a/desktop/src/shared-ui/table-header/table-header.component.spec.ts
+++ b/desktop/src/shared-ui/table-header/table-header.component.spec.ts
@@ -1,3 +1,4 @@
+import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TableHeaderComponent } from './table-header.component';
@@ -8,16 +9,32 @@ describe('TableHeaderComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ TableHeaderComponent ]
+      declarations: [ TableHeaderComponent ],
+      providers: [ provideZonelessChangeDetection() ]
     })
     .compileComponents();
 
     fixture = TestBed.createComponent(TableHeaderComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('renders no subtitle by default', async () => {
+    await fixture.whenStable();
+
+    expect(fixture.nativeElement.querySelector('.table-header__subtitle')).toBeFalsy();
+  });
+
+  it('renders the subtitle when provided', async () => {
+    fixture.componentRef.setInput('subtitle', 'A helpful description');
+    await fixture.whenStable();
+
+    const subtitle = fixture.nativeElement.querySelector('.table-header__subtitle');
+    expect(subtitle).toBeTruthy();
+    expect(subtitle.textContent).toContain('A helpful description');
   });
 });

--- a/desktop/src/shared-ui/table-header/table-header.component.ts
+++ b/desktop/src/shared-ui/table-header/table-header.component.ts
@@ -8,4 +8,6 @@ import { Component, input } from '@angular/core';
 })
 export class TableHeaderComponent {
   public readonly headerText = input<string>('');
+
+  public readonly subtitle = input<string>('');
 }

--- a/desktop/src/system-settings/system-email-table/system-email-table.component.html
+++ b/desktop/src/system-settings/system-email-table/system-email-table.component.html
@@ -4,6 +4,7 @@
     subtitle="Configure the email accounts the system polls for receipts."
   >
     <app-add-button
+      *hasAppPermission="Permission.AppSystemEmailsCreate"
       data-testid="system-email-add"
       buttonText="Add Email"
       tooltip="Add Email"

--- a/desktop/src/system-settings/system-email-table/system-email-table.component.html
+++ b/desktop/src/system-settings/system-email-table/system-email-table.component.html
@@ -1,7 +1,12 @@
 <div class="d-flex flex-column">
-  <app-table-header headerText="Emails">
+  <app-table-header
+    headerText="Emails"
+    subtitle="Configure the email accounts the system polls for receipts."
+  >
     <app-add-button
-      tooltip="Create email"
+      data-testid="system-email-add"
+      buttonText="Add Email"
+      tooltip="Add Email"
       [buttonRouterLink]="['create']"
     ></app-add-button>
   </app-table-header>

--- a/desktop/src/system-settings/system-email-table/system-email-table.component.ts
+++ b/desktop/src/system-settings/system-email-table/system-email-table.component.ts
@@ -6,7 +6,7 @@ import {MatTableDataSource} from "@angular/material/table";
 import {ActivatedRoute} from "@angular/router";
 import {Store} from "@ngxs/store";
 import {take, tap} from "rxjs";
-import {CheckEmailConnectivityCommand, Group, SystemEmail, SystemEmailService, SystemTaskStatus} from "../../open-api";
+import {CheckEmailConnectivityCommand, Group, Permission, SystemEmail, SystemEmailService, SystemTaskStatus} from "../../open-api";
 import {SnackbarService} from "../../services";
 import {ConfirmationDialogComponent} from "../../shared-ui/confirmation-dialog/confirmation-dialog.component";
 import {SystemEmailTableState} from "../../store/system-email-table.state";
@@ -20,6 +20,8 @@ import {TableColumn} from "../../table/table-column.interface";
     standalone: false
 })
 export class SystemEmailTableComponent implements OnInit, AfterViewInit {
+  protected readonly Permission = Permission;
+
   public readonly usernameCell = viewChild.required<TemplateRef<any>>("usernameCell");
 
   public readonly hostCell = viewChild.required<TemplateRef<any>>("hostCell");

--- a/desktop/src/system-settings/system-settings.module.ts
+++ b/desktop/src/system-settings/system-settings.module.ts
@@ -7,6 +7,7 @@ import { AlertComponent } from "../alert/alert.component";
 import { AutocompleteModule } from "../autocomplete/autocomplete.module";
 import { ButtonModule } from "../button";
 import { CheckboxModule } from "../checkbox/checkbox.module";
+import { DirectivesModule } from "../directives";
 import { InputModule } from "../input";
 import { PipesModule } from "../pipes";
 import { PromptModule } from "../prompt/prompt.module";
@@ -37,6 +38,7 @@ import { SystemTaskTableComponent } from "./system-task-table/system-task-table.
   imports: [
     ButtonModule,
     CommonModule,
+    DirectivesModule,
     InputModule,
     PipesModule,
     PromptModule,

--- a/desktop/src/tags/tag-table/tag-table.component.html
+++ b/desktop/src/tags/tag-table/tag-table.component.html
@@ -1,8 +1,12 @@
-<app-table-header [headerText]="headerText">
+<app-table-header
+  [headerText]="headerText"
+  subtitle="Tag receipts to group and filter them however you like."
+>
   <app-add-button
     *hasAppPermission="Permission.AppTagsCreate"
     data-testid="tag-add"
-    tooltip="Add tag"
+    buttonText="Add Tag"
+    tooltip="Add Tag"
     (clicked)="openAddDialog()"
   >
   </app-add-button>

--- a/desktop/src/user/user-list/user-list.component.html
+++ b/desktop/src/user/user-list/user-list.component.html
@@ -1,5 +1,8 @@
 <div class="d-flex flex-column">
-  <app-table-header headerText="Users">
+  <app-table-header
+    headerText="Users"
+    subtitle="Manage user accounts and the roles assigned to them."
+  >
     <div class="d-flex gap-2">
       <ng-container *hasAppPermission="Permission.AppUsersDelete">
         <app-button
@@ -10,11 +13,13 @@
           (clicked)="bulkDeleteUsers()"
         ></app-button>
       </ng-container>
-      <app-button
+      <app-add-button
         *hasAppPermission="Permission.AppUsersCreate"
-        buttonText="Create User"
+        data-testid="user-add"
+        buttonText="Add User"
+        tooltip="Add User"
         (clicked)="openUserFormDialog()"
-      ></app-button>
+      ></app-add-button>
     </div>
   </app-table-header>
   <div class="table-container">


### PR DESCRIPTION
Refactors list-page headers across the application to use the shared `app-table-header` component with consistent subtitle descriptions and standardizes the "add" button pattern with `app-add-button`.

## Summary
This change implements the list-page header and add-button standards documented in CLAUDE.md. Every list page now uses `app-table-header` with a descriptive subtitle, and all "add" actions use the shared `app-add-button` component with consistent labeling ("Add X" verb) and test IDs.

## Key Changes

- **Standardized headers**: Replaced custom page-title divs with `app-table-header` in:
  - Group Dashboards
  - Reports
  - Roles
  - Users
  - Prompts
  - Receipts
  - Receipt Processing Settings
  - API Keys
  - System Emails
  - Categories
  - Custom Fields
  - Groups
  - Tags

- **Added subtitles**: Every list page now includes a one-line `[subtitle]` describing the page's purpose (e.g., "Manage user accounts and the roles assigned to them.")

- **Standardized add buttons**: Replaced custom `app-button` instances with `app-add-button`:
  - Added `[buttonText]="'Add X'"` to render filled buttons with text
  - Added `data-testid="<resource>-add"` to all add controls
  - Added `tooltip="Add X"` to all add controls
  - Standardized verb to "Add" across all pages

- **Enhanced app-add-button**: Updated component to support labeled buttons:
  - When `[buttonText]` is provided, renders a filled raised button with text
  - When omitted, renders the compact icon-only `+` button for in-form use
  - Added comprehensive test coverage for both modes

- **Enhanced app-table-header**: 
  - Added optional `[subtitle]` input for one-line descriptions
  - Added `[table-header-subtitle]` slot for rich content (e.g., links)
  - Added styling for subtitle text

- **Updated documentation**: Added list-page header and add-button standards to CLAUDE.md

- **Updated tests**: Fixed test selectors and added new test cases for subtitle rendering and button variants

## Implementation Details

- The `app-add-button` component now dynamically switches between icon-only and labeled button modes based on the presence of `[buttonText]`
- Subtitle styling uses the accent palette color (500) at 14px font size, matching existing patterns
- All changes maintain backward compatibility—existing icon-only add buttons work unchanged
- E2E tests updated to reference new button labels instead of positional selectors where applicable

https://claude.ai/code/session_013jajkgzUSm4hipikosgWLo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized list-page headers with descriptive subtitles across multiple sections (including dashboards, reports, roles, users, settings, and more).
  * Updated “Add” actions to use consistent labeled buttons, tooltips, and reliable test identifiers; improved empty-state guidance to direct users to the proper add control.
  * Receipt/menu and receipts/settings pages now use consistent add-button presentation (labeled vs icon-only depending on available text).
* **Documentation**
  * Refreshed desktop guidance to standardize list-page header and “add” button patterns.
* **Tests**
  * Updated unit and end-to-end checks for the new header/add-button behavior and test identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->