### PR TITLE
Member isolation (presence privacy) for groups

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -653,10 +653,14 @@ dollars) — the truthful isolation guarantee wins.
   resolver used by **every group-scoped surface** and by settlement. `app.users.read` ⇒ unrestricted; a
   **non-isolated** group ⇒ unrestricted; an isolated group where the viewer holds a **`SeesAllMembers`**
   role ⇒ unrestricted; an isolated group where the viewer is a **plain member** ⇒ `{self} ∪` that group's
-  supervisors; a **non-member** ⇒ unrestricted (isolation only narrows for actual members — a non-member
-  is kept out by the membership/permission gate, mirroring the paid-by resolver). Not cached; a batch
-  spanning groups memoizes per group via `groupVisibilityResolver` / `visibleUserIdsByGroup` (the latter
-  resolves the AppData roster path in two queries total).
+  supervisors; a **non-member of an isolated group ⇒ `{self}` restricted** (an isolated roster must not
+  leak to a non-member reader — e.g. an `app.groups.read` holder hitting `GetGroupById` via
+  `OrAppPermissions` — who lacks the `app.users.read` directory exemption); a **non-member of a
+  non-isolated group ⇒ unrestricted** (open group, preserving the paid-by / reporting contract for
+  non-members, whose surfaces gate membership at the handler). `GetViewerGroupRow` LEFT-JOINs `groups` so
+  the isolate flag + membership are known even for a non-member. Not cached; a batch spanning groups
+  memoizes per group via `groupVisibilityResolver` / `visibleUserIdsByGroup` (the latter resolves the
+  AppData roster path in two queries total).
 - **`GetVisibleUserIdsForUser(viewerId)`** (the original UNION resolver, unchanged) is now used by
   **exactly one** surface: the flat `appData.users` directory (`FilterVisibleUserViews`). The union is
   mathematically the union of the per-group sets, so it already honors isolation (it never lists a peer
@@ -680,6 +684,11 @@ dollars) — the truthful isolation guarantee wins.
   not announced. `paid_by_user_id` is never masked (row visibility already guarantees a visible payer).
 - **Comments / activities (row drop)** — comments authored by a non-visible user are dropped;
   `GetActivitiesForGroups` drops rows whose `RanByUserId` is non-visible **in that activity's group**.
