### PR TITLE
Add password generation feature to input component

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -164,6 +164,17 @@ the user explicitly confirms the divergence**. Examples of standards to follow:
   place Save/Cancel buttons in the page header.
 - **Form fields:** `app-input`, `app-textarea`, `app-select`, `app-checkbox`, grouped with
   `app-form-section`; bind via the `formGet` pipe.
+- **Password fields:** `app-input` owns both password affordances as opt-in suffix icon buttons —
+  `[showVisibilityEye]="true"` (the eye) and `[showGeneratePassword]="true"`
+  (`data-testid="password-generate"`). Either flag masks the field on init. Generate fills the
+  control with `generateSecurePassword()` (`src/utils/password.utils.ts` — `crypto.getRandomValues`
+  with rejection sampling, one char per class, ambiguous glyphs excluded), reveals it, and copies it
+  to the clipboard with a toast via `PasswordGeneratorService`
+  (`src/services/password-generator.service.ts`). It is deliberately **admin-sets-someone-else's-
+  password only** — the user form, Set Password, and Convert Dummy User dialogs — not sign-up or the
+  fields that hold an existing external secret (system email, receipt-processing settings). The
+  generate handler is synchronous by design: `type` is a plain `@Input`, so under zoneless CD only
+  the click event's CD pass renders the reveal (the clipboard write is a detached side effect).
 - **Tables:** `app-table`; **dialogs:** `app-dialog` + `app-dialog-footer`.
 - **Simple filters:** the segmented `app-filter-bar` (`src/shared-ui/filter-bar/`) — pass `FilterTab[]`
   (`{ value, label, icon?, count? }`) and two-way bind the selected `value`.

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -600,6 +600,13 @@ In CI the same spec files run against the demo URL. GitHub secrets populate the 
 - Forms use a custom `<app-input>` wrapper over `<mat-form-field>`. `page.getByLabel('Username')` resolves through the `<mat-label>` association.
 - Submit buttons use `<app-button>` rendering `<button>` with visible text — `page.getByRole('button', { name: '...' })` works directly.
 - Error feedback is often a Material snackbar (not inline `<mat-error>`). When asserting errors, locate the snackbar container or its text, not the form.
+- **`getByLabel` matches substrings.** On any password field carrying the generate button, plain
+  `getByLabel('Password')` resolves *two* elements — the input and the button, whose accessible name
+  is "Generate password" — and fails on strict mode. Use `getByLabel('Password', { exact: true })`
+  for the Create User / Set Password dialogs (the login form has no generate button, so it is
+  unaffected). The generated password is asserted in `generate-password.spec.ts`, which also grants
+  `permissions: ['clipboard-read', 'clipboard-write']` in `test.use` — the only clipboard-reading
+  spec in the suite.
 
 ### Permission-gating specs (provisioned roles/users/groups)
 

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -165,8 +165,10 @@ the user explicitly confirms the divergence**. Examples of standards to follow:
 - **Form fields:** `app-input`, `app-textarea`, `app-select`, `app-checkbox`, grouped with
   `app-form-section`; bind via the `formGet` pipe.
 - **Password fields:** `app-input` owns both password affordances as opt-in suffix icon buttons —
-  `[showVisibilityEye]="true"` (the eye) and `[showGeneratePassword]="true"`
-  (`data-testid="password-generate"`). Either flag masks the field on init. Generate fills the
+  `[showVisibilityEye]="true"` (the eye, `data-testid="password-visibility-toggle"`) and
+  `[showGeneratePassword]="true"` (`data-testid="password-generate"`). Switching either flag on
+  masks the field — on the initial binding *and* on a later `false -> true` flip, so a field that
+  becomes a password field at runtime is never left in plain text. Generate fills the
   control with `generateSecurePassword()` (`src/utils/password.utils.ts` — `crypto.getRandomValues`
   with rejection sampling, one char per class, ambiguous glyphs excluded), reveals it, and copies it
   to the clipboard with a toast via `PasswordGeneratorService`

