### PR TITLE
Fix dashboards not loading on group switch via reactive effects

### DIFF
--- a/desktop/src/dashboard/group-dashboards/group-dashboards.component.spec.ts
+++ b/desktop/src/dashboard/group-dashboards/group-dashboards.component.spec.ts
@@ -5,6 +5,7 @@ import { ComponentFixture, TestBed, } from "@angular/core/testing";
 import { MatDialogModule } from "@angular/material/dialog";
 import { MatSnackBarModule } from "@angular/material/snack-bar";
 import { ActivatedRoute, Params, Router } from "@angular/router";
+import { By } from "@angular/platform-browser";
 import { NgxsModule, Store } from "@ngxs/store";
 import { BehaviorSubject } from "rxjs";
 import { PipesModule } from "src/pipes/pipes.module";
@@ -21,6 +22,35 @@ describe("GroupDashboardsComponent", () => {
   let component: GroupDashboardsComponent;
   let fixture: ComponentFixture<GroupDashboardsComponent>;
   let store: Store;
+
+  const dashboard = (id: number, groupId = 1): Dashboard => ({
+    id,
+    name: `dashboard-${id}`,
+    groupId,
+    userId: 1,
+  });
+
+  // navigateToDashboard defers the actual navigation via setTimeout(0); spying
+  // navigateByUrl keeps a real (routeless) Router from producing rejected
+  // navigations, and lets the navigation tests assert the target url.
+  const spyNavigate = () =>
+    jest
+      .spyOn(TestBed.inject(Router), "navigateByUrl")
+      .mockResolvedValue(true as any);
+
+  const seed = (
+    groups: Partial<{ selectedGroupId: string; selectedDashboardId: string }>,
+    dashboards: { [groupId: string]: Dashboard[] } = {}
+  ) => {
+    store.reset({
+      ...store.snapshot(),
+      groups: {
+        ...store.snapshot().groups,
+        ...groups,
+      },
+      dashboards: { dashboards },
+    });
+  };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -68,100 +98,93 @@ describe("GroupDashboardsComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  it("should set dashboards with dashboards", () => {
-    const dashboards: Dashboard[] = [
-      {
-        id: 1,
-        name: "test",
-        groupId: 1,
-        userId: 1,
-      },
-    ];
-    store.reset({
-      ...store.snapshot(),
-      groups: {
-        ...store.snapshot().groups,
-        selectedGroupId: "1",
-      },
-      dashboards: {
-        dashboards: {
-          "1": dashboards,
-        },
-      },
-    });
+  it("derives the current group's dashboards from the store", () => {
+    spyNavigate();
+    const dashboards = [dashboard(1)];
+    seed({ selectedGroupId: "1", selectedDashboardId: "" }, { "1": dashboards });
 
-    component.ngOnInit();
+    TestBed.flushEffects();
 
     expect(component.dashboards()).toEqual(dashboards);
   });
 
-  it("should set dashboards with dashboards on seleced group id change", () => {
-    const dashboards: Dashboard[] = [
-      {
-        id: 1,
-        name: "test",
-        groupId: 1,
-        userId: 1,
-      },
-    ];
-    const newDashboards: Dashboard[] = [
-      {
-        id: 2,
-        name: "test",
-        groupId: 1,
-        userId: 1,
-      },
-    ];
-    const activatedRoute = TestBed.inject(ActivatedRoute);
-    store.reset({
-      ...store.snapshot(),
-      groups: {
-        ...store.snapshot().groups,
-        selectedGroupId: "1",
-      },
-      dashboards: {
-        dashboards: {
-          "1": dashboards,
-        },
-      },
-    });
-    component.ngOnInit();
+  it("reacts to the selected group id changing", () => {
+    spyNavigate();
+    const g1 = [dashboard(1, 1)];
+    const g2 = [dashboard(2, 2)];
+    seed({ selectedGroupId: "1", selectedDashboardId: "" }, { "1": g1, "2": g2 });
+    TestBed.flushEffects();
 
-    expect(component.dashboards()).toEqual(dashboards);
+    expect(component.dashboards()).toEqual(g1);
 
     store.reset({
       ...store.snapshot(),
       groups: {
         ...store.snapshot().groups,
         selectedGroupId: "2",
-      },
-      dashboards: {
-        dashboards: {
-          "2": newDashboards,
-        },
+        selectedDashboardId: "",
       },
     });
+    TestBed.flushEffects();
 
-    (activatedRoute.params as any).next({
-      dashboardId: 2,
-    });
-
-    expect(component.dashboards()).toEqual(newDashboards);
+    expect(component.dashboards()).toEqual(g2);
   });
 
-  it("should not navigate to selected dashboard", () => {
-    const routerSpy = jest.spyOn(TestBed.inject(Router), "navigateByUrl");
-    store.reset({
-      ...store.snapshot(),
-      groups: {
-        ...store.snapshot().groups,
-        selectedDashboardId: undefined,
-      },
-    });
+  it("renders a chip per dashboard once they land in the store", async () => {
+    spyNavigate();
+    const chips = () =>
+      fixture.debugElement.queryAll(By.css("mat-chip-option"));
 
-    component.ngOnInit();
+    expect(chips().length).toBe(0);
 
-    expect(routerSpy).toHaveBeenCalledTimes(0);
+    seed({ selectedGroupId: "1", selectedDashboardId: "" }, { "1": [dashboard(1)] });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(chips().length).toBe(1);
+  });
+
+  it("auto-selects and navigates to the first dashboard once a cold group's data lands", () => {
+    jest.useFakeTimers();
+    const navSpy = spyNavigate();
+    seed({ selectedGroupId: "1", selectedDashboardId: "" }, { "1": [dashboard(7)] });
+
+    TestBed.flushEffects();
+
+    expect(store.selectSnapshot(GroupState.selectedDashboardId)).toBe("7");
+
+    jest.runOnlyPendingTimers();
+    expect(navSpy).toHaveBeenCalledWith("/dashboard/group/1/7");
+    jest.useRealTimers();
+  });
+
+  it("navigates to the already-selected dashboard when data lands (warm/deep-link)", () => {
+    jest.useFakeTimers();
+    const navSpy = spyNavigate();
+    seed(
+      { selectedGroupId: "1", selectedDashboardId: "5" },
+      { "1": [dashboard(5), dashboard(8)] }
+    );
+
+    TestBed.flushEffects();
+    jest.runOnlyPendingTimers();
+
+    expect(navSpy).toHaveBeenCalledWith("/dashboard/group/1/5");
+    expect(store.selectSnapshot(GroupState.selectedDashboardId)).toBe("5");
+    jest.useRealTimers();
+  });
+
+  it("does not navigate when the group has no dashboards and none is selected", () => {
+    jest.useFakeTimers();
+    const navSpy = spyNavigate();
+    seed({ selectedGroupId: "1", selectedDashboardId: "" }, {});
+
+    TestBed.flushEffects();
+    jest.runOnlyPendingTimers();
+
+    expect(navSpy).not.toHaveBeenCalled();
+    jest.useRealTimers();
   });
 
   it("should set selected dashboard id", () => {

--- a/desktop/src/dashboard/group-dashboards/group-dashboards.component.ts
+++ b/desktop/src/dashboard/group-dashboards/group-dashboards.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, OnInit, signal } from "@angular/core";
+import { Component, computed, effect } from "@angular/core";
 import { MatDialog } from "@angular/material/dialog";
 import { Router } from "@angular/router";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
@@ -13,6 +13,10 @@ import { SnackbarService } from "../../services";
 import { GroupState, SetSelectedDashboardId } from "../../store";
 import { DashboardFormComponent } from "../dashboard-form/dashboard-form.component";
 
+// Stable empty reference so the dashboards computed doesn't emit a fresh [] on
+// every recompute (which would needlessly re-run the auto-select effect).
+const EMPTY_DASHBOARDS: Dashboard[] = [];
+
 @UntilDestroy()
 @Component({
     selector: "app-group-dashboards",
@@ -20,15 +24,7 @@ import { DashboardFormComponent } from "../dashboard-form/dashboard-form.compone
     styleUrls: ["./group-dashboards.component.scss"],
     standalone: false
 })
-export class GroupDashboardsComponent implements OnInit {
-  constructor(
-    private dashboardService: DashboardService,
-    private matDialog: MatDialog,
-    private router: Router,
-    private snackbarService: SnackbarService,
-    private store: Store
-  ) {}
-
+export class GroupDashboardsComponent {
   public selectedGroupId = this.store.selectSignal(GroupState.selectedGroupId);
 
   // Dashboard CRUD buttons gate on the group-scoped permissions via
@@ -40,39 +36,46 @@ export class GroupDashboardsComponent implements OnInit {
     () => +(this.selectedGroupId() ?? 0)
   );
 
-  public selectedDashboardId = this.store.selectSignal(GroupState.selectedDashboardId);
+  public selectedDashboardId = this.store.selectSignal(
+    GroupState.selectedDashboardId
+  );
 
-  public dashboards = signal<Dashboard[]>([]);
+  private dashboardsByGroup = this.store.selectSignal(DashboardState.dashboards);
 
-  public ngOnInit(): void {
-    this.setDashboards();
-  }
+  // Derived reactively from the store so the chip list re-renders whenever the
+  // current group's dashboards land — including when the resolver's fetch
+  // resolves after this (reused) component has already reacted to the group
+  // switch. A snapshot read here would be untracked and reintroduce the
+  // "dashboards don't load on switch" bug.
+  public dashboards = computed<Dashboard[]>(
+    () => this.dashboardsByGroup()[this.selectedGroupId()] ?? EMPTY_DASHBOARDS
+  );
 
-  private checkForSelectedDashboard(): void {
-    const selectedDashboardId = this.store.selectSnapshot(
-      GroupState.selectedDashboardId
-    );
+  constructor(
+    private dashboardService: DashboardService,
+    private matDialog: MatDialog,
+    private router: Router,
+    private snackbarService: SnackbarService,
+    private store: Store
+  ) {
+    // Once the current group's dashboards are available, ensure a dashboard is
+    // selected and its outlet is showing. Depends only on dashboards();
+    // selectedDashboardId is read as an untracked snapshot and the effect's only
+    // write (SetSelectedDashboardId) changes neither dashboards() nor
+    // selectedGroupId, so it cannot re-trigger itself.
+    effect(() => {
+      const dashboards = this.dashboards();
+      const selectedDashboardId = this.store.selectSnapshot(
+        GroupState.selectedDashboardId
+      );
 
-    if (selectedDashboardId) {
-      this.navigateToDashboard(+selectedDashboardId);
-      return;
-    } else if (this.dashboards().length > 0) {
-      this.setSelectedDashboardId(this.dashboards()[0].id);
-      this.navigateToDashboard(this.dashboards()[0].id);
-    }
-  }
-
-  private setDashboards(): void {
-    this.store
-      .select(GroupState.selectedGroupId)
-      .pipe(
-        untilDestroyed(this),
-        tap((groupId) => {
-          this.refreshDashboards(groupId);
-          this.checkForSelectedDashboard();
-        })
-      )
-      .subscribe();
+      if (selectedDashboardId) {
+        this.navigateToDashboard(+selectedDashboardId);
+      } else if (dashboards.length > 0) {
+        this.setSelectedDashboardId(dashboards[0].id);
+        this.navigateToDashboard(dashboards[0].id);
+      }
+    });
   }
 
   public navigateToDashboard(dashboardId: number): void {
@@ -123,7 +126,6 @@ export class GroupDashboardsComponent implements OnInit {
               new UpdateDashBoardForGroup(groupId, dashboard.id, dashboard)
             );
           }
-          this.refreshDashboards(groupId);
         })
       )
       .subscribe();
@@ -131,18 +133,6 @@ export class GroupDashboardsComponent implements OnInit {
 
   public setSelectedDashboardId(dashboardId: number): void {
     this.store.dispatch(new SetSelectedDashboardId(dashboardId?.toString()));
-  }
-
-  private refreshDashboards(groupId: string): void {
-    this.store
-      .select(DashboardState.getDashboardsByGroupId(groupId))
-      .pipe(
-        take(1),
-        tap((dashboards) => {
-          this.dashboards.set(dashboards);
-        })
-      )
-      .subscribe();
   }
 
   public openDeleteConfirmationDialog(): void {
@@ -185,9 +175,6 @@ export class GroupDashboardsComponent implements OnInit {
                   );
                   this.store.dispatch(new SetSelectedDashboardId(undefined));
                   this.router.navigateByUrl(dashboardLink);
-                  this.refreshDashboards(
-                    this.store.selectSnapshot(GroupState.selectedGroupId)
-                  );
                 })
               )
               .subscribe();

--- a/desktop/src/dashboard/guards/dashboard.guard.spec.ts
+++ b/desktop/src/dashboard/guards/dashboard.guard.spec.ts
@@ -1,17 +1,74 @@
-import { TestBed } from '@angular/core/testing';
-import { CanActivateFn } from '@angular/router';
+import { TestBed } from "@angular/core/testing";
+import { Router } from "@angular/router";
+import { RouterTestingModule } from "@angular/router/testing";
+import { NgxsModule, Store } from "@ngxs/store";
+import { DashboardState } from "src/store/dashboard.state";
+import { Dashboard } from "../../open-api";
+import { GroupState, SetSelectedDashboardId } from "../../store";
+import { dashboardGuard } from "./dashboard.guard";
 
-import { dashboardGuard } from './dashboard.guard';
+describe("dashboardGuard", () => {
+  let store: Store;
+  let navigateSpy: jest.SpyInstance;
 
-describe('dashboardGuard', () => {
-  const executeGuard: CanActivateFn = (...guardParameters) => 
-      TestBed.runInInjectionContext(() => dashboardGuard(...guardParameters));
+  const executeGuard = (dashboardId: string) =>
+    TestBed.runInInjectionContext(() =>
+      dashboardGuard({ params: { dashboardId } } as any, {} as any)
+    );
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({});
+  const dashboard = (id: number): Dashboard => ({
+    id,
+    name: `dashboard-${id}`,
+    groupId: 1,
+    userId: 1,
   });
 
-  it('should be created', () => {
-    expect(executeGuard).toBeTruthy();
+  const seedDashboards = (dashboards: Dashboard[]) => {
+    store.reset({
+      ...store.snapshot(),
+      groups: { ...store.snapshot().groups, selectedGroupId: "1" },
+      dashboards: {
+        dashboards: dashboards.length ? { "1": dashboards } : {},
+      },
+    });
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        RouterTestingModule,
+        NgxsModule.forRoot([GroupState, DashboardState]),
+      ],
+    });
+    store = TestBed.inject(Store);
+    navigateSpy = jest
+      .spyOn(TestBed.inject(Router), "navigate")
+      .mockResolvedValue(true);
+  });
+
+  it("allows activation and selects the dashboard when it exists in the group", () => {
+    seedDashboards([dashboard(5)]);
+    const dispatchSpy = jest.spyOn(store, "dispatch");
+
+    expect(executeGuard("5")).toBe(true);
+    expect(dispatchSpy).toHaveBeenCalledWith(new SetSelectedDashboardId("5"));
+    expect(navigateSpy).not.toHaveBeenCalled();
+  });
+
+  it("redirects to the group base when the dashboard id is not in the group", () => {
+    seedDashboards([dashboard(5)]);
+
+    expect(executeGuard("999")).toBe(false);
+    expect(navigateSpy).toHaveBeenCalledWith(["/dashboard/group/1"]);
+  });
+
+  it("redirects when the group's dashboards have not been loaded yet", () => {
+    // Pre-fix failure mode: the resolver must populate DashboardState before the
+    // child route activates (SetDashboardsForGroup now awaits the HTTP), otherwise
+    // a valid id is bounced. With an empty store even a real id redirects.
+    seedDashboards([]);
+
+    expect(executeGuard("5")).toBe(false);
+    expect(navigateSpy).toHaveBeenCalledWith(["/dashboard/group/1"]);
   });
 });

--- a/desktop/src/dashboard/resolvers/dashboard.resolver.ts
+++ b/desktop/src/dashboard/resolvers/dashboard.resolver.ts
@@ -1,7 +1,8 @@
 import { inject } from "@angular/core";
 import { ResolveFn } from "@angular/router";
 import { Store } from "@ngxs/store";
-import { Observable, of } from "rxjs";
+import { map, Observable, of } from "rxjs";
+import { DashboardState } from "src/store/dashboard.state";
 import { SetDashboardsForGroup } from "src/store/dashboard.state.actions";
 import { Dashboard, Permission } from "../../open-api";
 import { AuthState } from "../../store";
@@ -24,5 +25,9 @@ export const dashboardResolverFn: ResolveFn<Observable<Dashboard[]>> = (
     return of([]);
   }
 
-  return store.dispatch(new SetDashboardsForGroup(groupId)) as any as Observable<Dashboard[]>;
+  // SetDashboardsForGroup now returns its HTTP observable, so the dispatch only
+  // completes once the store is populated — the route waits for real data.
+  return store
+    .dispatch(new SetDashboardsForGroup(groupId))
+    .pipe(map(() => store.selectSnapshot(DashboardState.getDashboardsByGroupId(groupId))));
 };

--- a/desktop/src/store/dashboard.state.spec.ts
+++ b/desktop/src/store/dashboard.state.spec.ts
@@ -1,0 +1,93 @@
+import { provideHttpClient, withInterceptorsFromDi } from "@angular/common/http";
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from "@angular/common/http/testing";
+import { TestBed } from "@angular/core/testing";
+import { NgxsModule, Store } from "@ngxs/store";
+import { Dashboard } from "../open-api";
+import { DashboardState } from "./dashboard.state";
+import { SetDashboardsForGroup } from "./dashboard.state.actions";
+
+describe("DashboardState", () => {
+  let store: Store;
+  let httpMock: HttpTestingController;
+
+  const dashboard = (id: number, groupId: number): Dashboard => ({
+    id,
+    name: `dashboard-${id}`,
+    groupId,
+    userId: 1,
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [NgxsModule.forRoot([DashboardState])],
+      providers: [
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+      ],
+    });
+    store = TestBed.inject(Store);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  describe("SetDashboardsForGroup", () => {
+    // Regression guard for the root cause of "dashboards don't load on group
+    // switch": the action must return its HTTP observable so NGXS keeps the
+    // dispatch (and the route resolver that relies on it) open until the store is
+    // populated. The old fire-and-forget `.subscribe()` form completed the
+    // dispatch before the request resolved and would fail this test.
+    it("patches the group's dashboards only after the service responds (awaits the HTTP)", () => {
+      let completed = false;
+      store
+        .dispatch(new SetDashboardsForGroup("2"))
+        .subscribe(() => (completed = true));
+
+      expect(completed).toBe(false);
+      expect(
+        store.selectSnapshot(DashboardState.getDashboardsByGroupId("2"))
+      ).toEqual([]);
+
+      httpMock
+        .expectOne((r) => r.method === "GET" && r.url.endsWith("/dashboard/2"))
+        .flush([dashboard(1, 2)]);
+
+      expect(completed).toBe(true);
+      expect(
+        store.selectSnapshot(DashboardState.getDashboardsByGroupId("2"))
+      ).toEqual([dashboard(1, 2)]);
+    });
+
+    it("does not clobber other groups' dashboards", () => {
+      store.reset({
+        ...store.snapshot(),
+        dashboards: { dashboards: { "1": [dashboard(9, 1)] } },
+      });
+
+      store.dispatch(new SetDashboardsForGroup("2"));
+      httpMock
+        .expectOne((r) => r.method === "GET" && r.url.endsWith("/dashboard/2"))
+        .flush([dashboard(1, 2)]);
+
+      expect(
+        store.selectSnapshot(DashboardState.getDashboardsByGroupId("1"))
+      ).toEqual([dashboard(9, 1)]);
+      expect(
+        store.selectSnapshot(DashboardState.getDashboardsByGroupId("2"))
+      ).toEqual([dashboard(1, 2)]);
+    });
+  });
+
+  describe("getDashboardsByGroupId", () => {
+    it("returns [] for a group with no dashboards", () => {
+      expect(
+        store.selectSnapshot(DashboardState.getDashboardsByGroupId("999"))
+      ).toEqual([]);
+    });
+  });
+});

--- a/desktop/src/store/dashboard.state.ts
+++ b/desktop/src/store/dashboard.state.ts
@@ -32,10 +32,15 @@ export class DashboardState {
   }
 
   @Action(SetDashboardsForGroup)
-  async setReceiptFilterData(
+  setDashboardsForGroup(
     { patchState, getState }: StateContext<DashboardStateInterface>,
     payload: SetDashboardsForGroup
   ) {
+    // Return the observable so NGXS awaits the HTTP request before completing the
+    // dispatch. Previously this subscribed internally and returned a Subscription,
+    // so the dispatch (and the route resolver that relies on it) completed before
+    // the dashboards loaded — the root cause of dashboards not rendering on a
+    // group switch.
     return this.dashboardService
       .getDashboardsForUserByGroupId(payload.groupId)
       .pipe(
@@ -45,8 +50,7 @@ export class DashboardState {
           newDashboards[payload.groupId] = dashboards;
           patchState({ dashboards: newDashboards });
         })
-      )
-      .subscribe();
+      );
   }
 
   @Action(AddDashboardToGroup)
@@ -91,9 +95,6 @@ export class DashboardState {
     newDashboards[payload.groupId] = groupDashboards.filter(
       (dashboard) => dashboard.id !== payload.dashboardId
     );
-
-    console.warn(payload.dashboardId);
-    console.warn(newDashboards);
 
     patchState({ dashboards: newDashboards });
   }


### PR DESCRIPTION
## Summary
Fixes a critical bug where dashboards fail to render when switching between groups. The root cause was that the `SetDashboardsForGroup` action was not awaiting the HTTP request before completing the dispatch, causing the route resolver to complete before data was available. This refactors the component to use Angular signals and effects for reactive data flow instead of imperative subscriptions.

## Key Changes

- **Fixed `SetDashboardsForGroup` action** (`dashboard.state.ts`): Now returns the HTTP observable instead of subscribing internally, ensuring NGXS waits for the request to complete before resolving the dispatch. This allows the route resolver to properly await data population.

- **Refactored `GroupDashboardsComponent`** to use Angular signals and effects:
  - Replaced `OnInit` lifecycle hook with constructor-based `effect()` for auto-selection logic
  - Converted `dashboards` from a mutable signal to a computed signal derived from store state
  - Removed imperative `setDashboards()` and `refreshDashboards()` methods
  - Eliminated manual subscription management; effects now reactively respond to store changes
  - The computed `dashboards()` signal automatically updates when the selected group changes, fixing the "dashboards don't load on switch" bug

- **Enhanced test coverage**:
  - Added comprehensive `DashboardState` tests verifying HTTP awaiting and multi-group isolation
  - Refactored `GroupDashboardsComponent` tests with helper functions (`dashboard()`, `spyNavigate()`, `seed()`) for clarity
  - Added tests for reactive behavior: group switching, chip rendering, auto-selection, and navigation
  - Improved `dashboardGuard` tests with realistic store seeding and guard behavior validation

- **Cleaned up stale code**:
  - Removed debug `console.warn()` statements from `RemoveDashboardFromGroup` action
  - Removed redundant `refreshDashboards()` calls after mutations (store updates are now the source of truth)

## Implementation Details

The fix leverages Angular's signal-based reactivity:
- `dashboards()` is a computed signal that derives from `dashboardsByGroup()[selectedGroupId()]`
- When the selected group ID changes, the computed signal automatically re-evaluates
- An `effect()` in the constructor watches `dashboards()` and handles auto-selection and navigation
- The effect reads `selectedDashboardId` as an untracked snapshot to avoid circular dependencies
- A stable `EMPTY_DASHBOARDS` reference prevents unnecessary effect re-runs when no dashboards exist

The resolver now properly awaits `SetDashboardsForGroup` before route activation, ensuring dashboards are in the store before the component renders.

https://claude.ai/code/session_01GjpZw5eVuhytf5pcc8tpkh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Dashboard lists now update automatically when switching groups.
  * Dashboards are selected and opened consistently when a group loads, including deep links to an existing dashboard.
  * Dashboard chips appear as soon as group dashboards are available.
  * Creating, updating, or deleting dashboards now refreshes the displayed list automatically.

* **Bug Fixes**
  * Invalid or unavailable dashboard links now redirect to the group dashboard view.
  * Dashboard pages now wait for dashboard data to finish loading before continuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->