### PR TITLE
Resolve AI category/tag IDs and record pre-transaction failures

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -788,9 +788,27 @@ a real paid-by and status — neither field is ever null/empty**. This is why th
   settings, **enforces required fields synchronously (400 before enqueue)** since quick scan is
   fire-and-forget, and resolves paid-by/status defaults (`UPLOADER` ⇒ the caller's user id). Categories/
   tags ride the multipart command as **per-file comma-joined id strings** (`QuickScanCommand.CategoryIds`/
-  `TagIds`; an empty paid-by string parses to `0` = unset). The async `ReceiptService.QuickScan` **merges**
-  the user's category/tag picks with the AI-filled ones (union, deduped by id; names resolved via
-  `CategoryRepository.GetByIds`/`TagsRepository.GetByIds` so the merged selections pass receipt validation).
+  `TagIds`; an empty paid-by string parses to `0` = unset). The async `ReceiptService.QuickScan`
+  **resolves** the union of the user's category/tag picks and the AI-assigned ones
+  (`resolveQuickScanCategories`/`resolveQuickScanTags`): the ids (AI first, then user, deduped) are looked
+  up via `CategoryRepository.GetByIds`/`TagsRepository.GetByIds` so each carries its real **name**. This is
+  load-bearing — the default prompt tells the model to return categories/tags **by id only** (`{ "id": N }`,
+  no name), which `UpsertReceiptCommand.Validate` (name required) would otherwise reject, silently dropping
+  the whole receipt. Ids that don't resolve (hallucinated / deleted) are **dropped**, as are ids the
+  triggering user isn't allowed to see (`resolveAllowedCategoryIds`/`resolveAllowedTagIds` reuse
+  `userBypassesGrants` + `GetGroupCategoryIdsForUser`/`GetGroupTagIdsForUser` — the same bypass+set logic as
+  the write-side check, dropping instead of rejecting). Validation deliberately stays strict (name required):
+  an id-only category reaching `UpdateReceipt` — which persists associations with `FullSaveAssociations: true`
+  — would upsert the category row and **blank its `not null; uniqueIndex` name**, so resolving names (not
+  relaxing validation) is the fix.
+- **Failed-task recording on pre-transaction errors:** `CreateReceiptUploadedSystemTask` only runs
+  **inside** the create-receipt transaction, so an error that aborts `QuickScan` *before* it (category/tag
+  resolution or receipt validation) used to leave the AI-processing tasks marked SUCCEEDED and **no record**
+  of why no receipt appeared — the failure only hit the log via `HandleError`. `QuickScan` now routes those
+  early returns through a `recordEarlyQuickScanFailure` closure that writes a FAILED `RECEIPT_UPLOADED` task
+  chained to the QUICK_SCAN parent; because `SystemTaskRepository.CreateSystemTask` flips a SUCCEEDED parent
+  to FAILED when a FAILED child references it, the QUICK_SCAN activity now surfaces the failure. `RanByUserId`
+  is left nil so the child stays hidden and only the flipped parent shows (mirroring the successful child).
 - **Grant enforcement (write-side):** because quick scan creates receipts through the service layer
   (bypassing the receipt-upsert path's `enforceReceiptGrantSelection`), the handler **synchronously
   grant-validates the user's per-file category/tag picks** before enqueue via
@@ -807,11 +825,21 @@ a real paid-by and status — neither field is ever null/empty**. This is why th
   status, receipt- and item-level categories/tags, items (amount / status / `chargedToUserId` /
   `isTaxed` / linked items), comments, and all five custom-field value types. This pins the
   AI→`CreateReceipt` contract (which passes items/comments/customFields through untouched, so a future
-  prompt emitting them just works), plus the paid-by/status backfill, the category/tag merge, refunds
+  prompt emitting them just works), plus the paid-by/status backfill, the category/tag resolution, refunds
   (negative amounts), and the all-or-nothing failure path (bad item status / invalid JSON persist
   nothing). Note: `UpsertReceiptCommand.Validate` deliberately does **not** validate `CustomFields`
   (unlike categories/tags/items/comments), so a custom-field value is persisted unchecked — the test
-  is the only guard against a regression that silently drops or mis-columns it.
+  is the only guard against a regression that silently drops or mis-columns it. The resolve/failure
+  behavior above is pinned by `TestQuickScan_ResolvesIdOnlyAiCategory` (id-only AI category gets its name
+  filled), `_DropsUnresolvableAiCategory` (hallucinated id dropped), `_DropsOutOfGrantAiCategory` (a
+  grant-restricted member's AI category dropped — seeds a restricted group role via the `postSeed` hook on
+  `runQuickScanWithSetup`), and `_ValidationFailureRecordsFailedSystemTask` + the extended
+  `_MissingItemStatusFailsAndPersistsNothing` (a pre-transaction failure flips the QUICK_SCAN task to
+  FAILED and records a FAILED RECEIPT_UPLOADED task, asserted via `quickScanSystemTaskByType`), plus the
+  unit-level `TestResolveQuickScan{Categories,Tags}`. **Known gap (follow-up):** resolution is
+  **receipt-level only** — item-level categories/tags (`receiptCommand.Items[].Categories/Tags`) aren't
+  produced by the default prompt and aren't resolved here, so a future prompt emitting id-only item-level
+  categories would hit the same validation failure.
 
 ## Reporting Engine (`internal/reporting`)
 