--- a/desktop/e2e/generate-password.spec.ts
+++ b/desktop/e2e/generate-password.spec.ts
@@ -1,0 +1,148 @@
+import { expect, Locator, Page, test } from '@playwright/test';
+import { stubTokenRefresh } from './helpers/auth';
+
+// The "Generate password" button lives in the shared app-input's suffix, next to
+// the visibility eye, and is opted into per field. Clicking it fills the control
+// with a generated password, reveals it, copies it to the clipboard and toasts.
+// These specs are deliberately non-mutating: every dialog is escaped, never
+// submitted, so no user is created and nothing needs tearing down.
+
+const GENERATED_PASSWORD_LENGTH = 20;
+const COPIED_MESSAGE = 'Password generated and copied to clipboard';
+
+function generateButton(scope: Page | Locator): Locator {
+  // Unlike the app-button-wrapped test IDs, this one sits on the native button.
+  return scope.getByTestId('password-generate');
+}
+
+async function openCreateUserDialog(page: Page): Promise<Locator> {
+  await page.goto('/users');
+  await page.getByTestId('user-add').click();
+  const dialog = page.getByRole('dialog').filter({ hasText: 'Create User' });
+  await expect(dialog).toBeVisible();
+  return dialog;
+}
+
+test.describe('Generate password — Create User', () => {
+  // Managing users is admin-only, and reading the clipboard back needs the
+  // permission granted explicitly (no other spec in the suite uses it yet).
+  test.use({
+    storageState: 'e2e/.auth/admin.json',
+    permissions: ['clipboard-read', 'clipboard-write'],
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await stubTokenRefresh(page);
+  });
+
+  test('fills, reveals and copies a generated password', async ({ page }) => {
+    const dialog = await openCreateUserDialog(page);
+    const password = dialog.getByLabel('Password', { exact: true });
+
+    await expect(password).toHaveAttribute('type', 'password');
+    await generateButton(dialog).click();
+
+    // The field is written synchronously on the click; the clipboard write and
+    // its toast follow as a detached promise.
+    await expect(password).toHaveAttribute('type', 'text');
+    const generated = await password.inputValue();
+    expect(generated).toHaveLength(GENERATED_PASSWORD_LENGTH);
+
+    // A clipboard failure would surface the error toast instead, so the success
+    // message also proves the write resolved.
+    await expect(page.getByText(COPIED_MESSAGE)).toBeVisible();
+    expect(await page.evaluate(() => navigator.clipboard.readText())).toEqual(
+      generated,
+    );
+
+    await page.keyboard.press('Escape');
+  });
+
+  test('generates a different password on each click', async ({ page }) => {
+    const dialog = await openCreateUserDialog(page);
+    const password = dialog.getByLabel('Password', { exact: true });
+
+    await generateButton(dialog).click();
+    const first = await password.inputValue();
+
+    await generateButton(dialog).click();
+    await expect(password).not.toHaveValue(first);
+
+    await page.keyboard.press('Escape');
+  });
+
+  test('re-masks a generated password with the visibility eye', async ({
+    page,
+  }) => {
+    const dialog = await openCreateUserDialog(page);
+    const password = dialog.getByLabel('Password', { exact: true });
+
+    await generateButton(dialog).click();
+    await expect(password).toHaveAttribute('type', 'text');
+
+    await dialog.locator('button.visibility-eye-button').click();
+    await expect(password).toHaveAttribute('type', 'password');
+    // Masking is display-only — the generated value is still submitted.
+    await expect(password).not.toHaveValue('');
+
+    await page.keyboard.press('Escape');
+  });
+
+  test('disables the generate button for a dummy user', async ({ page }) => {
+    const dialog = await openCreateUserDialog(page);
+
+    // Ticking "Is Dummy User?" clears and disables the password control, since a
+    // dummy user has no credentials — the generate button follows it.
+    await dialog.getByText('Is Dummy User?').click();
+    await expect(generateButton(dialog)).toBeDisabled();
+
+    await dialog.getByText('Is Dummy User?').click();
+    await expect(generateButton(dialog)).toBeEnabled();
+
+    await page.keyboard.press('Escape');
+  });
+});
+
+test.describe('Generate password — Set Password dialog', () => {
+  test.use({
+    storageState: 'e2e/.auth/admin.json',
+    permissions: ['clipboard-read', 'clipboard-write'],
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await stubTokenRefresh(page);
+  });
+
+  test('fills, reveals and copies a generated password', async ({ page }) => {
+    await page.goto('/users');
+    // Any row will do — the dialog is escaped, never submitted.
+    await page.getByTestId('user-set-password').first().click();
+    const dialog = page.getByRole('dialog').filter({ hasText: 'Set Password' });
+    await expect(dialog).toBeVisible();
+
+    const password = dialog.getByLabel('Password', { exact: true });
+    await generateButton(dialog).click();
+
+    await expect(password).toHaveAttribute('type', 'text');
+    expect(await password.inputValue()).toHaveLength(GENERATED_PASSWORD_LENGTH);
+    await expect(page.getByText(COPIED_MESSAGE)).toBeVisible();
+
+    await page.keyboard.press('Escape');
+  });
+});
+
+test.describe('password fields without a generate affordance', () => {
+  // Logged out: the login form is an eye-only password field. Guards against the
+  // shared input's showGeneratePassword default being flipped on.
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('the login form offers the eye but no generate button', async ({
+    page,
+  }) => {
+    await page.goto('/auth/login');
+    await expect(page.getByLabel('Password', { exact: true })).toBeVisible();
+
+    await expect(page.locator('button.visibility-eye-button')).toHaveCount(1);
+    await expect(generateButton(page)).toHaveCount(0);
+  });
+});

--- a/desktop/e2e/generate-password.spec.ts
+++ b/desktop/e2e/generate-password.spec.ts
@@ -10,9 +10,14 @@ import { stubTokenRefresh } from './helpers/auth';
 const GENERATED_PASSWORD_LENGTH = 20;
 const COPIED_MESSAGE = 'Password generated and copied to clipboard';
 