+  Activities are filtered **before count + pagination** (fetch unpaged → `filterActivitiesByVisibility` →
+  `paginateActivities` in Go), so `TotalCount` and the returned page both reflect only visible rows — a
+  restricted member cannot infer hidden-peer activity from the total. The comment-notification fan-out has
+  a **non-isolated fast path** (`recipientsWhoCannotSeeAuthor` reads the group's `isolate_members` once
+  and skips the roster fetch + per-member resolver loop when the group isn't isolated).
 - **Settlement** — `GetAmountOwedForUser` resolves visibility **per the receipt's group as it folds each
   item** into the counterparty balance map: a contribution counts only if the counterparty is visible in
   that receipt's group. So an isolated group contributes nothing about a hidden member even in the

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -640,67 +640,88 @@ is the **supervisor** exemption: its holders see every member of an isolated gro
 to every member. Both default `false`, so existing groups/roles/installs are unchanged (AutoMigrate adds
 the columns; no data migration).
 
-**Visible-set resolver.** `PermissionService.GetVisibleUserIdsForUser(viewerId)`
-(`services/member_visibility.go`) returns `(set, unrestricted, err)`. Invariants: **you always see
-yourself**; a holder of **`app.users.read` sees everyone** (unrestricted); membership in any
-non-isolated group — or an isolated group where the viewer holds a `SeesAllMembers` role — contributes
-all of that group's members; an isolated group where the viewer is a plain member contributes only that
-group's supervisors. **A viewer who is not an isolated (non-supervisor) member of any group returns
-`unrestricted == true`** — every filter below is then a no-op, which is exactly what preserves backward
-compatibility (non-isolated installs and every non-isolated member are byte-identical). Isolation only
-ever *narrows*. The resolver is NOT cached; callers resolve it once per request/batch (mirroring
-`PaidByListResolver`).
+**Isolation is resolved PER GROUP — "isolated means isolated."** Visibility is a function of
+**(viewer, group)**, never a union across the viewer's groups. Inside an isolated group you see only
+yourself + that group's supervisors, regardless of any other group you belong to. Co-members become
+visible **only** through a shared **non-isolated** group (open means open) — and even then only on that
+open group's own surfaces; the isolated group never leaks presence or settlement. This is deliberately
+allowed to leave a cross-group aggregate incomplete (a settlement/report total may omit a hidden group's
+dollars) — the truthful isolation guarantee wins.
 
-**Read enforcement — every surface a user identity can reach a client:**
-- **Directory + rosters** — `appData.users` and each group's `GroupMembers` are filtered to the
-  viewer's visible set at the **serialization boundary**: `services/auth.go` (AppData), the `GET /group/`
-  and `GET /group/{id}` handlers, and MCP `list_groups`. **Not** inside `GroupService.GetGroupsForUser` /
-  `UserRepository.GetAllUserViews` — those also feed internal accounting (`amount-owed`) and receipt
-  processing, which need the full roster.
-- **Receipts (row visibility)** — the visible set is intersected into the paid-by allowed set at the one
-  shared resolver (`services/paid_by_filter.go` `foldPaidByWithVisibility`), so a receipt whose
-  `paid_by_user_id` is non-visible disappears from every read surface at once (paged list, single GET,
+**Two resolvers** (`services/member_visibility.go`):
+- **`GetVisibleUserIdsForUserInGroup(viewerId, groupId)`** → `(set, unrestricted, err)` — the per-group
+  resolver used by **every group-scoped surface** and by settlement. `app.users.read` ⇒ unrestricted; a
+  **non-isolated** group ⇒ unrestricted; an isolated group where the viewer holds a **`SeesAllMembers`**
+  role ⇒ unrestricted; an isolated group where the viewer is a **plain member** ⇒ `{self} ∪` that group's
+  supervisors; a **non-member** ⇒ unrestricted (isolation only narrows for actual members — a non-member
+  is kept out by the membership/permission gate, mirroring the paid-by resolver). Not cached; a batch
+  spanning groups memoizes per group via `groupVisibilityResolver` / `visibleUserIdsByGroup` (the latter
+  resolves the AppData roster path in two queries total).
+- **`GetVisibleUserIdsForUser(viewerId)`** (the original UNION resolver, unchanged) is now used by
+  **exactly one** surface: the flat `appData.users` directory (`FilterVisibleUserViews`). The union is
+  mathematically the union of the per-group sets, so it already honors isolation (it never lists a peer
+  you share only an isolated group with) — it is the correct name-resolution table, since the roster
+  (`GroupMember`) carries only a `userId` and clients resolve the display name/avatar from this flat list.
+
+**Read enforcement — every surface a user identity can reach a client (all PER GROUP):**
+- **Directory** — `appData.users` uses the union resolver (above). **Rosters** — each group's
+  `GroupMembers` is filtered with **its own** per-group set at the serialization boundary
+  (`services/auth.go` AppData via `FilterGroupMembersForGroups`, the `GET /group/{id}` handler via
+  `FilterGroupMembersForGroup`, and MCP `list_groups`). **Not** inside `GroupService.GetGroupsForUser` /
+  `UserRepository.GetAllUserViews` — those also feed internal accounting and receipt processing.
+- **Receipts (row visibility)** — the per-group visible set is intersected into the paid-by allowed set
+  inside `paidByAllowedForGroup` (`services/paid_by_filter.go`), so a receipt whose `paid_by_user_id` is
+  non-visible **in its own group** disappears from every read surface at once (paged list, single GET,
   search, CSV export, duplicate, `GetReceiptsForGroupIds`, pie chart, report data).
-- **Field masking** — `services/member_masking.go` **nulls** user-reference fields whose id ∉ the visible
-  set: `BaseModel.CreatedBy`/`CreatedByString` on the receipt and every nested entity (items, linked
-  items, comments, custom-field values, image FileData), and item/linked-item `ChargedToUserId`. User
-  fields are nulled, **not** replaced with `(Restricted)` — presence must be hidden, not announced
-  (unlike category/tag grants). `paid_by_user_id` is never masked (row visibility already guarantees a
-  visible payer).
-- **Comments / activities (row drop)** — comments authored by a non-visible user are dropped from a
-  receipt payload; `GetActivitiesForGroups` drops rows whose `RanByUserId` is non-visible.
-- **Settlement** — `GetAmountOwedForUser` filters its per-user balance map to the visible set,
-  deliberately overriding the paid-by exemption for isolated viewers.
+- **Field masking** — `services/member_masking.go` resolves per `receipt.GroupId` (memoized across a
+  batch) and **nulls** user-reference fields whose id ∉ that receipt's group's visible set:
+  `BaseModel.CreatedBy`/`CreatedByString` on the receipt and every nested entity, and item/linked-item
+  `ChargedToUserId`. Fields are nulled, **not** replaced with `(Restricted)` — presence must be hidden,
+  not announced. `paid_by_user_id` is never masked (row visibility already guarantees a visible payer).
+- **Comments / activities (row drop)** — comments authored by a non-visible user are dropped;
+  `GetActivitiesForGroups` drops rows whose `RanByUserId` is non-visible **in that activity's group**.
+- **Settlement** — `GetAmountOwedForUser` resolves visibility **per the receipt's group as it folds each
+  item** into the counterparty balance map: a contribution counts only if the counterparty is visible in
+  that receipt's group. So an isolated group contributes nothing about a hidden member even in the
+  all-groups aggregate, while a shared open group contributes normally. This overrides the endpoint's
+  paid-by exemption for isolated viewers.
 - **Notifications** — the comment add/reply fan-out (`repositories/comments.go`, injected
-  `AuthorVisibilityResolver`) suppresses delivery to a recipient who can't see the comment author.
+  `AuthorVisibilityResolver func(authorId, recipientId, groupId)`) suppresses delivery to a recipient who
+  can't see the comment author in the receipt's group.
+- **Reporting + pie** — no dedicated code: reports read only through `ReportDataService.Rows` →
+  `PaidByListResolver` (per group), called once per group by `ReportService.loadRows`, so an isolated
+  group contributes only visible-payer receipts and an open group contributes everyone; the only
+  user-identity a report row exposes is `paid_by` (row-hidden, never masked).
 
-**Write-side guards (an isolated member must not expand their own visibility or plant a non-visible id):**
+**Write-side guards:**
 - **Receipt upsert** — `enforceReceiptMemberVisibilitySelection` rejects a `paidByUserId` or item
-  `chargedToUserId` outside the creator's visible set (403).
-- **Group-member invitation** — a non-supervisor/non-admin may only add users within their visible set:
-  inline in `GroupService.AuthorizeGroupMemberChanges` (update) and `AuthorizeAddedMembersVisibility`
-  (create). Without it an isolated member could add a guessed user id to a group they share and pull
-  that user into their own visible set.
+  `chargedToUserId` outside the creator's visible set **for the receipt's group** (403).
 - **Update preservation** — `enforceReceiptChargedToPreservation` blocks a restricted editor from saving
-  a receipt whose **stored** items are charged to a member they can't see: the wholesale item replace +
-  no stable item identity would silently drop the hidden charge (corrupting the split), so the edit is
-  rejected rather than lose data. **Known limitation** (same as item-level category/tag grants): letting
-  the edit proceed while preserving the hidden charge needs stable item identity — a separate change.
+  a receipt whose **stored** items are charged to a member they can't see in that group: the wholesale
+  item replace + no stable item identity would silently drop the hidden charge, so the edit is rejected
+  rather than lose data. **Known limitation** (same as item-level category/tag grants): preserving the
+  hidden charge needs stable item identity — a separate change.
+- **No member-invitation visibility guard.** Under per-group isolation, adding a user to a group never
+  widens visibility in any *other* group (and adding to an isolated group where the caller is a plain
+  member doesn't make the added user visible to the caller), so the old union-contamination attack is
+  gone. The dedicated member-visibility invite checks were **removed**; the GHSA-89mm CRUD-gate +
+  privilege-ceiling guard in `AuthorizeGroupMemberChanges` is untouched.
 
-**Operational invariant (not code-enforced):** a viewer's visibility is the UNION across their groups,
-so two isolated members must not also share a **non-isolated** group — someone who can see both (a
-supervisor/admin) could otherwise make them mutually visible through that open group. An isolated member
-cannot do this themselves (the invite guard blocks it).
+Co-members are visible only through a shared **non-isolated** group; an isolated group never leaks
+presence or settlement — no cross-group operational discipline is required (per-group makes a shared open
+group safe by design).
 
 **Persistence:** `isolateMembers` rides `UpsertGroupCommand` → `CreateGroup`/`UpdateGroup` (the update
 uses an explicit `Update("isolate_members", …)` so a toggle-off past the association `Omit` sticks);
 `seesAllMembers` rides `UpsertRoleCommand` → `CreateGroupRole`/`UpdateGroupRole` and is surfaced on
 `RoleView`, group scope only (mirroring `includeOwnPaidReceipts`). Both are on `swagger.yml`.
 
-**Tests:** `services/member_visibility_test.go` (resolver matrix + invite guard),
-`services/member_isolation_receipt_test.go`, `handlers/receipt_member_isolation_test.go`,
-`handlers/receipt_charge_preservation_test.go`, `handlers/system_task_test.go`, `handlers/users_test.go`
-(amount-owed), `services/member_visibility_notifications_test.go`, plus persistence round-trips in
+**Tests:** `services/member_visibility_test.go` (union + per-group resolver matrix, incl. the headline
+"open-group peer hidden inside the isolated group"), `services/member_isolation_receipt_test.go`,
+`services/report_data_test.go` (reporting isolation), `handlers/receipt_member_isolation_test.go`,
+`handlers/receipt_charge_preservation_test.go`, `handlers/system_task_test.go` (per-group activity drop),
+`handlers/users_test.go` (settlement incl. the cross-group isolated/open case),
+`services/member_visibility_notifications_test.go`, plus persistence round-trips in
 `repositories/groups_test.go` / `repositories/roles_grants_test.go` / `services/roles_test.go` /
 `commands/upsert_role_command_test.go`.
 

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -631,6 +631,79 @@ above); no dedicated data migration is needed, and
 upgrade path. Tests: `handlers/group_member_authorization_test.go` (the PoC + happy paths) and
 `services/group_member_authorization_test.go` (the guard's CRUD/ceiling matrix).
 
+### Member isolation (presence privacy)
+
+A group can be flagged **`IsolateMembers`** (`models.Group`): within it, a member cannot discover that
+other members exist — not through the user directory, the group roster, receipts, comments, activities,
+settlement, or notifications. A group role flagged **`SeesAllMembers`** (`models.GroupRoleDefinition`)
+is the **supervisor** exemption: its holders see every member of an isolated group **and** are visible
+to every member. Both default `false`, so existing groups/roles/installs are unchanged (AutoMigrate adds
+the columns; no data migration).
+
+**Visible-set resolver.** `PermissionService.GetVisibleUserIdsForUser(viewerId)`
+(`services/member_visibility.go`) returns `(set, unrestricted, err)`. Invariants: **you always see
+yourself**; a holder of **`app.users.read` sees everyone** (unrestricted); membership in any
+non-isolated group — or an isolated group where the viewer holds a `SeesAllMembers` role — contributes
+all of that group's members; an isolated group where the viewer is a plain member contributes only that
+group's supervisors. **A viewer who is not an isolated (non-supervisor) member of any group returns
+`unrestricted == true`** — every filter below is then a no-op, which is exactly what preserves backward
+compatibility (non-isolated installs and every non-isolated member are byte-identical). Isolation only
+ever *narrows*. The resolver is NOT cached; callers resolve it once per request/batch (mirroring
+`PaidByListResolver`).
+
+**Read enforcement — every surface a user identity can reach a client:**
+- **Directory + rosters** — `appData.users` and each group's `GroupMembers` are filtered to the
+  viewer's visible set at the **serialization boundary**: `services/auth.go` (AppData), the `GET /group/`
+  and `GET /group/{id}` handlers, and MCP `list_groups`. **Not** inside `GroupService.GetGroupsForUser` /
+  `UserRepository.GetAllUserViews` — those also feed internal accounting (`amount-owed`) and receipt
+  processing, which need the full roster.
+- **Receipts (row visibility)** — the visible set is intersected into the paid-by allowed set at the one
+  shared resolver (`services/paid_by_filter.go` `foldPaidByWithVisibility`), so a receipt whose
+  `paid_by_user_id` is non-visible disappears from every read surface at once (paged list, single GET,
+  search, CSV export, duplicate, `GetReceiptsForGroupIds`, pie chart, report data).
+- **Field masking** — `services/member_masking.go` **nulls** user-reference fields whose id ∉ the visible
+  set: `BaseModel.CreatedBy`/`CreatedByString` on the receipt and every nested entity (items, linked
+  items, comments, custom-field values, image FileData), and item/linked-item `ChargedToUserId`. User
+  fields are nulled, **not** replaced with `(Restricted)` — presence must be hidden, not announced
+  (unlike category/tag grants). `paid_by_user_id` is never masked (row visibility already guarantees a
+  visible payer).
+- **Comments / activities (row drop)** — comments authored by a non-visible user are dropped from a
+  receipt payload; `GetActivitiesForGroups` drops rows whose `RanByUserId` is non-visible.
+- **Settlement** — `GetAmountOwedForUser` filters its per-user balance map to the visible set,
+  deliberately overriding the paid-by exemption for isolated viewers.
+- **Notifications** — the comment add/reply fan-out (`repositories/comments.go`, injected
+  `AuthorVisibilityResolver`) suppresses delivery to a recipient who can't see the comment author.
+
+**Write-side guards (an isolated member must not expand their own visibility or plant a non-visible id):**
+- **Receipt upsert** — `enforceReceiptMemberVisibilitySelection` rejects a `paidByUserId` or item
+  `chargedToUserId` outside the creator's visible set (403).
+- **Group-member invitation** — a non-supervisor/non-admin may only add users within their visible set:
+  inline in `GroupService.AuthorizeGroupMemberChanges` (update) and `AuthorizeAddedMembersVisibility`
+  (create). Without it an isolated member could add a guessed user id to a group they share and pull
+  that user into their own visible set.
+- **Update preservation** — `enforceReceiptChargedToPreservation` blocks a restricted editor from saving
+  a receipt whose **stored** items are charged to a member they can't see: the wholesale item replace +
+  no stable item identity would silently drop the hidden charge (corrupting the split), so the edit is
+  rejected rather than lose data. **Known limitation** (same as item-level category/tag grants): letting
+  the edit proceed while preserving the hidden charge needs stable item identity — a separate change.
+
+**Operational invariant (not code-enforced):** a viewer's visibility is the UNION across their groups,
+so two isolated members must not also share a **non-isolated** group — someone who can see both (a
+supervisor/admin) could otherwise make them mutually visible through that open group. An isolated member
+cannot do this themselves (the invite guard blocks it).
+
+**Persistence:** `isolateMembers` rides `UpsertGroupCommand` → `CreateGroup`/`UpdateGroup` (the update
+uses an explicit `Update("isolate_members", …)` so a toggle-off past the association `Omit` sticks);
+`seesAllMembers` rides `UpsertRoleCommand` → `CreateGroupRole`/`UpdateGroupRole` and is surfaced on
+`RoleView`, group scope only (mirroring `includeOwnPaidReceipts`). Both are on `swagger.yml`.
+
+**Tests:** `services/member_visibility_test.go` (resolver matrix + invite guard),
+`services/member_isolation_receipt_test.go`, `handlers/receipt_member_isolation_test.go`,
+`handlers/receipt_charge_preservation_test.go`, `handlers/system_task_test.go`, `handlers/users_test.go`
+(amount-owed), `services/member_visibility_notifications_test.go`, plus persistence round-trips in
+`repositories/groups_test.go` / `repositories/roles_grants_test.go` / `services/roles_test.go` /
+`commands/upsert_role_command_test.go`.
+
 ### Enforcement status
 
 Authorization is enforced centrally in `HandleRequest` (`handlers/generic_handler.go`) via the

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -684,9 +684,12 @@ dollars) — the truthful isolation guarantee wins.
   not announced. `paid_by_user_id` is never masked (row visibility already guarantees a visible payer).
 - **Comments / activities (row drop)** — comments authored by a non-visible user are dropped;
   `GetActivitiesForGroups` drops rows whose `RanByUserId` is non-visible **in that activity's group**.
-  Activities are filtered **before count + pagination** (fetch unpaged → `filterActivitiesByVisibility` →
-  `paginateActivities` in Go), so `TotalCount` and the returned page both reflect only visible rows — a
-  restricted member cannot infer hidden-peer activity from the total. The comment-notification fan-out has
+  Activity visibility is filtered **in the SQL query, before `COUNT`/`LIMIT`**, via
+  `applyActivityVisibilityDisjunction` (`repositories/system_task.go`) — a per-group disjunction mirroring
+  `ReceiptRepository.ApplyPaidByDisjunction`, fed by `PermissionService.ActivityVisibilityResolver`
+  (the activity analogue of `PaidByListResolver`). So `TotalCount` and the returned page both reflect only
+  visible rows with DB-side `LIMIT/OFFSET` preserved — a restricted member cannot infer hidden-peer
+  activity from the total, and there is no unpaged in-memory fetch. The comment-notification fan-out has
   a **non-isolated fast path** (`recipientsWhoCannotSeeAuthor` reads the group's `isolate_members` once
   and skips the roster fetch + per-member resolver loop when the group isn't isolated).
 - **Settlement** — `GetAmountOwedForUser` resolves visibility **per the receipt's group as it folds each

--- a/api/internal/commands/upsert_group_command.go
+++ b/api/internal/commands/upsert_group_command.go
@@ -14,6 +14,9 @@ type UpsertGroupCommand struct {
 	Status         models.GroupStatus         `gorm:"default:'ACTIVE'; not null" json:"status"`
 	IsAllGroup     bool                       `json:"isAllGroup" gorm:"default:false"`
 	IsDefaultGroup bool                       `json:"isDefault"`
+	// IsolateMembers turns on member-presence isolation for the group. Default
+	// false ⇒ existing groups behave exactly as before.
+	IsolateMembers bool `json:"isolateMembers"`
 }
 
 func (command *UpsertGroupCommand) LoadDataFromRequest(w http.ResponseWriter, r *http.Request) error {

--- a/api/internal/commands/upsert_role_command.go
+++ b/api/internal/commands/upsert_role_command.go
@@ -30,6 +30,11 @@ type UpsertRoleCommand struct {
 	// therefore hides the member's own receipts too.
 	PaidByUserGrants       []uint `json:"paidByUserGrants"`
 	IncludeOwnPaidReceipts bool   `json:"includeOwnPaidReceipts"`
+	// SeesAllMembers is the "supervisor" exemption for member-presence isolation:
+	// holders of this group role see every member of an isolated group and are
+	// visible to every member. Group-scoped only; ignored (rejected) on APP scope,
+	// mirroring the paid-by flags. Default false ⇒ no effect on existing roles.
+	SeesAllMembers bool `json:"seesAllMembers"`
 	// ReportTemplateGrants restrict which report templates members of a group role
 	// may act on, per action. Group-scoped only and opt-in: an empty set means
 	// unrestricted (act on every template the role's group access reaches). Each
@@ -103,12 +108,14 @@ func (command *UpsertRoleCommand) Validate() structs.ValidatorError {
 		}
 	}
 
-	// Category/tag/paid-by grants are a group-role concept (they slice the global
-	// pool / narrow visibility per group role); they make no sense on an app role.
+	// Category/tag/paid-by grants and member-visibility settings are a group-role
+	// concept (they slice the global pool / narrow visibility per group role); they
+	// make no sense on an app role.
 	if command.Scope == permissions.ScopeApp &&
 		(len(command.CategoryGrants) > 0 || len(command.TagGrants) > 0 ||
-			len(command.PaidByUserGrants) > 0 || command.IncludeOwnPaidReceipts) {
-		errors["grants"] = "Category, tag, and paid-by grants are only valid on group roles"
+			len(command.PaidByUserGrants) > 0 || command.IncludeOwnPaidReceipts ||
+			command.SeesAllMembers) {
+		errors["grants"] = "Category, tag, paid-by, and member-visibility settings are only valid on group roles"
 	}
 
 	if hasDuplicateUint(command.CategoryGrants) {

--- a/api/internal/commands/upsert_role_command_test.go
+++ b/api/internal/commands/upsert_role_command_test.go
@@ -197,6 +197,34 @@ func TestUpsertRoleCommandIncludeOwnRejectedOnAppScope(t *testing.T) {
 	}
 }
 
+func TestUpsertRoleCommandSeesAllMembersValidOnGroupScope(t *testing.T) {
+	command := UpsertRoleCommand{
+		Name:           "Supervisor Group Role",
+		Scope:          permissions.ScopeGroup,
+		Permissions:    []string{permissions.GroupReceiptsRead},
+		SeesAllMembers: true,
+	}
+
+	vErr := command.Validate()
+	if len(vErr.Errors) > 0 {
+		t.Errorf("expected no errors, got %+v", vErr.Errors)
+	}
+}
+
+func TestUpsertRoleCommandSeesAllMembersRejectedOnAppScope(t *testing.T) {
+	command := UpsertRoleCommand{
+		Name:           "App Role With SeesAll",
+		Scope:          permissions.ScopeApp,
+		Permissions:    []string{permissions.AppUsersRead},
+		SeesAllMembers: true,
+	}
+
+	vErr := command.Validate()
+	if _, ok := vErr.Errors["grants"]; !ok {
+		t.Errorf("expected grants error, got %+v", vErr.Errors)
+	}
+}
+
 func TestUpsertRoleCommandDuplicatePaidByGrant(t *testing.T) {
 	command := UpsertRoleCommand{
 		Name:             "Dup Paid-By Grant",

--- a/api/internal/handlers/auth_test_helpers_test.go
+++ b/api/internal/handlers/auth_test_helpers_test.go
@@ -59,7 +59,7 @@ func grantGroupPerms(t *testing.T, userId uint, groupId uint, perms ...string) {
 	db := repositories.GetDB()
 
 	roleRepository := repositories.NewRoleRepository(nil)
-	role, err := roleRepository.CreateGroupRole(fmt.Sprintf("Test Group Role %d-%d", userId, groupId), "", perms, nil, nil, nil, false)
+	role, err := roleRepository.CreateGroupRole(fmt.Sprintf("Test Group Role %d-%d", userId, groupId), "", perms, nil, nil, nil, false, false)
 	if err != nil {
 		t.Fatalf("create group role: %v", err)
 	}
@@ -89,4 +89,31 @@ func grantAllAppPerms(t *testing.T, userId uint) {
 func grantAllGroupPerms(t *testing.T, userId uint, groupId uint) {
 	t.Helper()
 	grantGroupPerms(t, userId, groupId, permissions.LegacyGroupOwnerKeys()...)
+}
+
+// isolateGroupWithSupervisor turns on member-presence isolation for groupId and
+// assigns supervisorUserId a SeesAllMembers group role in it (so they remain
+// visible to isolated members). Members without such a role become mutually
+// invisible. Assumes the membership rows already exist.
+func isolateGroupWithSupervisor(t *testing.T, groupId uint, supervisorUserId uint) {
+	t.Helper()
+	services.ClearRolePermissionCacheForTests()
+	services.ClearGroupRoleGrantCacheForTests()
+	db := repositories.GetDB()
+
+	if err := db.Model(&models.Group{}).Where("id = ?", groupId).Update("isolate_members", true).Error; err != nil {
+		t.Fatalf("isolate group: %v", err)
+	}
+
+	supRole, err := repositories.NewRoleRepository(nil).CreateGroupRole(
+		fmt.Sprintf("Iso Supervisor %d-%d", groupId, supervisorUserId), "",
+		[]string{permissions.GroupReceiptsRead}, nil, nil, nil, false, true)
+	if err != nil {
+		t.Fatalf("create supervisor role: %v", err)
+	}
+	if err := db.Model(&models.GroupMember{}).
+		Where("user_id = ? AND group_id = ?", supervisorUserId, groupId).
+		Update("group_role_id", supRole.ID).Error; err != nil {
+		t.Fatalf("assign supervisor role: %v", err)
+	}
 }

--- a/api/internal/handlers/comments.go
+++ b/api/internal/handlers/comments.go
@@ -43,12 +43,13 @@ func AddComment(w http.ResponseWriter, r *http.Request) {
 		HandlerFunction: func(w http.ResponseWriter, r *http.Request) (int, error) {
 			commentRepository := repositories.NewCommentRepository(nil)
 
-			// Member isolation: a recipient who may not see the comment author must
-			// not receive an author-revealing notification. Resolve visibility from
-			// the recipient's side; unrestricted recipients always receive.
+			// Member isolation: a recipient who may not see the comment author IN THE
+			// RECEIPT'S GROUP must not receive an author-revealing notification.
+			// Resolve visibility per group from the recipient's side; unrestricted
+			// recipients always receive.
 			permissionService := services.NewPermissionService(nil)
-			authorVisibleTo := func(authorId uint, recipientId uint) (bool, error) {
-				visibleUserIds, unrestricted, err := permissionService.GetVisibleUserIdsForUser(recipientId)
+			authorVisibleTo := func(authorId uint, recipientId uint, groupId uint) (bool, error) {
+				visibleUserIds, unrestricted, err := permissionService.GetVisibleUserIdsForUserInGroup(recipientId, groupId)
 				if err != nil {
 					return false, err
 				}

--- a/api/internal/handlers/comments.go
+++ b/api/internal/handlers/comments.go
@@ -7,6 +7,7 @@ import (
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/permissions"
 	"receipt-wrangler/api/internal/repositories"
+	"receipt-wrangler/api/internal/services"
 	"receipt-wrangler/api/internal/structs"
 	"receipt-wrangler/api/internal/utils"
 
@@ -42,7 +43,23 @@ func AddComment(w http.ResponseWriter, r *http.Request) {
 		HandlerFunction: func(w http.ResponseWriter, r *http.Request) (int, error) {
 			commentRepository := repositories.NewCommentRepository(nil)
 
-			comment, err := commentRepository.AddComment(upsertCommentCommand)
+			// Member isolation: a recipient who may not see the comment author must
+			// not receive an author-revealing notification. Resolve visibility from
+			// the recipient's side; unrestricted recipients always receive.
+			permissionService := services.NewPermissionService(nil)
+			authorVisibleTo := func(authorId uint, recipientId uint) (bool, error) {
+				visibleUserIds, unrestricted, err := permissionService.GetVisibleUserIdsForUser(recipientId)
+				if err != nil {
+					return false, err
+				}
+				if unrestricted {
+					return true, nil
+				}
+				_, ok := visibleUserIds[authorId]
+				return ok, nil
+			}
+
+			comment, err := commentRepository.AddComment(upsertCommentCommand, authorVisibleTo)
 			if err != nil {
 				return http.StatusInternalServerError, err
 			}

--- a/api/internal/handlers/export.go
+++ b/api/internal/handlers/export.go
@@ -65,6 +65,13 @@ func ExportAllReceiptsFromGroup(w http.ResponseWriter, r *http.Request) {
 				return http.StatusInternalServerError, err
 			}
 
+			// Mask user references (created-by, item charged-to) the caller may
+			// not see before they are rendered into the CSV.
+			err = permissionService.MaskReceiptsForMemberVisibility(token.UserId, receipts)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
 			receiptCsvService := services.NewReceiptCsvService()
 			zip, err := receiptCsvService.GetZippedCsvFiles(receipts)
 			if err != nil {
@@ -105,7 +112,15 @@ func ExportReceiptsById(w http.ResponseWriter, r *http.Request) {
 				return http.StatusInternalServerError, err
 			}
 
-			err = services.NewPermissionService(nil).FilterReceiptCategoriesTags(token.UserId, receipts)
+			permissionService := services.NewPermissionService(nil)
+			err = permissionService.FilterReceiptCategoriesTags(token.UserId, receipts)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			// Mask user references (created-by, item charged-to) the caller may
+			// not see before they are rendered into the CSV.
+			err = permissionService.MaskReceiptsForMemberVisibility(token.UserId, receipts)
 			if err != nil {
 				return http.StatusInternalServerError, err
 			}

--- a/api/internal/handlers/groups.go
+++ b/api/internal/handlers/groups.go
@@ -125,6 +125,13 @@ func GetGroupsForUser(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 
+			// Member-presence isolation: strip each roster to the members the
+			// caller may see (no-op for unrestricted viewers).
+			permissionService := services.NewPermissionService(nil)
+			if err := permissionService.FilterGroupMembersForGroups(token.UserId, groups); err != nil {
+				return http.StatusInternalServerError, err
+			}
+
 			bytes, err := utils.MarshalResponseData(groups)
 			if err != nil {
 				return http.StatusInternalServerError, err
@@ -155,6 +162,14 @@ func GetGroupById(w http.ResponseWriter, r *http.Request) {
 			groupRepository := repositories.NewGroupRepository(nil)
 			groups, err := groupRepository.GetGroupById(id, true, true, true)
 			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			// Member-presence isolation: strip the roster to the members the caller
+			// may see (no-op for unrestricted viewers).
+			token := structs.GetClaims(r)
+			permissionService := services.NewPermissionService(nil)
+			if err := permissionService.FilterGroupMembersForGroup(token.UserId, &groups); err != nil {
 				return http.StatusInternalServerError, err
 			}
 
@@ -194,6 +209,16 @@ func CreateGroup(w http.ResponseWriter, r *http.Request) {
 			}
 
 			token := structs.GetClaims(r)
+
+			// Member-presence isolation: an isolated creator may only add members
+			// they can already see (no-op for unrestricted callers).
+			groupService := services.NewGroupService(nil)
+			if err := groupService.AuthorizeAddedMembersVisibility(token.UserId, command.GroupMembers); err != nil {
+				if errors.Is(err, services.ErrGroupMemberChangeForbidden) {
+					return http.StatusForbidden, err
+				}
+				return http.StatusInternalServerError, err
+			}
 
 			command.IsAllGroup = false
 			groupRepository := repositories.NewGroupRepository(nil)

--- a/api/internal/handlers/groups.go
+++ b/api/internal/handlers/groups.go
@@ -210,16 +210,6 @@ func CreateGroup(w http.ResponseWriter, r *http.Request) {
 
 			token := structs.GetClaims(r)
 
-			// Member-presence isolation: an isolated creator may only add members
-			// they can already see (no-op for unrestricted callers).
-			groupService := services.NewGroupService(nil)
-			if err := groupService.AuthorizeAddedMembersVisibility(token.UserId, command.GroupMembers); err != nil {
-				if errors.Is(err, services.ErrGroupMemberChangeForbidden) {
-					return http.StatusForbidden, err
-				}
-				return http.StatusInternalServerError, err
-			}
-
 			command.IsAllGroup = false
 			groupRepository := repositories.NewGroupRepository(nil)
 			group, err := groupRepository.CreateGroup(command, token.UserId)

--- a/api/internal/handlers/receipt_charge_preservation_test.go
+++ b/api/internal/handlers/receipt_charge_preservation_test.go
@@ -1,0 +1,82 @@
+package handlers
+
+import (
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/repositories"
+	"receipt-wrangler/api/internal/services"
+	"testing"
+)
+
+// An isolated editor may not save a receipt whose stored items are charged to a
+// member they cannot see (the wholesale item replace would silently drop the
+// charge). Visible charges and unrestricted callers are unaffected.
+func TestEnforceReceiptChargedToPreservation(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	services.ClearRolePermissionCacheForTests()
+
+	db := repositories.GetDB()
+
+	group := models.Group{Name: "iso-preserve", IsolateMembers: true}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("seed group: %v", err)
+	}
+	supRole := models.GroupRoleDefinition{Name: "iso-preserve-sup", SeesAllMembers: true}
+	memRole := models.GroupRoleDefinition{Name: "iso-preserve-mem", SeesAllMembers: false}
+	if err := db.Create(&supRole).Error; err != nil {
+		t.Fatalf("seed sup role: %v", err)
+	}
+	if err := db.Create(&memRole).Error; err != nil {
+		t.Fatalf("seed mem role: %v", err)
+	}
+
+	a := models.User{Username: "iso-pres-a", Password: "x"}
+	coord := models.User{Username: "iso-pres-coord", Password: "x"}
+	b := models.User{Username: "iso-pres-b", Password: "x"}
+	for _, user := range []*models.User{&a, &coord, &b} {
+		if err := db.Create(user).Error; err != nil {
+			t.Fatalf("seed user: %v", err)
+		}
+	}
+	members := []models.GroupMember{
+		{GroupID: group.ID, UserID: a.ID, GroupRoleID: &memRole.ID},
+		{GroupID: group.ID, UserID: coord.ID, GroupRoleID: &supRole.ID},
+		{GroupID: group.ID, UserID: b.ID, GroupRoleID: &memRole.ID},
+	}
+	for i := range members {
+		if err := db.Create(&members[i]).Error; err != nil {
+			t.Fatalf("seed member: %v", err)
+		}
+	}
+
+	// A stored item charged to B (non-visible peer) → editing is blocked for A.
+	chargedToB := models.Receipt{ReceiptItems: []models.Item{{ChargedToUserId: &b.ID}}}
+	allowed, message, err := enforceReceiptChargedToPreservation(a.ID, chargedToB)
+	if err != nil {
+		t.Fatalf("preservation check errored: %v", err)
+	}
+	if allowed {
+		t.Fatalf("expected the edit to be blocked when a stored item is charged to a non-visible member")
+	}
+	if message == "" {
+		t.Fatalf("expected a non-empty deny message")
+	}
+
+	// A stored item charged to the coordinator (visible) → allowed.
+	chargedToCoord := models.Receipt{ReceiptItems: []models.Item{{ChargedToUserId: &coord.ID}}}
+	allowed, _, err = enforceReceiptChargedToPreservation(a.ID, chargedToCoord)
+	if err != nil {
+		t.Fatalf("preservation check errored: %v", err)
+	}
+	if !allowed {
+		t.Fatalf("a charge to a visible member should be allowed")
+	}
+
+	// The supervisor is unrestricted → always allowed, even for the B charge.
+	allowed, _, err = enforceReceiptChargedToPreservation(coord.ID, chargedToB)
+	if err != nil {
+		t.Fatalf("preservation check errored: %v", err)
+	}
+	if !allowed {
+		t.Fatalf("an unrestricted caller should never be blocked")
+	}
+}

--- a/api/internal/handlers/receipt_charge_preservation_test.go
+++ b/api/internal/handlers/receipt_charge_preservation_test.go
@@ -49,7 +49,7 @@ func TestEnforceReceiptChargedToPreservation(t *testing.T) {
 	}
 
 	// A stored item charged to B (non-visible peer) → editing is blocked for A.
-	chargedToB := models.Receipt{ReceiptItems: []models.Item{{ChargedToUserId: &b.ID}}}
+	chargedToB := models.Receipt{GroupId: group.ID, ReceiptItems: []models.Item{{ChargedToUserId: &b.ID}}}
 	allowed, message, err := enforceReceiptChargedToPreservation(a.ID, chargedToB)
 	if err != nil {
 		t.Fatalf("preservation check errored: %v", err)
@@ -62,7 +62,7 @@ func TestEnforceReceiptChargedToPreservation(t *testing.T) {
 	}
 
 	// A stored item charged to the coordinator (visible) → allowed.
-	chargedToCoord := models.Receipt{ReceiptItems: []models.Item{{ChargedToUserId: &coord.ID}}}
+	chargedToCoord := models.Receipt{GroupId: group.ID, ReceiptItems: []models.Item{{ChargedToUserId: &coord.ID}}}
 	allowed, _, err = enforceReceiptChargedToPreservation(a.ID, chargedToCoord)
 	if err != nil {
 		t.Fatalf("preservation check errored: %v", err)

--- a/api/internal/handlers/receipt_grant_enforcement.go
+++ b/api/internal/handlers/receipt_grant_enforcement.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"receipt-wrangler/api/internal/commands"
+	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/permissions"
 	"receipt-wrangler/api/internal/services"
 )
@@ -46,6 +47,90 @@ func enforceReceiptGrantSelection(userId uint, groupId uint, command commands.Up
 	}
 
 	return true, "", nil
+}
+
+// enforceReceiptMemberVisibilitySelection checks that every user id a receipt upsert
+// plants — the payer (paidByUserId) and each item/linked-item chargedToUserId — is
+// within the creator's member-visible set, so an isolated member cannot attach a user
+// they may not see (which would leak that user's presence, or hand them a
+// receipt/charge). It mirrors enforceReceiptGrantSelection: returns (allowed,
+// denyMessage, error), and the caller responds 403 with denyMessage when not allowed.
+// No-op when the creator is unrestricted.
+func enforceReceiptMemberVisibilitySelection(userId uint, command commands.UpsertReceiptCommand) (bool, string, error) {
+	permissionService := services.NewPermissionService(nil)
+
+	chargedToUserIds := collectReceiptChargedToUserIds(command)
+
+	ok, err := permissionService.ValidateReceiptUserSelection(userId, command.PaidByUserID, chargedToUserIds)
+	if err != nil {
+		return false, "", err
+	}
+	if !ok {
+		return false, "You do not have access to one or more selected users", nil
+	}
+
+	return true, "", nil
+}
+
+// enforceReceiptChargedToPreservation blocks an isolated editor from updating a
+// receipt whose STORED items are charged to a user they cannot see. Because the
+// update replaces items wholesale and item commands carry no stable id, the hidden
+// charge (masked to unset when the editor read the receipt) would be silently
+// dropped on save — corrupting the split. Rather than lose the charge we reject the
+// edit and tell the caller to route it through someone with full access. No-op when
+// the editor is unrestricted. (Letting the edit proceed while preserving the hidden
+// charge needs stable item identity — a separate, larger change.) Returns
+// (allowed, denyMessage, error).
+func enforceReceiptChargedToPreservation(userId uint, current models.Receipt) (bool, string, error) {
+	permissionService := services.NewPermissionService(nil)
+
+	visible, unrestricted, err := permissionService.GetVisibleUserIdsForUser(userId)
+	if err != nil {
+		return false, "", err
+	}
+	if unrestricted {
+		return true, "", nil
+	}
+
+	hidden := func(chargedTo *uint) bool {
+		if chargedTo == nil || *chargedTo == 0 || *chargedTo == userId {
+			return false
+		}
+		_, ok := visible[*chargedTo]
+		return !ok
+	}
+
+	for _, item := range current.ReceiptItems {
+		if hidden(item.ChargedToUserId) {
+			return false, receiptHiddenChargeMessage, nil
+		}
+		for _, linkedItem := range item.LinkedItems {
+			if hidden(linkedItem.ChargedToUserId) {
+				return false, receiptHiddenChargeMessage, nil
+			}
+		}
+	}
+
+	return true, "", nil
+}
+
+const receiptHiddenChargeMessage = "This receipt includes a charge to a member you do not have access to and cannot be edited here. Ask an administrator or a member with full access to edit it."
+
+// collectReceiptChargedToUserIds walks a receipt command's items and linked items and
+// returns every charged-to user id referenced (skipping unset/zero ids).
+func collectReceiptChargedToUserIds(command commands.UpsertReceiptCommand) []uint {
+	var ids []uint
+	for _, item := range command.Items {
+		if item.ChargedToUserId != nil && *item.ChargedToUserId != 0 {
+			ids = append(ids, *item.ChargedToUserId)
+		}
+		for _, linkedItem := range item.LinkedItems {
+			if linkedItem.ChargedToUserId != nil && *linkedItem.ChargedToUserId != 0 {
+				ids = append(ids, *linkedItem.ChargedToUserId)
+			}
+		}
+	}
+	return ids
 }
 
 // enforceQuickScanGrantSelection checks a quick-scan command's per-file category/tag

--- a/api/internal/handlers/receipt_grant_enforcement.go
+++ b/api/internal/handlers/receipt_grant_enforcement.go
@@ -51,17 +51,17 @@ func enforceReceiptGrantSelection(userId uint, groupId uint, command commands.Up
 
 // enforceReceiptMemberVisibilitySelection checks that every user id a receipt upsert
 // plants — the payer (paidByUserId) and each item/linked-item chargedToUserId — is
-// within the creator's member-visible set, so an isolated member cannot attach a user
-// they may not see (which would leak that user's presence, or hand them a
-// receipt/charge). It mirrors enforceReceiptGrantSelection: returns (allowed,
-// denyMessage, error), and the caller responds 403 with denyMessage when not allowed.
-// No-op when the creator is unrestricted.
-func enforceReceiptMemberVisibilitySelection(userId uint, command commands.UpsertReceiptCommand) (bool, string, error) {
+// within the creator's member-visible set FOR THE RECEIPT'S GROUP, so an isolated member
+// cannot attach a user they may not see in that group (which would leak that user's
+// presence, or hand them a receipt/charge). It mirrors enforceReceiptGrantSelection:
+// returns (allowed, denyMessage, error), and the caller responds 403 with denyMessage
+// when not allowed. No-op when the creator is unrestricted in that group.
+func enforceReceiptMemberVisibilitySelection(userId uint, groupId uint, command commands.UpsertReceiptCommand) (bool, string, error) {
 	permissionService := services.NewPermissionService(nil)
 
 	chargedToUserIds := collectReceiptChargedToUserIds(command)
 
-	ok, err := permissionService.ValidateReceiptUserSelection(userId, command.PaidByUserID, chargedToUserIds)
+	ok, err := permissionService.ValidateReceiptUserSelection(userId, groupId, command.PaidByUserID, chargedToUserIds)
 	if err != nil {
 		return false, "", err
 	}
@@ -84,7 +84,7 @@ func enforceReceiptMemberVisibilitySelection(userId uint, command commands.Upser
 func enforceReceiptChargedToPreservation(userId uint, current models.Receipt) (bool, string, error) {
 	permissionService := services.NewPermissionService(nil)
 
-	visible, unrestricted, err := permissionService.GetVisibleUserIdsForUser(userId)
+	visible, unrestricted, err := permissionService.GetVisibleUserIdsForUserInGroup(userId, current.GroupId)
 	if err != nil {
 		return false, "", err
 	}

--- a/api/internal/handlers/receipt_grant_enforcement_test.go
+++ b/api/internal/handlers/receipt_grant_enforcement_test.go
@@ -55,7 +55,7 @@ func seedRestrictedReceiptCreatorWithGrants(t *testing.T, categoryGrantIds []uin
 		categoryGrantIds,
 		tagGrantIds,
 		nil,
-		false,
+		false, false,
 	)
 	if err != nil {
 		t.Fatalf("seed group role: %v", err)
@@ -100,7 +100,7 @@ func seedRestrictedQuickScanner(t *testing.T, categoryGrantIds []uint) (uint, ui
 		categoryGrantIds,
 		nil,
 		nil,
-		false,
+		false, false,
 	)
 	if err != nil {
 		t.Fatalf("seed group role: %v", err)

--- a/api/internal/handlers/receipt_member_isolation_test.go
+++ b/api/internal/handlers/receipt_member_isolation_test.go
@@ -291,3 +291,52 @@ func TestMemberIsolationBackwardCompatNonIsolatedGroupSeesEverything(t *testing.
 		utils.PrintTestError(t, w.Result().StatusCode, 200)
 	}
 }
+
+// GetGroupById permits a non-member through OrAppPermissions:[app.groups.read]. Such a
+// reader must NOT receive an isolated group's roster unless they also hold the
+// app.users.read directory exemption.
+func TestMemberIsolationGetGroupByIdHidesRosterFromNonMemberAppGroupsReader(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	fx := seedIsolatedReceiptGroupHandler(t, true)
+
+	callGetGroupById := func(userId uint) []uint {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "/api", nil)
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("groupId", utils.UintToString(fx.groupId))
+		r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+		r = r.WithContext(context.WithValue(r.Context(), jwtmiddleware.ContextKey{}, claimsForUser(userId)))
+		GetGroupById(w, r)
+		if w.Result().StatusCode != http.StatusOK {
+			t.Fatalf("GetGroupById status = %d, want 200", w.Result().StatusCode)
+		}
+		var group struct {
+			GroupMembers []struct {
+				UserID uint `json:"userId"`
+			} `json:"groupMembers"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &group); err != nil {
+			t.Fatalf("unmarshal group: %v", err)
+		}
+		ids := make([]uint, 0, len(group.GroupMembers))
+		for _, m := range group.GroupMembers {
+			ids = append(ids, m.UserID)
+		}
+		return ids
+	}
+
+	// app.groups.read alone (no directory exemption) -> isolated roster is stripped.
+	groupsReader := seedIsoHandlerUser(t, "iso-h-groups-reader")
+	grantAppPerms(t, groupsReader, permissions.AppGroupsRead)
+	if ids := callGetGroupById(groupsReader); len(ids) != 0 {
+		t.Errorf("non-member app.groups.read reader should see an empty isolated roster, got %v", ids)
+	}
+
+	// app.users.read (the directory exemption) -> full roster.
+	directoryReader := seedIsoHandlerUser(t, "iso-h-directory-reader")
+	grantAppPerms(t, directoryReader, permissions.AppGroupsRead, permissions.AppUsersRead)
+	if ids := callGetGroupById(directoryReader); len(ids) != 3 {
+		t.Errorf("app.users.read holder should see the full roster (3 members), got %v", ids)
+	}
+}

--- a/api/internal/handlers/receipt_member_isolation_test.go
+++ b/api/internal/handlers/receipt_member_isolation_test.go
@@ -1,0 +1,293 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"receipt-wrangler/api/internal/commands"
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/permissions"
+	"receipt-wrangler/api/internal/repositories"
+	"receipt-wrangler/api/internal/services"
+	"receipt-wrangler/api/internal/structs"
+	"receipt-wrangler/api/internal/utils"
+	"strings"
+	"testing"
+
+	jwtmiddleware "github.com/auth0/go-jwt-middleware/v2"
+	"github.com/go-chi/chi/v5"
+)
+
+// isoHandlerFixture is an isolated group with a supervisor (SeesAllMembers) and two
+// plain isolated members, all holding read/create/update on receipts. Members A and
+// B cannot see each other; both can see the supervisor.
+type isoHandlerFixture struct {
+	groupId      uint
+	supervisorId uint
+	memberAId    uint
+	memberBId    uint
+}
+
+func seedIsoHandlerUser(t *testing.T, username string) uint {
+	t.Helper()
+	user := models.User{Username: username, Password: "password"}
+	if err := repositories.GetDB().Create(&user).Error; err != nil {
+		t.Fatalf("seed user %s: %v", username, err)
+	}
+	return user.ID
+}
+
+func seedIsolatedReceiptGroupHandler(t *testing.T, isolate bool) isoHandlerFixture {
+	t.Helper()
+	services.ClearRolePermissionCacheForTests()
+	services.ClearGroupRoleGrantCacheForTests()
+	db := repositories.GetDB()
+	roleRepository := repositories.NewRoleRepository(nil)
+
+	perms := []string{
+		permissions.GroupReceiptsRead,
+		permissions.GroupReceiptsCreate,
+		permissions.GroupReceiptsUpdate,
+	}
+
+	group := models.Group{Name: "iso-handler-group", IsolateMembers: isolate}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("seed group: %v", err)
+	}
+
+	supRole, err := roleRepository.CreateGroupRole("Iso H Supervisor", "", perms, nil, nil, nil, false, true)
+	if err != nil {
+		t.Fatalf("seed supervisor role: %v", err)
+	}
+	memberRole, err := roleRepository.CreateGroupRole("Iso H Member", "", perms, nil, nil, nil, false, false)
+	if err != nil {
+		t.Fatalf("seed member role: %v", err)
+	}
+
+	sup := seedIsoHandlerUser(t, "iso-h-sup")
+	a := seedIsoHandlerUser(t, "iso-h-a")
+	b := seedIsoHandlerUser(t, "iso-h-b")
+
+	for _, m := range []models.GroupMember{
+		{GroupID: group.ID, UserID: sup, GroupRoleID: &supRole.ID},
+		{GroupID: group.ID, UserID: a, GroupRoleID: &memberRole.ID},
+		{GroupID: group.ID, UserID: b, GroupRoleID: &memberRole.ID},
+	} {
+		if err := db.Create(&m).Error; err != nil {
+			t.Fatalf("seed member: %v", err)
+		}
+	}
+
+	return isoHandlerFixture{groupId: group.ID, supervisorId: sup, memberAId: a, memberBId: b}
+}
+
+func createReceiptRequest(userId uint, body string) (*httptest.ResponseRecorder, *http.Request) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/api", strings.NewReader(body))
+	r = r.WithContext(context.WithValue(r.Context(), jwtmiddleware.ContextKey{}, claimsForUser(userId)))
+	return w, r
+}
+
+// --- Write-side guard (task 8) ---
+
+func TestMemberIsolationCreateDeniedForNonVisiblePaidBy(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	fx := seedIsolatedReceiptGroupHandler(t, true)
+
+	// Member A tries to plant member B (whom A cannot see) as the payer.
+	body := fmt.Sprintf(
+		`{"name":"R","amount":"5","date":"2024-01-01T00:00:00Z","groupId":%d,"paidByUserId":%d,"status":"OPEN"}`,
+		fx.groupId, fx.memberBId,
+	)
+	w, r := createReceiptRequest(fx.memberAId, body)
+	CreateReceipt(w, r)
+
+	if w.Result().StatusCode != 403 {
+		utils.PrintTestError(t, w.Result().StatusCode, 403)
+	}
+}
+
+func TestMemberIsolationCreateDeniedForNonVisibleChargedTo(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	fx := seedIsolatedReceiptGroupHandler(t, true)
+
+	// Payer is A (visible), but an item charges the non-visible member B.
+	body := fmt.Sprintf(
+		`{"name":"R","amount":"5","date":"2024-01-01T00:00:00Z","groupId":%d,"paidByUserId":%d,"status":"OPEN","receiptItems":[{"name":"I","amount":"5","status":"OPEN","chargedToUserId":%d}]}`,
+		fx.groupId, fx.memberAId, fx.memberBId,
+	)
+	w, r := createReceiptRequest(fx.memberAId, body)
+	CreateReceipt(w, r)
+
+	if w.Result().StatusCode != 403 {
+		utils.PrintTestError(t, w.Result().StatusCode, 403)
+	}
+}
+
+func TestMemberIsolationCreateAllowedForVisibleUsers(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	fx := seedIsolatedReceiptGroupHandler(t, true)
+
+	// Payer and charged-to are both A (self, always visible).
+	body := fmt.Sprintf(
+		`{"name":"R","amount":"5","date":"2024-01-01T00:00:00Z","groupId":%d,"paidByUserId":%d,"status":"OPEN","receiptItems":[{"name":"I","amount":"5","status":"OPEN","chargedToUserId":%d}]}`,
+		fx.groupId, fx.memberAId, fx.memberAId,
+	)
+	w, r := createReceiptRequest(fx.memberAId, body)
+	CreateReceipt(w, r)
+
+	if w.Result().StatusCode != 200 {
+		utils.PrintTestError(t, w.Result().StatusCode, 200)
+	}
+}
+
+func TestMemberIsolationUpdateDeniedForNonVisiblePaidBy(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	fx := seedIsolatedReceiptGroupHandler(t, true)
+	// A receipt A can access (paid by self), which A then tries to reassign to B.
+	receiptId := seedReceipt(t, fx.groupId, fx.memberAId, 0)
+
+	body := fmt.Sprintf(
+		`{"name":"R","amount":"5","date":"2024-01-01T00:00:00Z","groupId":%d,"paidByUserId":%d,"status":"OPEN"}`,
+		fx.groupId, fx.memberBId,
+	)
+	w, r := updateReceiptRequest(receiptId, fx.memberAId, body)
+	UpdateReceipt(w, r)
+
+	if w.Result().StatusCode != 403 {
+		utils.PrintTestError(t, w.Result().StatusCode, 403)
+	}
+}
+
+// --- Single receipt read (surface B via GetReceiptForUser) ---
+
+func TestMemberIsolationGetReceiptDeniedForNonVisiblePayer(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	fx := seedIsolatedReceiptGroupHandler(t, true)
+	// A receipt paid by the non-visible member B.
+	receiptId := seedReceipt(t, fx.groupId, fx.memberBId, 0)
+
+	w, r := getReceiptByIdRequest(receiptId, fx.memberAId)
+	GetReceipt(w, r)
+
+	if w.Result().StatusCode != 403 {
+		utils.PrintTestError(t, w.Result().StatusCode, 403)
+	}
+}
+
+func TestMemberIsolationGetReceiptAllowedForOwnReceipt(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	fx := seedIsolatedReceiptGroupHandler(t, true)
+	receiptId := seedReceipt(t, fx.groupId, fx.memberAId, 0)
+
+	w, r := getReceiptByIdRequest(receiptId, fx.memberAId)
+	GetReceipt(w, r)
+
+	if w.Result().StatusCode != 200 {
+		utils.PrintTestError(t, w.Result().StatusCode, 200)
+	}
+}
+
+// --- Paged list (surface B + count correctness) ---
+
+func pagedReceiptPayers(t *testing.T, w *httptest.ResponseRecorder) ([]uint, int64) {
+	t.Helper()
+	var pagedData structs.PagedData
+	if err := json.Unmarshal(w.Body.Bytes(), &pagedData); err != nil {
+		t.Fatalf("unmarshal paged data: %v", err)
+	}
+	payers := make([]uint, 0, len(pagedData.Data))
+	for _, entry := range pagedData.Data {
+		entryBytes, _ := json.Marshal(entry)
+		var receipt models.Receipt
+		json.Unmarshal(entryBytes, &receipt)
+		payers = append(payers, receipt.PaidByUserID)
+	}
+	return payers, pagedData.TotalCount
+}
+
+func TestMemberIsolationPagedListHidesNonVisiblePayer(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	fx := seedIsolatedReceiptGroupHandler(t, true)
+	seedReceipt(t, fx.groupId, fx.memberAId, 0) // A's own
+	seedReceipt(t, fx.groupId, fx.memberBId, 0) // B's — hidden from A
+
+	requestBody := commands.ReceiptPagedRequestCommand{
+		PagedRequestCommand: commands.PagedRequestCommand{Page: 1, PageSize: 10},
+	}
+	body, _ := json.Marshal(requestBody)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/api", strings.NewReader(string(body)))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("groupId", utils.UintToString(fx.groupId))
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+	r = r.WithContext(context.WithValue(r.Context(), jwtmiddleware.ContextKey{}, claimsForUser(fx.memberAId)))
+
+	GetPagedReceiptsForGroup(w, r)
+
+	if w.Result().StatusCode != 200 {
+		utils.PrintTestError(t, w.Result().StatusCode, 200)
+	}
+
+	payers, count := pagedReceiptPayers(t, w)
+	if count != 1 {
+		t.Errorf("expected totalCount 1 (only A's receipt), got %d", count)
+	}
+	if len(payers) != 1 || payers[0] != fx.memberAId {
+		t.Errorf("expected only A's receipt in the page, got payers %v", payers)
+	}
+}
+
+func TestMemberIsolationGetReceiptsForGroupIdsHidesNonVisiblePayer(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	fx := seedIsolatedReceiptGroupHandler(t, true)
+	seedReceipt(t, fx.groupId, fx.memberAId, 0)
+	seedReceipt(t, fx.groupId, fx.memberBId, 0)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/?groupIds="+utils.UintToString(fx.groupId), nil)
+	r = r.WithContext(context.WithValue(r.Context(), jwtmiddleware.ContextKey{}, claimsForUser(fx.memberAId)))
+
+	GetReceiptsForGroupIds(w, r)
+
+	if w.Result().StatusCode != 200 {
+		utils.PrintTestError(t, w.Result().StatusCode, 200)
+	}
+
+	var receipts []models.Receipt
+	if err := json.Unmarshal(w.Body.Bytes(), &receipts); err != nil {
+		t.Fatalf("unmarshal receipts: %v", err)
+	}
+	if len(receipts) != 1 || receipts[0].PaidByUserID != fx.memberAId {
+		t.Errorf("expected only A's receipt, got %d receipts", len(receipts))
+	}
+}
+
+// --- Backward compatibility ---
+
+func TestMemberIsolationBackwardCompatNonIsolatedGroupSeesEverything(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	// Same setup, but the group does NOT isolate members: A is unrestricted and
+	// sees B's receipt exactly as before.
+	fx := seedIsolatedReceiptGroupHandler(t, false)
+	receiptId := seedReceipt(t, fx.groupId, fx.memberBId, 0)
+
+	w, r := getReceiptByIdRequest(receiptId, fx.memberAId)
+	GetReceipt(w, r)
+
+	if w.Result().StatusCode != 200 {
+		utils.PrintTestError(t, w.Result().StatusCode, 200)
+	}
+}

--- a/api/internal/handlers/receipt_paid_by_enforcement_test.go
+++ b/api/internal/handlers/receipt_paid_by_enforcement_test.go
@@ -36,7 +36,7 @@ func seedPaidByRestrictedMember(t *testing.T, paidByUserGrantIds []uint, include
 		nil,
 		nil,
 		paidByUserGrantIds,
-		includeOwn,
+		includeOwn, false,
 	)
 	if err != nil {
 		t.Fatalf("seed group role: %v", err)

--- a/api/internal/handlers/receipts.go
+++ b/api/internal/handlers/receipts.go
@@ -77,6 +77,13 @@ func GetPagedReceiptsForGroup(w http.ResponseWriter, r *http.Request) {
 				return http.StatusInternalServerError, err
 			}
 
+			// Mask user references (created-by, charged-to) and drop non-visible
+			// comment authors the caller may not see.
+			err = permissionService.MaskReceiptsForMemberVisibility(token.UserId, receipts)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
 			anyData := make([]any, len(receipts))
 			for i := 0; i < len(receipts); i++ {
 				anyData[i] = receipts[i]
@@ -133,6 +140,13 @@ func GetReceiptsForGroupIds(w http.ResponseWriter, r *http.Request) {
 				return http.StatusInternalServerError, err
 			}
 
+			// Mask user references (created-by, charged-to) and drop non-visible
+			// comment authors the caller may not see.
+			err = permissionService.MaskReceiptsForMemberVisibility(token.UserId, receipts)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
 			bytes, err := utils.MarshalResponseData(receipts)
 			if err != nil {
 				return http.StatusInternalServerError, err
@@ -185,6 +199,17 @@ func CreateReceipt(w http.ResponseWriter, r *http.Request) {
 				return 0, nil
 			}
 
+			// An isolated member may not plant a payer or charged-to user outside
+			// their member-visible set.
+			allowed, denyMessage, err = enforceReceiptMemberVisibilitySelection(token.UserId, command)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+			if !allowed {
+				utils.WriteCustomErrorResponse(w, denyMessage, http.StatusForbidden)
+				return 0, nil
+			}
+
 			// A new receipt has no existing custom fields, so any custom field present
 			// is an add — blocked unless the caller can manage custom fields.
 			allowed, denyMessage, err = enforceReceiptCustomFieldSelection(token.UserId, command, nil)
@@ -202,7 +227,15 @@ func CreateReceipt(w http.ResponseWriter, r *http.Request) {
 				return http.StatusInternalServerError, err
 			}
 
-			err = services.NewPermissionService(nil).FilterReceiptCategoriesTagsForReceipt(token.UserId, &createdReceipt)
+			permissionService := services.NewPermissionService(nil)
+			err = permissionService.FilterReceiptCategoriesTagsForReceipt(token.UserId, &createdReceipt)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			// Mask user references (created-by, charged-to) and drop non-visible
+			// comment authors the caller may not see.
+			err = permissionService.MaskReceiptForMemberVisibility(token.UserId, &createdReceipt)
 			if err != nil {
 				return http.StatusInternalServerError, err
 			}
@@ -490,6 +523,28 @@ func UpdateReceipt(w http.ResponseWriter, r *http.Request) {
 				return 0, nil
 			}
 
+			// An isolated member may not plant a payer or charged-to user outside
+			// their member-visible set.
+			allowed, denyMessage, err = enforceReceiptMemberVisibilitySelection(token.UserId, command)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+			if !allowed {
+				utils.WriteCustomErrorResponse(w, denyMessage, http.StatusForbidden)
+				return 0, nil
+			}
+
+			// An isolated member may not silently drop a stored charge to a member
+			// they cannot see — the wholesale item replace would corrupt the split.
+			allowed, denyMessage, err = enforceReceiptChargedToPreservation(token.UserId, currentReceipt)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+			if !allowed {
+				utils.WriteCustomErrorResponse(w, denyMessage, http.StatusForbidden)
+				return 0, nil
+			}
+
 			// A caller without custom-field access may edit values but not change which
 			// custom fields are attached to the receipt.
 			currentCustomFieldIds := make([]uint, 0, len(currentReceipt.CustomFields))
@@ -519,6 +574,13 @@ func UpdateReceipt(w http.ResponseWriter, r *http.Request) {
 			}
 
 			err = permissionService.FilterReceiptCategoriesTagsForReceipt(token.UserId, &updatedReceipt)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
+			// Mask user references (created-by, charged-to) and drop non-visible
+			// comment authors the caller may not see.
+			err = permissionService.MaskReceiptForMemberVisibility(token.UserId, &updatedReceipt)
 			if err != nil {
 				return http.StatusInternalServerError, err
 			}

--- a/api/internal/handlers/receipts.go
+++ b/api/internal/handlers/receipts.go
@@ -200,8 +200,8 @@ func CreateReceipt(w http.ResponseWriter, r *http.Request) {
 			}
 
 			// An isolated member may not plant a payer or charged-to user outside
-			// their member-visible set.
-			allowed, denyMessage, err = enforceReceiptMemberVisibilitySelection(token.UserId, command)
+			// their member-visible set for the group.
+			allowed, denyMessage, err = enforceReceiptMemberVisibilitySelection(token.UserId, command.GroupId, command)
 			if err != nil {
 				return http.StatusInternalServerError, err
 			}
@@ -524,8 +524,8 @@ func UpdateReceipt(w http.ResponseWriter, r *http.Request) {
 			}
 
 			// An isolated member may not plant a payer or charged-to user outside
-			// their member-visible set.
-			allowed, denyMessage, err = enforceReceiptMemberVisibilitySelection(token.UserId, command)
+			// their member-visible set for the group.
+			allowed, denyMessage, err = enforceReceiptMemberVisibilitySelection(token.UserId, currentReceipt.GroupId, command)
 			if err != nil {
 				return http.StatusInternalServerError, err
 			}

--- a/api/internal/handlers/roles_test.go
+++ b/api/internal/handlers/roles_test.go
@@ -592,7 +592,7 @@ func TestShouldNotDeleteAssignedAppRole(t *testing.T) {
 func TestShouldNotDeleteAssignedGroupRole(t *testing.T) {
 	defer repositories.TruncateTestDb()
 	roleRepository := repositories.NewRoleRepository(nil)
-	created, err := roleRepository.CreateGroupRole("Group Role", "desc", []string{permissions.GroupReceiptsCreate}, nil, nil, nil, false)
+	created, err := roleRepository.CreateGroupRole("Group Role", "desc", []string{permissions.GroupReceiptsCreate}, nil, nil, nil, false, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return

--- a/api/internal/handlers/system_task.go
+++ b/api/internal/handlers/system_task.go
@@ -10,6 +10,7 @@ import (
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/permissions"
 	"receipt-wrangler/api/internal/repositories"
+	"receipt-wrangler/api/internal/services"
 	"receipt-wrangler/api/internal/structs"
 	"receipt-wrangler/api/internal/utils"
 	"receipt-wrangler/api/internal/wranglerasynq"
@@ -106,6 +107,16 @@ func GetActivitiesForGroups(w http.ResponseWriter, r *http.Request) {
 				return http.StatusInternalServerError, err
 			}
 
+			// Member isolation: drop activities run by a user the caller may not
+			// see (a nil RanByUserId is a system action and is always kept). No-op
+			// for unrestricted callers (backward compatible).
+			token := structs.GetClaims(r)
+			visibleUserIds, unrestricted, err := services.NewPermissionService(nil).GetVisibleUserIdsForUser(token.UserId)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+			activities = filterActivitiesByVisibility(activities, visibleUserIds, unrestricted)
+
 			pagedData := structs.PagedData{}
 			data := make([]any, 0)
 
@@ -129,6 +140,28 @@ func GetActivitiesForGroups(w http.ResponseWriter, r *http.Request) {
 	}
 
 	HandleRequest(handler)
+}
+
+// filterActivitiesByVisibility drops activities run by a user the viewer may not
+// see under member-presence isolation. An activity with a nil RanByUserId is a
+// system action and is always kept. When the viewer is unrestricted the input is
+// returned unchanged (backward compatible).
+func filterActivitiesByVisibility(activities []structs.Activity, visibleUserIds map[uint]struct{}, unrestricted bool) []structs.Activity {
+	if unrestricted {
+		return activities
+	}
+
+	visible := make([]structs.Activity, 0, len(activities))
+	for _, activity := range activities {
+		if activity.RanByUserId == nil {
+			visible = append(visible, activity)
+			continue
+		}
+		if _, ok := visibleUserIds[*activity.RanByUserId]; ok {
+			visible = append(visible, activity)
+		}
+	}
+	return visible
 }
 
 func RerunActivity(w http.ResponseWriter, r *http.Request) {

--- a/api/internal/handlers/system_task.go
+++ b/api/internal/handlers/system_task.go
@@ -97,33 +97,20 @@ func GetActivitiesForGroups(w http.ResponseWriter, r *http.Request) {
 			}
 
 			systemTaskRepository := repositories.NewSystemTaskRepository(nil)
-
-			// Fetch ALL matching activities unpaged so member-isolation filtering runs
-			// BEFORE count + pagination. Filtering an already-paged result would leak
-			// hidden-peer presence through TotalCount and could return a short page,
-			// since the DB limited/offset before the invisible rows were known.
-			unpagedCommand := command
-			unpagedCommand.Page = -1
-			unpagedCommand.PageSize = -1
-			activities, _, err := systemTaskRepository.GetPagedActivities(unpagedCommand)
-			if err != nil {
-				return http.StatusInternalServerError, err
-			}
-
-			// Member isolation: drop activities run by a user the caller may not see
-			// IN THAT ACTIVITY'S GROUP (a nil RanByUserId is a system action and is
-			// always kept). Resolved per group, so an isolated group hides its
-			// non-visible actors regardless of any open group the caller also shares.
 			token := structs.GetClaims(r)
-			activities, err = filterActivitiesByVisibility(services.NewPermissionService(nil), token.UserId, activities)
+
+			// Member isolation: activities run by a user the caller may not see in that
+			// activity's group are filtered IN THE QUERY (before Count + pagination), so
+			// TotalCount and the returned page both reflect only visible rows and DB-side
+			// LIMIT/OFFSET is preserved. See applyActivityVisibilityDisjunction (mirrors
+			// the paid-by disjunction).
+			permissionService := services.NewPermissionService(nil)
+			activities, count, err := systemTaskRepository.GetPagedActivities(
+				command, permissionService.ActivityVisibilityResolver(token.UserId),
+			)
 			if err != nil {
 				return http.StatusInternalServerError, err
 			}
-
-			// Count and paginate the FILTERED set, so both the total and the returned
-			// page reflect only what the caller may see.
-			totalCount := int64(len(activities))
-			activities = paginateActivities(activities, command.Page, command.PageSize)
 
 			err = wranglerasynq.SetActivityCanBeRestarted(&activities)
 			if err != nil {
@@ -138,7 +125,7 @@ func GetActivitiesForGroups(w http.ResponseWriter, r *http.Request) {
 			}
 
 			pagedData.Data = data
-			pagedData.TotalCount = totalCount
+			pagedData.TotalCount = count
 
 			responseBytes, err := utils.MarshalResponseData(pagedData)
 			if err != nil {
@@ -153,79 +140,6 @@ func GetActivitiesForGroups(w http.ResponseWriter, r *http.Request) {
 	}
 
 	HandleRequest(handler)
-}
-
-// filterActivitiesByVisibility drops activities run by a user the viewer may not see IN
-// THAT ACTIVITY'S GROUP, under member-presence isolation. An activity with a nil
-// RanByUserId (system action) or a nil GroupId (no group to scope against) is always
-// kept. Visibility is resolved per group and memoized, so an isolated group hides its
-// non-visible actors regardless of any open group the viewer also shares; a group where
-// the viewer is unrestricted (admin, supervisor, non-isolated) keeps every actor.
-func filterActivitiesByVisibility(permissionService services.PermissionService, viewerId uint, activities []structs.Activity) ([]structs.Activity, error) {
-	if len(activities) == 0 {
-		return activities, nil
-	}
-
-	type groupVis struct {
-		visible      map[uint]struct{}
-		unrestricted bool
-	}
-	cache := map[uint]groupVis{}
-
-	visible := make([]structs.Activity, 0, len(activities))
-	for _, activity := range activities {
-		if activity.RanByUserId == nil || activity.GroupId == nil {
-			visible = append(visible, activity)
-			continue
-		}
-		groupId := *activity.GroupId
-		v, ok := cache[groupId]
-		if !ok {
-			set, unrestricted, err := permissionService.GetVisibleUserIdsForUserInGroup(viewerId, groupId)
-			if err != nil {
-				return nil, err
-			}
-			v = groupVis{visible: set, unrestricted: unrestricted}
-			cache[groupId] = v
-		}
-		if v.unrestricted {
-			visible = append(visible, activity)
-			continue
-		}
-		if _, actorOk := v.visible[*activity.RanByUserId]; actorOk {
-			visible = append(visible, activity)
-		}
-	}
-	return visible, nil
-}
-
-// paginateActivities slices an already-filtered activity list to the requested page,
-// mirroring repositories.BaseRepository.Paginate so in-memory pagination matches the DB
-// semantics (1-indexed page; pageSize -1 = all; pageSize clamped to [1,100] with a
-// default of 10; page <= 0 treated as 1).
-func paginateActivities(activities []structs.Activity, page int, pageSize int) []structs.Activity {
-	if pageSize == -1 {
-		return activities
-	}
-	if page <= 0 {
-		page = 1
-	}
-	switch {
-	case pageSize > 100:
-		pageSize = 100
-	case pageSize <= 0:
-		pageSize = 10
-	}
-
-	offset := (page - 1) * pageSize
-	if offset >= len(activities) {
-		return []structs.Activity{}
-	}
-	end := offset + pageSize
-	if end > len(activities) {
-		end = len(activities)
-	}
-	return activities[offset:end]
 }
 
 func RerunActivity(w http.ResponseWriter, r *http.Request) {

--- a/api/internal/handlers/system_task.go
+++ b/api/internal/handlers/system_task.go
@@ -97,12 +97,15 @@ func GetActivitiesForGroups(w http.ResponseWriter, r *http.Request) {
 			}
 
 			systemTaskRepository := repositories.NewSystemTaskRepository(nil)
-			activities, count, err := systemTaskRepository.GetPagedActivities(command)
-			if err != nil {
-				return http.StatusInternalServerError, err
-			}
 
-			err = wranglerasynq.SetActivityCanBeRestarted(&activities)
+			// Fetch ALL matching activities unpaged so member-isolation filtering runs
+			// BEFORE count + pagination. Filtering an already-paged result would leak
+			// hidden-peer presence through TotalCount and could return a short page,
+			// since the DB limited/offset before the invisible rows were known.
+			unpagedCommand := command
+			unpagedCommand.Page = -1
+			unpagedCommand.PageSize = -1
+			activities, _, err := systemTaskRepository.GetPagedActivities(unpagedCommand)
 			if err != nil {
 				return http.StatusInternalServerError, err
 			}
@@ -117,6 +120,16 @@ func GetActivitiesForGroups(w http.ResponseWriter, r *http.Request) {
 				return http.StatusInternalServerError, err
 			}
 
+			// Count and paginate the FILTERED set, so both the total and the returned
+			// page reflect only what the caller may see.
+			totalCount := int64(len(activities))
+			activities = paginateActivities(activities, command.Page, command.PageSize)
+
+			err = wranglerasynq.SetActivityCanBeRestarted(&activities)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+
 			pagedData := structs.PagedData{}
 			data := make([]any, 0)
 
@@ -125,7 +138,7 @@ func GetActivitiesForGroups(w http.ResponseWriter, r *http.Request) {
 			}
 
 			pagedData.Data = data
-			pagedData.TotalCount = count
+			pagedData.TotalCount = totalCount
 
 			responseBytes, err := utils.MarshalResponseData(pagedData)
 			if err != nil {
@@ -184,6 +197,35 @@ func filterActivitiesByVisibility(permissionService services.PermissionService, 
 		}
 	}
 	return visible, nil
+}
+
+// paginateActivities slices an already-filtered activity list to the requested page,
+// mirroring repositories.BaseRepository.Paginate so in-memory pagination matches the DB
+// semantics (1-indexed page; pageSize -1 = all; pageSize clamped to [1,100] with a
+// default of 10; page <= 0 treated as 1).
+func paginateActivities(activities []structs.Activity, page int, pageSize int) []structs.Activity {
+	if pageSize == -1 {
+		return activities
+	}
+	if page <= 0 {
+		page = 1
+	}
+	switch {
+	case pageSize > 100:
+		pageSize = 100
+	case pageSize <= 0:
+		pageSize = 10
+	}
+
+	offset := (page - 1) * pageSize
+	if offset >= len(activities) {
+		return []structs.Activity{}
+	}
+	end := offset + pageSize
+	if end > len(activities) {
+		end = len(activities)
+	}
+	return activities[offset:end]
 }
 
 func RerunActivity(w http.ResponseWriter, r *http.Request) {

--- a/api/internal/handlers/system_task.go
+++ b/api/internal/handlers/system_task.go
@@ -107,15 +107,15 @@ func GetActivitiesForGroups(w http.ResponseWriter, r *http.Request) {
 				return http.StatusInternalServerError, err
 			}
 
-			// Member isolation: drop activities run by a user the caller may not
-			// see (a nil RanByUserId is a system action and is always kept). No-op
-			// for unrestricted callers (backward compatible).
+			// Member isolation: drop activities run by a user the caller may not see
+			// IN THAT ACTIVITY'S GROUP (a nil RanByUserId is a system action and is
+			// always kept). Resolved per group, so an isolated group hides its
+			// non-visible actors regardless of any open group the caller also shares.
 			token := structs.GetClaims(r)
-			visibleUserIds, unrestricted, err := services.NewPermissionService(nil).GetVisibleUserIdsForUser(token.UserId)
+			activities, err = filterActivitiesByVisibility(services.NewPermissionService(nil), token.UserId, activities)
 			if err != nil {
 				return http.StatusInternalServerError, err
 			}
-			activities = filterActivitiesByVisibility(activities, visibleUserIds, unrestricted)
 
 			pagedData := structs.PagedData{}
 			data := make([]any, 0)
@@ -142,26 +142,48 @@ func GetActivitiesForGroups(w http.ResponseWriter, r *http.Request) {
 	HandleRequest(handler)
 }
 
-// filterActivitiesByVisibility drops activities run by a user the viewer may not
-// see under member-presence isolation. An activity with a nil RanByUserId is a
-// system action and is always kept. When the viewer is unrestricted the input is
-// returned unchanged (backward compatible).
-func filterActivitiesByVisibility(activities []structs.Activity, visibleUserIds map[uint]struct{}, unrestricted bool) []structs.Activity {
-	if unrestricted {
-		return activities
+// filterActivitiesByVisibility drops activities run by a user the viewer may not see IN
+// THAT ACTIVITY'S GROUP, under member-presence isolation. An activity with a nil
+// RanByUserId (system action) or a nil GroupId (no group to scope against) is always
+// kept. Visibility is resolved per group and memoized, so an isolated group hides its
+// non-visible actors regardless of any open group the viewer also shares; a group where
+// the viewer is unrestricted (admin, supervisor, non-isolated) keeps every actor.
+func filterActivitiesByVisibility(permissionService services.PermissionService, viewerId uint, activities []structs.Activity) ([]structs.Activity, error) {
+	if len(activities) == 0 {
+		return activities, nil
 	}
+
+	type groupVis struct {
+		visible      map[uint]struct{}
+		unrestricted bool
+	}
+	cache := map[uint]groupVis{}
 
 	visible := make([]structs.Activity, 0, len(activities))
 	for _, activity := range activities {
-		if activity.RanByUserId == nil {
+		if activity.RanByUserId == nil || activity.GroupId == nil {
 			visible = append(visible, activity)
 			continue
 		}
-		if _, ok := visibleUserIds[*activity.RanByUserId]; ok {
+		groupId := *activity.GroupId
+		v, ok := cache[groupId]
+		if !ok {
+			set, unrestricted, err := permissionService.GetVisibleUserIdsForUserInGroup(viewerId, groupId)
+			if err != nil {
+				return nil, err
+			}
+			v = groupVis{visible: set, unrestricted: unrestricted}
+			cache[groupId] = v
+		}
+		if v.unrestricted {
+			visible = append(visible, activity)
+			continue
+		}
+		if _, actorOk := v.visible[*activity.RanByUserId]; actorOk {
 			visible = append(visible, activity)
 		}
 	}
-	return visible
+	return visible, nil
 }
 
 func RerunActivity(w http.ResponseWriter, r *http.Request) {

--- a/api/internal/handlers/system_task_test.go
+++ b/api/internal/handlers/system_task_test.go
@@ -1,51 +1,65 @@
 package handlers
 
 import (
+	"receipt-wrangler/api/internal/repositories"
+	"receipt-wrangler/api/internal/services"
 	"receipt-wrangler/api/internal/structs"
 	"testing"
 )
 
-func activityRunBy(id uint) structs.Activity {
-	return structs.Activity{RanByUserId: &id}
+func activityInGroup(ranBy uint, groupId uint) structs.Activity {
+	return structs.Activity{RanByUserId: &ranBy, GroupId: &groupId}
 }
 
-func systemActivity() structs.Activity {
-	return structs.Activity{RanByUserId: nil}
-}
-
-// An isolated (restricted) viewer sees only activities run by users in their
-// visible set; a system activity (nil RanByUserId) is always kept.
+// An isolated (restricted) viewer sees only activities run by users visible to them IN
+// THAT ACTIVITY'S GROUP; a system activity (nil RanByUserId) is always kept.
 func TestFilterActivitiesByVisibilityDropsInvisibleActor(t *testing.T) {
-	visibleUserIds := map[uint]struct{}{1: {}, 3: {}} // self + a supervisor
+	defer repositories.TruncateTestDb()
 
+	fx := seedIsolatedReceiptGroupHandler(t, true)
+	permissionService := services.NewPermissionService(nil)
+
+	groupId := fx.groupId
 	activities := []structs.Activity{
-		activityRunBy(2), // invisible peer -> dropped
-		activityRunBy(3), // visible supervisor -> kept
-		systemActivity(), // system -> kept
+		activityInGroup(fx.memberBId, fx.groupId),    // invisible peer -> dropped
+		activityInGroup(fx.supervisorId, fx.groupId), // visible supervisor -> kept
+		activityInGroup(fx.memberAId, fx.groupId),    // self -> kept
+		{RanByUserId: nil, GroupId: &groupId},        // system action -> kept
 	}
 
-	filtered := filterActivitiesByVisibility(activities, visibleUserIds, false)
-
-	if len(filtered) != 2 {
-		t.Fatalf("expected 2 visible activities, got %d (%v)", len(filtered), filtered)
+	filtered, err := filterActivitiesByVisibility(permissionService, fx.memberAId, activities)
+	if err != nil {
+		t.Fatalf("filter: %v", err)
+	}
+	if len(filtered) != 3 {
+		t.Fatalf("expected 3 visible activities, got %d (%v)", len(filtered), filtered)
 	}
 	for _, activity := range filtered {
-		if activity.RanByUserId != nil && *activity.RanByUserId == 2 {
-			t.Errorf("activity run by invisible user 2 should be dropped")
+		if activity.RanByUserId != nil && *activity.RanByUserId == fx.memberBId {
+			t.Errorf("activity run by invisible peer %d should be dropped", fx.memberBId)
 		}
 	}
 }
 
-// An unrestricted viewer is unaffected — every activity is kept unchanged.
+// A viewer unrestricted in the activity's group (here the supervisor of an isolated
+// group) keeps every activity unchanged.
 func TestFilterActivitiesByVisibilityUnrestrictedKeepsAll(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	fx := seedIsolatedReceiptGroupHandler(t, true)
+	permissionService := services.NewPermissionService(nil)
+
+	groupId := fx.groupId
 	activities := []structs.Activity{
-		activityRunBy(2),
-		activityRunBy(3),
-		systemActivity(),
+		activityInGroup(fx.memberAId, fx.groupId),
+		activityInGroup(fx.memberBId, fx.groupId),
+		{RanByUserId: nil, GroupId: &groupId},
 	}
 
-	filtered := filterActivitiesByVisibility(activities, nil, true)
-
+	filtered, err := filterActivitiesByVisibility(permissionService, fx.supervisorId, activities)
+	if err != nil {
+		t.Fatalf("filter: %v", err)
+	}
 	if len(filtered) != len(activities) {
 		t.Fatalf("unrestricted viewer should keep all %d activities, got %d", len(activities), len(filtered))
 	}

--- a/api/internal/handlers/system_task_test.go
+++ b/api/internal/handlers/system_task_test.go
@@ -1,0 +1,52 @@
+package handlers
+
+import (
+	"receipt-wrangler/api/internal/structs"
+	"testing"
+)
+
+func activityRunBy(id uint) structs.Activity {
+	return structs.Activity{RanByUserId: &id}
+}
+
+func systemActivity() structs.Activity {
+	return structs.Activity{RanByUserId: nil}
+}
+
+// An isolated (restricted) viewer sees only activities run by users in their
+// visible set; a system activity (nil RanByUserId) is always kept.
+func TestFilterActivitiesByVisibilityDropsInvisibleActor(t *testing.T) {
+	visibleUserIds := map[uint]struct{}{1: {}, 3: {}} // self + a supervisor
+
+	activities := []structs.Activity{
+		activityRunBy(2), // invisible peer -> dropped
+		activityRunBy(3), // visible supervisor -> kept
+		systemActivity(), // system -> kept
+	}
+
+	filtered := filterActivitiesByVisibility(activities, visibleUserIds, false)
+
+	if len(filtered) != 2 {
+		t.Fatalf("expected 2 visible activities, got %d (%v)", len(filtered), filtered)
+	}
+	for _, activity := range filtered {
+		if activity.RanByUserId != nil && *activity.RanByUserId == 2 {
+			t.Errorf("activity run by invisible user 2 should be dropped")
+		}
+	}
+}
+
+// An unrestricted viewer is unaffected — every activity is kept unchanged.
+func TestFilterActivitiesByVisibilityUnrestrictedKeepsAll(t *testing.T) {
+	activities := []structs.Activity{
+		activityRunBy(2),
+		activityRunBy(3),
+		systemActivity(),
+	}
+
+	filtered := filterActivitiesByVisibility(activities, nil, true)
+
+	if len(filtered) != len(activities) {
+		t.Fatalf("unrestricted viewer should keep all %d activities, got %d", len(activities), len(filtered))
+	}
+}

--- a/api/internal/handlers/system_task_test.go
+++ b/api/internal/handlers/system_task_test.go
@@ -9,71 +9,12 @@ import (
 	"receipt-wrangler/api/internal/permissions"
 	"receipt-wrangler/api/internal/repositories"
 	"receipt-wrangler/api/internal/services"
-	"receipt-wrangler/api/internal/structs"
 	"strings"
 	"testing"
 	"time"
 
 	jwtmiddleware "github.com/auth0/go-jwt-middleware/v2"
 )
-
-func activityInGroup(ranBy uint, groupId uint) structs.Activity {
-	return structs.Activity{RanByUserId: &ranBy, GroupId: &groupId}
-}
-
-// An isolated (restricted) viewer sees only activities run by users visible to them IN
-// THAT ACTIVITY'S GROUP; a system activity (nil RanByUserId) is always kept.
-func TestFilterActivitiesByVisibilityDropsInvisibleActor(t *testing.T) {
-	defer repositories.TruncateTestDb()
-
-	fx := seedIsolatedReceiptGroupHandler(t, true)
-	permissionService := services.NewPermissionService(nil)
-
-	groupId := fx.groupId
-	activities := []structs.Activity{
-		activityInGroup(fx.memberBId, fx.groupId),    // invisible peer -> dropped
-		activityInGroup(fx.supervisorId, fx.groupId), // visible supervisor -> kept
-		activityInGroup(fx.memberAId, fx.groupId),    // self -> kept
-		{RanByUserId: nil, GroupId: &groupId},        // system action -> kept
-	}
-
-	filtered, err := filterActivitiesByVisibility(permissionService, fx.memberAId, activities)
-	if err != nil {
-		t.Fatalf("filter: %v", err)
-	}
-	if len(filtered) != 3 {
-		t.Fatalf("expected 3 visible activities, got %d (%v)", len(filtered), filtered)
-	}
-	for _, activity := range filtered {
-		if activity.RanByUserId != nil && *activity.RanByUserId == fx.memberBId {
-			t.Errorf("activity run by invisible peer %d should be dropped", fx.memberBId)
-		}
-	}
-}
-
-// A viewer unrestricted in the activity's group (here the supervisor of an isolated
-// group) keeps every activity unchanged.
-func TestFilterActivitiesByVisibilityUnrestrictedKeepsAll(t *testing.T) {
-	defer repositories.TruncateTestDb()
-
-	fx := seedIsolatedReceiptGroupHandler(t, true)
-	permissionService := services.NewPermissionService(nil)
-
-	groupId := fx.groupId
-	activities := []structs.Activity{
-		activityInGroup(fx.memberAId, fx.groupId),
-		activityInGroup(fx.memberBId, fx.groupId),
-		{RanByUserId: nil, GroupId: &groupId},
-	}
-
-	filtered, err := filterActivitiesByVisibility(permissionService, fx.supervisorId, activities)
-	if err != nil {
-		t.Fatalf("filter: %v", err)
-	}
-	if len(filtered) != len(activities) {
-		t.Fatalf("unrestricted viewer should keep all %d activities, got %d", len(activities), len(filtered))
-	}
-}
 
 // End-to-end: a hidden-peer activity in an isolated group must affect NEITHER the
 // returned rows NOR TotalCount (the count is computed after member-isolation filtering,

--- a/api/internal/handlers/system_task_test.go
+++ b/api/internal/handlers/system_task_test.go
@@ -1,10 +1,20 @@
 package handlers
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/permissions"
 	"receipt-wrangler/api/internal/repositories"
 	"receipt-wrangler/api/internal/services"
 	"receipt-wrangler/api/internal/structs"
+	"strings"
 	"testing"
+	"time"
+
+	jwtmiddleware "github.com/auth0/go-jwt-middleware/v2"
 )
 
 func activityInGroup(ranBy uint, groupId uint) structs.Activity {
@@ -62,5 +72,106 @@ func TestFilterActivitiesByVisibilityUnrestrictedKeepsAll(t *testing.T) {
 	}
 	if len(filtered) != len(activities) {
 		t.Fatalf("unrestricted viewer should keep all %d activities, got %d", len(activities), len(filtered))
+	}
+}
+
+// End-to-end: a hidden-peer activity in an isolated group must affect NEITHER the
+// returned rows NOR TotalCount (the count is computed after member-isolation filtering,
+// not before pagination), so a restricted member cannot infer hidden activity.
+func TestGetActivitiesForGroupsFiltersCountAndRowsForIsolatedGroup(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	services.ClearRolePermissionCacheForTests()
+	services.ClearGroupRoleGrantCacheForTests()
+	// The handler calls SetActivityCanBeRestarted, which needs the Redis connection
+	// env vars to build an asynq inspector; point it at the local Redis (the inspector
+	// tolerates an empty/unreachable queue and no-ops).
+	t.Setenv("REDIS_HOST", "localhost")
+	t.Setenv("REDIS_PORT", "6379")
+
+	db := repositories.GetDB()
+	roleRepository := repositories.NewRoleRepository(nil)
+
+	group := models.Group{Name: "iso-activities", IsolateMembers: true}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("group: %v", err)
+	}
+
+	perms := []string{permissions.GroupActivitiesRead}
+	supRole, err := roleRepository.CreateGroupRole("Iso Act Sup", "", perms, nil, nil, nil, false, true)
+	if err != nil {
+		t.Fatalf("sup role: %v", err)
+	}
+	memRole, err := roleRepository.CreateGroupRole("Iso Act Mem", "", perms, nil, nil, nil, false, false)
+	if err != nil {
+		t.Fatalf("mem role: %v", err)
+	}
+
+	memberA := seedIsoHandlerUser(t, "iso-act-a")
+	memberB := seedIsoHandlerUser(t, "iso-act-b")
+	supervisor := seedIsoHandlerUser(t, "iso-act-sup")
+	for _, m := range []models.GroupMember{
+		{GroupID: group.ID, UserID: memberA, GroupRoleID: &memRole.ID},
+		{GroupID: group.ID, UserID: memberB, GroupRoleID: &memRole.ID},
+		{GroupID: group.ID, UserID: supervisor, GroupRoleID: &supRole.ID},
+	} {
+		if err := db.Create(&m).Error; err != nil {
+			t.Fatalf("member: %v", err)
+		}
+	}
+
+	// One activity per user in the group.
+	for _, ranBy := range []uint{memberA, memberB, supervisor} {
+		id := ranBy
+		gid := group.ID
+		task := models.SystemTask{
+			Type:                 models.QUICK_SCAN,
+			Status:               models.SYSTEM_TASK_SUCCEEDED,
+			AssociatedEntityType: models.NOOP_ENTITY_TYPE,
+			GroupId:              &gid,
+			RanByUserId:          &id,
+			StartedAt:            time.Now(),
+		}
+		if err := db.Create(&task).Error; err != nil {
+			t.Fatalf("task: %v", err)
+		}
+	}
+
+	// memberA is a plain isolated member: sees own + supervisor, never memberB.
+	body, _ := json.Marshal(map[string]any{
+		"groupIds":      []uint{group.ID},
+		"page":          1,
+		"pageSize":      10,
+		"orderBy":       "started_at",
+		"sortDirection": "desc",
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/api", strings.NewReader(string(body)))
+	r = r.WithContext(context.WithValue(r.Context(), jwtmiddleware.ContextKey{}, claimsForUser(memberA)))
+	GetActivitiesForGroups(w, r)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Result().StatusCode, w.Body.String())
+	}
+
+	var paged struct {
+		Data []struct {
+			RanByUserId *uint `json:"ranByUserId"`
+		} `json:"data"`
+		TotalCount int64 `json:"totalCount"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &paged); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if paged.TotalCount != 2 {
+		t.Errorf("TotalCount = %d, want 2 (hidden peer excluded from the total, not just the page)", paged.TotalCount)
+	}
+	if len(paged.Data) != 2 {
+		t.Errorf("returned %d rows, want 2", len(paged.Data))
+	}
+	for _, a := range paged.Data {
+		if a.RanByUserId != nil && *a.RanByUserId == memberB {
+			t.Errorf("hidden peer's activity leaked into the results")
+		}
 	}
 }

--- a/api/internal/handlers/users.go
+++ b/api/internal/handlers/users.go
@@ -234,6 +234,25 @@ func GetAmountOwedForUser(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 
+			// Member isolation: drop settlement entries naming a counterparty the
+			// caller may not see. This intentionally overrides the endpoint's
+			// paid-by exemption for isolated viewers. The caller's own id is always
+			// kept; no-op for unrestricted callers (backward compatible).
+			visibleUserIds, unrestricted, err := services.NewPermissionService(nil).GetVisibleUserIdsForUser(id)
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+			if !unrestricted {
+				for counterpartyId := range resultMap {
+					if counterpartyId == id {
+						continue
+					}
+					if _, ok := visibleUserIds[counterpartyId]; !ok {
+						delete(resultMap, counterpartyId)
+					}
+				}
+			}
+
 			bytes, err := json.Marshal(resultMap)
 			if err != nil {
 				return http.StatusInternalServerError, err

--- a/api/internal/handlers/users.go
+++ b/api/internal/handlers/users.go
@@ -22,6 +22,7 @@ type ItemView struct {
 	ReceiptId       uint
 	PaidByUserId    uint
 	ChargedToUserId uint
+	GroupId         uint
 	ItemAmount      decimal.Decimal
 }
 
@@ -198,19 +199,59 @@ func GetAmountOwedForUser(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 
-			err = db.Table("items").Select("items.id as item_id, items.receipt_id as receipt_id, items.amount as item_amount, items.charged_to_user_id, receipts.id, items.status, receipts.paid_by_user_id").Joins("inner join receipts on receipts.id=items.receipt_id").Where("items.charged_to_user_id=? AND receipts.paid_by_user_id !=? AND receipts.id IN ? AND items.status=?", id, id, totalReceiptIds, models.ITEM_OPEN).Scan(&itemsOwed).Error
+			err = db.Table("items").Select("items.id as item_id, items.receipt_id as receipt_id, items.amount as item_amount, items.charged_to_user_id, receipts.id, receipts.group_id, items.status, receipts.paid_by_user_id").Joins("inner join receipts on receipts.id=items.receipt_id").Where("items.charged_to_user_id=? AND receipts.paid_by_user_id !=? AND receipts.id IN ? AND items.status=?", id, id, totalReceiptIds, models.ITEM_OPEN).Scan(&itemsOwed).Error
 			if err != nil {
 				return http.StatusInternalServerError, err
 			}
 
-			err = db.Table("items").Select("items.id as item_id, items.receipt_id as receipt_id, items.amount as item_amount, items.charged_to_user_id, receipts.id, items.status, receipts.paid_by_user_id").Joins("inner join receipts on receipts.id=items.receipt_id").Where("items.charged_to_user_id !=? AND receipts.paid_by_user_id =? AND receipts.id IN ? AND items.status=?", id, id, totalReceiptIds, models.ITEM_OPEN).Scan(&itemsOthersOwe).Error
+			err = db.Table("items").Select("items.id as item_id, items.receipt_id as receipt_id, items.amount as item_amount, items.charged_to_user_id, receipts.id, receipts.group_id, items.status, receipts.paid_by_user_id").Joins("inner join receipts on receipts.id=items.receipt_id").Where("items.charged_to_user_id !=? AND receipts.paid_by_user_id =? AND receipts.id IN ? AND items.status=?", id, id, totalReceiptIds, models.ITEM_OPEN).Scan(&itemsOthersOwe).Error
 			if err != nil {
 				return http.StatusInternalServerError, err
+			}
+
+			// Member isolation is applied PER RECEIPT'S GROUP as items are folded in: a
+			// counterparty's contribution counts only if the caller may see them in
+			// that receipt's group, so an isolated group contributes nothing about a
+			// hidden member (even if the caller can see them via an open group they
+			// also share). The caller's own id is always visible. Resolved once per
+			// group. This intentionally overrides the endpoint's paid-by exemption for
+			// isolated viewers, and is a no-op for unrestricted callers.
+			permissionService := services.NewPermissionService(nil)
+			type settlementGroupVisibility struct {
+				visible      map[uint]struct{}
+				unrestricted bool
+			}
+			visibilityByGroup := map[uint]settlementGroupVisibility{}
+			counterpartyVisible := func(counterpartyId uint, groupId uint) (bool, error) {
+				if counterpartyId == id {
+					return true, nil
+				}
+				vis, ok := visibilityByGroup[groupId]
+				if !ok {
+					set, unrestricted, err := permissionService.GetVisibleUserIdsForUserInGroup(id, groupId)
+					if err != nil {
+						return false, err
+					}
+					vis = settlementGroupVisibility{visible: set, unrestricted: unrestricted}
+					visibilityByGroup[groupId] = vis
+				}
+				if vis.unrestricted {
+					return true, nil
+				}
+				_, visibleOk := vis.visible[counterpartyId]
+				return visibleOk, nil
 			}
 
 			// These are items from receipts that I did not pay for, so I owe these
 			for i := 0; i < len(itemsOwed); i++ {
 				item := itemsOwed[i]
+				visible, err := counterpartyVisible(item.PaidByUserId, item.GroupId)
+				if err != nil {
+					return http.StatusInternalServerError, err
+				}
+				if !visible {
+					continue
+				}
 				total = total.Add(item.ItemAmount)
 				amount, ok := resultMap[item.PaidByUserId]
 
@@ -224,6 +265,13 @@ func GetAmountOwedForUser(w http.ResponseWriter, r *http.Request) {
 			// These are items from receipts that I paid for, so they owe me
 			for i := 0; i < len(itemsOthersOwe); i++ {
 				item := itemsOthersOwe[i]
+				visible, err := counterpartyVisible(item.ChargedToUserId, item.GroupId)
+				if err != nil {
+					return http.StatusInternalServerError, err
+				}
+				if !visible {
+					continue
+				}
 				total = total.Sub(item.ItemAmount)
 				amount, ok := resultMap[item.ChargedToUserId]
 
@@ -231,25 +279,6 @@ func GetAmountOwedForUser(w http.ResponseWriter, r *http.Request) {
 					resultMap[item.ChargedToUserId] = amount.Sub(item.ItemAmount)
 				} else {
 					resultMap[item.ChargedToUserId] = item.ItemAmount.Mul(decimal.NewFromInt(-1))
-				}
-			}
-
-			// Member isolation: drop settlement entries naming a counterparty the
-			// caller may not see. This intentionally overrides the endpoint's
-			// paid-by exemption for isolated viewers. The caller's own id is always
-			// kept; no-op for unrestricted callers (backward compatible).
-			visibleUserIds, unrestricted, err := services.NewPermissionService(nil).GetVisibleUserIdsForUser(id)
-			if err != nil {
-				return http.StatusInternalServerError, err
-			}
-			if !unrestricted {
-				for counterpartyId := range resultMap {
-					if counterpartyId == id {
-						continue
-					}
-					if _, ok := visibleUserIds[counterpartyId]; !ok {
-						delete(resultMap, counterpartyId)
-					}
 				}
 			}
 

--- a/api/internal/handlers/users_test.go
+++ b/api/internal/handlers/users_test.go
@@ -395,6 +395,63 @@ func assertOwed(t *testing.T, result map[uint]decimal.Decimal, otherUserId uint,
 	}
 }
 
+// setupIsolatedAmountOwedTest seeds group 1 as an isolated group where user 1 is
+// the (restricted) caller, user 3 is a visible supervisor, and user 2 is an
+// invisible peer.
+func setupIsolatedAmountOwedTest(t *testing.T) {
+	repositories.CreateTestGroupWithUsers()
+	grantGroupPerms(t, 1, 1, permissions.GroupReceiptsRead)
+	isolateGroupWithSupervisor(t, 1, 3)
+}
+
+// --- Member isolation ---------------------------------------------------
+
+func TestGetAmountOwedForUserIsolatedViewerExcludesInvisibleCounterparty(t *testing.T) {
+	defer tearDownUserTest()
+	setupIsolatedAmountOwedTest(t)
+
+	// User 2 (invisible peer) paid; item charged to user 1 -> entry for user 2.
+	createReceiptWithItems(t, "Peer paid", 10, 2, 1, []commands.UpsertItemCommand{
+		chargedItem("peer item", 10, 1),
+	})
+	// User 3 (visible supervisor) paid; item charged to user 1 -> entry for user 3.
+	createReceiptWithItems(t, "Supervisor paid", 15, 3, 1, []commands.UpsertItemCommand{
+		chargedItem("sup item", 15, 1),
+	})
+
+	w, result := callGetAmountOwed(1, "1", nil)
+	if w.Result().StatusCode != http.StatusOK {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusOK)
+		return
+	}
+
+	if _, exists := result[2]; exists {
+		t.Errorf("invisible counterparty (user 2) should be excluded from settlement, got %v", result)
+	}
+	assertOwed(t, result, 3, 15)
+}
+
+func TestGetAmountOwedForUserUnrestrictedViewerUnaffectedByIsolation(t *testing.T) {
+	defer tearDownUserTest()
+	setupIsolatedAmountOwedTest(t)
+
+	// Elevate the caller to an admin (app.users.read) -> unrestricted visibility,
+	// so isolation must not filter the settlement map.
+	grantAppPerms(t, 1, permissions.AppUsersRead)
+
+	createReceiptWithItems(t, "Peer paid", 10, 2, 1, []commands.UpsertItemCommand{
+		chargedItem("peer item", 10, 1),
+	})
+
+	w, result := callGetAmountOwed(1, "1", nil)
+	if w.Result().StatusCode != http.StatusOK {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusOK)
+		return
+	}
+
+	assertOwed(t, result, 2, 10)
+}
+
 // --- A. Authorization ---------------------------------------------------
 
 func TestGetAmountOwedForUserReturnsForbiddenWhenCallerNotInGroup(t *testing.T) {

--- a/api/internal/handlers/users_test.go
+++ b/api/internal/handlers/users_test.go
@@ -452,6 +452,39 @@ func TestGetAmountOwedForUserUnrestrictedViewerUnaffectedByIsolation(t *testing.
 	assertOwed(t, result, 2, 10)
 }
 
+// Cross-group settlement: a counterparty shared via an OPEN group still appears (for
+// that group's portion), while their contribution from an ISOLATED group where the
+// caller cannot see them is excluded. "Isolated means isolated" — the isolated portion
+// is dropped even though the caller knows the counterparty from the open group.
+func TestGetAmountOwedForUserCrossGroupExcludesIsolatedPortionKeepsOpen(t *testing.T) {
+	defer tearDownUserTest()
+	setupIsolatedAmountOwedTest(t) // group 1 isolated (sup=3); user 1 is the restricted caller
+
+	// User 1 and user 2 ALSO share the OPEN group 2; user 1 may read both groups.
+	grantGroupPerms(t, 1, 2, permissions.GroupReceiptsRead)
+	grantGroupPerms(t, 2, 2, permissions.GroupReceiptsRead)
+
+	// Isolated group 1: user 2 (invisible peer here) paid, item charged to user 1 ($10).
+	r1 := createReceiptWithItems(t, "Iso peer paid", 10, 2, 1, []commands.UpsertItemCommand{
+		chargedItem("iso item", 10, 1),
+	})
+	// Open group 2: user 2 (visible here) paid, item charged to user 1 ($15).
+	r2 := createReceiptWithItems(t, "Open peer paid", 15, 2, 2, []commands.UpsertItemCommand{
+		chargedItem("open item", 15, 1),
+	})
+
+	w, result := callGetAmountOwed(1, "", []string{
+		utils.UintToString(r1.ID), utils.UintToString(r2.ID),
+	})
+	if w.Result().StatusCode != http.StatusOK {
+		utils.PrintTestError(t, w.Result().StatusCode, http.StatusOK)
+		return
+	}
+
+	// Only the open-group portion counts; the isolated-group portion is excluded.
+	assertOwed(t, result, 2, 15)
+}
+
 // --- A. Authorization ---------------------------------------------------
 
 func TestGetAmountOwedForUserReturnsForbiddenWhenCallerNotInGroup(t *testing.T) {

--- a/api/internal/mcp/mcp_test.go
+++ b/api/internal/mcp/mcp_test.go
@@ -148,7 +148,7 @@ func addGroupMemberWithGrants(
 ) {
 	t.Helper()
 	role, err := repositories.NewRoleRepository(nil).CreateGroupRole(
-		roleName, "", perms, categoryGrants, tagGrants, paidByGrants, includeOwn)
+		roleName, "", perms, categoryGrants, tagGrants, paidByGrants, includeOwn, false)
 	if err != nil {
 		t.Fatalf("failed to create group role: %v", err)
 	}

--- a/api/internal/mcp/tools.go
+++ b/api/internal/mcp/tools.go
@@ -131,6 +131,12 @@ func handleListGroups(ctx context.Context, req *mcpsdk.CallToolRequest, _ emptyI
 		return nil, nil, err
 	}
 
+	// Member-presence isolation: strip each roster to the members the caller may see.
+	permissionService := services.NewPermissionService(nil)
+	if err := permissionService.FilterGroupMembersForGroups(claims.UserId, groups); err != nil {
+		return nil, nil, err
+	}
+
 	return nil, groups, nil
 }
 

--- a/api/internal/models/group.go
+++ b/api/internal/models/group.go
@@ -15,6 +15,13 @@ type Group struct {
 	GroupReceiptSettings GroupReceiptSettings `json:"groupReceiptSettings"`
 	Status               GroupStatus          `gorm:"default:'ACTIVE'; not null" json:"status"`
 	IsAllGroup           bool                 `json:"isAllGroup" gorm:"default:false"`
+
+	// IsolateMembers turns on member-presence isolation for this group: members
+	// cannot discover that other members exist (through the user directory, group
+	// roster, receipts, comments, activities, settlement, or notifications) unless
+	// they hold a group role flagged SeesAllMembers, or the app-level app.users.read.
+	// Default false ⇒ existing groups behave exactly as before (no migration).
+	IsolateMembers bool `json:"isolateMembers" gorm:"not null;default:false"`
 }
 
 func (groupToUpdate *Group) BeforeUpdate(tx *gorm.DB) (err error) {

--- a/api/internal/models/group_role_definition.go
+++ b/api/internal/models/group_role_definition.go
@@ -14,6 +14,13 @@ type GroupRoleDefinition struct {
 	IsDefault   bool   `gorm:"not null;default:false" json:"isDefault"`
 	IsSystem    bool   `gorm:"not null;default:false" json:"isSystem"`
 
+	// SeesAllMembers is the "supervisor" exemption for member isolation (see
+	// Group.IsolateMembers): holders of this group role can see every member of an
+	// isolated group AND are visible to every member (so an isolated member can still
+	// see and transact with their coordinator). Only meaningful in an isolated group;
+	// default false ⇒ no effect on existing roles/groups.
+	SeesAllMembers bool `gorm:"not null;default:false" json:"seesAllMembers"`
+
 	// IncludeOwnPaidReceipts is the relative "their own receipts" token of the
 	// paid-by visibility filter: when true the role lets each member see receipts
 	// they paid for. It is stored separately from PaidByUserGrants because it

--- a/api/internal/repositories/comments.go
+++ b/api/internal/repositories/comments.go
@@ -13,6 +13,14 @@ type CommentRepository struct {
 	BaseRepository
 }
 
+// AuthorVisibilityResolver reports whether a notification recipient is allowed to
+// see the comment's author (member-presence isolation). It lets the comment
+// repository suppress a notification whose body names an author the recipient may
+// not see, without importing the service layer that resolves visibility (mirroring
+// the PaidByAllowedResolver injection). A nil resolver disables suppression, so
+// every recipient receives (backward compatible).
+type AuthorVisibilityResolver func(authorId uint, recipientId uint) (canSeeAuthor bool, err error)
+
 func NewCommentRepository(tx *gorm.DB) CommentRepository {
 	repository := CommentRepository{BaseRepository: BaseRepository{
 		DB: GetDB(),
@@ -21,7 +29,7 @@ func NewCommentRepository(tx *gorm.DB) CommentRepository {
 	return repository
 }
 
-func (repository CommentRepository) AddComment(command commands.UpsertCommentCommand) (models.Comment, error) {
+func (repository CommentRepository) AddComment(command commands.UpsertCommentCommand, authorVisibleTo AuthorVisibilityResolver) (models.Comment, error) {
 	db := repository.GetDB()
 	comment := models.Comment{
 		Comment:   command.Comment,
@@ -37,7 +45,7 @@ func (repository CommentRepository) AddComment(command commands.UpsertCommentCom
 			return err
 		}
 
-		err = repository.sendNotificationsToUsers(comment)
+		err = repository.sendNotificationsToUsers(comment, authorVisibleTo)
 		if err != nil {
 			return err
 		}
@@ -115,10 +123,11 @@ func (repository CommentRepository) DeleteComment(commentId string, tokenUserId 
 	return nil
 }
 
-func (repository CommentRepository) sendNotificationsToUsers(comment models.Comment) error {
+func (repository CommentRepository) sendNotificationsToUsers(comment models.Comment, authorVisibleTo AuthorVisibilityResolver) error {
 	var receipt models.Receipt
+	authorId := *comment.UserId
 	usersToOmit := make([]interface{}, 0)
-	usersToOmit = append(usersToOmit, *comment.UserId)
+	usersToOmit = append(usersToOmit, authorId)
 	notificationRepository := NewNotificationRepository(repository.TX)
 	receiptRepository := NewReceiptRepository(repository.TX)
 
@@ -128,7 +137,16 @@ func (repository CommentRepository) sendNotificationsToUsers(comment models.Comm
 	}
 
 	if comment.CommentId == nil {
-		err := notificationRepository.SendNotificationToGroup(receipt.GroupId, "Comment Added", fmt.Sprintf("%s has added a comment to a receipt in group %s. %s", BuildParamaterisedString("userId", *comment.UserId, "displayName", "string"), BuildParamaterisedString("groupId", receipt.GroupId, "name", "string"), BuildParamaterisedString("receiptId", comment.ReceiptId, "noop", "link")), models.NOTIFICATION_TYPE_NORMAL, usersToOmit)
+		// Member isolation: suppress the notification for any group member who may
+		// not see the comment's author (the body names them) by adding them to the
+		// omit list.
+		hiddenRecipients, err := repository.recipientsWhoCannotSeeAuthor(authorId, receipt.GroupId, authorVisibleTo)
+		if err != nil {
+			return err
+		}
+		usersToOmit = append(usersToOmit, hiddenRecipients...)
+
+		err = notificationRepository.SendNotificationToGroup(receipt.GroupId, "Comment Added", fmt.Sprintf("%s has added a comment to a receipt in group %s. %s", BuildParamaterisedString("userId", authorId, "displayName", "string"), BuildParamaterisedString("groupId", receipt.GroupId, "name", "string"), BuildParamaterisedString("receiptId", comment.ReceiptId, "noop", "link")), models.NOTIFICATION_TYPE_NORMAL, usersToOmit)
 		if err != nil {
 			return err
 		}
@@ -138,11 +156,65 @@ func (repository CommentRepository) sendNotificationsToUsers(comment models.Comm
 			return err
 		}
 
-		err = notificationRepository.SendNotificationToUsers(threadUsers, "Comment Replied", fmt.Sprintf("%s has replied to a thread that you are a part of.", BuildParamaterisedString("userId", *comment.UserId, "displayName", "string")), models.NOTIFICATION_TYPE_NORMAL, usersToOmit)
+		hiddenRecipients, err := omitRecipientsWhoCannotSeeAuthor(authorId, threadUsers, authorVisibleTo)
+		if err != nil {
+			return err
+		}
+		usersToOmit = append(usersToOmit, hiddenRecipients...)
+
+		err = notificationRepository.SendNotificationToUsers(threadUsers, "Comment Replied", fmt.Sprintf("%s has replied to a thread that you are a part of.", BuildParamaterisedString("userId", authorId, "displayName", "string")), models.NOTIFICATION_TYPE_NORMAL, usersToOmit)
 		if err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// recipientsWhoCannotSeeAuthor returns the ids of the group's members who may not
+// see the comment author under member isolation (so they can be added to a
+// notification's omit list). A nil resolver returns no ids.
+func (repository CommentRepository) recipientsWhoCannotSeeAuthor(authorId uint, groupId uint, authorVisibleTo AuthorVisibilityResolver) ([]interface{}, error) {
+	if authorVisibleTo == nil {
+		return nil, nil
+	}
+
+	groupMemberRepository := NewGroupMemberRepository(repository.TX)
+	members, err := groupMemberRepository.GetsGroupMembersByGroupId(utils.UintToString(groupId))
+	if err != nil {
+		return nil, err
+	}
+
+	recipientIds := make([]uint, 0, len(members))
+	for _, member := range members {
+		recipientIds = append(recipientIds, member.UserID)
+	}
+
+	return omitRecipientsWhoCannotSeeAuthor(authorId, recipientIds, authorVisibleTo)
+}
+
+// omitRecipientsWhoCannotSeeAuthor evaluates each candidate recipient against the
+// author-visibility resolver and returns those who may not see the author. The
+// author is never included. A nil resolver returns no ids.
+func omitRecipientsWhoCannotSeeAuthor(authorId uint, recipientIds []uint, authorVisibleTo AuthorVisibilityResolver) ([]interface{}, error) {
+	if authorVisibleTo == nil {
+		return nil, nil
+	}
+
+	hidden := make([]interface{}, 0)
+	for _, recipientId := range recipientIds {
+		if recipientId == authorId {
+			continue
+		}
+
+		canSee, err := authorVisibleTo(authorId, recipientId)
+		if err != nil {
+			return nil, err
+		}
+		if !canSee {
+			hidden = append(hidden, recipientId)
+		}
+	}
+
+	return hidden, nil
 }

--- a/api/internal/repositories/comments.go
+++ b/api/internal/repositories/comments.go
@@ -179,6 +179,22 @@ func (repository CommentRepository) recipientsWhoCannotSeeAuthor(authorId uint, 
 		return nil, nil
 	}
 
+	// Fast path: a non-isolated group hides nothing, so no recipient can fail to see the
+	// author. Skip the roster fetch and the per-member visibility lookups entirely — the
+	// common case does one cheap flag read instead of O(members) resolver calls.
+	var group struct {
+		IsolateMembers bool
+	}
+	if err := repository.GetDB().Model(&models.Group{}).
+		Select("isolate_members").
+		Where("id = ?", groupId).
+		Scan(&group).Error; err != nil {
+		return nil, err
+	}
+	if !group.IsolateMembers {
+		return nil, nil
+	}
+
 	groupMemberRepository := NewGroupMemberRepository(repository.TX)
 	members, err := groupMemberRepository.GetsGroupMembersByGroupId(utils.UintToString(groupId))
 	if err != nil {

--- a/api/internal/repositories/comments.go
+++ b/api/internal/repositories/comments.go
@@ -14,12 +14,12 @@ type CommentRepository struct {
 }
 
 // AuthorVisibilityResolver reports whether a notification recipient is allowed to
-// see the comment's author (member-presence isolation). It lets the comment
-// repository suppress a notification whose body names an author the recipient may
-// not see, without importing the service layer that resolves visibility (mirroring
-// the PaidByAllowedResolver injection). A nil resolver disables suppression, so
-// every recipient receives (backward compatible).
-type AuthorVisibilityResolver func(authorId uint, recipientId uint) (canSeeAuthor bool, err error)
+// see the comment's author WITHIN the receipt's group (member-presence isolation). It
+// lets the comment repository suppress a notification whose body names an author the
+// recipient may not see in that group, without importing the service layer that
+// resolves visibility (mirroring the PaidByAllowedResolver injection). A nil resolver
+// disables suppression, so every recipient receives (backward compatible).
+type AuthorVisibilityResolver func(authorId uint, recipientId uint, groupId uint) (canSeeAuthor bool, err error)
 
 func NewCommentRepository(tx *gorm.DB) CommentRepository {
 	repository := CommentRepository{BaseRepository: BaseRepository{
@@ -156,7 +156,7 @@ func (repository CommentRepository) sendNotificationsToUsers(comment models.Comm
 			return err
 		}
 
-		hiddenRecipients, err := omitRecipientsWhoCannotSeeAuthor(authorId, threadUsers, authorVisibleTo)
+		hiddenRecipients, err := omitRecipientsWhoCannotSeeAuthor(authorId, threadUsers, receipt.GroupId, authorVisibleTo)
 		if err != nil {
 			return err
 		}
@@ -190,13 +190,13 @@ func (repository CommentRepository) recipientsWhoCannotSeeAuthor(authorId uint, 
 		recipientIds = append(recipientIds, member.UserID)
 	}
 
-	return omitRecipientsWhoCannotSeeAuthor(authorId, recipientIds, authorVisibleTo)
+	return omitRecipientsWhoCannotSeeAuthor(authorId, recipientIds, groupId, authorVisibleTo)
 }
 
 // omitRecipientsWhoCannotSeeAuthor evaluates each candidate recipient against the
-// author-visibility resolver and returns those who may not see the author. The
-// author is never included. A nil resolver returns no ids.
-func omitRecipientsWhoCannotSeeAuthor(authorId uint, recipientIds []uint, authorVisibleTo AuthorVisibilityResolver) ([]interface{}, error) {
+// author-visibility resolver (scoped to groupId) and returns those who may not see the
+// author. The author is never included. A nil resolver returns no ids.
+func omitRecipientsWhoCannotSeeAuthor(authorId uint, recipientIds []uint, groupId uint, authorVisibleTo AuthorVisibilityResolver) ([]interface{}, error) {
 	if authorVisibleTo == nil {
 		return nil, nil
 	}
@@ -207,7 +207,7 @@ func omitRecipientsWhoCannotSeeAuthor(authorId uint, recipientIds []uint, author
 			continue
 		}
 
-		canSee, err := authorVisibleTo(authorId, recipientId)
+		canSee, err := authorVisibleTo(authorId, recipientId, groupId)
 		if err != nil {
 			return nil, err
 		}

--- a/api/internal/repositories/comments_test.go
+++ b/api/internal/repositories/comments_test.go
@@ -1,6 +1,7 @@
 package repositories
 
 import (
+	"errors"
 	"receipt-wrangler/api/internal/commands"
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/utils"
@@ -64,5 +65,83 @@ func TestShouldAddCommentAndSendNotificationToAllGroupUsers(t *testing.T) {
 	user3Notifications, _ := notificationRepository.GetNotificationsForUser(3)
 	if len(user3Notifications) != 1 {
 		utils.PrintTestError(t, len(user3Notifications), 1)
+	}
+}
+
+// The reply/thread notification path omits recipients who cannot see the reply author.
+// This branch is not reachable through the public AddComment (UpsertCommentCommand
+// carries no commentId, and AddComment never sets Comment.CommentId), so it is exercised
+// directly with an injected resolver — which also proves the groupId threading is wired.
+func TestSendNotificationsReplyBranchOmitsRecipientsWhoCannotSeeAuthor(t *testing.T) {
+	defer teardownCommentTest()
+	setupCommentTest()
+
+	author := uint(1)
+	hidden := uint(2)
+	visible := uint(3)
+	receiptId := uint(1)
+
+	db := GetDB()
+	parent := models.Comment{Comment: "parent", ReceiptId: receiptId, UserId: &hidden}
+	if err := db.Create(&parent).Error; err != nil {
+		t.Fatalf("parent: %v", err)
+	}
+	visComment := models.Comment{Comment: "vis", ReceiptId: receiptId, UserId: &visible, CommentId: &parent.ID}
+	if err := db.Create(&visComment).Error; err != nil {
+		t.Fatalf("vis comment: %v", err)
+	}
+	reply := models.Comment{Comment: "reply", ReceiptId: receiptId, UserId: &author, CommentId: &parent.ID}
+	if err := db.Create(&reply).Error; err != nil {
+		t.Fatalf("reply: %v", err)
+	}
+
+	// Everyone except `hidden` can see the author.
+	resolver := func(authorId uint, recipientId uint, groupId uint) (bool, error) {
+		return recipientId != hidden, nil
+	}
+	if err := commentRepository.sendNotificationsToUsers(reply, resolver); err != nil {
+		t.Fatalf("sendNotificationsToUsers: %v", err)
+	}
+
+	notificationRepository := NewNotificationRepository(nil)
+	count := func(userId uint) int {
+		ns, err := notificationRepository.GetNotificationsForUser(userId)
+		if err != nil {
+			t.Fatalf("notifications for %d: %v", userId, err)
+		}
+		return len(ns)
+	}
+	if got := count(hidden); got != 0 {
+		t.Errorf("recipient who cannot see the reply author should be omitted, got %d", got)
+	}
+	if got := count(visible); got != 1 {
+		t.Errorf("recipient who can see the reply author should receive the reply notification, got %d", got)
+	}
+	if got := count(author); got != 0 {
+		t.Errorf("author should not be notified of their own reply, got %d", got)
+	}
+}
+
+// A resolver error in the notification path propagates out of AddComment.
+func TestAddCommentPropagatesAuthorVisibilityResolverError(t *testing.T) {
+	defer teardownCommentTest()
+	setupCommentTest()
+
+	// Isolate the group so the notification path actually invokes the resolver (the
+	// non-isolated fast path would otherwise short-circuit before calling it).
+	if err := GetDB().Model(&models.Group{}).Where("id = ?", uint(1)).
+		Update("isolate_members", true).Error; err != nil {
+		t.Fatalf("isolate group: %v", err)
+	}
+
+	author := uint(1)
+	comment := commands.UpsertCommentCommand{Comment: "test", ReceiptId: 1, UserId: &author}
+	boom := errors.New("resolver boom")
+	resolver := func(authorId uint, recipientId uint, groupId uint) (bool, error) {
+		return false, boom
+	}
+
+	if _, err := commentRepository.AddComment(comment, resolver); !errors.Is(err, boom) {
+		t.Fatalf("expected the resolver error to propagate from AddComment, got %v", err)
 	}
 }

--- a/api/internal/repositories/comments_test.go
+++ b/api/internal/repositories/comments_test.go
@@ -39,7 +39,7 @@ func TestShouldAddCommentAndSendNotificationToAllGroupUsers(t *testing.T) {
 		UserId:    &userId,
 	}
 
-	newComment, err := commentRepository.AddComment(comment)
+	newComment, err := commentRepository.AddComment(comment, nil)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return

--- a/api/internal/repositories/data_migrations_test.go
+++ b/api/internal/repositories/data_migrations_test.go
@@ -258,7 +258,7 @@ func TestRunDataMigrationsDoesNotClobberExistingAssignment(t *testing.T) {
 		utils.PrintTestError(t, err, nil)
 		return
 	}
-	customGroupRole, err := roleRepository.CreateGroupRole("Custom Group Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false)
+	customGroupRole, err := roleRepository.CreateGroupRole("Custom Group Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return

--- a/api/internal/repositories/groups.go
+++ b/api/internal/repositories/groups.go
@@ -96,6 +96,7 @@ func (repository GroupRepository) CreateGroup(command commands.UpsertGroupComman
 	groupToCreate.Name = command.Name
 	groupToCreate.Status = command.Status
 	groupToCreate.IsAllGroup = command.IsAllGroup
+	groupToCreate.IsolateMembers = command.IsolateMembers
 	for i := 0; i < len(command.GroupMembers); i++ {
 		groupMember := buildGroupMemberFromCommand(command.GroupMembers[i])
 		groupToCreate.GroupMembers = append(groupToCreate.GroupMembers, groupMember)
@@ -191,6 +192,13 @@ func (repository GroupRepository) UpdateGroup(command commands.UpsertGroupComman
 
 	err = db.Transaction(func(tx *gorm.DB) error {
 		txErr := tx.Session(&gorm.Session{FullSaveAssociations: true}).Model(&groupToUpdate).Omit("ID", "is_all_group").Updates(&groupToUpdate).Error
+		if txErr != nil {
+			return txErr
+		}
+
+		// Persist isolate_members explicitly: a struct Updates skips a zero-value
+		// (false) bool, so toggling isolation off would otherwise not persist.
+		txErr = tx.Model(&models.Group{}).Where("id = ?", uintId).Update("isolate_members", command.IsolateMembers).Error
 		if txErr != nil {
 			return txErr
 		}

--- a/api/internal/repositories/groups_test.go
+++ b/api/internal/repositories/groups_test.go
@@ -208,6 +208,79 @@ func TestUpdateGroupHonorsMemberGroupRoleId(t *testing.T) {
 	}
 }
 
+func TestCreateGroupPersistsIsolateMembers(t *testing.T) {
+	defer teardownGroupTest()
+	setUpGroupTest()
+	groupRepository := setupGroupRepository()
+
+	created, err := groupRepository.CreateGroup(commands.UpsertGroupCommand{Name: "iso", IsolateMembers: true}, 1)
+	if err != nil {
+		utils.PrintTestError(t, err, "Expected no error")
+		return
+	}
+	if !created.IsolateMembers {
+		utils.PrintTestError(t, created.IsolateMembers, true)
+	}
+
+	reloaded, err := groupRepository.GetGroupById(utils.UintToString(created.ID), true, false, false)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if !reloaded.IsolateMembers {
+		utils.PrintTestError(t, reloaded.IsolateMembers, true)
+	}
+}
+
+func TestUpdateGroupPersistsIsolateMembersToggle(t *testing.T) {
+	defer teardownGroupTest()
+	setUpGroupTest()
+	groupRepository := setupGroupRepository()
+
+	created, err := groupRepository.CreateGroup(commands.UpsertGroupCommand{Name: "iso", IsolateMembers: true}, 1)
+	if err != nil {
+		utils.PrintTestError(t, err, "Expected no error")
+		return
+	}
+	groupId := utils.UintToString(created.ID)
+	members := []commands.UpsertGroupMemberCommand{{UserID: 1, GroupID: created.ID}}
+
+	// Toggle isolation OFF — the false value must persist (a struct Updates would
+	// skip the zero-value bool, leaving isolation stuck on).
+	_, err = groupRepository.UpdateGroup(commands.UpsertGroupCommand{
+		Name: "iso", Status: models.GROUP_ACTIVE, GroupMembers: members, IsolateMembers: false,
+	}, groupId)
+	if err != nil {
+		utils.PrintTestError(t, err, "Expected no error")
+		return
+	}
+	reloaded, err := groupRepository.GetGroupById(groupId, true, false, false)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if reloaded.IsolateMembers {
+		utils.PrintTestError(t, reloaded.IsolateMembers, false)
+	}
+
+	// Toggle isolation back ON.
+	_, err = groupRepository.UpdateGroup(commands.UpsertGroupCommand{
+		Name: "iso", Status: models.GROUP_ACTIVE, GroupMembers: members, IsolateMembers: true,
+	}, groupId)
+	if err != nil {
+		utils.PrintTestError(t, err, "Expected no error")
+		return
+	}
+	reloaded, err = groupRepository.GetGroupById(groupId, true, false, false)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if !reloaded.IsolateMembers {
+		utils.PrintTestError(t, reloaded.IsolateMembers, true)
+	}
+}
+
 func TestShouldGetGroupById(t *testing.T) {
 	defer teardownGroupTest()
 	CreateTestGroup()

--- a/api/internal/repositories/member_visibility.go
+++ b/api/internal/repositories/member_visibility.go
@@ -1,0 +1,77 @@
+package repositories
+
+import (
+	"receipt-wrangler/api/internal/models"
+)
+
+// ViewerGroupRow describes one of a viewer's group memberships for member-isolation
+// resolution: the group, whether that group isolates its members, and whether the
+// viewer's own role in it is a SeesAllMembers (supervisor) role. ViewerSeesAll is
+// nil when the membership has no group role (treated as false — a plain member).
+type ViewerGroupRow struct {
+	GroupID        uint
+	IsolateMembers bool
+	ViewerSeesAll  *bool
+}
+
+// GetViewerGroupRows returns, for each group the viewer belongs to, the group's
+// isolation flag and whether the viewer's role there sees all members. Nullable
+// ViewerSeesAll avoids a cross-engine COALESCE on a boolean column.
+func (repository GroupMemberRepository) GetViewerGroupRows(viewerId uint) ([]ViewerGroupRow, error) {
+	db := repository.GetDB()
+	var rows []ViewerGroupRow
+
+	err := db.Table("group_members AS gm").
+		Select("gm.group_id AS group_id, g.isolate_members AS isolate_members, grd.sees_all_members AS viewer_sees_all").
+		Joins("JOIN groups AS g ON g.id = gm.group_id").
+		Joins("LEFT JOIN group_role_definitions AS grd ON grd.id = gm.group_role_id").
+		Where("gm.user_id = ?", viewerId).
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return rows, nil
+}
+
+// GetDistinctUserIdsInGroups returns every distinct member user id across the
+// given groups.
+func (repository GroupMemberRepository) GetDistinctUserIdsInGroups(groupIds []uint) ([]uint, error) {
+	ids := []uint{}
+	if len(groupIds) == 0 {
+		return ids, nil
+	}
+
+	err := repository.GetDB().
+		Model(&models.GroupMember{}).
+		Where("group_id IN ?", groupIds).
+		Distinct().
+		Pluck("user_id", &ids).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return ids, nil
+}
+
+// GetSupervisorUserIdsInGroups returns the distinct member user ids across the
+// given groups whose group role is flagged SeesAllMembers (supervisors — visible
+// to every isolated member).
+func (repository GroupMemberRepository) GetSupervisorUserIdsInGroups(groupIds []uint) ([]uint, error) {
+	ids := []uint{}
+	if len(groupIds) == 0 {
+		return ids, nil
+	}
+
+	err := repository.GetDB().
+		Table("group_members AS gm").
+		Joins("JOIN group_role_definitions AS grd ON grd.id = gm.group_role_id").
+		Where("gm.group_id IN ? AND grd.sees_all_members = ?", groupIds, true).
+		Distinct().
+		Pluck("gm.user_id", &ids).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return ids, nil
+}

--- a/api/internal/repositories/member_visibility.go
+++ b/api/internal/repositories/member_visibility.go
@@ -14,6 +14,30 @@ type ViewerGroupRow struct {
 	ViewerSeesAll  *bool
 }
 
+// GetViewerGroupRow returns the single (viewer, group) membership row — the group's
+// isolation flag and whether the viewer's role there sees all members — or found=false
+// when the viewer is not a member of the group. It is the single-group counterpart of
+// GetViewerGroupRows, used by the per-group visibility resolver.
+func (repository GroupMemberRepository) GetViewerGroupRow(viewerId uint, groupId uint) (ViewerGroupRow, bool, error) {
+	db := repository.GetDB()
+	var rows []ViewerGroupRow
+
+	err := db.Table("group_members AS gm").
+		Select("gm.group_id AS group_id, g.isolate_members AS isolate_members, grd.sees_all_members AS viewer_sees_all").
+		Joins("JOIN groups AS g ON g.id = gm.group_id").
+		Joins("LEFT JOIN group_role_definitions AS grd ON grd.id = gm.group_role_id").
+		Where("gm.user_id = ? AND gm.group_id = ?", viewerId, groupId).
+		Limit(1).
+		Scan(&rows).Error
+	if err != nil {
+		return ViewerGroupRow{}, false, err
+	}
+	if len(rows) == 0 {
+		return ViewerGroupRow{}, false, nil
+	}
+	return rows[0], true, nil
+}
+
 // GetViewerGroupRows returns, for each group the viewer belongs to, the group's
 // isolation flag and whether the viewer's role there sees all members. Nullable
 // ViewerSeesAll avoids a cross-engine COALESCE on a boolean column.
@@ -74,4 +98,36 @@ func (repository GroupMemberRepository) GetSupervisorUserIdsInGroups(groupIds []
 	}
 
 	return ids, nil
+}
+
+// GetSupervisorUserIdsByGroup returns a map of group_id -> distinct supervisor user ids
+// (members whose group role is flagged SeesAllMembers) across the given groups, so a
+// multi-group roster filter resolves every group's supervisors in ONE query rather than
+// one per group. A group with no supervisors is simply absent from the map.
+func (repository GroupMemberRepository) GetSupervisorUserIdsByGroup(groupIds []uint) (map[uint][]uint, error) {
+	result := map[uint][]uint{}
+	if len(groupIds) == 0 {
+		return result, nil
+	}
+
+	type supervisorRow struct {
+		GroupID uint
+		UserID  uint
+	}
+	var rows []supervisorRow
+	err := repository.GetDB().
+		Table("group_members AS gm").
+		Select("gm.group_id AS group_id, gm.user_id AS user_id").
+		Joins("JOIN group_role_definitions AS grd ON grd.id = gm.group_role_id").
+		Where("gm.group_id IN ? AND grd.sees_all_members = ?", groupIds, true).
+		Distinct().
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	for _, row := range rows {
+		result[row.GroupID] = append(result[row.GroupID], row.UserID)
+	}
+	return result, nil
 }

--- a/api/internal/repositories/member_visibility.go
+++ b/api/internal/repositories/member_visibility.go
@@ -14,28 +14,44 @@ type ViewerGroupRow struct {
 	ViewerSeesAll  *bool
 }
 
-// GetViewerGroupRow returns the single (viewer, group) membership row — the group's
-// isolation flag and whether the viewer's role there sees all members — or found=false
-// when the viewer is not a member of the group. It is the single-group counterpart of
+// GetViewerGroupRow returns the single (viewer, group) row for member-isolation
+// resolution: the group's isolation flag, whether the viewer's role there sees all
+// members, and whether the viewer is a MEMBER of the group. It starts FROM groups and
+// LEFT JOINs the viewer's membership, so it returns the isolation flag even when the
+// viewer is not a member — needed to decide whether a non-member (e.g. an app.groups.read
+// reader hitting GetGroupById) may see an isolated group's roster. Returns found=false
+// only when the group itself does not exist. It is the single-group counterpart of
 // GetViewerGroupRows, used by the per-group visibility resolver.
-func (repository GroupMemberRepository) GetViewerGroupRow(viewerId uint, groupId uint) (ViewerGroupRow, bool, error) {
+func (repository GroupMemberRepository) GetViewerGroupRow(viewerId uint, groupId uint) (ViewerGroupRow, bool, bool, error) {
 	db := repository.GetDB()
-	var rows []ViewerGroupRow
 
-	err := db.Table("group_members AS gm").
-		Select("gm.group_id AS group_id, g.isolate_members AS isolate_members, grd.sees_all_members AS viewer_sees_all").
-		Joins("JOIN groups AS g ON g.id = gm.group_id").
+	type viewerGroupRowScan struct {
+		GroupID        uint
+		IsolateMembers bool
+		ViewerSeesAll  *bool
+		MemberUserId   *uint
+	}
+	var rows []viewerGroupRowScan
+
+	err := db.Table("groups AS g").
+		Select("g.id AS group_id, g.isolate_members AS isolate_members, grd.sees_all_members AS viewer_sees_all, gm.user_id AS member_user_id").
+		Joins("LEFT JOIN group_members AS gm ON gm.group_id = g.id AND gm.user_id = ?", viewerId).
 		Joins("LEFT JOIN group_role_definitions AS grd ON grd.id = gm.group_role_id").
-		Where("gm.user_id = ? AND gm.group_id = ?", viewerId, groupId).
+		Where("g.id = ?", groupId).
 		Limit(1).
 		Scan(&rows).Error
 	if err != nil {
-		return ViewerGroupRow{}, false, err
+		return ViewerGroupRow{}, false, false, err
 	}
 	if len(rows) == 0 {
-		return ViewerGroupRow{}, false, nil
+		return ViewerGroupRow{}, false, false, nil
 	}
-	return rows[0], true, nil
+	row := rows[0]
+	return ViewerGroupRow{
+		GroupID:        row.GroupID,
+		IsolateMembers: row.IsolateMembers,
+		ViewerSeesAll:  row.ViewerSeesAll,
+	}, true, row.MemberUserId != nil, nil
 }
 
 // GetViewerGroupRows returns, for each group the viewer belongs to, the group's

--- a/api/internal/repositories/report_template_grant_test.go
+++ b/api/internal/repositories/report_template_grant_test.go
@@ -29,7 +29,7 @@ func TestReportTemplateGrantAndGroupTablesMigrate(t *testing.T) {
 	repository := NewRoleRepository(nil)
 
 	templateId := makeTestReportTemplate(t, "Quarterly")
-	role, err := repository.CreateGroupRole("Role", "", []string{permissions.GroupReportsRead}, nil, nil, nil, false)
+	role, err := repository.CreateGroupRole("Role", "", []string{permissions.GroupReportsRead}, nil, nil, nil, false, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -55,7 +55,7 @@ func TestDeleteReportTemplateCascadesGrantAndGroupRows(t *testing.T) {
 	repository := NewRoleRepository(nil)
 
 	templateId := makeTestReportTemplate(t, "Cascade Template")
-	role, err := repository.CreateGroupRole("Role", "", []string{permissions.GroupReportsRead}, nil, nil, nil, false)
+	role, err := repository.CreateGroupRole("Role", "", []string{permissions.GroupReportsRead}, nil, nil, nil, false, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -88,7 +88,7 @@ func TestDeleteGroupRoleCascadesReportTemplateGrants(t *testing.T) {
 	repository := NewRoleRepository(nil)
 
 	templateId := makeTestReportTemplate(t, "Role Cascade Template")
-	role, err := repository.CreateGroupRole("Role", "", []string{permissions.GroupReportsRead}, nil, nil, nil, false)
+	role, err := repository.CreateGroupRole("Role", "", []string{permissions.GroupReportsRead}, nil, nil, nil, false, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -115,7 +115,7 @@ func TestReplaceGroupRoleReportTemplateGrantsPersistsAndReplaces(t *testing.T) {
 	t1 := makeTestReportTemplate(t, "T1")
 	t2 := makeTestReportTemplate(t, "T2")
 
-	role, err := repository.CreateGroupRole("Report Role", "", []string{permissions.GroupReportsRead}, nil, nil, nil, false)
+	role, err := repository.CreateGroupRole("Report Role", "", []string{permissions.GroupReportsRead}, nil, nil, nil, false, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -185,7 +185,7 @@ func TestReplaceGroupRoleReportTemplateGrantsEmptyClearsRestricted(t *testing.T)
 	repository := NewRoleRepository(nil)
 
 	t1 := makeTestReportTemplate(t, "T1")
-	role, err := repository.CreateGroupRole("Report Role", "", []string{permissions.GroupReportsRead}, nil, nil, nil, false)
+	role, err := repository.CreateGroupRole("Report Role", "", []string{permissions.GroupReportsRead}, nil, nil, nil, false, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return

--- a/api/internal/repositories/roles.go
+++ b/api/internal/repositories/roles.go
@@ -44,7 +44,7 @@ func (repository RoleRepository) CreateAppRole(name string, description string, 
 	return role, nil
 }
 
-func (repository RoleRepository) CreateGroupRole(name string, description string, perms []string, categoryGrantIds []uint, tagGrantIds []uint, paidByUserGrantIds []uint, includeOwnPaidReceipts bool) (models.GroupRoleDefinition, error) {
+func (repository RoleRepository) CreateGroupRole(name string, description string, perms []string, categoryGrantIds []uint, tagGrantIds []uint, paidByUserGrantIds []uint, includeOwnPaidReceipts bool, seesAllMembers bool) (models.GroupRoleDefinition, error) {
 	db := repository.GetDB()
 
 	rolePermissions := make([]models.GroupRolePermission, 0, len(perms))
@@ -57,6 +57,7 @@ func (repository RoleRepository) CreateGroupRole(name string, description string
 		Description:                description,
 		IncludeOwnPaidReceipts:     includeOwnPaidReceipts,
 		PaidByVisibilityRestricted: includeOwnPaidReceipts || len(paidByUserGrantIds) > 0,
+		SeesAllMembers:             seesAllMembers,
 		Permissions:                rolePermissions,
 	}
 
@@ -133,7 +134,7 @@ func (repository RoleRepository) UpdateAppRole(id uint, name string, description
 	return repository.GetAppRoleById(id)
 }
 
-func (repository RoleRepository) UpdateGroupRole(id uint, name string, description string, perms []string, categoryGrantIds []uint, tagGrantIds []uint, paidByUserGrantIds []uint, includeOwnPaidReceipts bool) (models.GroupRoleDefinition, error) {
+func (repository RoleRepository) UpdateGroupRole(id uint, name string, description string, perms []string, categoryGrantIds []uint, tagGrantIds []uint, paidByUserGrantIds []uint, includeOwnPaidReceipts bool, seesAllMembers bool) (models.GroupRoleDefinition, error) {
 	db := repository.GetDB()
 
 	err := db.Where("group_role_id = ?", id).Delete(&models.GroupRolePermission{}).Error
@@ -148,6 +149,7 @@ func (repository RoleRepository) UpdateGroupRole(id uint, name string, descripti
 		"description":                   description,
 		"include_own_paid_receipts":     includeOwnPaidReceipts,
 		"paid_by_visibility_restricted": includeOwnPaidReceipts || len(paidByUserGrantIds) > 0,
+		"sees_all_members":              seesAllMembers,
 	}).Error
 	if err != nil {
 		return models.GroupRoleDefinition{}, err
@@ -313,12 +315,12 @@ func (repository RoleRepository) GetAllRoles() ([]structs.RoleView, error) {
 		}
 
 		roles = append(roles, structs.RoleView{
-			Id:               role.ID,
-			Name:             role.Name,
-			Description:      role.Description,
-			Scope:            permissions.ScopeApp,
-			IsDefault:        role.IsDefault,
-			IsSystem:         role.IsSystem,
+			Id:                   role.ID,
+			Name:                 role.Name,
+			Description:          role.Description,
+			Scope:                permissions.ScopeApp,
+			IsDefault:            role.IsDefault,
+			IsSystem:             role.IsSystem,
 			Permissions:          perms,
 			AssignedCount:        appRoleCounts[role.ID],
 			CategoryGrants:       []uint{},
@@ -347,6 +349,7 @@ func (repository RoleRepository) GetAllRoles() ([]structs.RoleView, error) {
 			TagGrants:              tagGrantIdsFromRole(role),
 			PaidByUserGrants:       paidByUserGrantIdsFromRole(role),
 			IncludeOwnPaidReceipts: role.IncludeOwnPaidReceipts,
+			SeesAllMembers:         role.SeesAllMembers,
 			ReportTemplateGrants:   ReportTemplateGrantsFromRole(role),
 		})
 	}

--- a/api/internal/repositories/roles_grants_test.go
+++ b/api/internal/repositories/roles_grants_test.go
@@ -26,6 +26,73 @@ func makeTestTag(t *testing.T, name string) uint {
 	return tag.ID
 }
 
+func TestCreateGroupRolePersistsSeesAllMembers(t *testing.T) {
+	defer TruncateTestDb()
+	repository := NewRoleRepository(nil)
+
+	role, err := repository.CreateGroupRole("Supervisor Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false, true)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if !role.SeesAllMembers {
+		utils.PrintTestError(t, role.SeesAllMembers, true)
+	}
+
+	reloaded, err := repository.GetGroupRoleById(role.ID)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if !reloaded.SeesAllMembers {
+		utils.PrintTestError(t, reloaded.SeesAllMembers, true)
+	}
+}
+
+func TestUpdateGroupRolePersistsSeesAllMembersToggle(t *testing.T) {
+	defer TruncateTestDb()
+	repository := NewRoleRepository(nil)
+
+	created, err := repository.CreateGroupRole("Supervisor Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false, true)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+
+	// Toggle off — the false value must persist (map Updates form).
+	updated, err := repository.UpdateGroupRole(created.ID, "Supervisor Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false, false)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if updated.SeesAllMembers {
+		utils.PrintTestError(t, updated.SeesAllMembers, false)
+	}
+	reloaded, err := repository.GetGroupRoleById(created.ID)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if reloaded.SeesAllMembers {
+		utils.PrintTestError(t, reloaded.SeesAllMembers, false)
+	}
+
+	// Toggle back on.
+	_, err = repository.UpdateGroupRole(created.ID, "Supervisor Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false, true)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	reloaded, err = repository.GetGroupRoleById(created.ID)
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if !reloaded.SeesAllMembers {
+		utils.PrintTestError(t, reloaded.SeesAllMembers, true)
+	}
+}
+
 func TestCreateGroupRolePersistsCategoryAndTagGrants(t *testing.T) {
 	defer TruncateTestDb()
 	repository := NewRoleRepository(nil)
@@ -41,7 +108,7 @@ func TestCreateGroupRolePersistsCategoryAndTagGrants(t *testing.T) {
 		[]uint{cat1, cat2},
 		[]uint{tag1},
 		nil,
-		false,
+		false, false,
 	)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
@@ -81,7 +148,7 @@ func TestCreateGroupRoleWithNoGrantsIsUnrestricted(t *testing.T) {
 	defer TruncateTestDb()
 	repository := NewRoleRepository(nil)
 
-	role, err := repository.CreateGroupRole("Open Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false)
+	role, err := repository.CreateGroupRole("Open Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -106,14 +173,14 @@ func TestUpdateGroupRoleReplacesGrants(t *testing.T) {
 	cat3 := makeTestCategory(t, "Travel")
 	tag1 := makeTestTag(t, "Reimbursable")
 
-	created, err := repository.CreateGroupRole("Role", "", []string{permissions.GroupReceiptsRead}, []uint{cat1, cat2}, []uint{tag1}, nil, false)
+	created, err := repository.CreateGroupRole("Role", "", []string{permissions.GroupReceiptsRead}, []uint{cat1, cat2}, []uint{tag1}, nil, false, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
 	}
 
 	// Replace the grant sets entirely with cat3 and no tags.
-	updated, err := repository.UpdateGroupRole(created.ID, "Role", "", []string{permissions.GroupReceiptsRead}, []uint{cat3}, nil, nil, false)
+	updated, err := repository.UpdateGroupRole(created.ID, "Role", "", []string{permissions.GroupReceiptsRead}, []uint{cat3}, nil, nil, false, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -143,7 +210,7 @@ func TestDeleteGroupRoleCascadesGrants(t *testing.T) {
 	cat1 := makeTestCategory(t, "Groceries")
 	tag1 := makeTestTag(t, "Reimbursable")
 
-	created, err := repository.CreateGroupRole("Role", "", []string{permissions.GroupReceiptsRead}, []uint{cat1}, []uint{tag1}, nil, false)
+	created, err := repository.CreateGroupRole("Role", "", []string{permissions.GroupReceiptsRead}, []uint{cat1}, []uint{tag1}, nil, false, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -226,7 +293,7 @@ func TestCreateGroupRolePersistsPaidByGrants(t *testing.T) {
 		nil,
 		nil,
 		[]uint{payer1, payer2},
-		true,
+		true, false,
 	)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
@@ -268,7 +335,7 @@ func TestUpdateGroupRolePersistsIncludeOwnToggleOff(t *testing.T) {
 
 	payer := makeTestUser(t, "toggle-payer")
 
-	created, err := repository.CreateGroupRole("Toggle Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, []uint{payer}, true)
+	created, err := repository.CreateGroupRole("Toggle Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, []uint{payer}, true, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -276,7 +343,7 @@ func TestUpdateGroupRolePersistsIncludeOwnToggleOff(t *testing.T) {
 
 	// Toggle include-own OFF and drop the user grant. The map-based update must
 	// persist the false value (a struct update would skip the zero-value bool).
-	updated, err := repository.UpdateGroupRole(created.ID, "Toggle Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false)
+	updated, err := repository.UpdateGroupRole(created.ID, "Toggle Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -305,7 +372,7 @@ func TestDeleteGroupRoleCascadesPaidByGrants(t *testing.T) {
 
 	payer := makeTestUser(t, "cascade-payer")
 
-	created, err := repository.CreateGroupRole("Cascade Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, []uint{payer}, false)
+	created, err := repository.CreateGroupRole("Cascade Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, []uint{payer}, false, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -340,7 +407,7 @@ func TestGroupRolePaidByVisibilityRestrictedPersists(t *testing.T) {
 	}
 
 	// Specific-user grant (no include-own) is restricted.
-	usersOnly, err := repository.CreateGroupRole("Users Only", "", []string{permissions.GroupReceiptsRead}, nil, nil, []uint{payer}, false)
+	usersOnly, err := repository.CreateGroupRole("Users Only", "", []string{permissions.GroupReceiptsRead}, nil, nil, []uint{payer}, false, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -348,7 +415,7 @@ func TestGroupRolePaidByVisibilityRestrictedPersists(t *testing.T) {
 	assertRestricted(usersOnly.ID, true, "users-only role should be restricted")
 
 	// Include-own only is restricted.
-	ownOnly, err := repository.CreateGroupRole("Own Only", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, true)
+	ownOnly, err := repository.CreateGroupRole("Own Only", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, true, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -356,7 +423,7 @@ func TestGroupRolePaidByVisibilityRestrictedPersists(t *testing.T) {
 	assertRestricted(ownOnly.ID, true, "include-own role should be restricted")
 
 	// Empty paid-by config is NOT restricted (unrestricted = see everyone).
-	open, err := repository.CreateGroupRole("Open", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false)
+	open, err := repository.CreateGroupRole("Open", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -365,7 +432,7 @@ func TestGroupRolePaidByVisibilityRestrictedPersists(t *testing.T) {
 
 	// Updating a restricted role to an empty config clears the flag (map update
 	// persists the false value).
-	_, err = repository.UpdateGroupRole(usersOnly.ID, "Users Only", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false)
+	_, err = repository.UpdateGroupRole(usersOnly.ID, "Users Only", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return

--- a/api/internal/repositories/roles_test.go
+++ b/api/internal/repositories/roles_test.go
@@ -49,7 +49,7 @@ func TestCreateGroupRolePersistsPermissions(t *testing.T) {
 	repository := NewRoleRepository(nil)
 
 	perms := []string{permissions.GroupReceiptsCreate}
-	role, err := repository.CreateGroupRole("Group Role", "Description", perms, nil, nil, nil, false)
+	role, err := repository.CreateGroupRole("Group Role", "Description", perms, nil, nil, nil, false, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -93,13 +93,13 @@ func TestUpdateGroupRolePersistsChanges(t *testing.T) {
 	defer TruncateTestDb()
 	repository := NewRoleRepository(nil)
 
-	created, err := repository.CreateGroupRole("Group Role", "Description", []string{permissions.GroupReceiptsCreate}, nil, nil, nil, false)
+	created, err := repository.CreateGroupRole("Group Role", "Description", []string{permissions.GroupReceiptsCreate}, nil, nil, nil, false, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
 	}
 
-	updated, err := repository.UpdateGroupRole(created.ID, "Renamed Group Role", "New description", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false)
+	updated, err := repository.UpdateGroupRole(created.ID, "Renamed Group Role", "New description", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -228,7 +228,7 @@ func TestGetGroupRolePermissions(t *testing.T) {
 	repository := NewRoleRepository(nil)
 
 	perms := []string{permissions.GroupReceiptsRead}
-	role, err := repository.CreateGroupRole("Group Role", "", perms, nil, nil, nil, false)
+	role, err := repository.CreateGroupRole("Group Role", "", perms, nil, nil, nil, false, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -298,7 +298,7 @@ func TestGetGroupMemberRoleId(t *testing.T) {
 		utils.PrintTestError(t, err, nil)
 		return
 	}
-	role, err := repository.CreateGroupRole("Group Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false)
+	role, err := repository.CreateGroupRole("Group Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
@@ -378,12 +378,12 @@ func TestSetDefaultGroupRoleClearsOthers(t *testing.T) {
 	defer TruncateTestDb()
 	repository := NewRoleRepository(nil)
 
-	first, err := repository.CreateGroupRole("First", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false)
+	first, err := repository.CreateGroupRole("First", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return
 	}
-	second, err := repository.CreateGroupRole("Second", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false)
+	second, err := repository.CreateGroupRole("Second", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return

--- a/api/internal/repositories/system_task.go
+++ b/api/internal/repositories/system_task.go
@@ -59,7 +59,17 @@ func (repository SystemTaskRepository) GetPagedSystemTasks(command commands.GetS
 	return results, count, nil
 }
 
-func (repository SystemTaskRepository) GetPagedActivities(command commands.PagedActivityRequestCommand) (
+// ActivityVisibilityResolver reports, for a group, the ran-by user ids the caller may
+// see under member isolation, or unrestricted == true (see every actor). It is the
+// activity analogue of PaidByAllowedResolver: it lets the handler inject the service-layer
+// per-group visible set without the repository importing services. A nil resolver skips
+// isolation filtering (backward compatible).
+type ActivityVisibilityResolver func(groupId uint) (visibleUserIds []uint, unrestricted bool, err error)
+
+func (repository SystemTaskRepository) GetPagedActivities(
+	command commands.PagedActivityRequestCommand,
+	resolver ActivityVisibilityResolver,
+) (
 	[]structs.Activity,
 	int64,
 	error,
@@ -85,6 +95,14 @@ func (repository SystemTaskRepository) GetPagedActivities(command commands.Paged
 		Where("group_id IN ?", command.GroupIds).
 		Not(db.Where("type = ? AND ran_by_user_id IS NULL", models.RECEIPT_UPLOADED))
 
+	// Member isolation: drop activities run by a user the caller may not see in that
+	// activity's group IN THE QUERY (before Count + pagination), so TotalCount and the
+	// returned page both reflect only visible rows and DB-side LIMIT/OFFSET is preserved.
+	query, err := repository.applyActivityVisibilityDisjunction(query, command.GroupIds, resolver)
+	if err != nil {
+		return nil, 0, err
+	}
+
 	query.Count(&count)
 
 	query = repository.Sort(query, command.OrderBy, command.SortDirection)
@@ -93,6 +111,53 @@ func (repository SystemTaskRepository) GetPagedActivities(command commands.Paged
 	query.Find(&results)
 
 	return results, count, nil
+}
+
+// applyActivityVisibilityDisjunction AND-s a per-group actor-visibility disjunction onto
+// the query, mirroring ReceiptRepository.ApplyPaidByDisjunction. A nil resolver adds no
+// predicate. For each group the caller sees every actor (unrestricted) the clause is just
+// group_id = G; otherwise it is group_id = G AND (ran_by_user_id IS NULL OR ran_by_user_id
+// IN <visible ids>) — so system actions (nil ran-by) stay visible and only visible
+// members' activities survive. Applied before Count so pagination stays consistent.
+func (repository SystemTaskRepository) applyActivityVisibilityDisjunction(
+	query *gorm.DB,
+	groupIds []uint,
+	resolver ActivityVisibilityResolver,
+) (*gorm.DB, error) {
+	if resolver == nil {
+		return query, nil
+	}
+	if len(groupIds) == 0 {
+		return query.Where("1 = 0"), nil
+	}
+
+	disjunction := repository.GetDB().Session(&gorm.Session{NewDB: true})
+	for _, groupId := range groupIds {
+		visibleIds, unrestricted, err := resolver(groupId)
+		if err != nil {
+			return nil, err
+		}
+		if unrestricted {
+			disjunction = disjunction.Or("group_id = ?", groupId)
+		} else {
+			groupCondition := repository.GetDB().Session(&gorm.Session{NewDB: true}).
+				Where("group_id = ?", groupId).
+				Where("(ran_by_user_id IS NULL OR ran_by_user_id IN ?)", activityInValues(visibleIds))
+			disjunction = disjunction.Or(groupCondition)
+		}
+	}
+
+	return query.Where(disjunction), nil
+}
+
+// activityInValues guards the IN clause against an empty visible set (a restricted set
+// always contains at least the caller's own id, but guard defensively): ran-by user ids
+// start at 1, so 0 matches no row, yielding "see nothing" rather than a malformed IN ().
+func activityInValues(visibleUserIds []uint) []uint {
+	if len(visibleUserIds) == 0 {
+		return []uint{0}
+	}
+	return visibleUserIds
 }
 
 func isColumnNameValid(columnName string) bool {

--- a/api/internal/repositories/system_task_test.go
+++ b/api/internal/repositories/system_task_test.go
@@ -1,0 +1,122 @@
+package repositories
+
+import (
+	"receipt-wrangler/api/internal/commands"
+	"receipt-wrangler/api/internal/models"
+	"testing"
+	"time"
+)
+
+// GetPagedActivities applies the actor-visibility disjunction in SQL BEFORE COUNT/LIMIT:
+// a hidden actor's activities affect neither the returned rows nor the total, even when
+// they are newer and would otherwise fill the first page.
+func TestGetPagedActivitiesFiltersByVisibilityBeforeCountAndLimit(t *testing.T) {
+	defer TruncateTestDb()
+	db := GetDB()
+
+	group := models.Group{Name: "act-vis-grp"}
+	db.Create(&group)
+	visible := models.User{Username: "act-visible", Password: "x"}
+	hidden := models.User{Username: "act-hidden", Password: "x"}
+	db.Create(&visible)
+	db.Create(&hidden)
+
+	gid := group.ID
+	// Hidden activities are NEWER (sort first by started_at desc); the visible one is the
+	// oldest, so a limit applied before filtering would drop it.
+	for i := 0; i < 5; i++ {
+		hid := hidden.ID
+		db.Create(&models.SystemTask{
+			Type:                 models.QUICK_SCAN,
+			Status:               models.SYSTEM_TASK_SUCCEEDED,
+			AssociatedEntityType: models.NOOP_ENTITY_TYPE,
+			GroupId:              &gid,
+			RanByUserId:          &hid,
+			StartedAt:            time.Now().Add(time.Duration(i+1) * time.Hour),
+		})
+	}
+	vid := visible.ID
+	db.Create(&models.SystemTask{
+		Type:                 models.QUICK_SCAN,
+		Status:               models.SYSTEM_TASK_SUCCEEDED,
+		AssociatedEntityType: models.NOOP_ENTITY_TYPE,
+		GroupId:              &gid,
+		RanByUserId:          &vid,
+		StartedAt:            time.Now(),
+	})
+
+	// The resolver restricts the group to the visible actor only.
+	resolver := func(groupId uint) ([]uint, bool, error) {
+		return []uint{visible.ID}, false, nil
+	}
+
+	command := commands.PagedActivityRequestCommand{
+		PagedRequestCommand: commands.PagedRequestCommand{
+			Page:          1,
+			PageSize:      3,
+			OrderBy:       "started_at",
+			SortDirection: commands.DESCENDING,
+		},
+		GroupIds: []uint{group.ID},
+	}
+
+	activities, count, err := NewSystemTaskRepository(nil).GetPagedActivities(command, resolver)
+	if err != nil {
+		t.Fatalf("GetPagedActivities: %v", err)
+	}
+
+	// Only the visible actor's one activity is counted and returned, even though the
+	// hidden ones are newer and a pre-filter limit of 3 would have returned them.
+	if count != 1 {
+		t.Errorf("TotalCount = %d, want 1 (filtered before count)", count)
+	}
+	if len(activities) != 1 {
+		t.Fatalf("returned %d rows, want 1", len(activities))
+	}
+	if activities[0].RanByUserId == nil || *activities[0].RanByUserId != visible.ID {
+		t.Errorf("returned activity should be the visible actor's, got %+v", activities[0])
+	}
+}
+
+// A nil resolver adds no predicate (backward compatible): every matching activity is
+// returned and counted.
+func TestGetPagedActivitiesNilResolverUnfiltered(t *testing.T) {
+	defer TruncateTestDb()
+	db := GetDB()
+
+	group := models.Group{Name: "act-nil-grp"}
+	db.Create(&group)
+	user := models.User{Username: "act-nil-user", Password: "x"}
+	db.Create(&user)
+
+	gid := group.ID
+	uid := user.ID
+	for i := 0; i < 2; i++ {
+		db.Create(&models.SystemTask{
+			Type:                 models.QUICK_SCAN,
+			Status:               models.SYSTEM_TASK_SUCCEEDED,
+			AssociatedEntityType: models.NOOP_ENTITY_TYPE,
+			GroupId:              &gid,
+			RanByUserId:          &uid,
+			StartedAt:            time.Now(),
+		})
+	}
+
+	command := commands.PagedActivityRequestCommand{
+		PagedRequestCommand: commands.PagedRequestCommand{
+			Page:          1,
+			PageSize:      10,
+			OrderBy:       "started_at",
+			SortDirection: commands.DESCENDING,
+		},
+		GroupIds: []uint{group.ID},
+	}
+
+	activities, count, err := NewSystemTaskRepository(nil).GetPagedActivities(command, nil)
+	if err != nil {
+		t.Fatalf("GetPagedActivities: %v", err)
+	}
+	if count != 2 || len(activities) != 2 {
+		t.Errorf("nil resolver should return all rows unfiltered, got count=%d rows=%d", count, len(activities))
+	}
+}

--- a/api/internal/services/auth.go
+++ b/api/internal/services/auth.go
@@ -319,6 +319,18 @@ func GetAppData(userId uint, r *http.Request) (structs.AppData, error) {
 		tags = []models.Tag{}
 	}
 
+	// Member-presence isolation: an isolated member receives only the users and
+	// co-members they are allowed to see (no-op for unrestricted viewers). Applied
+	// at this serialization boundary, NOT inside GetGroupsForUser / GetAllUserViews,
+	// because those feed internal accounting/processing that needs the full roster.
+	users, err = permissionService.FilterVisibleUserViews(userId, users)
+	if err != nil {
+		return appData, err
+	}
+	if err := permissionService.FilterGroupMembersForGroups(userId, groups); err != nil {
+		return appData, err
+	}
+
 	appData.About = about
 	appData.Groups = groups
 	appData.Users = users

--- a/api/internal/services/auth_test.go
+++ b/api/internal/services/auth_test.go
@@ -439,6 +439,70 @@ func TestGetAppData_PopulatesFields(t *testing.T) {
 	}
 }
 
+// GetAppData applies member isolation at the serialization boundary: a plain member of
+// an isolated group sees neither a peer's user-directory entry nor the peer in that
+// group's roster, while self + the supervisor remain.
+func TestGetAppData_IsolationHidesPeerFromDirectoryAndRoster(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearRolePermissionCacheAll()
+
+	group := seedIsoGroup(t, "appdata-iso", true)
+	supRole := seedIsoRole(t, "appdata-iso-sup", true)
+	memberRole := seedIsoRole(t, "appdata-iso-mem", false)
+
+	viewer := seedIsoUser(t, "appdata-iso-viewer")
+	supervisor := seedIsoUser(t, "appdata-iso-sup-user")
+	peer := seedIsoUser(t, "appdata-iso-peer")
+	seedIsoMember(t, group.ID, viewer.ID, &memberRole.ID)
+	seedIsoMember(t, group.ID, supervisor.ID, &supRole.ID)
+	seedIsoMember(t, group.ID, peer.ID, &memberRole.ID)
+
+	appData, err := GetAppData(viewer.ID, nil)
+	if err != nil {
+		t.Fatalf("GetAppData: %v", err)
+	}
+
+	// Directory (appData.Users): peer absent; self + supervisor present.
+	inUsers := func(id uint) bool {
+		for _, u := range appData.Users {
+			if u.ID == id {
+				return true
+			}
+		}
+		return false
+	}
+	if inUsers(peer.ID) {
+		t.Errorf("peer should be hidden from appData.Users for an isolated member")
+	}
+	if !inUsers(viewer.ID) || !inUsers(supervisor.ID) {
+		t.Errorf("self + supervisor should remain in appData.Users")
+	}
+
+	// Roster of the isolated group: peer absent; self + supervisor present.
+	var isoRoster []uint
+	for _, g := range appData.Groups {
+		if g.ID == group.ID {
+			for _, m := range g.GroupMembers {
+				isoRoster = append(isoRoster, m.UserID)
+			}
+		}
+	}
+	contains := func(ids []uint, id uint) bool {
+		for _, x := range ids {
+			if x == id {
+				return true
+			}
+		}
+		return false
+	}
+	if contains(isoRoster, peer.ID) {
+		t.Errorf("peer should be hidden from the isolated group's roster, got %v", isoRoster)
+	}
+	if !contains(isoRoster, viewer.ID) || !contains(isoRoster, supervisor.ID) {
+		t.Errorf("self + supervisor should remain in the isolated group's roster, got %v", isoRoster)
+	}
+}
+
 // GetAppData with non-nil request that carries ValidatedClaims — Claims
 // should be populated on the AppData.
 func TestGetAppData_WithRequestPopulatesClaims(t *testing.T) {

--- a/api/internal/services/auth_test.go
+++ b/api/internal/services/auth_test.go
@@ -498,7 +498,7 @@ func TestGetAppData_PopulatesPermissions(t *testing.T) {
 	}
 
 	groupPerms := []string{permissions.GroupReceiptsRead, permissions.GroupReceiptsUpdate}
-	groupRole, err := roleRepository.CreateGroupRole("AppData Group Role", "", groupPerms, nil, nil, nil, false)
+	groupRole, err := roleRepository.CreateGroupRole("AppData Group Role", "", groupPerms, nil, nil, nil, false, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 	}
@@ -554,7 +554,7 @@ func TestGetAppData_GroupCategoriesFilteredByGrants(t *testing.T) {
 		utils.PrintTestError(t, err, nil)
 	}
 
-	groupRole, err := roleRepository.CreateGroupRole("AppData Restricted Role", "", []string{permissions.GroupReceiptsRead}, []uint{grantedCategory.ID}, nil, nil, false)
+	groupRole, err := roleRepository.CreateGroupRole("AppData Restricted Role", "", []string{permissions.GroupReceiptsRead}, []uint{grantedCategory.ID}, nil, nil, false, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 	}
@@ -604,7 +604,7 @@ func TestGetAppData_AdminGetsFlatCategoriesUnrestrictedGroup(t *testing.T) {
 		utils.PrintTestError(t, err, nil)
 	}
 
-	groupRole, err := roleRepository.CreateGroupRole("AppData Open Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false)
+	groupRole, err := roleRepository.CreateGroupRole("AppData Open Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 	}

--- a/api/internal/services/grant_filter_test.go
+++ b/api/internal/services/grant_filter_test.go
@@ -135,7 +135,7 @@ func TestFilterReceiptBatchPerGroup(t *testing.T) {
 	db := repositories.GetDB()
 	groupB := models.Group{Name: "group-b"}
 	db.Create(&groupB)
-	roleB, err := repositories.NewRoleRepository(nil).CreateGroupRole("Role B", "", []string{permissions.GroupReceiptsRead}, []uint{catB}, nil, nil, false)
+	roleB, err := repositories.NewRoleRepository(nil).CreateGroupRole("Role B", "", []string{permissions.GroupReceiptsRead}, []uint{catB}, nil, nil, false, false)
 	if err != nil {
 		t.Fatalf("create role B: %v", err)
 	}

--- a/api/internal/services/grant_test.go
+++ b/api/internal/services/grant_test.go
@@ -22,7 +22,7 @@ func seedMemberWithGroupRoleGrants(t *testing.T, username string, categoryGrantI
 	}
 
 	roleRepository := repositories.NewRoleRepository(nil)
-	role, err := roleRepository.CreateGroupRole("Grant Role "+username, "", []string{permissions.GroupReceiptsRead}, categoryGrantIds, tagGrantIds, nil, false)
+	role, err := roleRepository.CreateGroupRole("Grant Role "+username, "", []string{permissions.GroupReceiptsRead}, categoryGrantIds, tagGrantIds, nil, false, false)
 	if err != nil {
 		t.Fatalf("seed group role: %v", err)
 	}

--- a/api/internal/services/group_member_authorization_test.go
+++ b/api/internal/services/group_member_authorization_test.go
@@ -25,7 +25,7 @@ func TestAuthorizeGroupMemberChanges(t *testing.T) {
 	}
 
 	mustRole := func(name string, perms []string) uint {
-		role, err := roleRepository.CreateGroupRole(name, "", perms, nil, nil, nil, false)
+		role, err := roleRepository.CreateGroupRole(name, "", perms, nil, nil, nil, false, false)
 		if err != nil {
 			t.Fatalf("seed role %q: %v", name, err)
 		}

--- a/api/internal/services/groups.go
+++ b/api/internal/services/groups.go
@@ -47,31 +47,6 @@ func NewGroupService(tx *gorm.DB) GroupService {
 //     permissions are a subset of the caller's own current group permissions. This
 //     is what actually prevents self-escalation to owner and eviction of a
 //     more-privileged member.
-// AuthorizeAddedMembersVisibility rejects any member the caller is adding whom the
-// caller may not see, for member-presence isolation. Self is always allowed, and
-// unrestricted callers (admins/supervisors, and every caller on a non-isolated
-// install) are exempt. Used by the create-group path; the update path enforces the
-// same rule inline in AuthorizeGroupMemberChanges.
-func (service GroupService) AuthorizeAddedMembersVisibility(callerId uint, members []commands.UpsertGroupMemberCommand) error {
-	permissionService := NewPermissionService(service.TX)
-	visibleUsers, unrestricted, err := permissionService.GetVisibleUserIdsForUser(callerId)
-	if err != nil {
-		return err
-	}
-	if unrestricted {
-		return nil
-	}
-	for _, member := range members {
-		if member.UserID == callerId {
-			continue
-		}
-		if _, ok := visibleUsers[member.UserID]; !ok {
-			return ErrGroupMemberChangeForbidden
-		}
-	}
-	return nil
-}
-
 func (service GroupService) AuthorizeGroupMemberChanges(callerId uint, groupId uint, submitted []commands.UpsertGroupMemberCommand) error {
 	permissionService := NewPermissionService(service.TX)
 	roleRepository := repositories.NewRoleRepository(service.TX)
@@ -83,16 +58,6 @@ func (service GroupService) AuthorizeGroupMemberChanges(callerId uint, groupId u
 	hasCreate := permissions.HasAll(callerPerms, permissions.GroupMembersCreate)
 	hasUpdate := permissions.HasAll(callerPerms, permissions.GroupMembersUpdate)
 	hasDelete := permissions.HasAll(callerPerms, permissions.GroupMembersDelete)
-
-	// Member-presence isolation: an isolated caller may only add users they can
-	// already see. Without this a caller could enumerate/guess a non-visible user's
-	// id and pull them into a group they share, expanding their own visible set and
-	// defeating isolation. Unrestricted callers (admins, supervisors, and everyone
-	// on a non-isolated install) are exempt.
-	visibleUsers, visibleUnrestricted, err := permissionService.GetVisibleUserIdsForUser(callerId)
-	if err != nil {
-		return err
-	}
 
 	var existingMembers []models.GroupMember
 	if err := service.GetDB().Where("group_id = ?", groupId).Find(&existingMembers).Error; err != nil {
@@ -162,13 +127,6 @@ func (service GroupService) AuthorizeGroupMemberChanges(callerId uint, groupId u
 		if !isExisting {
 			if !hasCreate {
 				return ErrGroupMemberChangeForbidden
-			}
-			// The added user must be within the caller's visible set (self always
-			// allowed). Isolation-only: a no-op for unrestricted callers.
-			if !visibleUnrestricted && member.UserID != callerId {
-				if _, ok := visibleUsers[member.UserID]; !ok {
-					return ErrGroupMemberChangeForbidden
-				}
 			}
 			canAssign, err := callerCanWield(member.GroupRoleID)
 			if err != nil {

--- a/api/internal/services/groups.go
+++ b/api/internal/services/groups.go
@@ -47,6 +47,31 @@ func NewGroupService(tx *gorm.DB) GroupService {
 //     permissions are a subset of the caller's own current group permissions. This
 //     is what actually prevents self-escalation to owner and eviction of a
 //     more-privileged member.
+// AuthorizeAddedMembersVisibility rejects any member the caller is adding whom the
+// caller may not see, for member-presence isolation. Self is always allowed, and
+// unrestricted callers (admins/supervisors, and every caller on a non-isolated
+// install) are exempt. Used by the create-group path; the update path enforces the
+// same rule inline in AuthorizeGroupMemberChanges.
+func (service GroupService) AuthorizeAddedMembersVisibility(callerId uint, members []commands.UpsertGroupMemberCommand) error {
+	permissionService := NewPermissionService(service.TX)
+	visibleUsers, unrestricted, err := permissionService.GetVisibleUserIdsForUser(callerId)
+	if err != nil {
+		return err
+	}
+	if unrestricted {
+		return nil
+	}
+	for _, member := range members {
+		if member.UserID == callerId {
+			continue
+		}
+		if _, ok := visibleUsers[member.UserID]; !ok {
+			return ErrGroupMemberChangeForbidden
+		}
+	}
+	return nil
+}
+
 func (service GroupService) AuthorizeGroupMemberChanges(callerId uint, groupId uint, submitted []commands.UpsertGroupMemberCommand) error {
 	permissionService := NewPermissionService(service.TX)
 	roleRepository := repositories.NewRoleRepository(service.TX)
@@ -58,6 +83,16 @@ func (service GroupService) AuthorizeGroupMemberChanges(callerId uint, groupId u
 	hasCreate := permissions.HasAll(callerPerms, permissions.GroupMembersCreate)
 	hasUpdate := permissions.HasAll(callerPerms, permissions.GroupMembersUpdate)
 	hasDelete := permissions.HasAll(callerPerms, permissions.GroupMembersDelete)
+
+	// Member-presence isolation: an isolated caller may only add users they can
+	// already see. Without this a caller could enumerate/guess a non-visible user's
+	// id and pull them into a group they share, expanding their own visible set and
+	// defeating isolation. Unrestricted callers (admins, supervisors, and everyone
+	// on a non-isolated install) are exempt.
+	visibleUsers, visibleUnrestricted, err := permissionService.GetVisibleUserIdsForUser(callerId)
+	if err != nil {
+		return err
+	}
 
 	var existingMembers []models.GroupMember
 	if err := service.GetDB().Where("group_id = ?", groupId).Find(&existingMembers).Error; err != nil {
@@ -127,6 +162,13 @@ func (service GroupService) AuthorizeGroupMemberChanges(callerId uint, groupId u
 		if !isExisting {
 			if !hasCreate {
 				return ErrGroupMemberChangeForbidden
+			}
+			// The added user must be within the caller's visible set (self always
+			// allowed). Isolation-only: a no-op for unrestricted callers.
+			if !visibleUnrestricted && member.UserID != callerId {
+				if _, ok := visibleUsers[member.UserID]; !ok {
+					return ErrGroupMemberChangeForbidden
+				}
 			}
 			canAssign, err := callerCanWield(member.GroupRoleID)
 			if err != nil {

--- a/api/internal/services/member_isolation_receipt_test.go
+++ b/api/internal/services/member_isolation_receipt_test.go
@@ -1,0 +1,470 @@
+package services
+
+import (
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/permissions"
+	"receipt-wrangler/api/internal/repositories"
+	"testing"
+)
+
+// isolatedReceiptFixture is an isolated group with a supervisor (SeesAllMembers)
+// and two plain isolated members, all holding group.receipts.read. Member A and
+// member B cannot see each other; both can see the supervisor.
+type isolatedReceiptFixture struct {
+	groupId      uint
+	supervisorId uint
+	memberAId    uint
+	memberBId    uint
+	memberRoleId uint
+	supRoleId    uint
+}
+
+func seedIsolatedReceiptGroup(t *testing.T) isolatedReceiptFixture {
+	t.Helper()
+	db := repositories.GetDB()
+	roleRepository := repositories.NewRoleRepository(nil)
+
+	group := models.Group{Name: "iso-receipt-group", IsolateMembers: true}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("seed group: %v", err)
+	}
+
+	supRole, err := roleRepository.CreateGroupRole(
+		"Iso Supervisor", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false, true,
+	)
+	if err != nil {
+		t.Fatalf("seed supervisor role: %v", err)
+	}
+	memberRole, err := roleRepository.CreateGroupRole(
+		"Iso Member", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false, false,
+	)
+	if err != nil {
+		t.Fatalf("seed member role: %v", err)
+	}
+
+	sup := makeUser(t, "iso-supervisor-user")
+	a := makeUser(t, "iso-member-a")
+	b := makeUser(t, "iso-member-b")
+
+	seedIsoMember(t, group.ID, sup, &supRole.ID)
+	seedIsoMember(t, group.ID, a, &memberRole.ID)
+	seedIsoMember(t, group.ID, b, &memberRole.ID)
+
+	return isolatedReceiptFixture{
+		groupId:      group.ID,
+		supervisorId: sup,
+		memberAId:    a,
+		memberBId:    b,
+		memberRoleId: memberRole.ID,
+		supRoleId:    supRole.ID,
+	}
+}
+
+func resetIsolationCaches() {
+	clearRolePermissionCacheAll()
+	clearGroupRoleGrantCacheAll()
+}
+
+// --- Piece 1: paid-by fold (surface B) ---
+
+func TestMemberIsolation_PaidByFold_HidesReceiptPaidByNonVisibleMember(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	resetIsolationCaches()
+
+	fx := seedIsolatedReceiptGroup(t)
+	service := NewPermissionService(nil)
+
+	receipts := []models.Receipt{
+		{GroupId: fx.groupId, PaidByUserID: fx.memberAId},    // A's own
+		{GroupId: fx.groupId, PaidByUserID: fx.memberBId},    // B's — non-visible to A
+		{GroupId: fx.groupId, PaidByUserID: fx.supervisorId}, // supervisor — visible to A
+	}
+
+	filtered, err := service.FilterReceiptsByPaidBy(fx.memberAId, receipts)
+	if err != nil {
+		t.Fatalf("FilterReceiptsByPaidBy: %v", err)
+	}
+	if len(filtered) != 2 {
+		t.Fatalf("expected 2 visible receipts (own + supervisor), got %d: %v", len(filtered), filtered)
+	}
+	for _, r := range filtered {
+		if r.PaidByUserID == fx.memberBId {
+			t.Errorf("receipt paid by non-visible member B leaked to A")
+		}
+	}
+}
+
+func TestMemberIsolation_PaidByFold_ReceiptPaidByVisible(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	resetIsolationCaches()
+
+	fx := seedIsolatedReceiptGroup(t)
+	service := NewPermissionService(nil)
+
+	cases := []struct {
+		name   string
+		payer  uint
+		expect bool
+	}{
+		{"own receipt visible", fx.memberAId, true},
+		{"supervisor receipt visible", fx.supervisorId, true},
+		{"peer receipt hidden", fx.memberBId, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			visible, err := service.ReceiptPaidByVisible(fx.memberAId, fx.groupId, c.payer)
+			if err != nil {
+				t.Fatalf("ReceiptPaidByVisible: %v", err)
+			}
+			if visible != c.expect {
+				t.Errorf("visible = %v, want %v", visible, c.expect)
+			}
+		})
+	}
+}
+
+func TestMemberIsolation_PaidByFold_ResolverRestrictedToVisibleSet(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	resetIsolationCaches()
+
+	fx := seedIsolatedReceiptGroup(t)
+	service := NewPermissionService(nil)
+
+	resolver := service.PaidByListResolver(fx.memberAId)
+	allowed, unrestricted, err := resolver(fx.groupId)
+	if err != nil {
+		t.Fatalf("resolver: %v", err)
+	}
+	if unrestricted {
+		t.Fatal("expected an isolated member to resolve as restricted")
+	}
+
+	got := make(map[uint]struct{}, len(allowed))
+	for _, id := range allowed {
+		got[id] = struct{}{}
+	}
+	if _, ok := got[fx.memberAId]; !ok {
+		t.Errorf("expected own id in allowed set %v", allowed)
+	}
+	if _, ok := got[fx.supervisorId]; !ok {
+		t.Errorf("expected supervisor id in allowed set %v", allowed)
+	}
+	if _, ok := got[fx.memberBId]; ok {
+		t.Errorf("peer id must NOT be in allowed set %v", allowed)
+	}
+}
+
+func TestMemberIsolation_PaidByFold_SupervisorUnrestricted(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	resetIsolationCaches()
+
+	fx := seedIsolatedReceiptGroup(t)
+	service := NewPermissionService(nil)
+
+	// The supervisor sees every member, so paid-by is unaffected: all receipts survive.
+	receipts := []models.Receipt{
+		{GroupId: fx.groupId, PaidByUserID: fx.memberAId},
+		{GroupId: fx.groupId, PaidByUserID: fx.memberBId},
+	}
+	filtered, err := service.FilterReceiptsByPaidBy(fx.supervisorId, receipts)
+	if err != nil {
+		t.Fatalf("FilterReceiptsByPaidBy: %v", err)
+	}
+	if len(filtered) != 2 {
+		t.Errorf("expected supervisor to see all receipts, got %d", len(filtered))
+	}
+
+	_, unrestricted, err := service.PaidByListResolver(fx.supervisorId)(fx.groupId)
+	if err != nil {
+		t.Fatalf("resolver: %v", err)
+	}
+	if !unrestricted {
+		t.Error("expected supervisor resolver to be unrestricted")
+	}
+}
+
+// --- Piece 2: field masking (surface C) ---
+
+func TestMemberIsolation_Mask_CreatedByNulledForNonVisible(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	resetIsolationCaches()
+
+	fx := seedIsolatedReceiptGroup(t)
+	service := NewPermissionService(nil)
+
+	bId := fx.memberBId
+	receipt := models.Receipt{
+		BaseModel:    models.BaseModel{CreatedBy: &bId, CreatedByString: "Member B"},
+		GroupId:      fx.groupId,
+		PaidByUserID: fx.memberAId,
+	}
+
+	if err := service.MaskReceiptForMemberVisibility(fx.memberAId, &receipt); err != nil {
+		t.Fatalf("mask: %v", err)
+	}
+	if receipt.CreatedBy != nil {
+		t.Errorf("expected createdBy nulled for non-visible creator, got %v", *receipt.CreatedBy)
+	}
+	if receipt.CreatedByString != "" {
+		t.Errorf("expected createdByString cleared, got %q", receipt.CreatedByString)
+	}
+}
+
+func TestMemberIsolation_Mask_CreatedByUnchangedForVisible(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	resetIsolationCaches()
+
+	fx := seedIsolatedReceiptGroup(t)
+	service := NewPermissionService(nil)
+
+	supId := fx.supervisorId
+	receipt := models.Receipt{
+		BaseModel:    models.BaseModel{CreatedBy: &supId, CreatedByString: "Supervisor"},
+		GroupId:      fx.groupId,
+		PaidByUserID: fx.memberAId,
+	}
+
+	if err := service.MaskReceiptForMemberVisibility(fx.memberAId, &receipt); err != nil {
+		t.Fatalf("mask: %v", err)
+	}
+	if receipt.CreatedBy == nil || *receipt.CreatedBy != supId {
+		t.Errorf("expected createdBy for a visible creator to be unchanged, got %v", receipt.CreatedBy)
+	}
+	if receipt.CreatedByString != "Supervisor" {
+		t.Errorf("expected createdByString preserved, got %q", receipt.CreatedByString)
+	}
+}
+
+func TestMemberIsolation_Mask_ItemChargedToNonVisibleMasked(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	resetIsolationCaches()
+
+	fx := seedIsolatedReceiptGroup(t)
+	service := NewPermissionService(nil)
+
+	bId := fx.memberBId
+	aId := fx.memberAId
+	chargedUser := models.User{Username: "charged-b"}
+	chargedUser.ID = bId
+
+	receipt := models.Receipt{
+		GroupId:      fx.groupId,
+		PaidByUserID: aId,
+		ReceiptItems: []models.Item{
+			{
+				ChargedToUserId: &bId,
+				ChargedToUser:   chargedUser,
+				LinkedItems:     []models.Item{{ChargedToUserId: &bId}},
+			},
+			{ChargedToUserId: &aId}, // charged to self — stays visible
+		},
+	}
+
+	if err := service.MaskReceiptForMemberVisibility(aId, &receipt); err != nil {
+		t.Fatalf("mask: %v", err)
+	}
+
+	if receipt.ReceiptItems[0].ChargedToUserId != nil {
+		t.Errorf("expected item charged to non-visible B masked, got %v", *receipt.ReceiptItems[0].ChargedToUserId)
+	}
+	if receipt.ReceiptItems[0].ChargedToUser.ID != 0 {
+		t.Errorf("expected preloaded ChargedToUser nulled, got id %d", receipt.ReceiptItems[0].ChargedToUser.ID)
+	}
+	if receipt.ReceiptItems[0].LinkedItems[0].ChargedToUserId != nil {
+		t.Errorf("expected linked item charged to B masked, got %v", *receipt.ReceiptItems[0].LinkedItems[0].ChargedToUserId)
+	}
+	if receipt.ReceiptItems[1].ChargedToUserId == nil || *receipt.ReceiptItems[1].ChargedToUserId != aId {
+		t.Errorf("expected item charged to self (visible) preserved, got %v", receipt.ReceiptItems[1].ChargedToUserId)
+	}
+}
+
+func TestMemberIsolation_Mask_NoopForUnrestrictedViewer(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	resetIsolationCaches()
+
+	fx := seedIsolatedReceiptGroup(t)
+	service := NewPermissionService(nil)
+
+	bId := fx.memberBId
+	receipt := models.Receipt{
+		BaseModel:    models.BaseModel{CreatedBy: &bId, CreatedByString: "Member B"},
+		GroupId:      fx.groupId,
+		PaidByUserID: fx.memberBId,
+		ReceiptItems: []models.Item{{ChargedToUserId: &bId}},
+	}
+
+	// The supervisor is unrestricted, so nothing is masked.
+	if err := service.MaskReceiptForMemberVisibility(fx.supervisorId, &receipt); err != nil {
+		t.Fatalf("mask: %v", err)
+	}
+	if receipt.CreatedBy == nil || *receipt.CreatedBy != bId {
+		t.Errorf("expected createdBy unchanged for unrestricted viewer")
+	}
+	if receipt.ReceiptItems[0].ChargedToUserId == nil || *receipt.ReceiptItems[0].ChargedToUserId != bId {
+		t.Errorf("expected chargedTo unchanged for unrestricted viewer")
+	}
+}
+
+// --- Piece 3: comment author drop (surface D) ---
+
+func TestMemberIsolation_DropCommentAuthoredByNonVisible(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	resetIsolationCaches()
+
+	fx := seedIsolatedReceiptGroup(t)
+	service := NewPermissionService(nil)
+
+	aId := fx.memberAId
+	bId := fx.memberBId
+	receipt := models.Receipt{
+		GroupId:      fx.groupId,
+		PaidByUserID: aId,
+		Comments: []models.Comment{
+			{Comment: "from A", UserId: &aId},
+			{Comment: "from B", UserId: &bId},
+		},
+	}
+
+	if err := service.MaskReceiptForMemberVisibility(aId, &receipt); err != nil {
+		t.Fatalf("mask: %v", err)
+	}
+	if len(receipt.Comments) != 1 {
+		t.Fatalf("expected 1 surviving comment (A's), got %d: %v", len(receipt.Comments), receipt.Comments)
+	}
+	if receipt.Comments[0].UserId == nil || *receipt.Comments[0].UserId != aId {
+		t.Errorf("expected the surviving comment to be A's, got %v", receipt.Comments[0])
+	}
+}
+
+func TestMemberIsolation_DropComment_NoopForUnrestrictedViewer(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	resetIsolationCaches()
+
+	fx := seedIsolatedReceiptGroup(t)
+	service := NewPermissionService(nil)
+
+	aId := fx.memberAId
+	bId := fx.memberBId
+	receipt := models.Receipt{
+		GroupId:      fx.groupId,
+		PaidByUserID: aId,
+		Comments: []models.Comment{
+			{Comment: "from A", UserId: &aId},
+			{Comment: "from B", UserId: &bId},
+		},
+	}
+
+	if err := service.MaskReceiptForMemberVisibility(fx.supervisorId, &receipt); err != nil {
+		t.Fatalf("mask: %v", err)
+	}
+	if len(receipt.Comments) != 2 {
+		t.Errorf("expected both comments kept for unrestricted viewer, got %d", len(receipt.Comments))
+	}
+}
+
+// --- Piece 4: write-side guard (task 8) ---
+
+func TestMemberIsolation_ValidateReceiptUserSelection(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	resetIsolationCaches()
+
+	fx := seedIsolatedReceiptGroup(t)
+	service := NewPermissionService(nil)
+
+	cases := []struct {
+		name        string
+		viewer      uint
+		paidBy      uint
+		chargedTo   []uint
+		expectAllow bool
+	}{
+		{"A pays with non-visible B", fx.memberAId, fx.memberBId, nil, false},
+		{"A charges item to non-visible B", fx.memberAId, fx.memberAId, []uint{fx.memberBId}, false},
+		{"A pays self and charges self", fx.memberAId, fx.memberAId, []uint{fx.memberAId}, true},
+		{"A pays visible supervisor", fx.memberAId, fx.supervisorId, nil, true},
+		{"supervisor is unrestricted", fx.supervisorId, fx.memberBId, []uint{fx.memberAId}, true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			allowed, err := service.ValidateReceiptUserSelection(c.viewer, c.paidBy, c.chargedTo)
+			if err != nil {
+				t.Fatalf("ValidateReceiptUserSelection: %v", err)
+			}
+			if allowed != c.expectAllow {
+				t.Errorf("allowed = %v, want %v", allowed, c.expectAllow)
+			}
+		})
+	}
+}
+
+// --- Backward compatibility (non-isolated / unrestricted viewers) ---
+
+func TestMemberIsolation_BackwardCompat_NonIsolatedMemberUnaffected(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	resetIsolationCaches()
+
+	db := repositories.GetDB()
+	roleRepository := repositories.NewRoleRepository(nil)
+
+	group := models.Group{Name: "non-iso-group", IsolateMembers: false}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("seed group: %v", err)
+	}
+	role, err := roleRepository.CreateGroupRole(
+		"Plain Member", "", []string{permissions.GroupReceiptsRead}, nil, nil, nil, false, false,
+	)
+	if err != nil {
+		t.Fatalf("seed role: %v", err)
+	}
+	viewer := makeUser(t, "non-iso-viewer")
+	peer := makeUser(t, "non-iso-peer")
+	seedIsoMember(t, group.ID, viewer, &role.ID)
+	seedIsoMember(t, group.ID, peer, &role.ID)
+
+	service := NewPermissionService(nil)
+
+	// Paid-by: a receipt paid by a peer is still visible (no filtering).
+	receipts := []models.Receipt{
+		{GroupId: group.ID, PaidByUserID: peer},
+		{GroupId: group.ID, PaidByUserID: viewer},
+	}
+	filtered, err := service.FilterReceiptsByPaidBy(viewer, receipts)
+	if err != nil {
+		t.Fatalf("FilterReceiptsByPaidBy: %v", err)
+	}
+	if len(filtered) != 2 {
+		t.Errorf("expected non-isolated member to see all receipts, got %d", len(filtered))
+	}
+
+	// Masking: a peer's created-by / charged-to references are untouched.
+	peerId := peer
+	receipt := models.Receipt{
+		BaseModel:    models.BaseModel{CreatedBy: &peerId, CreatedByString: "Peer"},
+		GroupId:      group.ID,
+		PaidByUserID: viewer,
+		ReceiptItems: []models.Item{{ChargedToUserId: &peerId}},
+		Comments:     []models.Comment{{Comment: "peer comment", UserId: &peerId}},
+	}
+	if err := service.MaskReceiptForMemberVisibility(viewer, &receipt); err != nil {
+		t.Fatalf("mask: %v", err)
+	}
+	if receipt.CreatedBy == nil || *receipt.CreatedBy != peerId {
+		t.Errorf("expected createdBy untouched for non-isolated viewer")
+	}
+	if receipt.ReceiptItems[0].ChargedToUserId == nil {
+		t.Errorf("expected chargedTo untouched for non-isolated viewer")
+	}
+	if len(receipt.Comments) != 1 {
+		t.Errorf("expected peer comment kept for non-isolated viewer")
+	}
+
+	// Write guard: the viewer may reference the peer.
+	allowed, err := service.ValidateReceiptUserSelection(viewer, peer, []uint{peer})
+	if err != nil {
+		t.Fatalf("ValidateReceiptUserSelection: %v", err)
+	}
+	if !allowed {
+		t.Errorf("expected non-isolated viewer to freely reference a peer")
+	}
+}

--- a/api/internal/services/member_isolation_receipt_test.go
+++ b/api/internal/services/member_isolation_receipt_test.go
@@ -387,7 +387,7 @@ func TestMemberIsolation_ValidateReceiptUserSelection(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			allowed, err := service.ValidateReceiptUserSelection(c.viewer, c.paidBy, c.chargedTo)
+			allowed, err := service.ValidateReceiptUserSelection(c.viewer, fx.groupId, c.paidBy, c.chargedTo)
 			if err != nil {
 				t.Fatalf("ValidateReceiptUserSelection: %v", err)
 			}
@@ -460,7 +460,7 @@ func TestMemberIsolation_BackwardCompat_NonIsolatedMemberUnaffected(t *testing.T
 	}
 
 	// Write guard: the viewer may reference the peer.
-	allowed, err := service.ValidateReceiptUserSelection(viewer, peer, []uint{peer})
+	allowed, err := service.ValidateReceiptUserSelection(viewer, group.ID, peer, []uint{peer})
 	if err != nil {
 		t.Fatalf("ValidateReceiptUserSelection: %v", err)
 	}

--- a/api/internal/services/member_masking.go
+++ b/api/internal/services/member_masking.go
@@ -20,28 +20,25 @@ import (
 //     author would still reveal that the comment (and thus the author's activity)
 //     exists.
 //
-// All of it is a no-op when the viewer is unrestricted (admins, and anyone not an
-// isolated member), so non-isolated installs and unrestricted viewers are
-// byte-identical to before. The member-visible set is resolved once per pass.
+// All of it is a no-op for a receipt whose group does not restrict the viewer (admins,
+// supervisors, and non-isolated groups), so non-isolated installs and unrestricted
+// viewers are byte-identical to before. The member-visible set is resolved PER RECEIPT'S
+// GROUP (memoized across a batch), so a batch spanning an isolated and an open group
+// masks each receipt against its own group's set.
 
 // MaskReceiptsForMemberVisibility masks non-visible user references and drops
-// non-visible comment authors across a batch of receipts, resolving the viewer's
-// member-visible set once. No-op when the viewer is unrestricted.
+// non-visible comment authors across a batch of receipts, resolving each receipt's
+// group's member-visible set (memoized). No-op for receipts whose group is unrestricted.
 func (service PermissionService) MaskReceiptsForMemberVisibility(viewerId uint, receipts []models.Receipt) error {
 	if len(receipts) == 0 {
 		return nil
 	}
 
-	masker, err := service.newReceiptMemberMasker(viewerId)
-	if err != nil {
-		return err
-	}
-	if masker.unrestricted {
-		return nil
-	}
-
+	masker := service.newReceiptMemberMasker(viewerId)
 	for i := range receipts {
-		masker.apply(&receipts[i])
+		if err := masker.apply(&receipts[i]); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -54,42 +51,39 @@ func (service PermissionService) MaskReceiptForMemberVisibility(viewerId uint, r
 		return nil
 	}
 
-	masker, err := service.newReceiptMemberMasker(viewerId)
-	if err != nil {
-		return err
-	}
-	if masker.unrestricted {
-		return nil
-	}
-
-	masker.apply(receipt)
-	return nil
+	masker := service.newReceiptMemberMasker(viewerId)
+	return masker.apply(receipt)
 }
 
-// receiptMemberMasker caches the viewer's resolved member-visible set for the
-// lifetime of one masking pass so a batch of receipts resolves it exactly once.
+// receiptMemberMasker resolves the viewer's member-visible set per receipt's group
+// (memoized by the groupVisibilityResolver) so a batch spanning several groups resolves
+// each group's set exactly once. visible is the current receipt's set, set in apply.
 type receiptMemberMasker struct {
-	viewerId     uint
-	visible      map[uint]struct{}
-	unrestricted bool
+	viewerId uint
+	resolver *groupVisibilityResolver
+	visible  map[uint]struct{}
 }
 
-func (service PermissionService) newReceiptMemberMasker(viewerId uint) (*receiptMemberMasker, error) {
-	visible, unrestricted, err := service.GetVisibleUserIdsForUser(viewerId)
-	if err != nil {
-		return nil, err
-	}
-
+func (service PermissionService) newReceiptMemberMasker(viewerId uint) *receiptMemberMasker {
 	return &receiptMemberMasker{
-		viewerId:     viewerId,
-		visible:      visible,
-		unrestricted: unrestricted,
-	}, nil
+		viewerId: viewerId,
+		resolver: service.newGroupVisibilityResolver(viewerId),
+	}
 }
 
 // apply masks non-visible user references and drops non-visible comment authors on a
-// receipt and every nested serialized entity.
-func (masker *receiptMemberMasker) apply(receipt *models.Receipt) {
+// receipt and every nested serialized entity, using the receipt's group's visible set.
+// No-op when that group does not restrict the viewer.
+func (masker *receiptMemberMasker) apply(receipt *models.Receipt) error {
+	visible, unrestricted, err := masker.resolver.forGroup(receipt.GroupId)
+	if err != nil {
+		return err
+	}
+	if unrestricted {
+		return nil
+	}
+	masker.visible = visible
+
 	masker.maskBaseModel(&receipt.BaseModel)
 
 	for i := range receipt.ReceiptItems {
@@ -109,6 +103,7 @@ func (masker *receiptMemberMasker) apply(receipt *models.Receipt) {
 	}
 
 	receipt.Comments = masker.filterComments(receipt.Comments)
+	return nil
 }
 
 // maskItem masks an item's creator and its charged-to user reference.

--- a/api/internal/services/member_masking.go
+++ b/api/internal/services/member_masking.go
@@ -1,0 +1,156 @@
+package services
+
+import (
+	"receipt-wrangler/api/internal/models"
+)
+
+// This file holds member-isolation enforcement on a receipt PAYLOAD, as opposed to
+// paid_by_filter.go which hides whole receipts by payer. A receipt an isolated
+// member may still see can carry references to users OUTSIDE their member-visible
+// set — a creator, an item's charged-to user, or a comment author. Those are hidden
+// here two ways:
+//
+//   - user-reference fields are MASKED (nulled): created-by (id + denormalized name)
+//     on the receipt and every nested entity, and an item's charged-to user. Nulling
+//     rather than a "(Restricted)" placeholder is deliberate — a user's PRESENCE must
+//     be hidden, not announced (unlike categories/tags). paid_by_user_id needs no
+//     masking: surface B already hides the whole receipt when the payer is
+//     non-visible, so a visible receipt's payer is always visible.
+//   - comments authored by a non-visible user are DROPPED entirely — masking the
+//     author would still reveal that the comment (and thus the author's activity)
+//     exists.
+//
+// All of it is a no-op when the viewer is unrestricted (admins, and anyone not an
+// isolated member), so non-isolated installs and unrestricted viewers are
+// byte-identical to before. The member-visible set is resolved once per pass.
+
+// MaskReceiptsForMemberVisibility masks non-visible user references and drops
+// non-visible comment authors across a batch of receipts, resolving the viewer's
+// member-visible set once. No-op when the viewer is unrestricted.
+func (service PermissionService) MaskReceiptsForMemberVisibility(viewerId uint, receipts []models.Receipt) error {
+	if len(receipts) == 0 {
+		return nil
+	}
+
+	masker, err := service.newReceiptMemberMasker(viewerId)
+	if err != nil {
+		return err
+	}
+	if masker.unrestricted {
+		return nil
+	}
+
+	for i := range receipts {
+		masker.apply(&receipts[i])
+	}
+	return nil
+}
+
+// MaskReceiptForMemberVisibility is the single-receipt counterpart of
+// MaskReceiptsForMemberVisibility (single GetReceipt, duplicate source, create/update
+// responses).
+func (service PermissionService) MaskReceiptForMemberVisibility(viewerId uint, receipt *models.Receipt) error {
+	if receipt == nil {
+		return nil
+	}
+
+	masker, err := service.newReceiptMemberMasker(viewerId)
+	if err != nil {
+		return err
+	}
+	if masker.unrestricted {
+		return nil
+	}
+
+	masker.apply(receipt)
+	return nil
+}
+
+// receiptMemberMasker caches the viewer's resolved member-visible set for the
+// lifetime of one masking pass so a batch of receipts resolves it exactly once.
+type receiptMemberMasker struct {
+	viewerId     uint
+	visible      map[uint]struct{}
+	unrestricted bool
+}
+
+func (service PermissionService) newReceiptMemberMasker(viewerId uint) (*receiptMemberMasker, error) {
+	visible, unrestricted, err := service.GetVisibleUserIdsForUser(viewerId)
+	if err != nil {
+		return nil, err
+	}
+
+	return &receiptMemberMasker{
+		viewerId:     viewerId,
+		visible:      visible,
+		unrestricted: unrestricted,
+	}, nil
+}
+
+// apply masks non-visible user references and drops non-visible comment authors on a
+// receipt and every nested serialized entity.
+func (masker *receiptMemberMasker) apply(receipt *models.Receipt) {
+	masker.maskBaseModel(&receipt.BaseModel)
+
+	for i := range receipt.ReceiptItems {
+		item := &receipt.ReceiptItems[i]
+		masker.maskItem(item)
+		for j := range item.LinkedItems {
+			masker.maskItem(&item.LinkedItems[j])
+		}
+	}
+
+	for i := range receipt.CustomFields {
+		masker.maskBaseModel(&receipt.CustomFields[i].BaseModel)
+	}
+
+	for i := range receipt.ImageFiles {
+		masker.maskBaseModel(&receipt.ImageFiles[i].BaseModel)
+	}
+
+	receipt.Comments = masker.filterComments(receipt.Comments)
+}
+
+// maskItem masks an item's creator and its charged-to user reference.
+func (masker *receiptMemberMasker) maskItem(item *models.Item) {
+	masker.maskBaseModel(&item.BaseModel)
+	if item.ChargedToUserId != nil && !masker.isVisible(*item.ChargedToUserId) {
+		item.ChargedToUserId = nil
+		item.ChargedToUser = models.User{}
+	}
+}
+
+// maskBaseModel nulls the created-by reference (id + denormalized name) when the
+// creator is outside the viewer's visible set.
+func (masker *receiptMemberMasker) maskBaseModel(base *models.BaseModel) {
+	if base.CreatedBy != nil && !masker.isVisible(*base.CreatedBy) {
+		base.CreatedBy = nil
+		base.CreatedByString = ""
+	}
+}
+
+// filterComments drops comments authored by a non-visible user (recursing into
+// replies so a hidden reply is removed even under a visible parent), and masks the
+// created-by reference on the survivors. A comment with no author (nil UserId)
+// references no user, so it is kept.
+func (masker *receiptMemberMasker) filterComments(comments []models.Comment) []models.Comment {
+	if len(comments) == 0 {
+		return comments
+	}
+
+	filtered := make([]models.Comment, 0, len(comments))
+	for i := range comments {
+		comment := comments[i]
+		if comment.UserId != nil && !masker.isVisible(*comment.UserId) {
+			continue
+		}
+		masker.maskBaseModel(&comment.BaseModel)
+		comment.Replies = masker.filterComments(comment.Replies)
+		filtered = append(filtered, comment)
+	}
+	return filtered
+}
+
+func (masker *receiptMemberMasker) isVisible(targetId uint) bool {
+	return isUserVisible(targetId, masker.viewerId, masker.visible)
+}

--- a/api/internal/services/member_visibility.go
+++ b/api/internal/services/member_visibility.go
@@ -79,6 +79,168 @@ func (service PermissionService) GetVisibleUserIdsForUser(viewerId uint) (map[ui
 	return visible, false, nil
 }
 
+// GetVisibleUserIdsForUserInGroup resolves the set of user ids viewerId is allowed to
+// see WITHIN groupId, for member-presence isolation. It returns (set, unrestricted,
+// err); when unrestricted is true the set is nil and the caller MUST treat every user
+// as visible (no filtering).
+//
+// Unlike GetVisibleUserIdsForUser (which unions every group the viewer belongs to and
+// backs the flat user directory), this resolves visibility for ONE group in isolation:
+// the viewer's presence in some OTHER group never widens what they may see here. This
+// is what makes isolation truthful — "isolated means isolated," regardless of any open
+// group the viewer also shares.
+//
+// Invariants: a holder of app.users.read sees everyone (unrestricted); a non-isolated
+// group is unrestricted; in an isolated group a SeesAllMembers (supervisor) role is
+// unrestricted, while a plain member sees only themselves and that group's supervisors.
+// A non-member is unrestricted — isolation only ever NARROWS for actual isolated
+// members; a non-member is protected by the membership/permission gate, not by this
+// filter (mirroring the paid-by resolver, which is also unrestricted for a non-member
+// group).
+//
+// The result is a freshly allocated set and is NOT cached; callers resolving it across a
+// batch of groups should use a groupVisibilityResolver (below) to memoize per group.
+func (service PermissionService) GetVisibleUserIdsForUserInGroup(viewerId uint, groupId uint) (map[uint]struct{}, bool, error) {
+	isAdmin, err := service.HasAppPermissions(viewerId, permissions.AppUsersRead)
+	if err != nil {
+		return nil, false, err
+	}
+	if isAdmin {
+		return nil, true, nil
+	}
+
+	memberRepository := repositories.NewGroupMemberRepository(service.TX)
+	row, found, err := memberRepository.GetViewerGroupRow(viewerId, groupId)
+	if err != nil {
+		return nil, false, err
+	}
+	if !found {
+		return nil, true, nil
+	}
+
+	viewerIsSupervisor := row.ViewerSeesAll != nil && *row.ViewerSeesAll
+	if !row.IsolateMembers || viewerIsSupervisor {
+		return nil, true, nil
+	}
+
+	visible := map[uint]struct{}{viewerId: {}} // self is always visible
+	supervisorIds, err := memberRepository.GetSupervisorUserIdsInGroups([]uint{groupId})
+	if err != nil {
+		return nil, false, err
+	}
+	for _, id := range supervisorIds {
+		visible[id] = struct{}{}
+	}
+	return visible, false, nil
+}
+
+// groupVisibility is one group's resolved member-visible set. unrestricted == true
+// (with a nil set) means "see every member of this group."
+type groupVisibility struct {
+	visible      map[uint]struct{}
+	unrestricted bool
+}
+
+// groupVisibilityResolver memoizes GetVisibleUserIdsForUserInGroup by group id for the
+// lifetime of one request/batch, so a batch of receipts, activities, or roster rows
+// spanning several groups resolves each group's set exactly once. Mirrors the per-group
+// cache pattern in FilterReceiptsByPaidBy.
+type groupVisibilityResolver struct {
+	service  PermissionService
+	viewerId uint
+	cache    map[uint]groupVisibility
+}
+
+func (service PermissionService) newGroupVisibilityResolver(viewerId uint) *groupVisibilityResolver {
+	return &groupVisibilityResolver{
+		service:  service,
+		viewerId: viewerId,
+		cache:    map[uint]groupVisibility{},
+	}
+}
+
+// forGroup returns (set, unrestricted) for groupId, resolving and caching on first use.
+func (resolver *groupVisibilityResolver) forGroup(groupId uint) (map[uint]struct{}, bool, error) {
+	if cached, ok := resolver.cache[groupId]; ok {
+		return cached.visible, cached.unrestricted, nil
+	}
+	visible, unrestricted, err := resolver.service.GetVisibleUserIdsForUserInGroup(resolver.viewerId, groupId)
+	if err != nil {
+		return nil, false, err
+	}
+	resolver.cache[groupId] = groupVisibility{visible: visible, unrestricted: unrestricted}
+	return visible, unrestricted, nil
+}
+
+// isVisible reports whether targetId is visible to the viewer within groupId.
+func (resolver *groupVisibilityResolver) isVisible(groupId uint, targetId uint) (bool, error) {
+	visible, unrestricted, err := resolver.forGroup(groupId)
+	if err != nil {
+		return false, err
+	}
+	if unrestricted {
+		return true, nil
+	}
+	return isUserVisible(targetId, resolver.viewerId, visible), nil
+}
+
+// visibleUserIdsByGroup resolves the member-visible set for each of the given groups in
+// a fixed TWO queries (rather than two per group), for the AppData roster path where N
+// can be large. Admins short-circuit to a single unrestricted marker (nil map, true).
+// The returned map is keyed by group id; a group the viewer does not belong to resolves
+// to unrestricted (isolation only narrows for actual members; the AppData path only
+// ever passes the viewer's own groups anyway).
+func (service PermissionService) visibleUserIdsByGroup(viewerId uint, groupIds []uint) (map[uint]groupVisibility, bool, error) {
+	isAdmin, err := service.HasAppPermissions(viewerId, permissions.AppUsersRead)
+	if err != nil {
+		return nil, false, err
+	}
+	if isAdmin {
+		return nil, true, nil
+	}
+
+	memberRepository := repositories.NewGroupMemberRepository(service.TX)
+	rows, err := memberRepository.GetViewerGroupRows(viewerId)
+	if err != nil {
+		return nil, false, err
+	}
+
+	rowByGroup := make(map[uint]repositories.ViewerGroupRow, len(rows))
+	var isolatedRestrictedGroupIds []uint
+	for _, row := range rows {
+		rowByGroup[row.GroupID] = row
+		viewerIsSupervisor := row.ViewerSeesAll != nil && *row.ViewerSeesAll
+		if row.IsolateMembers && !viewerIsSupervisor {
+			isolatedRestrictedGroupIds = append(isolatedRestrictedGroupIds, row.GroupID)
+		}
+	}
+
+	supervisorsByGroup, err := memberRepository.GetSupervisorUserIdsByGroup(isolatedRestrictedGroupIds)
+	if err != nil {
+		return nil, false, err
+	}
+
+	result := make(map[uint]groupVisibility, len(groupIds))
+	for _, groupId := range groupIds {
+		row, isMember := rowByGroup[groupId]
+		if !isMember {
+			result[groupId] = groupVisibility{visible: nil, unrestricted: true}
+			continue
+		}
+		viewerIsSupervisor := row.ViewerSeesAll != nil && *row.ViewerSeesAll
+		if !row.IsolateMembers || viewerIsSupervisor {
+			result[groupId] = groupVisibility{visible: nil, unrestricted: true}
+			continue
+		}
+		visible := map[uint]struct{}{viewerId: {}}
+		for _, id := range supervisorsByGroup[groupId] {
+			visible[id] = struct{}{}
+		}
+		result[groupId] = groupVisibility{visible: visible, unrestricted: false}
+	}
+	return result, false, nil
+}
+
 // FilterVisibleUserViews returns the subset of users visible to viewerId, always
 // retaining the viewer's own view. It is a pass-through when the viewer is
 // unrestricted.
@@ -101,11 +263,22 @@ func (service PermissionService) FilterVisibleUserViews(viewerId uint, users []s
 }
 
 // FilterGroupMembersForGroups strips each group's GroupMembers to those visible to
-// viewerId (the viewer's own membership is always retained). No-op when the viewer
-// is unrestricted. This is the roster boundary for GetGroupsForUser (so MCP
-// list_groups and AppData groups inherit it).
+// viewerId WITHIN THAT GROUP (the viewer's own membership is always retained). Each
+// group is resolved independently, so an isolated group shows only self + its
+// supervisors regardless of any open group the viewer also belongs to. This is the
+// roster boundary for GetGroupsForUser (so MCP list_groups and AppData groups inherit
+// it). Resolves every group's set in two queries via visibleUserIdsByGroup.
 func (service PermissionService) FilterGroupMembersForGroups(viewerId uint, groups []models.Group) error {
-	visible, unrestricted, err := service.GetVisibleUserIdsForUser(viewerId)
+	if len(groups) == 0 {
+		return nil
+	}
+
+	groupIds := make([]uint, len(groups))
+	for i := range groups {
+		groupIds[i] = groups[i].ID
+	}
+
+	visibilityByGroup, unrestricted, err := service.visibleUserIdsByGroup(viewerId, groupIds)
 	if err != nil {
 		return err
 	}
@@ -114,15 +287,20 @@ func (service PermissionService) FilterGroupMembersForGroups(viewerId uint, grou
 	}
 
 	for i := range groups {
-		groups[i].GroupMembers = filterVisibleGroupMembers(groups[i].GroupMembers, viewerId, visible)
+		visibility := visibilityByGroup[groups[i].ID]
+		if visibility.unrestricted {
+			continue
+		}
+		groups[i].GroupMembers = filterVisibleGroupMembers(groups[i].GroupMembers, viewerId, visibility.visible)
 	}
 	return nil
 }
 
 // FilterGroupMembersForGroup is the single-group counterpart of
-// FilterGroupMembersForGroups (used by GetGroupById).
+// FilterGroupMembersForGroups (used by GetGroupById), resolving visibility for that one
+// group.
 func (service PermissionService) FilterGroupMembersForGroup(viewerId uint, group *models.Group) error {
-	visible, unrestricted, err := service.GetVisibleUserIdsForUser(viewerId)
+	visible, unrestricted, err := service.GetVisibleUserIdsForUserInGroup(viewerId, group.ID)
 	if err != nil {
 		return err
 	}
@@ -136,12 +314,13 @@ func (service PermissionService) FilterGroupMembersForGroup(viewerId uint, group
 
 // ValidateReceiptUserSelection reports whether every user id a receipt upsert plants
 // — the payer (paidByUserId) and each item / linked-item chargedToUserId — is within
-// the caller's member-visible set. Unrestricted callers always pass. Used on receipt
-// create/update so an isolated member cannot attach a user they may not see (which
-// would leak that user's presence, or hand them a receipt/charge). A zero id is
-// skipped (unset). Returns (allowed, err); the caller responds 403 when not allowed.
-func (service PermissionService) ValidateReceiptUserSelection(viewerId uint, paidByUserId uint, chargedToUserIds []uint) (bool, error) {
-	visible, unrestricted, err := service.GetVisibleUserIdsForUser(viewerId)
+// the caller's member-visible set FOR THE RECEIPT'S GROUP. Unrestricted callers always
+// pass. Used on receipt create/update so an isolated member cannot attach a user they
+// may not see in that group (which would leak that user's presence, or hand them a
+// receipt/charge). A zero id is skipped (unset). Returns (allowed, err); the caller
+// responds 403 when not allowed.
+func (service PermissionService) ValidateReceiptUserSelection(viewerId uint, groupId uint, paidByUserId uint, chargedToUserIds []uint) (bool, error) {
+	visible, unrestricted, err := service.GetVisibleUserIdsForUserInGroup(viewerId, groupId)
 	if err != nil {
 		return false, err
 	}

--- a/api/internal/services/member_visibility.go
+++ b/api/internal/services/member_visibility.go
@@ -144,6 +144,23 @@ func (service PermissionService) GetVisibleUserIdsForUserInGroup(viewerId uint, 
 	return visible, false, nil
 }
 
+// ActivityVisibilityResolver returns the injected resolver the system-task repository uses
+// to filter activities by member isolation IN SQL: for a group it reports the ran-by user
+// ids the caller may see, or unrestricted == true (see every actor). Mirrors
+// PaidByListResolver, so the repository stays free of the service layer.
+func (service PermissionService) ActivityVisibilityResolver(userId uint) repositories.ActivityVisibilityResolver {
+	return func(groupId uint) ([]uint, bool, error) {
+		set, unrestricted, err := service.GetVisibleUserIdsForUserInGroup(userId, groupId)
+		if err != nil {
+			return nil, false, err
+		}
+		if unrestricted {
+			return nil, true, nil
+		}
+		return uintSetToSlice(set), false, nil
+	}
+}
+
 // groupVisibility is one group's resolved member-visible set. unrestricted == true
 // (with a nil set) means "see every member of this group."
 type groupVisibility struct {

--- a/api/internal/services/member_visibility.go
+++ b/api/internal/services/member_visibility.go
@@ -1,0 +1,181 @@
+package services
+
+import (
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/permissions"
+	"receipt-wrangler/api/internal/repositories"
+	"receipt-wrangler/api/internal/structs"
+)
+
+// GetVisibleUserIdsForUser resolves the set of user ids that viewerId is allowed
+// to see, for member-presence isolation. It returns (set, unrestricted, err):
+// when unrestricted is true the set is nil and the caller MUST treat every user
+// as visible (no filtering).
+//
+// Invariants: a viewer always sees themselves; a holder of app.users.read sees
+// everyone; a SeesAllMembers (supervisor) role — and membership in any
+// non-isolated group — contributes all of that group's members.
+//
+// A viewer who is not an isolated (non-supervisor) member of any group is
+// UNRESTRICTED, so non-isolated installs and every non-isolated member behave
+// exactly as before — no directory or content change. Isolation only ever
+// narrows what an isolated member sees.
+//
+// The result is a freshly allocated set. It is NOT cached, so callers should
+// resolve it once per request and reuse it across a batch (mirroring the
+// PaidByListResolver closure pattern) rather than calling per row.
+func (service PermissionService) GetVisibleUserIdsForUser(viewerId uint) (map[uint]struct{}, bool, error) {
+	isAdmin, err := service.HasAppPermissions(viewerId, permissions.AppUsersRead)
+	if err != nil {
+		return nil, false, err
+	}
+	if isAdmin {
+		return nil, true, nil
+	}
+
+	memberRepository := repositories.NewGroupMemberRepository(service.TX)
+	rows, err := memberRepository.GetViewerGroupRows(viewerId)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Groups where the viewer sees every member (non-isolated groups, or isolated
+	// groups where the viewer holds a supervisor role) vs. isolated groups where the
+	// viewer sees only supervisors.
+	var seeAllGroupIds []uint
+	var isolatedRestrictedGroupIds []uint
+	for _, row := range rows {
+		viewerIsSupervisor := row.ViewerSeesAll != nil && *row.ViewerSeesAll
+		if !row.IsolateMembers || viewerIsSupervisor {
+			seeAllGroupIds = append(seeAllGroupIds, row.GroupID)
+		} else {
+			isolatedRestrictedGroupIds = append(isolatedRestrictedGroupIds, row.GroupID)
+		}
+	}
+
+	// Not isolated in any group ⇒ unrestricted (backward compatible).
+	if len(isolatedRestrictedGroupIds) == 0 {
+		return nil, true, nil
+	}
+
+	visible := map[uint]struct{}{viewerId: {}} // self is always visible
+
+	seeAllIds, err := memberRepository.GetDistinctUserIdsInGroups(seeAllGroupIds)
+	if err != nil {
+		return nil, false, err
+	}
+	for _, id := range seeAllIds {
+		visible[id] = struct{}{}
+	}
+
+	supervisorIds, err := memberRepository.GetSupervisorUserIdsInGroups(isolatedRestrictedGroupIds)
+	if err != nil {
+		return nil, false, err
+	}
+	for _, id := range supervisorIds {
+		visible[id] = struct{}{}
+	}
+
+	return visible, false, nil
+}
+
+// FilterVisibleUserViews returns the subset of users visible to viewerId, always
+// retaining the viewer's own view. It is a pass-through when the viewer is
+// unrestricted.
+func (service PermissionService) FilterVisibleUserViews(viewerId uint, users []structs.UserView) ([]structs.UserView, error) {
+	visible, unrestricted, err := service.GetVisibleUserIdsForUser(viewerId)
+	if err != nil {
+		return nil, err
+	}
+	if unrestricted {
+		return users, nil
+	}
+
+	filtered := make([]structs.UserView, 0, len(users))
+	for _, user := range users {
+		if isUserVisible(user.ID, viewerId, visible) {
+			filtered = append(filtered, user)
+		}
+	}
+	return filtered, nil
+}
+
+// FilterGroupMembersForGroups strips each group's GroupMembers to those visible to
+// viewerId (the viewer's own membership is always retained). No-op when the viewer
+// is unrestricted. This is the roster boundary for GetGroupsForUser (so MCP
+// list_groups and AppData groups inherit it).
+func (service PermissionService) FilterGroupMembersForGroups(viewerId uint, groups []models.Group) error {
+	visible, unrestricted, err := service.GetVisibleUserIdsForUser(viewerId)
+	if err != nil {
+		return err
+	}
+	if unrestricted {
+		return nil
+	}
+
+	for i := range groups {
+		groups[i].GroupMembers = filterVisibleGroupMembers(groups[i].GroupMembers, viewerId, visible)
+	}
+	return nil
+}
+
+// FilterGroupMembersForGroup is the single-group counterpart of
+// FilterGroupMembersForGroups (used by GetGroupById).
+func (service PermissionService) FilterGroupMembersForGroup(viewerId uint, group *models.Group) error {
+	visible, unrestricted, err := service.GetVisibleUserIdsForUser(viewerId)
+	if err != nil {
+		return err
+	}
+	if unrestricted {
+		return nil
+	}
+
+	group.GroupMembers = filterVisibleGroupMembers(group.GroupMembers, viewerId, visible)
+	return nil
+}
+
+// ValidateReceiptUserSelection reports whether every user id a receipt upsert plants
+// — the payer (paidByUserId) and each item / linked-item chargedToUserId — is within
+// the caller's member-visible set. Unrestricted callers always pass. Used on receipt
+// create/update so an isolated member cannot attach a user they may not see (which
+// would leak that user's presence, or hand them a receipt/charge). A zero id is
+// skipped (unset). Returns (allowed, err); the caller responds 403 when not allowed.
+func (service PermissionService) ValidateReceiptUserSelection(viewerId uint, paidByUserId uint, chargedToUserIds []uint) (bool, error) {
+	visible, unrestricted, err := service.GetVisibleUserIdsForUser(viewerId)
+	if err != nil {
+		return false, err
+	}
+	if unrestricted {
+		return true, nil
+	}
+
+	if paidByUserId != 0 && !isUserVisible(paidByUserId, viewerId, visible) {
+		return false, nil
+	}
+	for _, id := range chargedToUserIds {
+		if id != 0 && !isUserVisible(id, viewerId, visible) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func filterVisibleGroupMembers(members []models.GroupMember, viewerId uint, visible map[uint]struct{}) []models.GroupMember {
+	filtered := make([]models.GroupMember, 0, len(members))
+	for _, member := range members {
+		if isUserVisible(member.UserID, viewerId, visible) {
+			filtered = append(filtered, member)
+		}
+	}
+	return filtered
+}
+
+// isUserVisible reports whether targetId is in the viewer's visible set. The
+// viewer is always visible to themselves, defensively, even if absent from the set.
+func isUserVisible(targetId uint, viewerId uint, visible map[uint]struct{}) bool {
+	if targetId == viewerId {
+		return true
+	}
+	_, ok := visible[targetId]
+	return ok
+}

--- a/api/internal/services/member_visibility.go
+++ b/api/internal/services/member_visibility.go
@@ -162,8 +162,13 @@ func (service PermissionService) ActivityVisibilityResolver(userId uint, groupId
 			return nil, true, nil
 		}
 		vis, ok := byGroup[groupId]
-		if !ok || vis.unrestricted {
+		if ok && vis.unrestricted {
 			return nil, true, nil
+		}
+		if !ok {
+			// Defensive: an unrequested groupId must not default to unrestricted
+			// (member isolation fails closed). Self-only is the minimum-visibility set.
+			return []uint{userId}, false, nil
 		}
 		return uintSetToSlice(vis.visible), false, nil
 	}, nil

--- a/api/internal/services/member_visibility.go
+++ b/api/internal/services/member_visibility.go
@@ -93,10 +93,11 @@ func (service PermissionService) GetVisibleUserIdsForUser(viewerId uint) (map[ui
 // Invariants: a holder of app.users.read sees everyone (unrestricted); a non-isolated
 // group is unrestricted; in an isolated group a SeesAllMembers (supervisor) role is
 // unrestricted, while a plain member sees only themselves and that group's supervisors.
-// A non-member is unrestricted — isolation only ever NARROWS for actual isolated
-// members; a non-member is protected by the membership/permission gate, not by this
-// filter (mirroring the paid-by resolver, which is also unrestricted for a non-member
-// group).
+// A non-member of an ISOLATED group is restricted to {self} — an isolated roster must not
+// leak to a non-member reader (e.g. an app.groups.read holder hitting GetGroupById) who
+// lacks the app.users.read directory exemption checked above; a non-member of a
+// NON-isolated group is unrestricted (open group), which preserves the paid-by / reporting
+// contract for non-members (those surfaces gate membership at the handler).
 //
 // The result is a freshly allocated set and is NOT cached; callers resolving it across a
 // batch of groups should use a groupVisibilityResolver (below) to memoize per group.
@@ -110,11 +111,20 @@ func (service PermissionService) GetVisibleUserIdsForUserInGroup(viewerId uint, 
 	}
 
 	memberRepository := repositories.NewGroupMemberRepository(service.TX)
-	row, found, err := memberRepository.GetViewerGroupRow(viewerId, groupId)
+	row, found, isMember, err := memberRepository.GetViewerGroupRow(viewerId, groupId)
 	if err != nil {
 		return nil, false, err
 	}
 	if !found {
+		// The group does not exist — nothing to filter.
+		return nil, true, nil
+	}
+	if !isMember {
+		// A non-member (non-admin) reaching a group-scoped surface. An isolated group's
+		// roster must stay hidden from them; a non-isolated group adds no restriction.
+		if row.IsolateMembers {
+			return map[uint]struct{}{viewerId: {}}, false, nil
+		}
 		return nil, true, nil
 	}
 

--- a/api/internal/services/member_visibility_notifications_test.go
+++ b/api/internal/services/member_visibility_notifications_test.go
@@ -12,8 +12,8 @@ import (
 // notification suppression is exercised end-to-end.
 func authorVisibleToResolver() repositories.AuthorVisibilityResolver {
 	permissionService := NewPermissionService(nil)
-	return func(authorId uint, recipientId uint) (bool, error) {
-		visible, unrestricted, err := permissionService.GetVisibleUserIdsForUser(recipientId)
+	return func(authorId uint, recipientId uint, groupId uint) (bool, error) {
+		visible, unrestricted, err := permissionService.GetVisibleUserIdsForUserInGroup(recipientId, groupId)
 		if err != nil {
 			return false, err
 		}

--- a/api/internal/services/member_visibility_notifications_test.go
+++ b/api/internal/services/member_visibility_notifications_test.go
@@ -1,0 +1,105 @@
+package services
+
+import (
+	"receipt-wrangler/api/internal/commands"
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/repositories"
+	"testing"
+)
+
+// authorVisibleToResolver builds the same author-visibility resolver the comment
+// handler injects, backed by the real PermissionService, so the repository's
+// notification suppression is exercised end-to-end.
+func authorVisibleToResolver() repositories.AuthorVisibilityResolver {
+	permissionService := NewPermissionService(nil)
+	return func(authorId uint, recipientId uint) (bool, error) {
+		visible, unrestricted, err := permissionService.GetVisibleUserIdsForUser(recipientId)
+		if err != nil {
+			return false, err
+		}
+		if unrestricted {
+			return true, nil
+		}
+		_, ok := visible[authorId]
+		return ok, nil
+	}
+}
+
+func seedIsoReceipt(t *testing.T, groupId uint, paidByUserId uint) models.Receipt {
+	t.Helper()
+	receipt := models.Receipt{Name: "iso-receipt", GroupId: groupId, PaidByUserID: paidByUserId}
+	if err := repositories.GetDB().Create(&receipt).Error; err != nil {
+		t.Fatalf("seed receipt: %v", err)
+	}
+	return receipt
+}
+
+func countNotifications(t *testing.T, userId uint) int {
+	t.Helper()
+	notifications, err := repositories.NewNotificationRepository(nil).GetNotificationsForUser(userId)
+	if err != nil {
+		t.Fatalf("get notifications for %d: %v", userId, err)
+	}
+	return len(notifications)
+}
+
+// A comment notification is suppressed for an isolated recipient who cannot see
+// the author, while a supervisor (who can) still receives it.
+func TestCommentNotificationSuppressedForIsolatedRecipient(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearRolePermissionCacheAll()
+
+	group := seedIsoGroup(t, "iso-comment", true)
+	supRole := seedIsoRole(t, "iso-comment-sup", true)
+	memberRole := seedIsoRole(t, "iso-comment-mem", false)
+
+	author := seedIsoUser(t, "iso-comment-author")
+	peer := seedIsoUser(t, "iso-comment-peer")
+	supervisor := seedIsoUser(t, "iso-comment-sup-user")
+	seedIsoMember(t, group.ID, author.ID, &memberRole.ID)
+	seedIsoMember(t, group.ID, peer.ID, &memberRole.ID)
+	seedIsoMember(t, group.ID, supervisor.ID, &supRole.ID)
+
+	receipt := seedIsoReceipt(t, group.ID, author.ID)
+
+	comment := commands.UpsertCommentCommand{Comment: "hello", ReceiptId: receipt.ID, UserId: &author.ID}
+	if _, err := repositories.NewCommentRepository(nil).AddComment(comment, authorVisibleToResolver()); err != nil {
+		t.Fatalf("add comment: %v", err)
+	}
+
+	if got := countNotifications(t, peer.ID); got != 0 {
+		t.Errorf("isolated peer who cannot see author should get 0 notifications, got %d", got)
+	}
+	if got := countNotifications(t, supervisor.ID); got != 1 {
+		t.Errorf("supervisor who sees the author should get 1 notification, got %d", got)
+	}
+	if got := countNotifications(t, author.ID); got != 0 {
+		t.Errorf("author should never be notified of their own comment, got %d", got)
+	}
+}
+
+// Backward compatibility: in a non-isolated group every recipient is unrestricted,
+// so the comment notification is delivered to all of them.
+func TestCommentNotificationDeliveredToAllInNonIsolatedGroup(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearRolePermissionCacheAll()
+
+	group := seedIsoGroup(t, "non-iso-comment", false)
+	memberRole := seedIsoRole(t, "non-iso-comment-mem", false)
+
+	author := seedIsoUser(t, "non-iso-author")
+	peer := seedIsoUser(t, "non-iso-peer")
+	seedIsoMember(t, group.ID, author.ID, &memberRole.ID)
+	seedIsoMember(t, group.ID, peer.ID, &memberRole.ID)
+
+	receipt := seedIsoReceipt(t, group.ID, author.ID)
+
+	comment := commands.UpsertCommentCommand{Comment: "hello", ReceiptId: receipt.ID, UserId: &author.ID}
+	if _, err := repositories.NewCommentRepository(nil).AddComment(comment, authorVisibleToResolver()); err != nil {
+		t.Fatalf("add comment: %v", err)
+	}
+
+	if got := countNotifications(t, peer.ID); got != 1 {
+		t.Errorf("peer in a non-isolated group should receive the notification, got %d", got)
+	}
+}

--- a/api/internal/services/member_visibility_test.go
+++ b/api/internal/services/member_visibility_test.go
@@ -1,8 +1,6 @@
 package services
 
 import (
-	"errors"
-	"receipt-wrangler/api/internal/commands"
 	"receipt-wrangler/api/internal/models"
 	"receipt-wrangler/api/internal/permissions"
 	"receipt-wrangler/api/internal/repositories"
@@ -159,34 +157,136 @@ func TestVisibleUsers_AppUsersReadShortCircuits(t *testing.T) {
 	assertVisible(t, admin.ID, nil, true)
 }
 
-// An isolated member cannot add (invite) a user they cannot see; a visible user,
-// themselves, and any target for an unrestricted caller are allowed.
-func TestAuthorizeAddedMembersVisibility(t *testing.T) {
+func assertVisibleInGroup(t *testing.T, viewerId uint, groupId uint, wantIds []uint, wantUnrestricted bool) {
+	t.Helper()
+	service := NewPermissionService(nil)
+	set, unrestricted, err := service.GetVisibleUserIdsForUserInGroup(viewerId, groupId)
+	if err != nil {
+		t.Fatalf("per-group resolver error: %v", err)
+	}
+	if unrestricted != wantUnrestricted {
+		t.Fatalf("unrestricted = %v, want %v (set=%v)", unrestricted, wantUnrestricted, set)
+	}
+	if wantUnrestricted {
+		if set != nil {
+			t.Fatalf("unrestricted set should be nil, got %v", set)
+		}
+		return
+	}
+	if len(set) != len(wantIds) {
+		t.Fatalf("visible set = %v, want ids %v", set, wantIds)
+	}
+	for _, id := range wantIds {
+		if _, ok := set[id]; !ok {
+			t.Errorf("expected user %d visible, set = %v", id, set)
+		}
+	}
+}
+
+// The headline of the per-group rework: a viewer who shares an OPEN group with a peer
+// still cannot see that peer INSIDE an isolated group they also share. The union
+// resolver (the flat directory) does show the peer — the viewer legitimately knows them
+// from the open group — but the per-group resolver for the isolated group does not.
+// "Isolated means isolated."
+func TestVisibleUsersInGroup_OpenGroupPeerHiddenInIsolatedGroup(t *testing.T) {
 	defer repositories.TruncateTestDb()
 	clearRolePermissionCacheAll()
 
-	group := seedIsoGroup(t, "iso-invite", true)
-	supRole := seedIsoRole(t, "iso-invite-sup", true)
-	memberRole := seedIsoRole(t, "iso-invite-mem", false)
-	a := seedIsoUser(t, "iso-invite-a")
-	coord := seedIsoUser(t, "iso-invite-coord")
-	b := seedIsoUser(t, "iso-invite-b")
-	seedIsoMember(t, group.ID, a.ID, &memberRole.ID)
-	seedIsoMember(t, group.ID, coord.ID, &supRole.ID)
-	seedIsoMember(t, group.ID, b.ID, &memberRole.ID)
+	iso := seedIsoGroup(t, "pg-iso", true)
+	open := seedIsoGroup(t, "pg-open", false)
+	supRole := seedIsoRole(t, "pg-sup", true)
+	memberRole := seedIsoRole(t, "pg-mem", false)
 
-	service := NewGroupService(nil)
+	viewer := seedIsoUser(t, "pg-viewer")
+	coord := seedIsoUser(t, "pg-coord")
+	peer := seedIsoUser(t, "pg-peer")
 
-	// A (isolated) cannot invite B (a non-visible peer).
-	if err := service.AuthorizeAddedMembersVisibility(a.ID, []commands.UpsertGroupMemberCommand{{UserID: b.ID}}); !errors.Is(err, ErrGroupMemberChangeForbidden) {
-		t.Fatalf("inviting a non-visible user should be forbidden, got %v", err)
+	// viewer + peer share BOTH the isolated group and the open group; coord is the
+	// isolated group's supervisor.
+	seedIsoMember(t, iso.ID, viewer.ID, &memberRole.ID)
+	seedIsoMember(t, iso.ID, coord.ID, &supRole.ID)
+	seedIsoMember(t, iso.ID, peer.ID, &memberRole.ID)
+	seedIsoMember(t, open.ID, viewer.ID, nil)
+	seedIsoMember(t, open.ID, peer.ID, nil)
+
+	// Per-group, INSIDE the isolated group: only self + supervisor. Peer is hidden
+	// despite the shared open group.
+	assertVisibleInGroup(t, viewer.ID, iso.ID, []uint{viewer.ID, coord.ID}, false)
+	// Per-group, INSIDE the open group: everyone (non-isolated).
+	assertVisibleInGroup(t, viewer.ID, open.ID, nil, true)
+	// The union resolver (flat directory) still lists the peer — known via the open group.
+	assertVisible(t, viewer.ID, []uint{viewer.ID, coord.ID, peer.ID}, false)
+}
+
+// A supervisor sees every member of the isolated group (unrestricted for that group).
+func TestVisibleUsersInGroup_SupervisorUnrestricted(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearRolePermissionCacheAll()
+
+	iso := seedIsoGroup(t, "pg-sup-iso", true)
+	supRole := seedIsoRole(t, "pg-sup-role", true)
+	memberRole := seedIsoRole(t, "pg-sup-mem", false)
+	coord := seedIsoUser(t, "pg-sup-coord")
+	member := seedIsoUser(t, "pg-sup-member")
+	seedIsoMember(t, iso.ID, coord.ID, &supRole.ID)
+	seedIsoMember(t, iso.ID, member.ID, &memberRole.ID)
+
+	assertVisibleInGroup(t, coord.ID, iso.ID, nil, true)
+}
+
+// A non-isolated group is unrestricted for a plain member.
+func TestVisibleUsersInGroup_NonIsolatedUnrestricted(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearRolePermissionCacheAll()
+
+	open := seedIsoGroup(t, "pg-open-only", false)
+	a := seedIsoUser(t, "pg-open-a")
+	b := seedIsoUser(t, "pg-open-b")
+	seedIsoMember(t, open.ID, a.ID, nil)
+	seedIsoMember(t, open.ID, b.ID, nil)
+
+	assertVisibleInGroup(t, a.ID, open.ID, nil, true)
+}
+
+// A non-member is unrestricted for a group they don't belong to: isolation only narrows
+// for actual isolated members, and a non-member is kept out by the membership/permission
+// gate, not by this filter (mirroring the paid-by resolver).
+func TestVisibleUsersInGroup_NonMemberUnrestricted(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearRolePermissionCacheAll()
+
+	iso := seedIsoGroup(t, "pg-nonmember-iso", true)
+	memberRole := seedIsoRole(t, "pg-nonmember-mem", false)
+	member := seedIsoUser(t, "pg-nonmember-member")
+	outsider := seedIsoUser(t, "pg-nonmember-outsider")
+	seedIsoMember(t, iso.ID, member.ID, &memberRole.ID)
+
+	assertVisibleInGroup(t, outsider.ID, iso.ID, nil, true)
+}
+
+// app.users.read short-circuits the per-group resolver to unrestricted.
+func TestVisibleUsersInGroup_AppUsersReadShortCircuits(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearRolePermissionCacheAll()
+
+	iso := seedIsoGroup(t, "pg-admin-iso", true)
+	memberRole := seedIsoRole(t, "pg-admin-mem", false)
+	admin := seedIsoUser(t, "pg-admin-user")
+	other := seedIsoUser(t, "pg-admin-other")
+	seedIsoMember(t, iso.ID, admin.ID, &memberRole.ID)
+	seedIsoMember(t, iso.ID, other.ID, &memberRole.ID)
+
+	appRole := models.AppRole{
+		Name:        "pg-app-admin-role",
+		Permissions: []models.AppRolePermission{{Permission: permissions.AppUsersRead}},
 	}
-	// A can invite the coordinator (visible) and add themselves.
-	if err := service.AuthorizeAddedMembersVisibility(a.ID, []commands.UpsertGroupMemberCommand{{UserID: coord.ID}, {UserID: a.ID}}); err != nil {
-		t.Fatalf("inviting a visible user + self should be allowed, got %v", err)
+	if err := repositories.GetDB().Create(&appRole).Error; err != nil {
+		t.Fatalf("seed app role: %v", err)
 	}
-	// The supervisor is unrestricted and may invite anyone.
-	if err := service.AuthorizeAddedMembersVisibility(coord.ID, []commands.UpsertGroupMemberCommand{{UserID: b.ID}}); err != nil {
-		t.Fatalf("an unrestricted caller should be able to invite anyone, got %v", err)
+	if err := repositories.GetDB().Model(&models.User{}).Where("id = ?", admin.ID).
+		Update("app_role_id", appRole.ID).Error; err != nil {
+		t.Fatalf("assign app role: %v", err)
 	}
+
+	assertVisibleInGroup(t, admin.ID, iso.ID, nil, true)
 }

--- a/api/internal/services/member_visibility_test.go
+++ b/api/internal/services/member_visibility_test.go
@@ -248,20 +248,25 @@ func TestVisibleUsersInGroup_NonIsolatedUnrestricted(t *testing.T) {
 	assertVisibleInGroup(t, a.ID, open.ID, nil, true)
 }
 
-// A non-member is unrestricted for a group they don't belong to: isolation only narrows
-// for actual isolated members, and a non-member is kept out by the membership/permission
-// gate, not by this filter (mirroring the paid-by resolver).
-func TestVisibleUsersInGroup_NonMemberUnrestricted(t *testing.T) {
+// A non-member of an ISOLATED group is restricted to themselves — the isolated roster
+// must not leak to a non-member reader (e.g. an app.groups.read holder without the
+// app.users.read exemption). A non-member of a NON-isolated group is unrestricted.
+func TestVisibleUsersInGroup_NonMember(t *testing.T) {
 	defer repositories.TruncateTestDb()
 	clearRolePermissionCacheAll()
 
 	iso := seedIsoGroup(t, "pg-nonmember-iso", true)
+	open := seedIsoGroup(t, "pg-nonmember-open", false)
 	memberRole := seedIsoRole(t, "pg-nonmember-mem", false)
 	member := seedIsoUser(t, "pg-nonmember-member")
 	outsider := seedIsoUser(t, "pg-nonmember-outsider")
 	seedIsoMember(t, iso.ID, member.ID, &memberRole.ID)
+	seedIsoMember(t, open.ID, member.ID, nil)
 
-	assertVisibleInGroup(t, outsider.ID, iso.ID, nil, true)
+	// Isolated group -> restricted to self (roster hidden from the non-member).
+	assertVisibleInGroup(t, outsider.ID, iso.ID, []uint{outsider.ID}, false)
+	// Non-isolated group -> unrestricted (open group).
+	assertVisibleInGroup(t, outsider.ID, open.ID, nil, true)
 }
 
 // app.users.read short-circuits the per-group resolver to unrestricted.

--- a/api/internal/services/member_visibility_test.go
+++ b/api/internal/services/member_visibility_test.go
@@ -295,3 +295,32 @@ func TestVisibleUsersInGroup_AppUsersReadShortCircuits(t *testing.T) {
 
 	assertVisibleInGroup(t, admin.ID, iso.ID, nil, true)
 }
+
+// ActivityVisibilityResolver fails CLOSED for a groupId it was never asked to resolve:
+// an unrecognized group must restrict to the viewer alone, never default to unrestricted
+// (member isolation must never fail open). Built with an empty groupIds list so the
+// per-group map is empty and any group misses.
+func TestActivityVisibilityResolverFailsClosedOnUnknownGroup(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearRolePermissionCacheAll()
+
+	// A plain user with no app role → no app.users.read, so unrestrictedAll is false.
+	viewer := seedIsoUser(t, "act-failclosed-user")
+
+	service := NewPermissionService(nil)
+	resolver, err := service.ActivityVisibilityResolver(viewer.ID, nil)
+	if err != nil {
+		t.Fatalf("ActivityVisibilityResolver: %v", err)
+	}
+
+	ids, unrestricted, err := resolver(9999) // a group never passed to the resolver
+	if err != nil {
+		t.Fatalf("resolver closure: %v", err)
+	}
+	if unrestricted {
+		t.Fatalf("unknown group resolved to unrestricted (fail-open); want restricted")
+	}
+	if len(ids) != 1 || ids[0] != viewer.ID {
+		t.Errorf("unknown group should fail closed to {self} (%d), got %v", viewer.ID, ids)
+	}
+}

--- a/api/internal/services/member_visibility_test.go
+++ b/api/internal/services/member_visibility_test.go
@@ -1,0 +1,192 @@
+package services
+
+import (
+	"errors"
+	"receipt-wrangler/api/internal/commands"
+	"receipt-wrangler/api/internal/models"
+	"receipt-wrangler/api/internal/permissions"
+	"receipt-wrangler/api/internal/repositories"
+	"testing"
+)
+
+func seedIsoUser(t *testing.T, username string) models.User {
+	t.Helper()
+	user := models.User{Username: username, Password: "password"}
+	if err := repositories.GetDB().Create(&user).Error; err != nil {
+		t.Fatalf("seed user %s: %v", username, err)
+	}
+	return user
+}
+
+func seedIsoGroup(t *testing.T, name string, isolate bool) models.Group {
+	t.Helper()
+	group := models.Group{Name: name, IsolateMembers: isolate}
+	if err := repositories.GetDB().Create(&group).Error; err != nil {
+		t.Fatalf("seed group %s: %v", name, err)
+	}
+	return group
+}
+
+func seedIsoRole(t *testing.T, name string, seesAll bool) models.GroupRoleDefinition {
+	t.Helper()
+	role := models.GroupRoleDefinition{Name: name, SeesAllMembers: seesAll}
+	if err := repositories.GetDB().Create(&role).Error; err != nil {
+		t.Fatalf("seed role %s: %v", name, err)
+	}
+	return role
+}
+
+func seedIsoMember(t *testing.T, groupId uint, userId uint, roleId *uint) {
+	t.Helper()
+	member := models.GroupMember{GroupID: groupId, UserID: userId, GroupRoleID: roleId}
+	if err := repositories.GetDB().Create(&member).Error; err != nil {
+		t.Fatalf("seed member: %v", err)
+	}
+}
+
+func assertVisible(t *testing.T, viewerId uint, wantIds []uint, wantUnrestricted bool) {
+	t.Helper()
+	service := NewPermissionService(nil)
+	set, unrestricted, err := service.GetVisibleUserIdsForUser(viewerId)
+	if err != nil {
+		t.Fatalf("resolver error: %v", err)
+	}
+	if unrestricted != wantUnrestricted {
+		t.Fatalf("unrestricted = %v, want %v (set=%v)", unrestricted, wantUnrestricted, set)
+	}
+	if wantUnrestricted {
+		if set != nil {
+			t.Fatalf("unrestricted set should be nil, got %v", set)
+		}
+		return
+	}
+	if len(set) != len(wantIds) {
+		t.Fatalf("visible set = %v, want ids %v", set, wantIds)
+	}
+	for _, id := range wantIds {
+		if _, ok := set[id]; !ok {
+			t.Errorf("expected user %d visible, set = %v", id, set)
+		}
+	}
+}
+
+// A viewer with only non-isolated memberships is unrestricted (backward compatible).
+func TestVisibleUsers_NotIsolated_Unrestricted(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearRolePermissionCacheAll()
+
+	group := seedIsoGroup(t, "iso-normal", false)
+	a := seedIsoUser(t, "iso-a")
+	b := seedIsoUser(t, "iso-b")
+	seedIsoMember(t, group.ID, a.ID, nil)
+	seedIsoMember(t, group.ID, b.ID, nil)
+
+	assertVisible(t, a.ID, nil, true)
+}
+
+// An isolated (non-supervisor) member sees only themselves + supervisors, never peers.
+func TestVisibleUsers_IsolatedMember_SelfAndSupervisorsOnly(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearRolePermissionCacheAll()
+
+	group := seedIsoGroup(t, "iso-home", true)
+	supRole := seedIsoRole(t, "iso-supervisor", true)
+	memberRole := seedIsoRole(t, "iso-member", false)
+
+	coord := seedIsoUser(t, "iso-coord")
+	p1 := seedIsoUser(t, "iso-parent1")
+	p2 := seedIsoUser(t, "iso-parent2")
+	seedIsoMember(t, group.ID, coord.ID, &supRole.ID)
+	seedIsoMember(t, group.ID, p1.ID, &memberRole.ID)
+	seedIsoMember(t, group.ID, p2.ID, &memberRole.ID)
+
+	// p1 sees self + coordinator, but NOT p2 (asymmetric peer invisibility).
+	assertVisible(t, p1.ID, []uint{p1.ID, coord.ID}, false)
+	assertVisible(t, p2.ID, []uint{p2.ID, coord.ID}, false)
+	// The supervisor is unrestricted (no isolated-restricted group of their own).
+	assertVisible(t, coord.ID, nil, true)
+}
+
+// A viewer in a mix of isolated and non-isolated groups: sees supervisors of the
+// isolated group + all members of the non-isolated group, never the isolated peer.
+func TestVisibleUsers_MixedGroups(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearRolePermissionCacheAll()
+
+	iso := seedIsoGroup(t, "iso-mixed-iso", true)
+	normal := seedIsoGroup(t, "iso-mixed-normal", false)
+	supRole := seedIsoRole(t, "iso-mixed-sup", true)
+	memberRole := seedIsoRole(t, "iso-mixed-mem", false)
+
+	viewer := seedIsoUser(t, "iso-mixed-viewer")
+	coord := seedIsoUser(t, "iso-mixed-coord")
+	otherIso := seedIsoUser(t, "iso-mixed-other")
+	normalPeer := seedIsoUser(t, "iso-mixed-peer")
+
+	seedIsoMember(t, iso.ID, viewer.ID, &memberRole.ID)
+	seedIsoMember(t, iso.ID, coord.ID, &supRole.ID)
+	seedIsoMember(t, iso.ID, otherIso.ID, &memberRole.ID)
+	seedIsoMember(t, normal.ID, viewer.ID, nil)
+	seedIsoMember(t, normal.ID, normalPeer.ID, nil)
+
+	assertVisible(t, viewer.ID, []uint{viewer.ID, coord.ID, normalPeer.ID}, false)
+}
+
+// app.users.read short-circuits to unrestricted even for an isolated member.
+func TestVisibleUsers_AppUsersReadShortCircuits(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearRolePermissionCacheAll()
+
+	iso := seedIsoGroup(t, "iso-admin-group", true)
+	memberRole := seedIsoRole(t, "iso-admin-mem", false)
+	admin := seedIsoUser(t, "iso-admin-user")
+	other := seedIsoUser(t, "iso-admin-other")
+	seedIsoMember(t, iso.ID, admin.ID, &memberRole.ID)
+	seedIsoMember(t, iso.ID, other.ID, &memberRole.ID)
+
+	appRole := models.AppRole{
+		Name:        "iso-app-admin-role",
+		Permissions: []models.AppRolePermission{{Permission: permissions.AppUsersRead}},
+	}
+	if err := repositories.GetDB().Create(&appRole).Error; err != nil {
+		t.Fatalf("seed app role: %v", err)
+	}
+	if err := repositories.GetDB().Model(&models.User{}).Where("id = ?", admin.ID).
+		Update("app_role_id", appRole.ID).Error; err != nil {
+		t.Fatalf("assign app role: %v", err)
+	}
+
+	assertVisible(t, admin.ID, nil, true)
+}
+
+// An isolated member cannot add (invite) a user they cannot see; a visible user,
+// themselves, and any target for an unrestricted caller are allowed.
+func TestAuthorizeAddedMembersVisibility(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearRolePermissionCacheAll()
+
+	group := seedIsoGroup(t, "iso-invite", true)
+	supRole := seedIsoRole(t, "iso-invite-sup", true)
+	memberRole := seedIsoRole(t, "iso-invite-mem", false)
+	a := seedIsoUser(t, "iso-invite-a")
+	coord := seedIsoUser(t, "iso-invite-coord")
+	b := seedIsoUser(t, "iso-invite-b")
+	seedIsoMember(t, group.ID, a.ID, &memberRole.ID)
+	seedIsoMember(t, group.ID, coord.ID, &supRole.ID)
+	seedIsoMember(t, group.ID, b.ID, &memberRole.ID)
+
+	service := NewGroupService(nil)
+
+	// A (isolated) cannot invite B (a non-visible peer).
+	if err := service.AuthorizeAddedMembersVisibility(a.ID, []commands.UpsertGroupMemberCommand{{UserID: b.ID}}); !errors.Is(err, ErrGroupMemberChangeForbidden) {
+		t.Fatalf("inviting a non-visible user should be forbidden, got %v", err)
+	}
+	// A can invite the coordinator (visible) and add themselves.
+	if err := service.AuthorizeAddedMembersVisibility(a.ID, []commands.UpsertGroupMemberCommand{{UserID: coord.ID}, {UserID: a.ID}}); err != nil {
+		t.Fatalf("inviting a visible user + self should be allowed, got %v", err)
+	}
+	// The supervisor is unrestricted and may invite anyone.
+	if err := service.AuthorizeAddedMembersVisibility(coord.ID, []commands.UpsertGroupMemberCommand{{UserID: b.ID}}); err != nil {
+		t.Fatalf("an unrestricted caller should be able to invite anyone, got %v", err)
+	}
+}

--- a/api/internal/services/paid_by_filter.go
+++ b/api/internal/services/paid_by_filter.go
@@ -18,26 +18,23 @@ import (
 //
 // Member isolation is folded in at the single shared resolution point
 // (paidByAllowedForGroup) so all three consumers below inherit it: an isolated
-// member must not see a receipt paid by a user outside their member-visible set,
-// even in a group whose role applies no paid-by restriction of its own. The
-// member-visible set is resolved ONCE per consumer (not per group/row) and
-// intersected into each group's paid-by allowed set. It is a no-op for
-// unrestricted viewers (admins, and anyone not an isolated member), so
+// member must not see a receipt paid by a user outside their member-visible set for
+// that group, even in a group whose role applies no paid-by restriction of its own.
+// The member-visible set is resolved PER GROUP (GetVisibleUserIdsForUserInGroup) and
+// intersected into that group's paid-by allowed set, so an isolated group hides its
+// non-visible payers regardless of any open group the viewer also shares. It is a
+// no-op for unrestricted viewers (admins, supervisors, and non-isolated members), so
 // non-isolated installs behave exactly as before.
 
 // PaidByListResolver adapts paidByAllowedForGroup to the per-group resolver the
 // receipt repository uses to build its paged WHERE clause. The returned closure
 // reports the allowed paid_by_user_id values for userId in a group, or
-// unrestricted == true (see every payer). The member-visible set is resolved once,
-// here, and threaded into every per-group resolution. Pass the result to
+// unrestricted == true (see every payer). Both the paid-by grants and the member-visible
+// set are resolved per group inside paidByAllowedForGroup. Pass the result to
 // GetPagedReceiptsByGroupId; pass nil there to skip paid-by filtering.
 func (service PermissionService) PaidByListResolver(userId uint) repositories.PaidByAllowedResolver {
-	visibleSet, memberUnrestricted, visErr := service.GetVisibleUserIdsForUser(userId)
 	return func(groupId uint) ([]uint, bool, error) {
-		if visErr != nil {
-			return nil, false, visErr
-		}
-		allowed, unrestricted, err := service.paidByAllowedForGroup(userId, groupId, visibleSet, memberUnrestricted)
+		allowed, unrestricted, err := service.paidByAllowedForGroup(userId, groupId)
 		if err != nil || unrestricted {
 			return nil, unrestricted, err
 		}
@@ -51,11 +48,7 @@ func (service PermissionService) PaidByListResolver(userId uint) repositories.Pa
 // duplicate source, update/delete) for a receipt hidden by the paid-by filter or
 // by member isolation (payer outside the caller's member-visible set).
 func (service PermissionService) ReceiptPaidByVisible(userId uint, groupId uint, paidByUserId uint) (bool, error) {
-	visibleSet, memberUnrestricted, err := service.GetVisibleUserIdsForUser(userId)
-	if err != nil {
-		return false, err
-	}
-	allowed, unrestricted, err := service.paidByAllowedForGroup(userId, groupId, visibleSet, memberUnrestricted)
+	allowed, unrestricted, err := service.paidByAllowedForGroup(userId, groupId)
 	if err != nil {
 		return false, err
 	}
@@ -67,36 +60,31 @@ func (service PermissionService) ReceiptPaidByVisible(userId uint, groupId uint,
 }
 
 // FilterReceiptsByPaidBy drops the receipts a user may not see by the paid-by
-// filter (or by member isolation), resolving the member-visible set once and each
-// group's allowed set at most once. Used by the unpaginated read surfaces (search,
-// group-ids list) where there is no totalCount to keep consistent, so removing
-// rows is safe.
+// filter (or by member isolation), resolving each group's allowed set (paid-by grants
+// ∩ that group's member-visible set) at most once. Used by the unpaginated read
+// surfaces (search, group-ids list) where there is no totalCount to keep consistent, so
+// removing rows is safe.
 func (service PermissionService) FilterReceiptsByPaidBy(userId uint, receipts []models.Receipt) ([]models.Receipt, error) {
 	if len(receipts) == 0 {
 		return receipts, nil
 	}
 
-	visibleSet, memberUnrestricted, err := service.GetVisibleUserIdsForUser(userId)
-	if err != nil {
-		return nil, err
-	}
-
-	type groupVisibility struct {
+	type groupAllowed struct {
 		allowed      map[uint]struct{}
 		unrestricted bool
 	}
-	cache := map[uint]groupVisibility{}
+	cache := map[uint]groupAllowed{}
 
 	filtered := make([]models.Receipt, 0, len(receipts))
 	for i := range receipts {
 		groupId := receipts[i].GroupId
 		visibility, ok := cache[groupId]
 		if !ok {
-			allowed, unrestricted, err := service.paidByAllowedForGroup(userId, groupId, visibleSet, memberUnrestricted)
+			allowed, unrestricted, err := service.paidByAllowedForGroup(userId, groupId)
 			if err != nil {
 				return nil, err
 			}
-			visibility = groupVisibility{allowed: allowed, unrestricted: unrestricted}
+			visibility = groupAllowed{allowed: allowed, unrestricted: unrestricted}
 			cache[groupId] = visibility
 		}
 
@@ -113,19 +101,18 @@ func (service PermissionService) FilterReceiptsByPaidBy(userId uint, receipts []
 }
 
 // paidByAllowedForGroup resolves a group's paid-by allowed set for a user and folds
-// in the caller's already-resolved member-visible set. This is the single shared
-// point where paid-by grants and member isolation combine, so every read surface
-// (paged list, single GET, search, export, GetReceiptsForGroupIds, pie chart,
-// report data) inherits both restrictions. visibleSet / memberUnrestricted come
-// from one GetVisibleUserIdsForUser call per consumer; passing them in keeps the
-// member-visible set from being re-resolved per group/row.
-func (service PermissionService) paidByAllowedForGroup(
-	userId uint,
-	groupId uint,
-	visibleSet map[uint]struct{},
-	memberUnrestricted bool,
-) (map[uint]struct{}, bool, error) {
+// in the caller's member-visible set FOR THAT GROUP. This is the single shared point
+// where paid-by grants and member isolation combine, so every read surface (paged list,
+// single GET, search, export, GetReceiptsForGroupIds, pie chart, report data) inherits
+// both restrictions. Both narrowings are resolved per group here, so an isolated group
+// hides receipts paid by a non-visible member regardless of any other group the viewer
+// shares with them.
+func (service PermissionService) paidByAllowedForGroup(userId uint, groupId uint) (map[uint]struct{}, bool, error) {
 	paidBySet, paidByUnrestricted, err := service.GetGroupPaidByUserIdsForUser(userId, groupId)
+	if err != nil {
+		return nil, false, err
+	}
+	visibleSet, memberUnrestricted, err := service.GetVisibleUserIdsForUserInGroup(userId, groupId)
 	if err != nil {
 		return nil, false, err
 	}

--- a/api/internal/services/paid_by_filter.go
+++ b/api/internal/services/paid_by_filter.go
@@ -15,15 +15,29 @@ import (
 // paged query already row-filters on the allowed set, a caller filtering by a
 // payer they cannot see is neutralized by that AND (a hidden id intersects to
 // nothing), so it cannot probe receipt existence.
+//
+// Member isolation is folded in at the single shared resolution point
+// (paidByAllowedForGroup) so all three consumers below inherit it: an isolated
+// member must not see a receipt paid by a user outside their member-visible set,
+// even in a group whose role applies no paid-by restriction of its own. The
+// member-visible set is resolved ONCE per consumer (not per group/row) and
+// intersected into each group's paid-by allowed set. It is a no-op for
+// unrestricted viewers (admins, and anyone not an isolated member), so
+// non-isolated installs behave exactly as before.
 
-// PaidByListResolver adapts GetGroupPaidByUserIdsForUser to the per-group
-// resolver the receipt repository uses to build its paged WHERE clause. The
-// returned closure reports the allowed paid_by_user_id values for userId in a
-// group, or unrestricted == true (see every payer). Pass the result to
+// PaidByListResolver adapts paidByAllowedForGroup to the per-group resolver the
+// receipt repository uses to build its paged WHERE clause. The returned closure
+// reports the allowed paid_by_user_id values for userId in a group, or
+// unrestricted == true (see every payer). The member-visible set is resolved once,
+// here, and threaded into every per-group resolution. Pass the result to
 // GetPagedReceiptsByGroupId; pass nil there to skip paid-by filtering.
 func (service PermissionService) PaidByListResolver(userId uint) repositories.PaidByAllowedResolver {
+	visibleSet, memberUnrestricted, visErr := service.GetVisibleUserIdsForUser(userId)
 	return func(groupId uint) ([]uint, bool, error) {
-		allowed, unrestricted, err := service.GetGroupPaidByUserIdsForUser(userId, groupId)
+		if visErr != nil {
+			return nil, false, visErr
+		}
+		allowed, unrestricted, err := service.paidByAllowedForGroup(userId, groupId, visibleSet, memberUnrestricted)
 		if err != nil || unrestricted {
 			return nil, unrestricted, err
 		}
@@ -34,9 +48,14 @@ func (service PermissionService) PaidByListResolver(userId uint) repositories.Pa
 // ReceiptPaidByVisible reports whether a user may see a receipt given its group
 // and paid_by user. Unrestricted users (and non-members, who have no group role)
 // always pass. Used to deny single-receipt and dependent reads (image, comments,
-// duplicate source, update/delete) for a receipt hidden by the paid-by filter.
+// duplicate source, update/delete) for a receipt hidden by the paid-by filter or
+// by member isolation (payer outside the caller's member-visible set).
 func (service PermissionService) ReceiptPaidByVisible(userId uint, groupId uint, paidByUserId uint) (bool, error) {
-	allowed, unrestricted, err := service.GetGroupPaidByUserIdsForUser(userId, groupId)
+	visibleSet, memberUnrestricted, err := service.GetVisibleUserIdsForUser(userId)
+	if err != nil {
+		return false, err
+	}
+	allowed, unrestricted, err := service.paidByAllowedForGroup(userId, groupId, visibleSet, memberUnrestricted)
 	if err != nil {
 		return false, err
 	}
@@ -48,12 +67,18 @@ func (service PermissionService) ReceiptPaidByVisible(userId uint, groupId uint,
 }
 
 // FilterReceiptsByPaidBy drops the receipts a user may not see by the paid-by
-// filter, resolving each group's allowed set at most once. Used by the
-// unpaginated read surfaces (search, group-ids list) where there is no
-// totalCount to keep consistent, so removing rows is safe.
+// filter (or by member isolation), resolving the member-visible set once and each
+// group's allowed set at most once. Used by the unpaginated read surfaces (search,
+// group-ids list) where there is no totalCount to keep consistent, so removing
+// rows is safe.
 func (service PermissionService) FilterReceiptsByPaidBy(userId uint, receipts []models.Receipt) ([]models.Receipt, error) {
 	if len(receipts) == 0 {
 		return receipts, nil
+	}
+
+	visibleSet, memberUnrestricted, err := service.GetVisibleUserIdsForUser(userId)
+	if err != nil {
+		return nil, err
 	}
 
 	type groupVisibility struct {
@@ -67,7 +92,7 @@ func (service PermissionService) FilterReceiptsByPaidBy(userId uint, receipts []
 		groupId := receipts[i].GroupId
 		visibility, ok := cache[groupId]
 		if !ok {
-			allowed, unrestricted, err := service.GetGroupPaidByUserIdsForUser(userId, groupId)
+			allowed, unrestricted, err := service.paidByAllowedForGroup(userId, groupId, visibleSet, memberUnrestricted)
 			if err != nil {
 				return nil, err
 			}
@@ -85,6 +110,64 @@ func (service PermissionService) FilterReceiptsByPaidBy(userId uint, receipts []
 	}
 
 	return filtered, nil
+}
+
+// paidByAllowedForGroup resolves a group's paid-by allowed set for a user and folds
+// in the caller's already-resolved member-visible set. This is the single shared
+// point where paid-by grants and member isolation combine, so every read surface
+// (paged list, single GET, search, export, GetReceiptsForGroupIds, pie chart,
+// report data) inherits both restrictions. visibleSet / memberUnrestricted come
+// from one GetVisibleUserIdsForUser call per consumer; passing them in keeps the
+// member-visible set from being re-resolved per group/row.
+func (service PermissionService) paidByAllowedForGroup(
+	userId uint,
+	groupId uint,
+	visibleSet map[uint]struct{},
+	memberUnrestricted bool,
+) (map[uint]struct{}, bool, error) {
+	paidBySet, paidByUnrestricted, err := service.GetGroupPaidByUserIdsForUser(userId, groupId)
+	if err != nil {
+		return nil, false, err
+	}
+	allowed, unrestricted := foldPaidByWithVisibility(paidBySet, paidByUnrestricted, visibleSet, memberUnrestricted)
+	return allowed, unrestricted, nil
+}
+
+// foldPaidByWithVisibility combines a group's paid-by allowed set with the caller's
+// member-visible set. The two are independent narrowings of which receipts a member
+// may see by payer, so the effective allowed set is their intersection:
+//
+//   - both unrestricted        -> unrestricted (nil), no filtering (backward compatible)
+//   - only member restricted   -> visibleSet (paid-by adds nothing)
+//   - only paid-by restricted  -> paidBySet (isolation adds nothing)
+//   - both restricted          -> paidBySet ∩ visibleSet
+//
+// A restricted result may be empty ("see nothing"), preserved downstream by the
+// IN (0) sentinel. visibleSet is treated read-only, so the restricted-only branch
+// may return it directly.
+func foldPaidByWithVisibility(
+	paidBySet map[uint]struct{},
+	paidByUnrestricted bool,
+	visibleSet map[uint]struct{},
+	memberUnrestricted bool,
+) (map[uint]struct{}, bool) {
+	if paidByUnrestricted && memberUnrestricted {
+		return nil, true
+	}
+	if memberUnrestricted {
+		return paidBySet, false
+	}
+	if paidByUnrestricted {
+		return visibleSet, false
+	}
+
+	intersection := make(map[uint]struct{}, len(paidBySet))
+	for id := range paidBySet {
+		if _, ok := visibleSet[id]; ok {
+			intersection[id] = struct{}{}
+		}
+	}
+	return intersection, false
 }
 
 // uintSetToSlice flattens a set to a slice (order is irrelevant for an IN clause).

--- a/api/internal/services/paid_by_filter_test.go
+++ b/api/internal/services/paid_by_filter_test.go
@@ -30,7 +30,7 @@ func seedMemberWithPaidByRole(t *testing.T, username string, paidByUserGrantIds 
 	}
 
 	roleRepository := repositories.NewRoleRepository(nil)
-	role, err := roleRepository.CreateGroupRole("PaidBy Role "+username, "", []string{permissions.GroupReceiptsRead}, nil, nil, paidByUserGrantIds, includeOwn)
+	role, err := roleRepository.CreateGroupRole("PaidBy Role "+username, "", []string{permissions.GroupReceiptsRead}, nil, nil, paidByUserGrantIds, includeOwn, false)
 	if err != nil {
 		t.Fatalf("seed group role: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestGetGroupPaidByUserIdsDoesNotMutateCacheAcrossUsers(t *testing.T) {
 	}
 
 	roleRepository := repositories.NewRoleRepository(nil)
-	role, err := roleRepository.CreateGroupRole("PaidBy Shared Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, []uint{payer}, true)
+	role, err := roleRepository.CreateGroupRole("PaidBy Shared Role", "", []string{permissions.GroupReceiptsRead}, nil, nil, []uint{payer}, true, false)
 	if err != nil {
 		t.Fatalf("seed role: %v", err)
 	}

--- a/api/internal/services/permission_test.go
+++ b/api/internal/services/permission_test.go
@@ -42,7 +42,7 @@ func seedMemberWithGroupRole(t *testing.T, username string, perms []string) (uin
 	}
 
 	roleRepository := repositories.NewRoleRepository(nil)
-	role, err := roleRepository.CreateGroupRole("Group Role", "", perms, nil, nil, nil, false)
+	role, err := roleRepository.CreateGroupRole("Group Role", "", perms, nil, nil, nil, false, false)
 	if err != nil {
 		t.Fatalf("seed group role: %v", err)
 	}

--- a/api/internal/services/receipts.go
+++ b/api/internal/services/receipts.go
@@ -99,6 +99,12 @@ func (service ReceiptService) GetReceiptForUser(userId uint, receiptId string) (
 		return models.Receipt{}, err
 	}
 
+	// Mask user references (created-by, charged-to) and drop non-visible comment
+	// authors outside the caller's member-visible set.
+	if err := permissionService.MaskReceiptForMemberVisibility(userId, &receipt); err != nil {
+		return models.Receipt{}, err
+	}
+
 	return receipt, nil
 }
 
@@ -477,6 +483,13 @@ func (service ReceiptService) DuplicateReceipt(
 	// copied onto the new receipt.
 	permissionService := NewPermissionService(nil)
 	err = permissionService.FilterReceiptCategoriesTagsForReceipt(userId, &receipt)
+	if err != nil {
+		return models.Receipt{}, err
+	}
+
+	// Mask user references outside the caller's member-visible set (e.g. an item
+	// charged to a non-visible user) so they are not carried onto the copy.
+	err = permissionService.MaskReceiptForMemberVisibility(userId, &receipt)
 	if err != nil {
 		return models.Receipt{}, err
 	}

--- a/api/internal/services/receipts_test.go
+++ b/api/internal/services/receipts_test.go
@@ -50,7 +50,7 @@ func seedReceiptMember(
 		t.Fatalf("seed group: %v", err)
 	}
 
-	role, err := repositories.NewRoleRepository(nil).CreateGroupRole(roleName, "", perms, categoryGrants, tagGrants, paidByGrants, includeOwn)
+	role, err := repositories.NewRoleRepository(nil).CreateGroupRole(roleName, "", perms, categoryGrants, tagGrants, paidByGrants, includeOwn, false)
 	if err != nil {
 		t.Fatalf("seed group role: %v", err)
 	}

--- a/api/internal/services/report_authz_test.go
+++ b/api/internal/services/report_authz_test.go
@@ -43,7 +43,7 @@ func joinGroup(t *testing.T, userId uint, groupName string, groupPerms []string)
 	if err := db.Create(&group).Error; err != nil {
 		t.Fatalf("seed group: %v", err)
 	}
-	role, err := repositories.NewRoleRepository(nil).CreateGroupRole("Role "+groupName, "", groupPerms, nil, nil, nil, false)
+	role, err := repositories.NewRoleRepository(nil).CreateGroupRole("Role "+groupName, "", groupPerms, nil, nil, nil, false, false)
 	if err != nil {
 		t.Fatalf("seed group role: %v", err)
 	}

--- a/api/internal/services/report_data_test.go
+++ b/api/internal/services/report_data_test.go
@@ -74,6 +74,44 @@ func TestReportDataService_HidesReceiptsByPaidBy(t *testing.T) {
 	}
 }
 
+// Reporting inherits per-group member isolation through the shared paid-by resolver: a
+// receipt paid by a member the viewer cannot see in an isolated group never reaches the
+// report engine, while the viewer's own and a visible supervisor's receipts do.
+func TestReportDataService_MemberIsolationHidesPeerPaidReceipts(t *testing.T) {
+	defer repositories.TruncateTestDb()
+	clearGroupRoleGrantCacheAll()
+	clearRolePermissionCacheAll()
+
+	iso := seedIsoGroup(t, "rpt-iso", true)
+	supRole := seedIsoRole(t, "rpt-iso-sup", true)
+	memRole := seedIsoRole(t, "rpt-iso-mem", false)
+
+	viewer := seedIsoUser(t, "rpt-iso-viewer")
+	coord := seedIsoUser(t, "rpt-iso-coord")
+	peer := seedIsoUser(t, "rpt-iso-peer")
+	seedIsoMember(t, iso.ID, viewer.ID, &memRole.ID)
+	seedIsoMember(t, iso.ID, coord.ID, &supRole.ID)
+	seedIsoMember(t, iso.ID, peer.ID, &memRole.ID)
+
+	own := createReportReceipt(t, "own", viewer.ID, iso.ID, nil)
+	supPaid := createReportReceipt(t, "sup", coord.ID, iso.ID, nil)
+	createReportReceipt(t, "peer", peer.ID, iso.ID, nil) // paid by a hidden peer -> excluded
+
+	_, rows, err := NewReportDataService(nil).Rows(viewer.ID, groupIdString(iso.ID), commands.ReceiptPagedRequestFilter{})
+	if err != nil {
+		t.Fatalf("Rows: %v", err)
+	}
+
+	gotIds := map[int64]bool{}
+	for _, row := range rows {
+		id, _ := row.Measure(receiptsource.KeyReceiptID).Decimal()
+		gotIds[id.IntPart()] = true
+	}
+	if len(gotIds) != 2 || !gotIds[int64(own.ID)] || !gotIds[int64(supPaid.ID)] {
+		t.Fatalf("expected only the viewer's own + supervisor receipts, got %v", gotIds)
+	}
+}
+
 // A category the caller may not see becomes (Restricted) in the row rather than
 // being stripped (which would silently drop it from the totals).
 func TestReportDataService_SubstitutesRestrictedCategory(t *testing.T) {

--- a/api/internal/services/report_service_test.go
+++ b/api/internal/services/report_service_test.go
@@ -362,7 +362,7 @@ func seedReportUserInGroups(t *testing.T, username string, groupNames ...string)
 	role, err := roleRepository.CreateGroupRole(
 		"Report Role "+username, "",
 		[]string{permissions.GroupReportsRead, permissions.GroupReceiptsRead},
-		nil, nil, nil, false,
+		nil, nil, nil, false, false,
 	)
 	if err != nil {
 		t.Fatalf("seed group role: %v", err)

--- a/api/internal/services/roles.go
+++ b/api/internal/services/roles.go
@@ -74,7 +74,7 @@ func (service RoleService) CreateRole(command commands.UpsertRoleCommand) (struc
 			return txErr
 		}
 
-		role, txErr := roleRepository.CreateGroupRole(command.Name, command.Description, perms, categoryGrants, tagGrants, paidByUserGrants, command.IncludeOwnPaidReceipts)
+		role, txErr := roleRepository.CreateGroupRole(command.Name, command.Description, perms, categoryGrants, tagGrants, paidByUserGrants, command.IncludeOwnPaidReceipts, command.SeesAllMembers)
 		if txErr != nil {
 			return txErr
 		}
@@ -94,6 +94,7 @@ func (service RoleService) CreateRole(command commands.UpsertRoleCommand) (struc
 			TagGrants:              tagGrants,
 			PaidByUserGrants:       paidByUserGrants,
 			IncludeOwnPaidReceipts: command.IncludeOwnPaidReceipts,
+			SeesAllMembers:         command.SeesAllMembers,
 			ReportTemplateGrants:   reportTemplateGrantsToView(reportTemplateGrants),
 		}
 
@@ -170,7 +171,7 @@ func (service RoleService) UpdateRole(id uint, command commands.UpsertRoleComman
 			return txErr
 		}
 
-		role, txErr := roleRepository.UpdateGroupRole(id, command.Name, command.Description, perms, categoryGrants, tagGrants, paidByUserGrants, command.IncludeOwnPaidReceipts)
+		role, txErr := roleRepository.UpdateGroupRole(id, command.Name, command.Description, perms, categoryGrants, tagGrants, paidByUserGrants, command.IncludeOwnPaidReceipts, command.SeesAllMembers)
 		if txErr != nil {
 			return txErr
 		}
@@ -191,6 +192,7 @@ func (service RoleService) UpdateRole(id uint, command commands.UpsertRoleComman
 			TagGrants:              tagGrants,
 			PaidByUserGrants:       paidByUserGrants,
 			IncludeOwnPaidReceipts: command.IncludeOwnPaidReceipts,
+			SeesAllMembers:         command.SeesAllMembers,
 			ReportTemplateGrants:   reportTemplateGrantsToView(reportTemplateGrants),
 		}
 
@@ -526,6 +528,7 @@ func groupRoleToView(role models.GroupRoleDefinition, isDefault bool) structs.Ro
 		TagGrants:              tagGrants,
 		PaidByUserGrants:       paidByUserGrants,
 		IncludeOwnPaidReceipts: role.IncludeOwnPaidReceipts,
+		SeesAllMembers:         role.SeesAllMembers,
 		ReportTemplateGrants:   repositories.ReportTemplateGrantsFromRole(role),
 	}
 }

--- a/api/internal/services/roles_test.go
+++ b/api/internal/services/roles_test.go
@@ -41,6 +41,59 @@ func TestCreateGroupRoleWithGrantsExposesGrantIds(t *testing.T) {
 	}
 }
 
+func TestGroupRoleSeesAllMembersRoundTrips(t *testing.T) {
+	defer repositories.TruncateTestDb()
+
+	service := NewRoleService(nil)
+	created, err := service.CreateRole(commands.UpsertRoleCommand{
+		Name:           "Supervisor Role",
+		Scope:          permissions.ScopeGroup,
+		Permissions:    []string{permissions.GroupReceiptsRead},
+		SeesAllMembers: true,
+	})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if !created.SeesAllMembers {
+		utils.PrintTestError(t, created.SeesAllMembers, true)
+	}
+
+	// It surfaces on the read model too.
+	roles, err := service.GetRoles()
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	found := false
+	for _, role := range roles {
+		if role.Id == created.Id {
+			found = true
+			if !role.SeesAllMembers {
+				utils.PrintTestError(t, role.SeesAllMembers, true)
+			}
+		}
+	}
+	if !found {
+		utils.PrintTestError(t, "role not found in GetRoles", created.Id)
+	}
+
+	// Update toggles it off; the returned view reflects false.
+	updated, err := service.UpdateRole(created.Id, commands.UpsertRoleCommand{
+		Name:           "Supervisor Role",
+		Scope:          permissions.ScopeGroup,
+		Permissions:    []string{permissions.GroupReceiptsRead},
+		SeesAllMembers: false,
+	})
+	if err != nil {
+		utils.PrintTestError(t, err, nil)
+		return
+	}
+	if updated.SeesAllMembers {
+		utils.PrintTestError(t, updated.SeesAllMembers, false)
+	}
+}
+
 func TestCreateGroupRoleRejectsNonExistentGrant(t *testing.T) {
 	defer repositories.TruncateTestDb()
 
@@ -184,7 +237,7 @@ func TestUpdateGroupRoleServiceReplacesGrants(t *testing.T) {
 	catB := models.Category{Name: "B"}
 	repositories.GetDB().Create(&catB)
 
-	created, err := roleRepository.CreateGroupRole("Role", "", []string{permissions.GroupReceiptsRead}, []uint{catA.ID}, nil, nil, false)
+	created, err := roleRepository.CreateGroupRole("Role", "", []string{permissions.GroupReceiptsRead}, []uint{catA.ID}, nil, nil, false, false)
 	if err != nil {
 		utils.PrintTestError(t, err, nil)
 		return

--- a/api/internal/services/users_test.go
+++ b/api/internal/services/users_test.go
@@ -351,7 +351,7 @@ func TestDeleteUser_WithPaidByGrant(t *testing.T) {
 		nil,
 		nil,
 		[]uint{user.ID},
-		false,
+		false, false,
 	)
 	if err != nil {
 		t.Fatalf("create group role: %v", err)

--- a/api/internal/structs/role_view.go
+++ b/api/internal/structs/role_view.go
@@ -22,6 +22,10 @@ type RoleView struct {
 	// slice and false.
 	PaidByUserGrants       []uint `json:"paidByUserGrants"`
 	IncludeOwnPaidReceipts bool   `json:"includeOwnPaidReceipts"`
+	// SeesAllMembers marks a group role whose members are exempt from member-presence
+	// isolation (they see, and are seen by, every member of an isolated group).
+	// Always group-scoped; app roles serialize false.
+	SeesAllMembers bool `json:"seesAllMembers"`
 	// ReportTemplateGrants restrict which report templates a group role's members
 	// may act on, per action. Empty means unrestricted (every template the role's
 	// group access reaches). Always group-scoped; app roles serialize an empty

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -3489,6 +3489,12 @@ components:
           description: >-
             Whether a GROUP role lets each member see receipts they paid for. Part
             of the paid-by visibility filter; always false for app roles.
+        seesAllMembers:
+          type: boolean
+          description: >-
+            Whether a GROUP role exempts its members from member-presence isolation
+            (they see, and are seen by, every member of an isolated group). Always
+            false for app roles.
         reportTemplateGrants:
           type: array
           description: >-
@@ -3544,6 +3550,12 @@ components:
           description: >-
             Whether to also let each member see receipts they paid for. Only valid
             on group roles.
+        seesAllMembers:
+          type: boolean
+          description: >-
+            Whether a GROUP role exempts its members from member-presence isolation
+            (they see, and are seen by, every member of an isolated group). Only
+            valid on group roles.
         reportTemplateGrants:
           type: array
           description: >-
@@ -3904,6 +3916,12 @@ components:
         isAllGroup:
           type: boolean
           description: Is all group for user
+        isolateMembers:
+          type: boolean
+          description: >-
+            Whether member-presence isolation is enabled for the group. When on,
+            members cannot discover other members unless they hold a group role
+            flagged seesAllMembers. Defaults to false.
         status:
           type: string
           $ref: "#/components/schemas/GroupStatus"
@@ -3931,6 +3949,12 @@ components:
         isAllGroup:
           type: boolean
           description: Is all group for user
+        isolateMembers:
+          type: boolean
+          description: >-
+            Whether to enable member-presence isolation for the group. When on,
+            members cannot discover other members unless they hold a group role
+            flagged seesAllMembers. Defaults to false.
         status:
           type: string
           $ref: "#/components/schemas/GroupStatus"

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -246,9 +246,15 @@ gated by `appPermissionGuard` requiring `app.roles.read` (see **Permission-based
   can see, and be seen by, all members"** `app-checkbox` in `role-form` (a "Member visibility" `rw-card`
   inside the `@if (showGrants())` block), bound to `seesAllMembers` on the `UpsertRoleCommand` (mirrors
   `includeOwnPaidReceipts`; hydrates on edit, resets on type switch, serialized only for GROUP scope).
-  Everything else is enforced **server-side** — the desktop simply receives the already-filtered
-  `appData.users` / group rosters / receipts, so no client-side filtering is needed (and mobile needs no
-  change). The larger `UserAccessService` / `UserView`-retype consolidation is a deferred follow-up.
+  Isolation is resolved **per group** on the backend ("isolated means isolated" — an isolated group hides
+  co-members and their settlement/report data regardless of any other group you share; co-members are
+  visible only through a shared **non-isolated** group). Everything is enforced **server-side** — the
+  desktop simply receives the already-filtered `appData.users` (union name-table) and per-group filtered
+  group rosters / receipts / Group-Summary settlement, so no client-side filtering is needed (and mobile
+  needs no change). This works because every group-context user picker sources its SET from the group
+  roster (`group.groupMembers`) or `roster ∩ flat-list`, using the flat `UserState.users` only to resolve
+  a name/avatar by id (see `GroupMemberUserService.getUsersInGroup`). The larger `UserAccessService` /
+  `UserView`-retype consolidation is a deferred follow-up.
 - **Permission-based UI gating.** The UI gates on the user's effective permissions, mirroring the
   backend's enforcement. Permissions are delivered on **AppData** (`appPermissions: string[]` and
   `groupPermissions: { [groupId]: string[] }`) and stored in `AuthState` via the dedicated

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -239,6 +239,16 @@ gated by `appPermissionGuard` requiring `app.roles.read` (see **Permission-based
     `AuthState.hasGroupPermission`), mirroring the backend `UpdateGroup` guard (see `api/CLAUDE.md` →
     "Group member management"). They default to enabled in **create** mode (no group yet; the creator
     becomes owner). This is UI-only; the server re-enforces on every request.
+- **Member isolation (presence privacy).** Two config controls drive the backend member-isolation
+  feature (see `api/CLAUDE.md` → "Member isolation"): (1) an **"Isolate members"** `app-checkbox` in the
+  `group-form` "Group Details" section, bound to `isolateMembers` on the `UpsertGroupCommand` — an
+  isolated group's members can't discover each other; (2) a group-scope-only **"Members with this role
+  can see, and be seen by, all members"** `app-checkbox` in `role-form` (a "Member visibility" `rw-card`
+  inside the `@if (showGrants())` block), bound to `seesAllMembers` on the `UpsertRoleCommand` (mirrors
+  `includeOwnPaidReceipts`; hydrates on edit, resets on type switch, serialized only for GROUP scope).
+  Everything else is enforced **server-side** — the desktop simply receives the already-filtered
+  `appData.users` / group rosters / receipts, so no client-side filtering is needed (and mobile needs no
+  change). The larger `UserAccessService` / `UserView`-retype consolidation is a deferred follow-up.
 - **Permission-based UI gating.** The UI gates on the user's effective permissions, mirroring the
   backend's enforcement. Permissions are delivered on **AppData** (`appPermissions: string[]` and
   `groupPermissions: { [groupId]: string[] }`) and stored in `AuthState` via the dedicated

--- a/desktop/src/group/group-form/group-form.component.html
+++ b/desktop/src/group/group-form/group-form.component.html
@@ -28,6 +28,12 @@
         [inputFormControl]="form | formGet : 'status'"
         [options]="groupStatusOptions"
       ></app-select>
+      <app-checkbox
+        label="Isolate members"
+        helpText="When on, members of this group can't see each other. Members with a role that can see all members remain visible to everyone."
+        [readonly]="formConfig.mode | inputReadonly"
+        [inputFormControl]="form | formGet : 'isolateMembers'"
+      ></app-checkbox>
     </app-form-section>
     <app-form-section
       headerText="Group Members"

--- a/desktop/src/group/group-form/group-form.component.spec.ts
+++ b/desktop/src/group/group-form/group-form.component.spec.ts
@@ -15,6 +15,7 @@ import { SelectModule } from "src/select/select.module";
 import { SharedUiModule } from "src/shared-ui/shared-ui.module";
 import { TableModule } from "src/table/table.module";
 import { UserAutocompleteModule } from "src/user-autocomplete/user-autocomplete.module";
+import { CheckboxModule } from "../../checkbox/checkbox.module";
 import { ButtonModule } from "../../button";
 import { InputModule } from "../../input";
 import { ApiModule, Group, GroupsService, GroupStatus, Permission } from "../../open-api";
@@ -35,6 +36,7 @@ describe("GroupFormComponent", () => {
     declarations: [GroupFormComponent, GroupMemberFormComponent],
     imports: [ApiModule,
         ButtonModule,
+        CheckboxModule,
         PipesModule,
         InputModule,
         MatCardModule,
@@ -231,6 +233,7 @@ describe("GroupFormComponent", () => {
       name: "test",
       status: GroupStatus.Active,
       groupMembers: [],
+      isolateMembers: false,
     } as any);
     expect(storeSpy).toHaveBeenCalledWith(new AddGroup(returnValue));
     expect(routerSpy).toHaveBeenCalledWith(["/groups/1/details/view"], {
@@ -321,6 +324,7 @@ describe("GroupFormComponent", () => {
             groupId: 1,
           },
         ],
+        isolateMembers: false,
       } as Group
     );
     expect(storeSpy).toHaveBeenCalledWith(new UpdateGroup(returnValue));
@@ -329,6 +333,53 @@ describe("GroupFormComponent", () => {
         tab: "details",
       }
     });
+  });
+
+  it("includes isolateMembers in the create payload when enabled", () => {
+    const createSpy = jest.spyOn(TestBed.inject(GroupsService), "createGroup");
+    jest.spyOn(TestBed.inject(Router), "navigate").mockResolvedValue(true);
+    jest.spyOn(TestBed.inject(AppInitService), "getAppData").mockReturnValue(of([]));
+
+    const route = TestBed.inject(ActivatedRoute);
+    route.snapshot.data = {
+      formConfig: {
+        mode: FormMode.add,
+      },
+    };
+
+    component.ngOnInit();
+    component.ngAfterViewInit();
+
+    component.form.patchValue({
+      name: "test",
+      isolateMembers: true,
+    });
+
+    createSpy.mockReturnValue(of({ ...component.form.value, id: 1 }));
+
+    component.submit();
+
+    expect(createSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ isolateMembers: true })
+    );
+  });
+
+  it("hydrates isolateMembers from the group on edit", () => {
+    const route = TestBed.inject(ActivatedRoute);
+    route.snapshot.data = {
+      group: {
+        id: 1,
+        name: "test",
+        status: GroupStatus.Active,
+        isolateMembers: true,
+        groupMembers: [],
+      },
+      formConfig: { mode: FormMode.edit },
+    };
+
+    component.ngOnInit();
+
+    expect(component.form.get("isolateMembers")?.value).toBe(true);
   });
 
   it("submits in edit mode even when no member holds an owner role", () => {

--- a/desktop/src/group/group-form/group-form.component.ts
+++ b/desktop/src/group/group-form/group-form.component.ts
@@ -198,6 +198,7 @@ export class GroupFormComponent implements OnInit, AfterViewInit {
       name: [this.originalGroup?.name ?? "", Validators.required],
       groupMembers: this.formBuilder.array(groupMembers),
       status: this.originalGroup?.status ?? GroupStatus.Active,
+      isolateMembers: this.originalGroup?.isolateMembers ?? false,
     });
 
     this.groupMembers.valueChanges

--- a/desktop/src/open-api/model/group.ts
+++ b/desktop/src/open-api/model/group.ts
@@ -38,6 +38,10 @@ export interface Group {
      * Is all group for user
      */
     isAllGroup: boolean;
+    /**
+     * Whether member-presence isolation is enabled for the group. When on, members cannot discover other members unless they hold a group role flagged seesAllMembers. Defaults to false.
+     */
+    isolateMembers?: boolean;
     status: GroupStatus;
     updatedAt?: string;
 }

--- a/desktop/src/open-api/model/pagedDataDataInner.ts
+++ b/desktop/src/open-api/model/pagedDataDataInner.ts
@@ -110,6 +110,10 @@ export interface PagedDataDataInner {
      */
     isAllGroup: boolean;
     /**
+     * Whether member-presence isolation is enabled for the group. When on, members cannot discover other members unless they hold a group role flagged seesAllMembers. Defaults to false.
+     */
+    isolateMembers?: boolean;
+    /**
      * Number of receipts associated with this tag
      */
     numberOfReceipts: number;

--- a/desktop/src/open-api/model/role.ts
+++ b/desktop/src/open-api/model/role.ts
@@ -44,6 +44,10 @@ export interface Role {
      */
     includeOwnPaidReceipts?: boolean;
     /**
+     * Whether a GROUP role exempts its members from member-presence isolation (they see, and are seen by, every member of an isolated group). Always false for app roles.
+     */
+    seesAllMembers?: boolean;
+    /**
      * Per-template action grants restricting which report templates a GROUP role\'s members may act on. Empty means unrestricted (every template the role\'s group access reaches). Always empty for app roles.
      */
     reportTemplateGrants?: Array<ReportTemplateGrant>;

--- a/desktop/src/open-api/model/upsertGroupCommand.ts
+++ b/desktop/src/open-api/model/upsertGroupCommand.ts
@@ -28,6 +28,10 @@ export interface UpsertGroupCommand {
      * Is all group for user
      */
     isAllGroup?: boolean;
+    /**
+     * Whether to enable member-presence isolation for the group. When on, members cannot discover other members unless they hold a group role flagged seesAllMembers. Defaults to false.
+     */
+    isolateMembers?: boolean;
     status: GroupStatus;
 }
 export namespace UpsertGroupCommand {

--- a/desktop/src/open-api/model/upsertRoleCommand.ts
+++ b/desktop/src/open-api/model/upsertRoleCommand.ts
@@ -34,6 +34,10 @@ export interface UpsertRoleCommand {
      */
     includeOwnPaidReceipts?: boolean;
     /**
+     * Whether a GROUP role exempts its members from member-presence isolation (they see, and are seen by, every member of an isolated group). Only valid on group roles.
+     */
+    seesAllMembers?: boolean;
+    /**
      * Per-template action grants for a GROUP role, restricting which report templates its members may act on. Only valid on group roles; omit or leave empty for unrestricted access.
      */
     reportTemplateGrants?: Array<ReportTemplateGrant>;

--- a/desktop/src/roles/role-form/role-form.component.html
+++ b/desktop/src/roles/role-form/role-form.component.html
@@ -196,6 +196,25 @@
           <div class="rw-card rw-form-section">
             <div class="rw-perm-header">
               <div>
+                <h2>Member visibility</h2>
+                <div class="hint hint-inline">
+                  In an isolated group, members can't see each other. Turn this
+                  on so holders of this role can see, and be seen by, all
+                  members.
+                </div>
+              </div>
+            </div>
+
+            <app-checkbox
+              label="Members with this role can see, and be seen by, all members"
+              [inputFormControl]="form | formGet: 'seesAllMembers'"
+              [readonly]="isViewMode()"
+            ></app-checkbox>
+          </div>
+
+          <div class="rw-card rw-form-section">
+            <div class="rw-perm-header">
+              <div>
                 <h2>Category &amp; tag access</h2>
                 <div class="hint hint-inline">
                   Limit members to specific categories and tags. Leave empty for

--- a/desktop/src/roles/role-form/role-form.component.spec.ts
+++ b/desktop/src/roles/role-form/role-form.component.spec.ts
@@ -420,6 +420,51 @@ describe("RoleFormComponent", () => {
     expect(component.grantedPaidByUsers.length).toBe(0);
   });
 
+  it("includes seesAllMembers in a GROUP payload when enabled", async () => {
+    const { component } = await setup();
+    component.pickType("group");
+    component.form.controls.name.setValue("Supervisor Role");
+    component.toggle("group.receipts.read");
+    component.form.controls.seesAllMembers.setValue(true);
+
+    component.submit();
+
+    expect(component.lastPayload?.scope).toBe("GROUP");
+    expect(component.lastPayload?.seesAllMembers).toBe(true);
+  });
+
+  it("defaults seesAllMembers to false in a GROUP payload", async () => {
+    const { component } = await setup();
+    component.pickType("group");
+    component.form.controls.name.setValue("Plain Group Role");
+    component.toggle("group.receipts.read");
+
+    component.submit();
+
+    expect(component.lastPayload?.seesAllMembers).toBe(false);
+  });
+
+  it("omits seesAllMembers from an APP payload", async () => {
+    const { component } = await setup();
+    component.form.controls.name.setValue("App Role");
+    component.toggle("app.users.read");
+    // Even if the control somehow held true, an app payload must not carry it.
+    component.form.controls.seesAllMembers.setValue(true);
+
+    component.submit();
+
+    expect(component.lastPayload?.seesAllMembers).toBeUndefined();
+  });
+
+  it("resets seesAllMembers when switching role type", async () => {
+    const { component } = await setup();
+    component.pickType("group");
+    component.form.controls.seesAllMembers.setValue(true);
+
+    component.pickType("app");
+    expect(component.form.controls.seesAllMembers.value).toBe(false);
+  });
+
   it("includes report template grants in a GROUP payload", async () => {
     const { component } = await setup();
     component.pickType("group");
@@ -609,6 +654,25 @@ describe("RoleFormComponent", () => {
         .map((option) => option.id)
         .sort((a, b) => a - b);
       expect(selectedIds).toEqual([RoleFormComponent.OWN_PAID_RECEIPTS_OPTION_ID, 42].sort((a, b) => a - b));
+    });
+
+    it("rehydrates seesAllMembers on edit", async () => {
+      const seesAllGroupRole: Role = {
+        id: 13,
+        name: "Supervisor Group Role",
+        scope: "GROUP",
+        isDefault: false,
+        isSystem: false,
+        permissions: ["group.receipts.read"],
+        seesAllMembers: true,
+      };
+      const { component } = await setup(ALL_DESCRIPTORS, {
+        routeId: "13",
+        routeScope: "group",
+        roles: [seesAllGroupRole],
+      });
+
+      expect(component.form.controls.seesAllMembers.value).toBe(true);
     });
 
     it("rehydrates report template grants on edit", async () => {

--- a/desktop/src/roles/role-form/role-form.component.ts
+++ b/desktop/src/roles/role-form/role-form.component.ts
@@ -71,6 +71,9 @@ export class RoleFormComponent {
   public readonly form = new FormGroup({
     name: new FormControl<string>("", { nonNullable: true, validators: [Validators.required] }),
     description: new FormControl<string>("", { nonNullable: true }),
+    // Group-role-only flag: holders can see, and be seen by, all members of an
+    // isolated group. Ignored for app roles (serialized only when showGrants()).
+    seesAllMembers: new FormControl<boolean>(false, { nonNullable: true }),
   });
 
   // ----- State signals -----
@@ -355,7 +358,11 @@ export class RoleFormComponent {
 
         // System roles are immutable — open them read-only.
         this.mode.set(role.isSystem ? FormMode.view : FormMode.edit);
-        this.form.patchValue({ name: role.name, description: role.description ?? "" });
+        this.form.patchValue({
+          name: role.name,
+          description: role.description ?? "",
+          seesAllMembers: role.seesAllMembers ?? false,
+        });
         this.type.set(role.scope === PermissionScope.Group ? "group" : "app");
         this.granted.set(new Set(role.permissions));
         this.pendingCategoryGrantIds.set(role.categoryGrants ?? []);
@@ -427,6 +434,7 @@ export class RoleFormComponent {
     this.setGrantArray(this.grantedTags, []);
     this.setGrantArray(this.grantedPaidByUsers, []);
     this.reportTemplateGrants.set(new Map());
+    this.form.controls.seesAllMembers.setValue(false);
   }
 
   // ----- Report template matrix helpers -----
@@ -559,6 +567,10 @@ export class RoleFormComponent {
       payload.reportTemplateGrants = [...this.reportTemplateGrants().entries()].map(
         ([reportTemplateId, actions]) => ({ reportTemplateId, permissions: [...actions] }),
       );
+
+      // Supervisor exemption: holders see, and are seen by, all members of an
+      // isolated group. Only meaningful on group roles.
+      payload.seesAllMembers = this.form.controls.seesAllMembers.value;
     }
 
     this.lastPayload = payload;

--- a/desktop/src/roles/roles.module.ts
+++ b/desktop/src/roles/roles.module.ts
@@ -4,6 +4,7 @@ import { ReactiveFormsModule } from "@angular/forms";
 import { MatIconModule } from "@angular/material/icon";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { RouterModule } from "@angular/router";
+import { CheckboxModule } from "src/checkbox/checkbox.module";
 import { PipesModule } from "src/pipes/pipes.module";
 import { AutocompleteModule } from "../autocomplete/autocomplete.module";
 import { ButtonModule } from "../button";
@@ -22,6 +23,7 @@ import { RolesRoutingModule } from "./roles-routing.module";
   declarations: [RoleListComponent, RoleFormComponent],
   imports: [
     ButtonModule,
+    CheckboxModule,
     CommonModule,
     InputModule,
     MatIconModule,


### PR DESCRIPTION
## Summary

Adds an opt-in **member isolation** mode for groups: within an isolated group a member cannot discover that other members exist — not through the user directory, the group roster, receipts, comments, activities, the Group Summary (settlement) widget, reports, or notifications.

Isolation is resolved **per group** — *"isolated means isolated."* Visibility is a function of `(viewer, group)`, never a union across the viewer's groups: inside an isolated group you see only **yourself + that group's supervisors**, regardless of any other group you belong to. Co-members become visible **only** through a shared **non-isolated** group (open means open), and even then only on that open group's own surfaces. This deliberately allows a cross-group aggregate (a settlement or report total) to be incomplete when it would otherwise reveal a hidden group's data — the truthful isolation guarantee wins over completeness.

Two opt-in flags, both default `false`, so existing groups/roles/installs are unchanged (AutoMigrate adds the columns; no data migration):
- **`IsolateMembers`** on a group — turns isolation on.
- **`SeesAllMembers`** on a group role — a **supervisor** exemption whose holders see, and are seen by, every member of an isolated group.

## Model

- **`GetVisibleUserIdsForUserInGroup(viewerId, groupId)`** — the per-group resolver used by every group-scoped surface and by settlement. `app.users.read` ⇒ unrestricted; a non-isolated group ⇒ unrestricted; a `SeesAllMembers` holder ⇒ unrestricted; a plain member of an isolated group ⇒ `{self}` + that group's supervisors; a non-member ⇒ unrestricted (isolation only narrows for actual members — non-members are kept out by the membership/permission gate).
- The original **union** resolver is retained for exactly one surface: the flat `appData.users` name-directory (it is the union of the per-group sets, so it already excludes a peer you share only an isolated group with — the correct name-resolution table, since clients resolve a display name/avatar from this flat list by id).

## Read enforcement (all per group)

Group rosters (AppData, `GET /group/{id}`, MCP `list_groups`), receipt **row visibility** (folded into the shared paid-by resolver → covers paged list / single GET / search / export / duplicate / pie chart / report data), **field masking** of `createdBy` and item `chargedToUserId` across the receipt tree (per receipt's group), comment-author and activity-actor **row drops**, the **Group Summary / amount-owed** balance map (resolved per receipt's group as each item is folded), and comment-notification fan-out. Reporting and the pie chart inherit isolation with no dedicated code.

## Write-side guards

- Reject planting a non-visible payer / charged-to on a receipt (create + update).
- Block an edit that would silently drop a stored charge to a member the editor can't see (no stable item identity to preserve it).
- Adding a member never widens visibility in another group, so **no member-invitation visibility guard is needed**; the existing GHSA-89mm CRUD + privilege-ceiling guard is untouched.

## Desktop

- An **"Isolate members"** checkbox on the group form (`isolateMembers`).
- A group-scope-only **"can see, and be seen by, all members"** checkbox in the role editor (`seesAllMembers`).
- Everything else is enforced server-side; the desktop already sources every group-context user picker from the group roster (using the flat list only for name-by-id), so no client-side filtering is required. Mobile needs no change for the same reason.

## Scope / compatibility

Backend + two small desktop config controls. **No API-shape change** for the per-group behavior (no swagger/client regeneration; no DB schema change beyond the two flag columns added by the initial commit). Non-isolated installs and every non-isolated member are byte-identical to before.

## Testing

Full Go suite green. Coverage includes the per-group + union resolver matrix, the headline **open-group-peer-hidden-inside-the-isolated-group** case, **cross-group settlement** (isolated portion excluded, open portion kept), **reporting isolation**, per-group activity drops, field masking, comment-notification suppression, the write-side guards, and the flag persistence round-trips.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added member-presence isolation for groups (`isolateMembers`), including a supervisor exemption via group-role `seesAllMembers`.
* **Bug Fixes**
  * Enforced member-specific visibility for receipt paid-by/charged-to selection, masking, and comment notifications; ensured activities, counts, exports, and settlement/owed results reflect what a viewer can see.
  * Preserved hidden charged-to references correctly on receipt edits for isolated viewers.
* **Documentation**
  * Updated API schemas and desktop UI for `isolateMembers` and `seesAllMembers`.
* **Tests**
  * Added/expanded isolation and visibility enforcement coverage across handlers and services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->