--- a/api/internal/services/quick_scan_ingest_test.go
+++ b/api/internal/services/quick_scan_ingest_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -865,6 +866,32 @@ func TestQuickScan_ValidationFailureRecordsFailedSystemTask(t *testing.T) {
 	}
 	if uploaded.GroupId == nil || *uploaded.GroupId == 0 {
 		utils.PrintTestError(t, uploaded.GroupId, "the real group id")
+	}
+}
+
+// TestCombineEarlyFailureErrors pins the pre-transaction failure-wrapping used by
+// recordEarlyQuickScanFailure: when system-task recording itself fails, both the original failure and
+// the recording error must stay reachable via errors.Is (the recording error is wrapped, not just
+// string-interpolated), with the original failure leading.
+func TestCombineEarlyFailureErrors(t *testing.T) {
+	failureErr := errors.New("receipt validation failed")
+	taskErr := errors.New("system task write failed")
+
+	// No recording error: the original failure passes through unchanged.
+	if got := combineEarlyFailureErrors(failureErr, nil); got != failureErr {
+		utils.PrintTestError(t, got, failureErr)
+	}
+
+	// Both errors stay reachable via errors.Is, with failureErr's message leading.
+	combined := combineEarlyFailureErrors(failureErr, taskErr)
+	if !errors.Is(combined, failureErr) {
+		utils.PrintTestError(t, combined, "errors.Is finds failureErr")
+	}
+	if !errors.Is(combined, taskErr) {
+		utils.PrintTestError(t, combined, "errors.Is finds taskErr")
+	}
+	if !strings.Contains(combined.Error(), "receipt validation failed") {
+		utils.PrintTestError(t, combined.Error(), "message leads with the original failure")
 	}
 }
 