+// Both suffix controls put their test ID on the native button, so neither needs
+// the .locator('button') hop the app-button-wrapped test IDs do.
 function generateButton(scope: Page | Locator): Locator {
-  // Unlike the app-button-wrapped test IDs, this one sits on the native button.
   return scope.getByTestId('password-generate');
+}
+
+function visibilityToggle(scope: Page | Locator): Locator {
+  return scope.getByTestId('password-visibility-toggle');
 }
 
 async function openCreateUserDialog(page: Page): Promise<Locator> {
@@ -80,7 +85,7 @@ test.describe('Generate password — Create User', () => {
     await generateButton(dialog).click();
     await expect(password).toHaveAttribute('type', 'text');
 
-    await dialog.locator('button.visibility-eye-button').click();
+    await visibilityToggle(dialog).click();
     await expect(password).toHaveAttribute('type', 'password');
     // Masking is display-only — the generated value is still submitted.
     await expect(password).not.toHaveValue('');
@@ -142,7 +147,7 @@ test.describe('password fields without a generate affordance', () => {
     await page.goto('/auth/login');
     await expect(page.getByLabel('Password', { exact: true })).toBeVisible();
 
-    await expect(page.locator('button.visibility-eye-button')).toHaveCount(1);
+    await expect(visibilityToggle(page)).toHaveCount(1);
     await expect(generateButton(page)).toHaveCount(0);
   });
 });

--- a/desktop/e2e/helpers/provisioning.ts
+++ b/desktop/e2e/helpers/provisioning.ts
@@ -114,7 +114,7 @@ export async function createUserWithRole(
   await expect(dialog).toBeVisible();
   await dialog.getByLabel('Username').fill(opts.username);
   await dialog.getByLabel('Displayname').fill(opts.username);
-  await dialog.getByLabel('Password').fill(opts.password);
+  await dialog.getByLabel('Password', { exact: true }).fill(opts.password);
   await dialog.getByRole('combobox', { name: 'App Role' }).click();
   // The option panel is a floating overlay rendered on the page, not the dialog.
   await page.getByRole('option', { name: opts.role, exact: true }).click();

--- a/desktop/e2e/role-assignment.spec.ts
+++ b/desktop/e2e/role-assignment.spec.ts
@@ -32,7 +32,7 @@ test.describe('assigning modern roles (admin)', () => {
 
     await dialog.getByLabel('Username').fill(username);
     await dialog.getByLabel('Displayname').fill('E2E App Role');
-    await dialog.getByLabel('Password').fill('a-really-secure-password');
+    await dialog.getByLabel('Password', { exact: true }).fill('a-really-secure-password');
 
     // The app-role selector defaults to the configured default app role.
     const roleSelect = selectByLabel(page, 'App Role');

--- a/desktop/e2e/system-settings-tab-gating.spec.ts
+++ b/desktop/e2e/system-settings-tab-gating.spec.ts
@@ -77,7 +77,7 @@ async function createUserWithRole(
   await expect(dialog).toBeVisible();
   await dialog.getByLabel('Username').fill(opts.username);
   await dialog.getByLabel('Displayname').fill(opts.username);
-  await dialog.getByLabel('Password').fill(opts.password);
+  await dialog.getByLabel('Password', { exact: true }).fill(opts.password);
   await dialog.getByRole('combobox', { name: 'App Role' }).click();
   await page.getByRole('option', { name: opts.role, exact: true }).click();
   await dialog.locator('app-submit-button button').click();

--- a/desktop/src/input/input.module.ts
+++ b/desktop/src/input/input.module.ts
@@ -5,6 +5,7 @@ import { MatButtonModule } from "@angular/material/button";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatIconModule } from "@angular/material/icon";
 import { MatInputModule } from "@angular/material/input";
+import { MatSnackBarModule } from "@angular/material/snack-bar";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { NgxMaskDirective, provideNgxMask } from "ngx-mask";
 import { InputComponent } from "./input/input.component";
@@ -17,6 +18,8 @@ import { InputComponent } from "./input/input.component";
     MatFormFieldModule,
     MatIconModule,
     MatInputModule,
+    // Provides MatSnackBar for the generate-password toast (PasswordGeneratorService).
+    MatSnackBarModule,
     MatTooltipModule,
     NgxMaskDirective,
     ReactiveFormsModule,

--- a/desktop/src/input/input/input.component.html
+++ b/desktop/src/input/input/input.component.html
@@ -22,7 +22,20 @@
         err.message
       }}
     </mat-error>
-    <div matSuffix *ngIf="showVisibilityEye">
+    <div matSuffix *ngIf="showVisibilityEye || showGeneratePassword">
+      <button
+        *ngIf="showGeneratePassword"
+        class="generate-password-button"
+        mat-icon-button
+        type="button"
+        data-testid="password-generate"
+        aria-label="Generate password"
+        matTooltip="Generate password"
+        [disabled]="inputFormControl.disabled || readonly"
+        (click)="generatePassword()"
+      >
+        <mat-icon>autorenew</mat-icon>
+      </button>
       <button
         *ngIf="showVisibilityEye"
         class="visibility-eye-button"

--- a/desktop/src/input/input/input.component.html
+++ b/desktop/src/input/input/input.component.html
@@ -41,6 +41,7 @@
         class="visibility-eye-button"
         mat-icon-button
         type="button"
+        data-testid="password-visibility-toggle"
         [matTooltip]="type === 'password' ? 'Show ' + label : 'Hide ' + label"
         (click)="toggleVisibility()"
       >

--- a/desktop/src/input/input/input.component.spec.ts
+++ b/desktop/src/input/input/input.component.spec.ts
@@ -100,6 +100,32 @@ describe("InputComponent", () => {
       expect(component.type).toEqual("password");
     });
 
+    it("masks the field when the generate button is enabled later", async () => {
+      fixture.componentRef.setInput("showGeneratePassword", false);
+      await fixture.whenStable();
+      expect(component.type).toEqual("text");
+
+      // A parent flipping the flag on after init still turns this into a
+      // password field — otherwise typed passwords would sit in plain text.
+      fixture.componentRef.setInput("showGeneratePassword", true);
+      await fixture.whenStable();
+
+      expect(component.type).toEqual("password");
+    });
+
+    it("does not re-mask a revealed password when an unrelated input changes", async () => {
+      fixture.componentRef.setInput("showGeneratePassword", true);
+      await fixture.whenStable();
+
+      component.generatePassword();
+      expect(component.type).toEqual("text");
+
+      fixture.componentRef.setInput("label", "New Password");
+      await fixture.whenStable();
+
+      expect(component.type).toEqual("text");
+    });
+
     it("fills the control with a generated password and reveals it", async () => {
       fixture.componentRef.setInput("inputFormControl", new FormControl(""));
       fixture.componentRef.setInput("showGeneratePassword", true);

--- a/desktop/src/input/input/input.component.spec.ts
+++ b/desktop/src/input/input/input.component.spec.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from "@angular/common";
+import { provideZonelessChangeDetection } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
-import { ReactiveFormsModule } from "@angular/forms";
+import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { MatButtonModule } from "@angular/material/button";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatIconModule } from "@angular/material/icon";
@@ -9,14 +10,22 @@ import { MatTooltipModule } from "@angular/material/tooltip";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { NgxsModule } from "@ngxs/store";
 import { NgxMaskDirective, provideNgxMask } from "ngx-mask";
+import { PasswordGeneratorService } from "../../services/password-generator.service";
 import { SystemSettingsState } from "../../store/system-settings.state";
 import { InputComponent } from "./input.component";
+
+const GENERATED_PASSWORD = "Fixed-Pass-1";
 
 describe("InputComponent", () => {
   let component: InputComponent;
   let fixture: ComponentFixture<InputComponent>;
+  let passwordGeneratorService: { generateAndCopy: jest.Mock };
 
   beforeEach(async () => {
+    passwordGeneratorService = {
+      generateAndCopy: jest.fn().mockReturnValue(GENERATED_PASSWORD),
+    };
+
     await TestBed.configureTestingModule({
       declarations: [InputComponent],
       imports: [
@@ -31,7 +40,14 @@ describe("InputComponent", () => {
         NgxMaskDirective,
         NgxsModule.forRoot([SystemSettingsState]),
       ],
-      providers: [provideNgxMask()],
+      providers: [
+        provideNgxMask(),
+        provideZonelessChangeDetection(),
+        {
+          provide: PasswordGeneratorService,
+          useValue: passwordGeneratorService,
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(InputComponent);
@@ -41,5 +57,98 @@ describe("InputComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  describe("generate password button", () => {
+    function generateButton(): HTMLButtonElement | null {
+      return fixture.nativeElement.querySelector(
+        '[data-testid="password-generate"]'
+      );
+    }
+
+    function iconButtonCount(): number {
+      return fixture.nativeElement.querySelectorAll("button[mat-icon-button]")
+        .length;
+    }
+
+    it("is not rendered by default", () => {
+      expect(generateButton()).toBeNull();
+      expect(iconButtonCount()).toEqual(0);
+    });
+
+    it("is not rendered for a field that only shows the visibility eye", async () => {
+      fixture.componentRef.setInput("showVisibilityEye", true);
+      await fixture.whenStable();
+
+      expect(generateButton()).toBeNull();
+      expect(iconButtonCount()).toEqual(1);
+    });
+
+    it("renders alongside the visibility eye when enabled", async () => {
+      fixture.componentRef.setInput("showVisibilityEye", true);
+      fixture.componentRef.setInput("showGeneratePassword", true);
+      await fixture.whenStable();
+
+      expect(generateButton()).not.toBeNull();
+      expect(iconButtonCount()).toEqual(2);
+    });
+
+    it("masks the field on init when only the generate button is enabled", async () => {
+      fixture.componentRef.setInput("showGeneratePassword", true);
+      await fixture.whenStable();
+
+      expect(component.type).toEqual("password");
+    });
+
+    it("fills the control with a generated password and reveals it", async () => {
+      fixture.componentRef.setInput("inputFormControl", new FormControl(""));
+      fixture.componentRef.setInput("showGeneratePassword", true);
+      await fixture.whenStable();
+
+      generateButton()?.click();
+      await fixture.whenStable();
+
+      expect(passwordGeneratorService.generateAndCopy).toHaveBeenCalled();
+      expect(component.inputFormControl.value).toEqual(GENERATED_PASSWORD);
+      expect(component.inputFormControl.dirty).toEqual(true);
+      expect(component.type).toEqual("text");
+      expect(
+        fixture.nativeElement.querySelector("input").getAttribute("type")
+      ).toEqual("text");
+    });
+
+    it("can be re-masked with the visibility eye after generating", () => {
+      component.type = "password";
+
+      component.generatePassword();
+      expect(component.type).toEqual("text");
+
+      component.toggleVisibility();
+      expect(component.type).toEqual("password");
+    });
+
+    it("does nothing for a disabled control", async () => {
+      fixture.componentRef.setInput(
+        "inputFormControl",
+        new FormControl({ value: "", disabled: true })
+      );
+      fixture.componentRef.setInput("showGeneratePassword", true);
+      await fixture.whenStable();
+
+      expect(generateButton()?.disabled).toEqual(true);
+
+      component.generatePassword();
+
+      expect(passwordGeneratorService.generateAndCopy).not.toHaveBeenCalled();
+      expect(component.inputFormControl.value).toEqual("");
+    });
+
+    it("does nothing for a readonly field", () => {
+      fixture.componentRef.setInput("readonly", true);
+
+      component.generatePassword();
+
+      expect(passwordGeneratorService.generateAndCopy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/desktop/src/input/input/input.component.ts
+++ b/desktop/src/input/input/input.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnChanges, SimpleChanges, input, viewChild } from "@a
 import { Store } from "@ngxs/store";
 import { BaseInputComponent } from "../../base-input";
 import { CurrencySeparator, CurrencySymbolPosition } from "../../open-api/index";
+import { PasswordGeneratorService } from "../../services/password-generator.service";
 import { SystemSettingsState } from "../../store/system-settings.state";
 import { InputInterface } from "../input.interface";
 
@@ -32,6 +33,8 @@ export class InputComponent
 
   @Input() public showVisibilityEye = false;
 
+  @Input() public showGeneratePassword = false;
+
   public readonly isCurrency = input<boolean>(false);
 
   @Input() public mask: string = "";
@@ -44,13 +47,20 @@ export class InputComponent
 
   @Input() public decimalMarker: CurrencySeparator = CurrencySeparator.Period;
 
-  constructor(private store: Store) {
+  constructor(
+    private store: Store,
+    private passwordGeneratorService: PasswordGeneratorService
+  ) {
     super();
   }
 
 
   public ngOnChanges(changes: SimpleChanges): void {
-    if (changes["showVisibilityEye"]?.firstChange && changes["showVisibilityEye"]?.currentValue) {
+    // Either password affordance implies a password field, so mask it up front.
+    const becamePasswordField =
+      (changes["showVisibilityEye"]?.firstChange && this.showVisibilityEye) ||
+      (changes["showGeneratePassword"]?.firstChange && this.showGeneratePassword);
+    if (becamePasswordField) {
       this.type = "password";
     }
 
@@ -81,6 +91,22 @@ export class InputComponent
       this.thousandSeparator = "";
       this.decimalMarker = CurrencySeparator.Period;
     }
+  }
+
+  /**
+   * Fills the field with a freshly generated password and reveals it so the
+   * user can see what landed on their clipboard. Everything that affects the
+   * view is set synchronously — under zoneless change detection only the click
+   * event's change-detection pass will render it.
+   */
+  public generatePassword(): void {
+    if (this.inputFormControl.disabled || this.readonly) {
+      return;
+    }
+
+    this.inputFormControl.setValue(this.passwordGeneratorService.generateAndCopy());
+    this.inputFormControl.markAsDirty();
+    this.type = "text";
   }
 
   public toggleVisibility(): void {

--- a/desktop/src/input/input/input.component.ts
+++ b/desktop/src/input/input/input.component.ts
@@ -56,10 +56,13 @@ export class InputComponent
 
 
   public ngOnChanges(changes: SimpleChanges): void {
-    // Either password affordance implies a password field, so mask it up front.
+    // Either password affordance implies a password field, so mask it whenever
+    // one is switched on — `changes` only carries a key that actually changed,
+    // so this fires on the initial binding and on a later false -> true flip,
+    // and never re-masks a field the user has revealed.
     const becamePasswordField =
-      (changes["showVisibilityEye"]?.firstChange && this.showVisibilityEye) ||
-      (changes["showGeneratePassword"]?.firstChange && this.showGeneratePassword);
+      changes["showVisibilityEye"]?.currentValue ||
+      changes["showGeneratePassword"]?.currentValue;
     if (becamePasswordField) {
       this.type = "password";
     }

--- a/desktop/src/services/index.ts
+++ b/desktop/src/services/index.ts
@@ -1,5 +1,6 @@
 export * from './app-init.service';
 export * from './claims.service';
+export * from './password-generator.service';
 export * from './snackbar.service';
 export * from './keyboard-shortcut.service';
 export * from './token-refresh.service';

--- a/desktop/src/services/password-generator.service.spec.ts
+++ b/desktop/src/services/password-generator.service.spec.ts
@@ -1,0 +1,89 @@
+import { provideZonelessChangeDetection } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { GENERATED_PASSWORD_LENGTH } from "../utils/password.utils";
+import {
+  PASSWORD_COPIED_MESSAGE,
+  PASSWORD_COPY_FAILED_MESSAGE,
+  PasswordGeneratorService,
+} from "./password-generator.service";
+import { SnackbarService } from "./snackbar.service";
+
+describe("PasswordGeneratorService", () => {
+  let service: PasswordGeneratorService;
+  let snackbarService: { success: jest.Mock; error: jest.Mock };
+  let originalClipboard: any;
+
+  beforeEach(() => {
+    snackbarService = { success: jest.fn(), error: jest.fn() };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: SnackbarService, useValue: snackbarService },
+      ],
+    });
+
+    service = TestBed.inject(PasswordGeneratorService);
+    originalClipboard = (navigator as any).clipboard;
+  });
+
+  afterEach(() => {
+    (navigator as any).clipboard = originalClipboard;
+  });
+
+  it("creates", () => {
+    expect(service).toBeTruthy();
+  });
+
+  it("returns a generated password and copies that same value", () => {
+    const copyAndNotify = jest
+      .spyOn(service, "copyAndNotify")
+      .mockResolvedValue(undefined);
+
+    const password = service.generateAndCopy();
+
+    expect(password.length).toEqual(GENERATED_PASSWORD_LENGTH);
+    expect(copyAndNotify).toHaveBeenCalledWith(password);
+  });
+
+  it("writes the password to the clipboard and toasts success", async () => {
+    const writeText = jest
+      .fn<Promise<void>, [string]>()
+      .mockResolvedValue(undefined);
+    (navigator as any).clipboard = { writeText };
+
+    await service.copyAndNotify("hunter2");
+
+    expect(writeText).toHaveBeenCalledWith("hunter2");
+    expect(snackbarService.success).toHaveBeenCalledWith(
+      PASSWORD_COPIED_MESSAGE
+    );
+    expect(snackbarService.error).not.toHaveBeenCalled();
+  });
+
+  it("toasts an error when the clipboard write is rejected", async () => {
+    (navigator as any).clipboard = {
+      writeText: jest
+        .fn<Promise<void>, [string]>()
+        .mockRejectedValue(new Error("blocked")),
+    };
+
+    await service.copyAndNotify("hunter2");
+
+    expect(snackbarService.error).toHaveBeenCalledWith(
+      PASSWORD_COPY_FAILED_MESSAGE
+    );
+    expect(snackbarService.success).not.toHaveBeenCalled();
+  });
+
+  it("toasts an error without throwing when the clipboard is unavailable", async () => {
+    (navigator as any).clipboard = undefined;
+
+    await service.copyAndNotify("hunter2");
+
+    expect(snackbarService.error).toHaveBeenCalledWith(
+      PASSWORD_COPY_FAILED_MESSAGE
+    );
+    expect(snackbarService.success).not.toHaveBeenCalled();
+  });
+});

--- a/desktop/src/services/password-generator.service.ts
+++ b/desktop/src/services/password-generator.service.ts
@@ -1,0 +1,53 @@
+import { Injectable } from "@angular/core";
+import { generateSecurePassword } from "../utils/password.utils";
+import { SnackbarService } from "./snackbar.service";
+
+export const PASSWORD_COPIED_MESSAGE =
+  "Password generated and copied to clipboard";
+
+export const PASSWORD_COPY_FAILED_MESSAGE =
+  "Password generated, but copying to the clipboard failed";
+
+/**
+ * Generates a password and copies it to the clipboard, toasting the outcome.
+ *
+ * Keeps the clipboard/snackbar policy in one place so every "Generate
+ * Password" control behaves identically, and so the generic `app-input` that
+ * hosts the control stays free of clipboard handling.
+ */
+@Injectable({
+  providedIn: "root",
+})
+export class PasswordGeneratorService {
+  constructor(private snackbarService: SnackbarService) {}
+
+  /**
+   * Returns a new password **synchronously** — callers run under zoneless
+   * change detection, where state set after an `await` would not re-render.
+   * The clipboard write and its toast run as a detached side effect.
+   */
+  public generateAndCopy(length?: number): string {
+    const password = generateSecurePassword(length);
+    void this.copyAndNotify(password);
+
+    return password;
+  }
+
+  public async copyAndNotify(password: string): Promise<void> {
+    // Non-secure context or unsupported browser: the password is still in the
+    // field, so tell the user to copy it manually rather than failing silently.
+    if (!navigator?.clipboard?.writeText) {
+      this.snackbarService.error(PASSWORD_COPY_FAILED_MESSAGE);
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(password);
+    } catch {
+      this.snackbarService.error(PASSWORD_COPY_FAILED_MESSAGE);
+      return;
+    }
+
+    this.snackbarService.success(PASSWORD_COPIED_MESSAGE);
+  }
+}

--- a/desktop/src/user/dummy-user-conversion-dialog/dummy-user-conversion-dialog.component.html
+++ b/desktop/src/user/dummy-user-conversion-dialog/dummy-user-conversion-dialog.component.html
@@ -4,6 +4,7 @@
       label="Password"
       type="password"
       [inputFormControl]="form | formGet : 'password'"
+      [showGeneratePassword]="true"
       [showVisibilityEye]="true"
     ></app-input>
   </form>

--- a/desktop/src/user/reset-password/reset-password.component.html
+++ b/desktop/src/user/reset-password/reset-password.component.html
@@ -5,6 +5,7 @@
       label="Password"
       type="password"
       [inputFormControl]="form | formGet : 'password'"
+      [showGeneratePassword]="true"
       [showVisibilityEye]="true"
     ></app-input>
     <div class="d-flex justify-content-end align-items-center">

--- a/desktop/src/user/user-form/user-form.component.html
+++ b/desktop/src/user/user-form/user-form.component.html
@@ -17,6 +17,7 @@
         label="Password"
         type="password"
         [inputFormControl]="form | formGet : 'password'"
+        [showGeneratePassword]="true"
         [showVisibilityEye]="true"
       ></app-input>
       <div class="d-flex align-items-center">

--- a/desktop/src/user/user-list/user-list.component.html
+++ b/desktop/src/user/user-list/user-list.component.html
@@ -70,6 +70,7 @@
     ></app-button>
     <app-button
       *hasAppPermission="Permission.AppUsersUpdate"
+      data-testid="user-set-password"
       matButtonType="iconButton"
       icon="password"
       tooltip="Set password"

--- a/desktop/src/utils/index.ts
+++ b/desktop/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from "./form.utils";
 export * from "./paramterterized-data-parser";
+export * from "./password.utils";
 export * from "./permission.utils";
 export * from "./sort-by-displayname";
 export * from "./status.utils";

--- a/desktop/src/utils/password.utils.spec.ts
+++ b/desktop/src/utils/password.utils.spec.ts
@@ -1,0 +1,100 @@
+import {
+  GENERATED_PASSWORD_LENGTH,
+  PASSWORD_CHARACTER_CLASSES,
+  PASSWORD_CHARACTER_POOL,
+  generateSecurePassword,
+} from "./password.utils";
+
+const ITERATIONS = 200;
+
+describe("generateSecurePassword", () => {
+  it("defaults to the configured length", () => {
+    expect(generateSecurePassword().length).toEqual(GENERATED_PASSWORD_LENGTH);
+  });
+
+  it("honors an explicit length", () => {
+    expect(generateSecurePassword(32).length).toEqual(32);
+  });
+
+  it("throws when the length cannot satisfy every character class", () => {
+    expect(() =>
+      generateSecurePassword(PASSWORD_CHARACTER_CLASSES.length - 1)
+    ).toThrow(RangeError);
+  });
+
+  it("always contains at least one character from each class", () => {
+    for (let i = 0; i < ITERATIONS; i++) {
+      const password = generateSecurePassword();
+
+      PASSWORD_CHARACTER_CLASSES.forEach((characterClass) => {
+        expect(
+          [...password].some((character) => characterClass.includes(character))
+        ).toEqual(true);
+      });
+    }
+  });
+
+  it("only uses characters from the pool", () => {
+    for (let i = 0; i < ITERATIONS; i++) {
+      [...generateSecurePassword()].forEach((character) => {
+        expect(PASSWORD_CHARACTER_POOL).toContain(character);
+      });
+    }
+  });
+
+  it("excludes visually ambiguous characters", () => {
+    [..."0O1lI"].forEach((character) => {
+      expect(PASSWORD_CHARACTER_POOL).not.toContain(character);
+    });
+  });
+
+  it("does not repeat itself", () => {
+    const passwords = new Set<string>();
+
+    for (let i = 0; i < ITERATIONS; i++) {
+      passwords.add(generateSecurePassword());
+    }
+
+    expect(passwords.size).toEqual(ITERATIONS);
+  });
+
+  it("sources randomness from crypto and not Math.random", () => {
+    const getRandomValues = jest.spyOn(crypto, "getRandomValues");
+    const random = jest.spyOn(Math, "random");
+
+    try {
+      generateSecurePassword();
+
+      expect(getRandomValues).toHaveBeenCalled();
+      expect(random).not.toHaveBeenCalled();
+    } finally {
+      getRandomValues.mockRestore();
+      random.mockRestore();
+    }
+  });
+
+  it("rejects biased random bytes instead of taking them modulo the pool size", () => {
+    // The first draw is from the 25-character lowercase class, whose unbiased
+    // range is 0-249 — bytes 250-255 must be discarded and redrawn. A naive
+    // `% 25` implementation would consume them instead of rejecting them.
+    const scriptedBytes = [250, 251, 252, 253, 254, 255];
+    let call = 0;
+    const getRandomValues = jest
+      .spyOn(crypto, "getRandomValues")
+      .mockImplementation((array: any) => {
+        array[0] = call < scriptedBytes.length ? scriptedBytes[call] : 5;
+        call++;
+        return array;
+      });
+
+    try {
+      const password = generateSecurePassword(4);
+
+      // Every scripted byte was rejected, so the first draw fell through to 5.
+      expect(call).toBeGreaterThan(scriptedBytes.length);
+      expect(password.length).toEqual(4);
+    } finally {
+      getRandomValues.mockRestore();
+    }
+  });
+});

--- a/desktop/src/utils/password.utils.spec.ts
+++ b/desktop/src/utils/password.utils.spec.ts
@@ -22,6 +22,15 @@ describe("generateSecurePassword", () => {
     ).toThrow(RangeError);
   });
 
+  // Without the integer guard, Infinity spins the fill loop forever and NaN
+  // falls through it, returning only the class-guaranteed characters.
+  it.each([Infinity, -Infinity, NaN, 20.5])(
+    "throws for the non-integer length %p",
+    (length) => {
+      expect(() => generateSecurePassword(length)).toThrow(RangeError);
+    }
+  );
+
   it("always contains at least one character from each class", () => {
     for (let i = 0; i < ITERATIONS; i++) {
       const password = generateSecurePassword();

--- a/desktop/src/utils/password.utils.ts
+++ b/desktop/src/utils/password.utils.ts
@@ -45,9 +45,12 @@ export const GENERATED_PASSWORD_LENGTH = 20;
 export function generateSecurePassword(
   length: number = GENERATED_PASSWORD_LENGTH
 ): string {
-  if (length < PASSWORD_CHARACTER_CLASSES.length) {
+  // Guard the loop below: Infinity would spin forever, and NaN would fall
+  // straight through and silently yield a password of only the guaranteed
+  // characters.
+  if (!Number.isInteger(length) || length < PASSWORD_CHARACTER_CLASSES.length) {
     throw new RangeError(
-      `Password length must be at least ${PASSWORD_CHARACTER_CLASSES.length}.`
+      `Password length must be a whole number of at least ${PASSWORD_CHARACTER_CLASSES.length}.`
     );
   }
 

--- a/desktop/src/utils/password.utils.ts
+++ b/desktop/src/utils/password.utils.ts
@@ -1,0 +1,94 @@
+/**
+ * Secure password generation for the admin-facing "Generate Password" control.
+ *
+ * Randomness comes from `crypto.getRandomValues` with rejection sampling — a
+ * plain `% charsetLength` would skew the distribution toward the first
+ * characters of each pool. Generated passwords are shown on screen and handed
+ * off by an administrator, so the pools omit visually ambiguous glyphs
+ * (`0/O`, `1/l/I`) to keep them readable and transcribable.
+ */
+
+const LOWERCASE_CHARACTERS = "abcdefghijkmnopqrstuvwxyz";
+
+const UPPERCASE_CHARACTERS = "ABCDEFGHJKLMNPQRSTUVWXYZ";
+
+const DIGIT_CHARACTERS = "23456789";
+
+const SYMBOL_CHARACTERS = "!@#$%^&*()-_=+[]{}";
+
+/**
+ * The character classes a generated password is guaranteed to draw from at
+ * least once.
+ */
+export const PASSWORD_CHARACTER_CLASSES: readonly string[] = [
+  LOWERCASE_CHARACTERS,
+  UPPERCASE_CHARACTERS,
+  DIGIT_CHARACTERS,
+  SYMBOL_CHARACTERS,
+];
+
+/** Every character a generated password may contain. */
+export const PASSWORD_CHARACTER_POOL = PASSWORD_CHARACTER_CLASSES.join("");
+
+/**
+ * Default generated password length. Comfortably strong (~120 bits of entropy
+ * over the pool above) while staying well inside bcrypt's 72-byte input limit.
+ */
+export const GENERATED_PASSWORD_LENGTH = 20;
+
+/**
+ * Generates a cryptographically random password containing at least one
+ * character from each class in {@link PASSWORD_CHARACTER_CLASSES}.
+ *
+ * @throws RangeError when `length` is too short to satisfy that guarantee.
+ */
+export function generateSecurePassword(
+  length: number = GENERATED_PASSWORD_LENGTH
+): string {
+  if (length < PASSWORD_CHARACTER_CLASSES.length) {
+    throw new RangeError(
+      `Password length must be at least ${PASSWORD_CHARACTER_CLASSES.length}.`
+    );
+  }
+
+  const characters = PASSWORD_CHARACTER_CLASSES.map((characterClass) =>
+    randomCharacter(characterClass)
+  );
+
+  while (characters.length < length) {
+    characters.push(randomCharacter(PASSWORD_CHARACTER_POOL));
+  }
+
+  // The class-guaranteed characters were appended in a fixed order, so shuffle
+  // to keep their positions unpredictable.
+  return shuffle(characters).join("");
+}
+
+function randomCharacter(characters: string): string {
+  return characters.charAt(randomIndex(characters.length));
+}
+
+/**
+ * Returns a uniformly distributed integer in `[0, maxExclusive)` by discarding
+ * random bytes that fall into the biased tail of the byte range.
+ */
+function randomIndex(maxExclusive: number): number {
+  const buffer = new Uint8Array(1);
+  const largestUnbiasedValue = 256 - (256 % maxExclusive);
+
+  for (;;) {
+    crypto.getRandomValues(buffer);
+    if (buffer[0] < largestUnbiasedValue) {
+      return buffer[0] % maxExclusive;
+    }
+  }
+}
+
+function shuffle(characters: string[]): string[] {
+  for (let i = characters.length - 1; i > 0; i--) {
+    const j = randomIndex(i + 1);
+    [characters[i], characters[j]] = [characters[j], characters[i]];
+  }
+
+  return characters;
+}


### PR DESCRIPTION
## Summary
Adds a secure password generation feature to the `app-input` component, allowing administrators to generate and auto-fill strong passwords in password fields across the application (user creation, password reset, and dummy user conversion dialogs).

## Key Changes

- **New password generation utility** (`src/utils/password.utils.ts`):
  - `generateSecurePassword()` function using `crypto.getRandomValues()` with rejection sampling for uniform distribution
  - Guarantees at least one character from each class (lowercase, uppercase, digits, symbols)
  - Excludes visually ambiguous characters (0/O, 1/l/I) for readability
  - Default length of 20 characters (~120 bits of entropy)
  - Comprehensive test coverage including bias rejection and randomness verification

- **New password generator service** (`src/services/password-generator.service.ts`):
  - `generateAndCopy()` method that generates a password and copies it to clipboard
  - `copyAndNotify()` handles clipboard operations with user feedback via snackbar
  - Graceful error handling for unavailable/blocked clipboard access
  - Designed for zoneless change detection (synchronous password generation, async clipboard side effect)

- **Enhanced input component**:
  - New `[showGeneratePassword]` input property to opt-in to the generate button
  - `generatePassword()` method that fills the control, marks it dirty, and reveals the password
  - Respects disabled/readonly state (button disabled, method returns early)
  - Updated template with generate button (autorenew icon) alongside existing visibility eye
  - Both password affordances mask the field on init

- **Updated password fields** across the application:
  - User form (`user-form.component.html`)
  - Reset password dialog (`reset-password.component.html`)
  - Dummy user conversion dialog (`dummy-user-conversion-dialog.component.html`)

- **Test coverage**:
  - Comprehensive unit tests for password generation utility (randomness, distribution, entropy)
  - Service tests covering clipboard operations and error scenarios
  - Component tests for button rendering, state management, and interaction

## Implementation Details

- Password generation is **synchronous** to work correctly under zoneless change detection; clipboard operations run as detached side effects
- Uses rejection sampling to avoid modulo bias in random byte selection
- Passwords are revealed after generation so users can verify what was copied to clipboard
- Feature is admin-only (no user self-service password generation)
- Integrates with existing snackbar service for user feedback

https://claude.ai/code/session_017o1djQfgrAdbm5dLqVkrgc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secure password generation to supported password fields (user creation, reset, and conversion) with an optional “Generate password” control.
  * Generated passwords can be revealed and copied to the clipboard, with success feedback.
* **Bug Fixes**
  * Generation/reveal/copy is disabled for disabled or read-only inputs and handles clipboard failures gracefully.
* **Tests**
  * Expanded E2E coverage for generate/reveal/copy flows across dialogs, including stricter password label matching (`exact: true`).
* **Documentation**
  * Updated password-field guidance with opt-in rules and locator notes for reliable testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->