### PR TITLE
Add vertical rhythm to table-header component and update system-task-table

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -172,7 +172,9 @@ the user explicitly confirms the divergence**. Examples of standards to follow:
   (`src/shared-ui/table-header/`), which takes `[headerText]` and an optional `[subtitle]` one-line
   description — every list should set a subtitle. For a subtitle that needs rich content (e.g. a link),
   project it via the `[table-header-subtitle]` slot instead of the string input (see
-  `role-list`). The primary create control is the shared **`app-add-button`**
+  `role-list`). The component owns its own vertical rhythm via a `:host` margin (a small gap above,
+  a larger gap below to separate it from the table), so pages should **not** re-add margins around it.
+  The primary create control is the shared **`app-add-button`**
   (`src/shared-ui/add-button/`): pass `[buttonText]="'Add X'"` to render a filled **`+ Add X`** button;
   omit `buttonText` and it stays the compact icon-only **`+`** used for in-form section-header adds
   (Add Item / Share / Widget / shortcut / option). Standardize the verb on **"Add X"**; give every add

--- a/desktop/src/reports/report-template-list/report-template-list.component.scss
+++ b/desktop/src/reports/report-template-list/report-template-list.component.scss
@@ -10,11 +10,6 @@ $border: rgba(0, 0, 0, 0.06);
   flex-direction: column;
 }
 
-.report-templates-page app-table-header {
-  display: block;
-  margin: variables.$spacing-sm 0 variables.$spacing-lg;
-}
-
 /* ---------- Empty state ---------- */
 .empty-state {
   display: flex;

--- a/desktop/src/roles/role-list/role-list.component.scss
+++ b/desktop/src/roles/role-list/role-list.component.scss
@@ -17,11 +17,6 @@ $group-accent-bar: #a78bfa;
   flex-direction: column;
 }
 
-.roles-page app-table-header {
-  display: block;
-  margin: variables.$spacing-sm 0 variables.$spacing-lg;
-}
-
 .subtitle {
   color: $fg-muted;
   font-size: 14px;

--- a/desktop/src/shared-ui/table-header/table-header.component.scss
+++ b/desktop/src/shared-ui/table-header/table-header.component.scss
@@ -1,6 +1,15 @@
 @use "sass:map";
 @use "../../variables.scss" as variables;
 
+// This header sits directly above a list page's table, so it owns the vertical
+// rhythm: a small gap above and a larger gap below to separate it from the
+// table. Applying it on :host makes every list page inherit the same spacing
+// (the reporting and roles pages keep their own identical page-scoped rules).
+:host {
+  display: block;
+  margin: variables.$spacing-sm 0 variables.$spacing-lg;
+}
+
 .table-header__subtitle {
   color: map.get(variables.$accent-palette, 500);
   font-size: 14px;

--- a/desktop/src/shared-ui/table-header/table-header.component.scss
+++ b/desktop/src/shared-ui/table-header/table-header.component.scss
@@ -3,8 +3,8 @@
 
 // This header sits directly above a list page's table, so it owns the vertical
 // rhythm: a small gap above and a larger gap below to separate it from the
-// table. Applying it on :host makes every list page inherit the same spacing
-// (the reporting and roles pages keep their own identical page-scoped rules).
+// table. Keeping it on :host makes this the single source of that spacing, so
+// consuming pages never re-declare a margin around app-table-header.
 :host {
   display: block;
   margin: variables.$spacing-sm 0 variables.$spacing-lg;

--- a/desktop/src/system-settings/system-task-table/system-task-table.component.html
+++ b/desktop/src/system-settings/system-task-table/system-task-table.component.html
@@ -1,4 +1,7 @@
-<app-table-header headerText="System Tasks">
+<app-table-header
+  headerText="System Tasks"
+  subtitle="Review the background tasks the system has run and their results."
+>
   <app-button
     matButtonType="iconButton"
     icon="refresh"


### PR DESCRIPTION
## Summary
Standardizes vertical spacing for the table-header component by adding `:host` margin rules, and updates the system-task-table to include a subtitle. Also documents the spacing convention in CLAUDE.md to prevent pages from re-adding margins.

## Key Changes
- **table-header.component.scss**: Added `:host` block with `display: block` and margin (small gap above, larger gap below) to establish consistent vertical rhythm across all list pages
- **system-task-table.component.html**: Added subtitle to the table-header: "Review the background tasks the system has run and their results."
- **CLAUDE.md**: Updated documentation to clarify that table-header owns its own vertical rhythm and pages should not re-add margins around it

## Implementation Details
The `:host` margin approach ensures every list page (reporting, roles, system tasks, etc.) inherits the same spacing without requiring individual page-scoped rules. This centralizes the spacing logic in the shared component and reduces duplication across list pages.

https://claude.ai/code/session_01Jh9ueg4s6GhFivqcZZtuN3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the System Tasks table header to include additional guidance, prompting users to review background tasks and their results.

* **Style**
  * Standardized table header spacing and layout across list pages for a more consistent visual rhythm.
  * Removed page-specific spacing overrides so the table header manages its own vertical spacing.

* **Documentation**
  * Refreshed internal guidance for list-page header usage to match the updated spacing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->