--- a/api/internal/services/quick_scan_ingest_test.go
+++ b/api/internal/services/quick_scan_ingest_test.go
@@ -9,9 +9,11 @@ import (
 	"path/filepath"
 	"receipt-wrangler/api/internal/commands"
 	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/permissions"
 	"receipt-wrangler/api/internal/repositories"
 	"receipt-wrangler/api/internal/structs"
 	"receipt-wrangler/api/internal/utils"
+	"strings"
 	"testing"
 
 	"github.com/shopspring/decimal"
@@ -125,6 +127,21 @@ func runQuickScan(
 	tagPicks []uint,
 	aiJSONFor func(user models.User, group models.Group) string,
 ) (models.Receipt, models.User, models.Group, error) {
+	return runQuickScanWithSetup(t, paidByArg, status, categoryPicks, tagPicks, aiJSONFor, nil)
+}
+
+// runQuickScanWithSetup is runQuickScan with an optional postSeed hook that runs after the pipeline +
+// categories/tags are seeded and before the AI body is set - so a test can, e.g., assign the seeded
+// member a grant-restricted group role to exercise the out-of-grant drop.
+func runQuickScanWithSetup(
+	t *testing.T,
+	paidByArg func(user models.User) uint,
+	status models.ReceiptStatus,
+	categoryPicks []uint,
+	tagPicks []uint,
+	aiJSONFor func(user models.User, group models.Group) string,
+	postSeed func(t *testing.T, user models.User, group models.Group),
+) (models.Receipt, models.User, models.Group, error) {
 	t.Helper()
 
 	var body string
@@ -132,6 +149,10 @@ func runQuickScan(
 	user, group, _ := seedReceiptImagePipeline(t, server.URL)
 	repositories.CreateTestCategories()
 	createTestTags()
+
+	if postSeed != nil {
+		postSeed(t, user, group)
+	}
 
 	body = ollamaReceiptResponse(t, aiJSONFor(user, group))
 	tempPath := writeQuickScanTempFile(t)
@@ -638,6 +659,15 @@ func TestQuickScan_MissingItemStatusFailsAndPersistsNothing(t *testing.T) {
 	if count := quickScanCreatedReceiptCount(); count != 0 {
 		utils.PrintTestError(t, count, int64(0))
 	}
+
+	// The pre-transaction failure must be recorded (not just logged): the QUICK_SCAN parent flips to
+	// FAILED and a FAILED RECEIPT_UPLOADED task carries the error.
+	if parent, ok := quickScanSystemTaskByType(models.QUICK_SCAN); !ok || parent.Status != models.SYSTEM_TASK_FAILED {
+		utils.PrintTestError(t, parent.Status, models.SYSTEM_TASK_FAILED)
+	}
+	if uploaded, ok := quickScanSystemTaskByType(models.RECEIPT_UPLOADED); !ok || uploaded.Status != models.SYSTEM_TASK_FAILED {
+		utils.PrintTestError(t, "missing FAILED RECEIPT_UPLOADED task", "a FAILED RECEIPT_UPLOADED task")
+	}
 }
 
 // TestQuickScan_InvalidAiJsonReturnsError proves a non-JSON AI response surfaces as an error from
@@ -664,6 +694,180 @@ func TestQuickScan_InvalidAiJsonReturnsError(t *testing.T) {
 	}
 }
 
+// TestQuickScan_ResolvesIdOnlyAiCategory covers the quick-scan bug: the default prompt tells the AI to
+// return categories/tags by id only (no name), which previously failed receipt validation ("name is
+// required") and silently dropped the whole receipt. QuickScan now resolves each id to its real record
+// so the receipt is created with the name filled in.
+func TestQuickScan_ResolvesIdOnlyAiCategory(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	created, _, _, err := runQuickScan(
+		t,
+		func(u models.User) uint { return u.ID },
+		models.OPEN,
+		nil,
+		nil,
+		func(u models.User, g models.Group) string {
+			// Category/tag by id only - the exact shape the default prompt produces.
+			return `{"name": "Walmart", "amount": 98.21, "date": "2024-01-01T00:00:00Z", "categories": [{"id": 1}], "tags": [{"id": 1}]}`
+		},
+	)
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+
+	receipt, err := repositories.NewReceiptRepository(nil).GetFullyLoadedReceiptById(utils.UintToString(created.ID))
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+	if len(receipt.Categories) != 1 || !hasCategoryId(receipt.Categories, 1) {
+		utils.PrintTestError(t, receipt.Categories, "category 1 resolved")
+		return
+	}
+	if receipt.Categories[0].Name != "test" {
+		utils.PrintTestError(t, receipt.Categories[0].Name, "test")
+	}
+	if len(receipt.Tags) != 1 || !hasTagId(receipt.Tags, 1) {
+		utils.PrintTestError(t, receipt.Tags, "tag 1 resolved")
+		return
+	}
+	if receipt.Tags[0].Name != "tag-a" {
+		utils.PrintTestError(t, receipt.Tags[0].Name, "tag-a")
+	}
+}
+
+// TestQuickScan_DropsUnresolvableAiCategory proves a hallucinated AI category id (no matching row) is
+// dropped rather than failing the whole scan.
+func TestQuickScan_DropsUnresolvableAiCategory(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	created, _, _, err := runQuickScan(
+		t,
+		func(u models.User) uint { return u.ID },
+		models.OPEN,
+		nil,
+		nil,
+		func(u models.User, g models.Group) string {
+			return `{"name": "Junk", "amount": 5.00, "date": "2024-01-01T00:00:00Z", "categories": [{"id": 1}, {"id": 999}]}`
+		},
+	)
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+
+	receipt, err := repositories.NewReceiptRepository(nil).GetFullyLoadedReceiptById(utils.UintToString(created.ID))
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+	if len(receipt.Categories) != 1 || !hasCategoryId(receipt.Categories, 1) {
+		utils.PrintTestError(t, receipt.Categories, "only category 1 (999 dropped)")
+	}
+}
+
+// TestQuickScan_DropsOutOfGrantAiCategory proves an AI-assigned category the triggering user isn't
+// allowed to see (their group role grants only a subset) is dropped, matching the write-side grant
+// enforcement.
+func TestQuickScan_DropsOutOfGrantAiCategory(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	created, _, _, err := runQuickScanWithSetup(
+		t,
+		func(u models.User) uint { return u.ID },
+		models.OPEN,
+		nil,
+		nil,
+		func(u models.User, g models.Group) string {
+			// AI assigns categories 1 and 2; the user's role grants only category 1.
+			return `{"name": "Restricted", "amount": 7.00, "date": "2024-01-01T00:00:00Z", "categories": [{"id": 1}, {"id": 2}]}`
+		},
+		func(t *testing.T, user models.User, group models.Group) {
+			clearGroupRoleGrantCacheAll()
+			clearRolePermissionCacheAll()
+			role, err := repositories.NewRoleRepository(nil).CreateGroupRole(
+				"restricted-cat", "", []string{permissions.GroupReceiptsRead}, []uint{1}, nil, nil, false)
+			if err != nil {
+				t.Fatalf("create restricted role: %v", err)
+			}
+			if err := repositories.GetDB().Model(&models.GroupMember{}).
+				Where("group_id = ? AND user_id = ?", group.ID, user.ID).
+				Update("group_role_id", role.ID).Error; err != nil {
+				t.Fatalf("assign role to member: %v", err)
+			}
+		},
+	)
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+
+	receipt, err := repositories.NewReceiptRepository(nil).GetFullyLoadedReceiptById(utils.UintToString(created.ID))
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+		return
+	}
+	if len(receipt.Categories) != 1 || !hasCategoryId(receipt.Categories, 1) {
+		utils.PrintTestError(t, receipt.Categories, "only category 1 (2 out-of-grant dropped)")
+	}
+}
+
+// TestQuickScan_ValidationFailureRecordsFailedSystemTask covers the "missing system task" gap: a
+// failure AFTER AI processing succeeds but BEFORE the receipt is created (here receipt validation) used
+// to vanish into the log, leaving the AI tasks marked SUCCEEDED and no record of why no receipt
+// appeared. The AI JSON parses (so the QUICK_SCAN task is SUCCEEDED), then fails validation (no name);
+// QuickScan now records a FAILED RECEIPT_UPLOADED task and flips the QUICK_SCAN parent to FAILED.
+func TestQuickScan_ValidationFailureRecordsFailedSystemTask(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	_, _, _, err := runQuickScan(
+		t,
+		func(u models.User) uint { return u.ID },
+		models.OPEN,
+		nil,
+		nil,
+		func(u models.User, g models.Group) string {
+			// Parses fine (QUICK_SCAN succeeds) but has no name -> validation fails after AI processing.
+			return `{"amount": 12.34, "date": "2024-01-01T00:00:00Z"}`
+		},
+	)
+	if err == nil {
+		utils.PrintTestError(t, nil, "a validation error")
+	}
+	if count := quickScanCreatedReceiptCount(); count != 0 {
+		utils.PrintTestError(t, count, int64(0))
+	}
+
+	// The QUICK_SCAN parent must be flipped to FAILED - this is what the activity feed shows.
+	parent, ok := quickScanSystemTaskByType(models.QUICK_SCAN)
+	if !ok {
+		utils.PrintTestError(t, "no QUICK_SCAN task", "a QUICK_SCAN task")
+		return
+	}
+	if parent.Status != models.SYSTEM_TASK_FAILED {
+		utils.PrintTestError(t, parent.Status, models.SYSTEM_TASK_FAILED)
+	}
+
+	// A FAILED RECEIPT_UPLOADED task carrying the validation error must be recorded, attributed to the
+	// real group.
+	uploaded, ok := quickScanSystemTaskByType(models.RECEIPT_UPLOADED)
+	if !ok {
+		utils.PrintTestError(t, "no RECEIPT_UPLOADED task", "a FAILED RECEIPT_UPLOADED task")
+		return
+	}
+	if uploaded.Status != models.SYSTEM_TASK_FAILED {
+		utils.PrintTestError(t, uploaded.Status, models.SYSTEM_TASK_FAILED)
+	}
+	if !strings.Contains(uploaded.ResultDescription, "validation failed") {
+		utils.PrintTestError(t, uploaded.ResultDescription, "contains 'validation failed'")
+	}
+	if uploaded.GroupId == nil || *uploaded.GroupId == 0 {
+		utils.PrintTestError(t, uploaded.GroupId, "the real group id")
+	}
+}
+
 // quickScanCreatedReceiptCount counts receipts written through CreateReceipt (which stamps
 // created_by), excluding the pipeline's seeded baseline receipt (created_by NULL). It is the "nothing
 // was persisted" probe for the failure-path tests.
@@ -671,6 +875,19 @@ func quickScanCreatedReceiptCount() int64 {
 	var count int64
 	repositories.GetDB().Model(&models.Receipt{}).Where("created_by IS NOT NULL").Count(&count)
 	return count
+}
+
+// quickScanSystemTaskByType fetches the single system task of the given type written by a runQuickScan
+// call (all carry asynqTaskId "test-task"). Returns false when none exists.
+func quickScanSystemTaskByType(taskType models.SystemTaskType) (models.SystemTask, bool) {
+	var task models.SystemTask
+	err := repositories.GetDB().
+		Where("asynq_task_id = ? AND type = ?", "test-task", taskType).
+		First(&task).Error
+	if err != nil {
+		return models.SystemTask{}, false
+	}
+	return task, true
 }
 
 // TestMagicFill_ParsesAllReceiptFields isolates the deserialization layer: a maximal AI response is

--- a/api/internal/services/quick_scan_merge_test.go
+++ b/api/internal/services/quick_scan_merge_test.go
@@ -34,25 +34,26 @@ func containsTagId(tags []commands.UpsertTagCommand, id uint) bool {
 	return count == 1
 }
 
-func TestMergeQuickScanCategories(t *testing.T) {
+func TestResolveQuickScanCategories(t *testing.T) {
 	defer repositories.TruncateTestDb()
 	repositories.CreateTestCategories()
 	service := NewReceiptService(nil)
 
 	id1 := uint(1)
 
-	// No selections leaves the AI-filled categories untouched.
-	existing := []commands.UpsertCategoryCommand{{Id: &id1, Name: "test"}}
-	result, err := service.mergeQuickScanCategories(existing, []uint{})
+	// AI returns category 1 by id only (no name); it is resolved to its real record so the name is
+	// filled in, even with no user picks. userId/groupId 0 => unrestricted (no grants apply).
+	aiCategories := []commands.UpsertCategoryCommand{{Id: &id1}}
+	result, err := service.resolveQuickScanCategories(aiCategories, nil, 0, 0)
 	if err != nil {
 		utils.PrintTestError(t, err, "no error")
 	}
-	if len(result) != 1 {
-		utils.PrintTestError(t, result, "unchanged existing")
+	if len(result) != 1 || !containsCategoryId(result, 1) || result[0].Name != "test" {
+		utils.PrintTestError(t, result, "category 1 resolved with name")
 	}
 
 	// Union of AI (id 1) and user picks (ids 2, 3), all present exactly once, names resolved.
-	result, err = service.mergeQuickScanCategories(existing, []uint{2, 3})
+	result, err = service.resolveQuickScanCategories(aiCategories, []uint{2, 3}, 0, 0)
 	if err != nil {
 		utils.PrintTestError(t, err, "no error")
 	}
@@ -66,33 +67,49 @@ func TestMergeQuickScanCategories(t *testing.T) {
 	}
 
 	// Overlap between AI and user pick (both id 1) is deduped, not duplicated.
-	result, err = service.mergeQuickScanCategories(existing, []uint{1, 2})
+	result, err = service.resolveQuickScanCategories(aiCategories, []uint{1, 2}, 0, 0)
 	if err != nil {
 		utils.PrintTestError(t, err, "no error")
 	}
 	if len(result) != 2 || !containsCategoryId(result, 1) || !containsCategoryId(result, 2) {
 		utils.PrintTestError(t, result, "categories 1,2 deduped")
 	}
+
+	// A hallucinated / non-existent id is dropped rather than surfaced.
+	badId := uint(999)
+	result, err = service.resolveQuickScanCategories([]commands.UpsertCategoryCommand{{Id: &id1}, {Id: &badId}}, nil, 0, 0)
+	if err != nil {
+		utils.PrintTestError(t, err, "no error")
+	}
+	if len(result) != 1 || !containsCategoryId(result, 1) {
+		utils.PrintTestError(t, result, "only category 1 (999 dropped)")
+	}
 }
 
-func TestMergeQuickScanTags(t *testing.T) {
+func TestResolveQuickScanTags(t *testing.T) {
 	defer repositories.TruncateTestDb()
 	createTestTags()
 	service := NewReceiptService(nil)
 
 	id1 := uint(1)
-	existing := []commands.UpsertTagCommand{{Id: &id1, Name: "tag-a"}}
+	aiTags := []commands.UpsertTagCommand{{Id: &id1}}
 
-	result, err := service.mergeQuickScanTags(existing, []uint{2})
+	// AI tag by id only is resolved (name filled) and unioned with the user's pick.
+	result, err := service.resolveQuickScanTags(aiTags, []uint{2}, 0, 0)
 	if err != nil {
 		utils.PrintTestError(t, err, "no error")
 	}
 	if len(result) != 2 || !containsTagId(result, 1) || !containsTagId(result, 2) {
 		utils.PrintTestError(t, result, "tags 1,2 unioned")
 	}
+	for _, tag := range result {
+		if len(tag.Name) == 0 {
+			utils.PrintTestError(t, tag, "name resolved for merged tag")
+		}
+	}
 
 	// Dedup overlap.
-	result, err = service.mergeQuickScanTags(existing, []uint{1})
+	result, err = service.resolveQuickScanTags(aiTags, []uint{1}, 0, 0)
 	if err != nil {
 		utils.PrintTestError(t, err, "no error")
 	}

--- a/api/internal/services/receipts.go
+++ b/api/internal/services/receipts.go
@@ -324,7 +324,9 @@ func (service ReceiptService) QuickScan(
 			AssociatedSystemTaskId: &parentId,
 		}, failureErr)
 		if taskErr != nil {
-			return taskErr
+			// Task recording failed; still surface the original failure as the primary cause (the
+			// reason no receipt was created), noting the recording error as secondary context.
+			return fmt.Errorf("%w (recording the failure system task also failed: %v)", failureErr, taskErr)
 		}
 		return failureErr
 	}

--- a/api/internal/services/receipts.go
+++ b/api/internal/services/receipts.go
@@ -295,23 +295,58 @@ func (service ReceiptService) QuickScan(
 
 	receiptCommand.GroupId = groupId
 
-	// Merge the user's quick-scan category/tag picks with whatever the AI auto-assigned (union,
-	// deduped by id). Names are resolved from the ids so the merged selections pass receipt
-	// validation, which requires a category/tag name.
-	receiptCommand.Categories, err = service.mergeQuickScanCategories(receiptCommand.Categories, categoryIds)
-	if err != nil {
-		return models.Receipt{}, err
+	// Record a FAILED system task for any error that aborts the quick scan *before* the
+	// create-receipt transaction (category/tag resolution or receipt validation). The
+	// in-transaction CreateReceipt failure is already covered by CreateReceiptUploadedSystemTask;
+	// this closes the gap where a pre-transaction failure (notably a validation error) left the AI
+	// processing tasks marked SUCCEEDED and no record of why no receipt was created. Chaining a
+	// FAILED child to the quick-scan parent flips that parent to FAILED (see
+	// SystemTaskRepository.CreateSystemTask) so the failure surfaces in the activity feed.
+	// RanByUserId is deliberately left nil so the child stays hidden and only the flipped parent
+	// shows, mirroring the successful RECEIPT_UPLOADED child.
+	recordEarlyQuickScanFailure := func(failureErr error) error {
+		parentTask := quickScanSystemTasks.SystemTask
+		if quickScanSystemTasks.FallbackSystemTask.Status == models.SYSTEM_TASK_SUCCEEDED {
+			parentTask = quickScanSystemTasks.FallbackSystemTask
+		}
+		if parentTask.ID == 0 {
+			return failureErr
+		}
+
+		parentId := parentTask.ID
+		_, taskErr := systemTaskService.CreateSystemTaskFromError(commands.UpsertSystemTaskCommand{
+			Type:                   models.RECEIPT_UPLOADED,
+			AssociatedEntityType:   models.RECEIPT_PROCESSING_SETTINGS,
+			AssociatedEntityId:     parentTask.AssociatedEntityId,
+			StartedAt:              finishedAt,
+			AsynqTaskId:            asynqTaskId,
+			GroupId:                &groupId,
+			AssociatedSystemTaskId: &parentId,
+		}, failureErr)
+		if taskErr != nil {
+			return taskErr
+		}
+		return failureErr
 	}
 
-	receiptCommand.Tags, err = service.mergeQuickScanTags(receiptCommand.Tags, tagIds)
+	// Resolve the AI-assigned and user-picked category/tag ids to real records: names are filled
+	// from the database (the AI returns ids only, which would otherwise fail receipt validation),
+	// ids that don't resolve are dropped (hallucinated/non-existent), and ids the triggering user
+	// isn't allowed to see are dropped too (defense-in-depth alongside the prompt's grant filter).
+	receiptCommand.Categories, err = service.resolveQuickScanCategories(receiptCommand.Categories, categoryIds, token.UserId, groupId)
 	if err != nil {
-		return models.Receipt{}, err
+		return models.Receipt{}, recordEarlyQuickScanFailure(err)
+	}
+
+	receiptCommand.Tags, err = service.resolveQuickScanTags(receiptCommand.Tags, tagIds, token.UserId, groupId)
+	if err != nil {
+		return models.Receipt{}, recordEarlyQuickScanFailure(err)
 	}
 
 	vErr := receiptCommand.Validate(token.UserId, true)
 	if len(vErr.Errors) > 0 {
 		errBytes, _ := json.Marshal(vErr.Errors)
-		return models.Receipt{}, fmt.Errorf("receipt validation failed: %s", string(errBytes))
+		return models.Receipt{}, recordEarlyQuickScanFailure(fmt.Errorf("receipt validation failed: %s", string(errBytes)))
 	}
 
 	err = db.Transaction(func(tx *gorm.DB) error {
@@ -361,84 +396,168 @@ func (service ReceiptService) QuickScan(
 	return createdReceipt, nil
 }
 
-// mergeQuickScanCategories appends the user-selected category ids to the AI-filled categories,
-// skipping any already present. Names are loaded from the ids so the result passes receipt
-// validation.
-func (service ReceiptService) mergeQuickScanCategories(
-	existing []commands.UpsertCategoryCommand,
-	categoryIds []uint,
+// resolveQuickScanCategories turns the AI-assigned and user-picked category ids into a validated
+// selection. The union of ids (AI-assigned first, then the user's picks, deduped) is resolved against
+// the database so each carries its real name — the AI returns ids only, which would otherwise fail
+// receipt validation. Ids that don't resolve are dropped (hallucinated / deleted), and ids the
+// triggering user isn't allowed to see are dropped too (defense-in-depth alongside the prompt's grant
+// filter). Returns an empty slice when there is nothing to resolve.
+func (service ReceiptService) resolveQuickScanCategories(
+	aiCategories []commands.UpsertCategoryCommand,
+	userCategoryIds []uint,
+	userId uint,
+	groupId uint,
 ) ([]commands.UpsertCategoryCommand, error) {
-	if len(categoryIds) == 0 {
-		return existing, nil
+	orderedIds := make([]uint, 0, len(aiCategories)+len(userCategoryIds))
+	seen := make(map[uint]bool)
+	appendId := func(id uint) {
+		if !seen[id] {
+			seen[id] = true
+			orderedIds = append(orderedIds, id)
+		}
+	}
+	for _, category := range aiCategories {
+		if category.Id != nil {
+			appendId(*category.Id)
+		}
+	}
+	for _, id := range userCategoryIds {
+		appendId(id)
+	}
+	if len(orderedIds) == 0 {
+		return []commands.UpsertCategoryCommand{}, nil
 	}
 
 	categoryRepository := repositories.NewCategoryRepository(service.TX)
-	categories, err := categoryRepository.GetByIds(categoryIds)
+	records, err := categoryRepository.GetByIds(orderedIds)
+	if err != nil {
+		return nil, err
+	}
+	recordsById := make(map[uint]models.Category, len(records))
+	for _, record := range records {
+		recordsById[record.ID] = record
+	}
+
+	allowed, unrestricted, err := service.resolveAllowedCategoryIds(userId, groupId)
 	if err != nil {
 		return nil, err
 	}
 
-	presentIds := make(map[uint]bool)
-	for _, category := range existing {
-		if category.Id != nil {
-			presentIds[*category.Id] = true
+	resolved := make([]commands.UpsertCategoryCommand, 0, len(orderedIds))
+	for _, id := range orderedIds {
+		record, ok := recordsById[id]
+		if !ok {
+			continue // id did not resolve to a real category
 		}
-	}
-
-	for _, category := range categories {
-		if presentIds[category.ID] {
-			continue
+		if !unrestricted {
+			if _, visible := allowed[id]; !visible {
+				continue // category the user is not allowed to see
+			}
 		}
 
-		id := category.ID
-		existing = append(existing, commands.UpsertCategoryCommand{
-			Id:          &id,
-			Name:        category.Name,
-			Description: category.Description,
+		recordId := record.ID
+		resolved = append(resolved, commands.UpsertCategoryCommand{
+			Id:          &recordId,
+			Name:        record.Name,
+			Description: record.Description,
 		})
-		presentIds[id] = true
 	}
 
-	return existing, nil
+	return resolved, nil
 }
 
-// mergeQuickScanTags is the tag counterpart of mergeQuickScanCategories.
-func (service ReceiptService) mergeQuickScanTags(
-	existing []commands.UpsertTagCommand,
-	tagIds []uint,
+// resolveQuickScanTags is the tag counterpart of resolveQuickScanCategories.
+func (service ReceiptService) resolveQuickScanTags(
+	aiTags []commands.UpsertTagCommand,
+	userTagIds []uint,
+	userId uint,
+	groupId uint,
 ) ([]commands.UpsertTagCommand, error) {
-	if len(tagIds) == 0 {
-		return existing, nil
+	orderedIds := make([]uint, 0, len(aiTags)+len(userTagIds))
+	seen := make(map[uint]bool)
+	appendId := func(id uint) {
+		if !seen[id] {
+			seen[id] = true
+			orderedIds = append(orderedIds, id)
+		}
+	}
+	for _, tag := range aiTags {
+		if tag.Id != nil {
+			appendId(*tag.Id)
+		}
+	}
+	for _, id := range userTagIds {
+		appendId(id)
+	}
+	if len(orderedIds) == 0 {
+		return []commands.UpsertTagCommand{}, nil
 	}
 
 	tagsRepository := repositories.NewTagsRepository(service.TX)
-	tags, err := tagsRepository.GetByIds(tagIds)
+	records, err := tagsRepository.GetByIds(orderedIds)
+	if err != nil {
+		return nil, err
+	}
+	recordsById := make(map[uint]models.Tag, len(records))
+	for _, record := range records {
+		recordsById[record.ID] = record
+	}
+
+	allowed, unrestricted, err := service.resolveAllowedTagIds(userId, groupId)
 	if err != nil {
 		return nil, err
 	}
 
-	presentIds := make(map[uint]bool)
-	for _, tag := range existing {
-		if tag.Id != nil {
-			presentIds[*tag.Id] = true
+	resolved := make([]commands.UpsertTagCommand, 0, len(orderedIds))
+	for _, id := range orderedIds {
+		record, ok := recordsById[id]
+		if !ok {
+			continue // id did not resolve to a real tag
 		}
-	}
-
-	for _, tag := range tags {
-		if presentIds[tag.ID] {
-			continue
+		if !unrestricted {
+			if _, visible := allowed[id]; !visible {
+				continue // tag the user is not allowed to see
+			}
 		}
 
-		id := tag.ID
-		existing = append(existing, commands.UpsertTagCommand{
-			Id:          &id,
-			Name:        tag.Name,
-			Description: tag.Description,
+		recordId := record.ID
+		resolved = append(resolved, commands.UpsertTagCommand{
+			Id:          &recordId,
+			Name:        record.Name,
+			Description: record.Description,
 		})
-		presentIds[id] = true
 	}
 
-	return existing, nil
+	return resolved, nil
+}
+
+// resolveAllowedCategoryIds returns the set of category ids the triggering user may see in the group,
+// or unrestricted=true (see-all) when the user bypasses grants (holds app.categories.read) or their
+// group role grants nothing for categories. The returned set is shared grant-cache state and must
+// only be read.
+func (service ReceiptService) resolveAllowedCategoryIds(userId uint, groupId uint) (map[uint]struct{}, bool, error) {
+	permissionService := NewPermissionService(service.TX)
+	bypass, err := permissionService.userBypassesGrants(userId, permissions.AppCategoriesRead)
+	if err != nil {
+		return nil, false, err
+	}
+	if bypass {
+		return nil, true, nil
+	}
+	return permissionService.GetGroupCategoryIdsForUser(userId, groupId)
+}
+
+// resolveAllowedTagIds is the tag counterpart of resolveAllowedCategoryIds.
+func (service ReceiptService) resolveAllowedTagIds(userId uint, groupId uint) (map[uint]struct{}, bool, error) {
+	permissionService := NewPermissionService(service.TX)
+	bypass, err := permissionService.userBypassesGrants(userId, permissions.AppTagsRead)
+	if err != nil {
+		return nil, false, err
+	}
+	if bypass {
+		return nil, true, nil
+	}
+	return permissionService.GetGroupTagIdsForUser(userId, groupId)
 }
 
 func (service ReceiptService) DuplicateReceipt(

--- a/api/internal/services/receipts.go
+++ b/api/internal/services/receipts.go
@@ -323,12 +323,7 @@ func (service ReceiptService) QuickScan(
 			GroupId:                &groupId,
 			AssociatedSystemTaskId: &parentId,
 		}, failureErr)
-		if taskErr != nil {
-			// Task recording failed; still surface the original failure as the primary cause (the
-			// reason no receipt was created), noting the recording error as secondary context.
-			return fmt.Errorf("%w (recording the failure system task also failed: %v)", failureErr, taskErr)
-		}
-		return failureErr
+		return combineEarlyFailureErrors(failureErr, taskErr)
 	}
 
 	// Resolve the AI-assigned and user-picked category/tag ids to real records: names are filled
@@ -396,6 +391,16 @@ func (service ReceiptService) QuickScan(
 
 	os.Remove(tempPath)
 	return createdReceipt, nil
+}
+
+// combineEarlyFailureErrors keeps failureErr as the primary, inspectable cause (the reason no receipt
+// was created) while also preserving taskErr in the unwrap chain when system-task recording itself
+// failed, so errors.Is/As can reach either.
+func combineEarlyFailureErrors(failureErr, taskErr error) error {
+	if taskErr == nil {
+		return failureErr
+	}
+	return fmt.Errorf("%w (recording the failure system task also failed: %w)", failureErr, taskErr)
 }
 
 // resolveQuickScanCategories turns the AI-assigned and user-picked category ids into a validated


### PR DESCRIPTION
## Summary
Fixes two related quick-scan bugs: (1) the default AI prompt returns categories/tags by ID only, which failed validation and silently dropped receipts, and (2) pre-transaction failures (category/tag resolution, validation) left no audit trail — the AI tasks stayed marked SUCCEEDED with no record of why the receipt wasn't created.

## Key Changes

- **Resolve AI-assigned category/tag IDs to real records**: Renamed `mergeQuickScanCategories`/`mergeQuickScanTags` to `resolveQuickScanCategories`/`resolveQuickScanTags`. These now:
  - Look up each ID (AI-assigned first, then user picks, deduped) in the database to fill in the required `name` field
  - Drop hallucinated/non-existent IDs rather than failing the whole scan
  - Drop IDs the triggering user isn't allowed to see (grant-restricted group roles), matching write-side enforcement via new `resolveAllowedCategoryIds`/`resolveAllowedTagIds` helpers

- **Record pre-transaction failures as system tasks**: Added `recordEarlyQuickScanFailure` closure that:
  - Writes a FAILED `RECEIPT_UPLOADED` task chained to the QUICK_SCAN parent for any error before the create-receipt transaction (category/tag resolution, validation)
  - Leverages `SystemTaskRepository.CreateSystemTask`'s logic to flip a SUCCEEDED parent to FAILED when a FAILED child references it
  - Leaves `RanByUserId` nil so the child stays hidden and only the flipped parent surfaces in the activity feed (mirroring successful receipts)

- **Updated tests**: 
  - Renamed `TestMergeQuickScan*` to `TestResolveQuickScan*` and updated assertions to verify name resolution
  - Added `TestQuickScan_ResolvesIdOnlyAiCategory` to prove the default prompt's id-only shape now works
  - Added `TestQuickScan_DropsUnresolvableAiCategory` and `TestQuickScan_DropsOutOfGrantAiCategory` to verify graceful degradation
  - Added `TestQuickScan_ValidationFailureRecordsFailedSystemTask` to verify the audit trail
  - Added `runQuickScanWithSetup` hook for grant-restriction tests
  - Added `quickScanSystemTaskByType` helper to query system tasks by type

## Implementation Details

- The resolution logic preserves order (AI assignments first, then user picks) and dedupes by ID
- Grant checking reuses existing `userBypassesGrants` + `GetGroupCategoryIdsForUser`/`GetGroupTagIdsForUser` logic, ensuring consistency with write-side enforcement
- Validation remains strict (name required) to prevent blank names from reaching `UpdateReceipt`'s `FullSaveAssociations: true` upsert
- The CLAUDE.md documentation was updated to explain the resolution contract and failed-task recording

https://claude.ai/code/session_01J3jVoj94cutELvrK6TKMw5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quick Scan now resolves AI-provided category/tag IDs to real names, deduplicates results, and combines AI selections with user picks while omitting invalid or inaccessible entries.
* **Bug Fixes**
  * Failures occurring before receipt creation are now surfaced in activity history as FAILED tasks, including validation-related receipt-upload failure details.
* **Tests**
  * Expanded ingest and resolution test coverage for ID-only AI outputs, dropped IDs, permission enforcement, and early-failure recording.
* **Documentation**
  * Updated Quick Scan field configuration docs to reflect resolution behavior and clarified receipt-level-only scope (item-level gap remains).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->